### PR TITLE
Stage 07: paper production pipeline redesign

### DIFF
--- a/.claude/skills/guides/citation-discipline.md
+++ b/.claude/skills/guides/citation-discipline.md
@@ -1,0 +1,431 @@
+# Citation Discipline and Hallucination Prevention
+
+Use this reference only when the built-in DBLP/CrossRef workflow in `paper-write` is not enough.
+
+This is an intentionally longer reference. It is not meant to replace the main workflow. Instead, it gives stricter standards for handling citations when:
+
+- the title, authors, year, or venue are ambiguous,
+- multiple papers could match the same description,
+- DBLP / CrossRef do not return a sufficiently clean result,
+- you need to verify that a specific factual claim really comes from the cited paper,
+- or you need to clean and standardize a bibliography in a more disciplined way.
+
+## Contents
+
+- [Why Citation Verification Matters](#why-citation-verification-matters)
+- [Useful Sources and APIs](#useful-sources-and-apis)
+- [Standard Verification Workflow](#standard-verification-workflow)
+- [How to Add an Entry to the Bibliography](#how-to-add-an-entry-to-the-bibliography)
+- [BibTeX Management Rules](#bibtex-management-rules)
+- [Common Entry Templates](#common-entry-templates)
+- [Common Failures and Troubleshooting](#common-failures-and-troubleshooting)
+- [Final Verification Checklist](#final-verification-checklist)
+
+## Why Citation Verification Matters
+
+### Typical Citation Hallucination Patterns
+
+The dangerous case is usually not a wildly fake citation. It is a citation that looks *plausible enough* to slip through:
+
+- real authors plus a fake title,
+- a real title plus the wrong year,
+- a real arXiv ID plus the wrong venue,
+- a real topic plus a non-existent DOI,
+- or a preprint version and published version silently merged into one entry.
+
+These mistakes are easy to miss by eye and disproportionately damaging during submission, review, and rebuttal.
+
+### Consequences
+
+If citation quality is weak, the mild consequences include:
+
+- reviewers conclude the related-work section is unreliable,
+- the bibliography looks messy and exposes a low-trust workflow,
+- claims appear unsupported because the cited source does not actually say what the paper attributes to it.
+
+The more serious consequences include:
+
+- being called out for hallucinated references,
+- surfacing compliance problems in desk checks or later review,
+- and creating an avoidable trust crisis around the paper.
+
+### Core Principle
+
+**Never generate citations from memory.**
+
+If a citation cannot be verified programmatically or from trusted project materials:
+
+- mark it explicitly as unresolved,
+- tell the user,
+- and do not fabricate a plausible-looking BibTeX entry.
+
+## Useful Sources and APIs
+
+### Primary Sources
+
+| Source | Best Use | Strengths | Caveats |
+|--------|----------|-----------|---------|
+| DBLP | CS/ML conference papers, BibTeX retrieval | Strong structure, strong venue metadata | Some preprints are better covered by arXiv |
+| CrossRef | DOI lookup, BibTeX content negotiation | Official metadata source, ideal when DOI exists | Quality depends on DOI registration |
+| Semantic Scholar | Paper search, citation graph, abstract lookup | Good discovery experience for ML literature | Free access may be rate limited |
+| arXiv | Preprint lookup | Strong coverage for ML preprints | Not a substitute for formal publication metadata |
+| OpenAlex | Open metadata graph, cross-checking | Broad coverage and useful as a second source | Structure may differ from DBLP conventions |
+
+### How to Choose
+
+Common decision logic:
+
+```text
+Need to search ML papers -> Semantic Scholar / DBLP
+Already have a DOI -> CrossRef content negotiation
+Only have an arXiv clue -> arXiv + CrossRef / Semantic Scholar for cross-checking
+Need a second verification source -> OpenAlex / Semantic Scholar / arXiv
+```
+
+### About Google Scholar
+
+Google Scholar is not the default verification backbone here. Do not treat “I found something by hand in Scholar” as the same thing as clean, trustworthy, structured metadata.
+
+## Standard Verification Workflow
+
+### Five-Step Process
+
+```text
+1. SEARCH   -> find candidate papers
+2. VERIFY   -> confirm the paper exists in at least two trustworthy sources
+3. RETRIEVE -> get BibTeX programmatically
+4. VALIDATE -> confirm the claim you cite is really supported by the paper
+5. ADD      -> add the entry to the bibliography with clean keys and formatting
+```
+
+### Step 1: Search
+
+Prefer **specific searches**, not broad topic words.
+
+Good query patterns:
+
+- `paper title + first author`
+- `method name + dataset + first author`
+- `claim keyword + author`
+- exact phrases from the title
+
+While searching, record:
+
+- title,
+- authors,
+- year,
+- DOI,
+- arXiv ID,
+- venue / journal.
+
+If multiple similar papers appear, do not add anything to `.bib` yet. First compare title details, year, and author order.
+
+### Step 2: Verify Existence
+
+In the ideal case, confirm the same paper in at least two sources:
+
+- Semantic Scholar + CrossRef,
+- DBLP + DOI,
+- arXiv + Semantic Scholar,
+- DBLP + OpenAlex.
+
+The minimum standard for “this is the same paper” is:
+
+- highly matching title,
+- matching first author,
+- matching or explainable year,
+- matching DOI and/or arXiv ID.
+
+If you only found the paper in one place, the citation is still not very stable.
+
+### Step 3: Retrieve BibTeX Programmatically
+
+Preferred order:
+
+1. direct DBLP `.bib`,
+2. DOI content negotiation,
+3. manual completion only if the metadata base is already trustworthy.
+
+DBLP pattern:
+
+```bash
+curl -s "https://dblp.org/search/publ/api?q=TITLE+AUTHOR&format=json&h=3"
+curl -s "https://dblp.org/rec/{key}.bib"
+```
+
+CrossRef / DOI pattern:
+
+```bash
+curl -sLH "Accept: application/x-bibtex" "https://doi.org/{doi}"
+```
+
+If both DBLP and DOI fail, move to explicit placeholder handling instead of guessing.
+
+### Step 4: Validate the Claim
+
+This is the step people most often skip and the step that matters the most.
+
+Before writing claims such as:
+
+- “X first proved …”
+- “Y showed that …”
+- “Prior work found …”
+- “Z outperformed B on benchmark A …”
+
+check that the cited paper really supports that statement.
+
+The minimum standard is:
+
+- the claim is directly supported by the title, abstract, or introduction,
+- or you have read the relevant section, table, theorem, or figure in the paper itself.
+
+Do **not**:
+
+- assume a paper supports your claim because the title sounds related,
+- inherit a claim from someone else’s related-work section without checking,
+- confuse “this paper is about the same topic” with “this paper establishes this exact statement.”
+
+### Step 5: Add the Entry
+
+Only after Steps 1-4 are complete should the entry go into `.bib`.
+
+Check before adding:
+
+- Is the entry type correct?
+- Are the authors complete?
+- Are the year and venue accurate?
+- Does the citation key match the project style?
+- Is this a duplicate of an existing entry?
+
+## How to Add an Entry to the Bibliography
+
+### Recommended Decision Tree
+
+```text
+Is there already a project-local .bib entry?
+  Yes -> reuse it, then verify it
+  No  -> continue
+
+Can DBLP provide a direct .bib entry?
+  Yes -> use DBLP
+  No  -> continue
+
+Do you have a DOI?
+  Yes -> use DOI content negotiation
+  No  -> continue
+
+Can you confirm the paper in two trustworthy sources with enough metadata?
+  Yes -> manually complete an entry from trusted metadata
+  No  -> use an explicit placeholder and report it to the user
+```
+
+### Placeholder Policy
+
+If verification fails, leave an explicit placeholder such as:
+
+```latex
+% TODO: verify before submission
+\cite{PLACEHOLDER_author2024_verify}
+```
+
+Or mark uncertainty inside the `.bib` file:
+
+```bibtex
+% [VERIFY] could not confirm DOI / venue / exact title
+```
+
+The principle is:
+
+- make uncertainty visible,
+- keep bad metadata out of the final draft,
+- and report unresolved citations before finalization.
+
+## BibTeX Management Rules
+
+### BibTeX vs BibLaTeX
+
+This `insleep`-derived workflow still prioritizes compatibility with existing conference templates. It does not force a move to BibLaTeX.
+
+Still, you should know the tradeoff:
+
+| Aspect | BibTeX | BibLaTeX |
+|--------|--------|----------|
+| Unicode support | Weaker | Better |
+| Entry types | Standard | Richer |
+| Backend | `bibtex` | `biber` |
+| Compatibility with older venue templates | Usually stronger | Not always safe |
+
+In this skill pack, if the template is already fixed, prefer compatibility over modernization.
+
+### Citation Key Format
+
+Prefer a stable key format:
+
+```text
+firstauthor_year_keyword
+```
+
+For example:
+
+```text
+vaswani_2017_attention
+devlin_2019_bert
+brown_2020_language
+```
+
+If the project already uses a different key style, preserve consistency rather than mixing styles.
+
+### Keep Only Cited Entries
+
+Do not let `references.bib` become a dumping ground.
+
+Rules:
+
+- keep only entries that are actually cited,
+- remove duplicates,
+- remove abandoned keys,
+- and choose explicitly between preprint and published versions when both exist.
+
+### When to Prefer the Published Version
+
+Prefer the formal published version when:
+
+- a conference or journal version clearly exists,
+- you need stable venue information for related work,
+- page / volume / publisher metadata matters for submission quality.
+
+Keeping the arXiv version can still be appropriate when:
+
+- the work is not formally published yet,
+- the community primarily cites the preprint,
+- or the specific version matters for the content you are citing.
+
+## Common Entry Templates
+
+### Conference Paper
+
+```bibtex
+@inproceedings{vaswani_2017_attention,
+  title = {Attention Is All You Need},
+  author = {Vaswani, Ashish and Shazeer, Noam and Parmar, Niki and
+            Uszkoreit, Jakob and Jones, Llion and Gomez, Aidan N. and
+            Kaiser, Lukasz and Polosukhin, Illia},
+  booktitle = {Advances in Neural Information Processing Systems},
+  year = {2017}
+}
+```
+
+### Journal Article
+
+```bibtex
+@article{hochreiter_1997_long,
+  title = {Long Short-Term Memory},
+  author = {Hochreiter, Sepp and Schmidhuber, J{\"u}rgen},
+  journal = {Neural Computation},
+  volume = {9},
+  number = {8},
+  pages = {1735--1780},
+  year = {1997}
+}
+```
+
+### arXiv Preprint
+
+```bibtex
+@misc{brown_2020_language,
+  title = {Language Models are Few-Shot Learners},
+  author = {Brown, Tom and Mann, Benjamin and Ryder, Nick and others},
+  year = {2020},
+  eprint = {2005.14165},
+  archiveprefix = {arXiv},
+  primaryclass = {cs.CL}
+}
+```
+
+## Common Failures and Troubleshooting
+
+### Case 1: No Results Found
+
+Check:
+
+- Was the title misspelled?
+- Was the author misspelled?
+- Is the query too broad?
+- Should the search use an exact phrase instead?
+
+Useful fixes:
+
+- add the first author,
+- add the year,
+- search with a distinctive title phrase rather than a broad topic term.
+
+### Case 2: DOI Does Not Resolve Cleanly
+
+Possible reasons:
+
+- the DOI exists but is not well connected through CrossRef,
+- the DOI is not the best lookup path for this paper,
+- the work mainly exists as an arXiv preprint.
+
+Useful fixes:
+
+- return to DBLP,
+- cross-check the DOI in Semantic Scholar / OpenAlex,
+- manually complete an entry from trusted metadata only when the metadata is already reliable.
+
+### Case 3: Several Papers Look Similar
+
+This is one of the most dangerous situations.
+
+Check:
+
+- author order,
+- year,
+- title wording,
+- abstract-level claim,
+- and, if needed, the PDF front page or the relevant section.
+
+Until those match, do not assume any of them is the correct paper.
+
+### Case 4: BibTeX Compilation Errors
+
+Common causes:
+
+- missing commas,
+- unmatched braces,
+- unescaped special characters,
+- Unicode that does not play well with the template.
+
+Check:
+
+- whether each field ends correctly,
+- whether title text needs LaTeX escaping,
+- whether accented names are encoded safely.
+
+### Case 5: The Same Paper Exists Under Two Keys
+
+Fix it by:
+
+- choosing one canonical key,
+- updating all in-text citations,
+- and deleting the duplicate entry.
+
+Do not leave two nearly identical entries in the final bibliography.
+
+## Final Verification Checklist
+
+Before treating a citation as complete, verify:
+
+- [ ] the paper was confirmed in at least two trustworthy sources,
+- [ ] the DOI or arXiv ID was checked,
+- [ ] the BibTeX was retrieved programmatically or completed from trusted metadata,
+- [ ] the entry type is correct (`@inproceedings`, `@article`, `@misc`, etc.),
+- [ ] the author list is complete and well formatted,
+- [ ] the year and venue were checked,
+- [ ] the citation key matches the project style,
+- [ ] the specific claim you cite is actually supported by the paper,
+- [ ] any unresolved uncertainty is marked with `[VERIFY]` or an explicit placeholder.
+
+## Bottom Line
+
+**When a citation is uncertain, leave an explicit gap instead of silently inventing metadata.**

--- a/.claude/skills/guides/venue-checklists.md
+++ b/.claude/skills/guides/venue-checklists.md
@@ -1,0 +1,73 @@
+# Venue Checklists for ICLR, NeurIPS, and ICML
+
+Use this reference near the end of `paper-plan` and during the final checks in `paper-write`.
+
+## When to Read
+
+- Read once when setting the target venue.
+- Read again before locking the outline.
+- Read again during final submission-readiness checks.
+
+## Universal Requirements
+
+Across these venues, the following are usually expected:
+
+- anonymous submission unless preparing a camera-ready version,
+- references and appendices outside the main page budget,
+- enough experimental detail for reproduction,
+- honest limitations and scope boundaries,
+- clear mapping from claims to evidence.
+
+## NeurIPS
+
+Planning implications:
+
+- The paper checklist is mandatory.
+- Claims in the Abstract and Introduction must align with the actual evidence.
+- The paper should discuss limitations honestly.
+- Reproducibility details, hyperparameters, data access, and compute usage should be documented.
+- Statistical reporting should specify error bars, number of runs, and how uncertainty is computed.
+
+Final-check implications:
+
+- Confirm the paper checklist is complete.
+- Ensure limitations, reproducibility details, and compute reporting exist somewhere appropriate.
+- Verify theory papers include assumptions and full proofs in the main paper or appendix.
+
+## ICML
+
+Planning implications:
+
+- The paper must budget space for an ICML-style Broader Impact statement.
+- Reproducibility expectations are strong: data splits, hyperparameters, search ranges, and compute should be documented.
+- Statistical reporting should state whether uncertainty uses standard deviation, standard error, or confidence intervals.
+
+Final-check implications:
+
+- Ensure the Broader Impact statement is present in the expected location.
+- Confirm anonymization is strict: no author names, acknowledgments, grant IDs, or self-identifying repository links.
+- Verify experimental details are detailed enough for replication.
+
+## ICLR
+
+Planning implications:
+
+- Reproducibility and ethics statements are often recommended even if not always mandatory.
+- If LLMs materially contributed to ideation or writing to the point of authorship-like contribution, plan a disclosure section or appendix note.
+- Keep the story front-loaded because ICLR reviewers often judge quickly from the early pages.
+
+Final-check implications:
+
+- Decide whether LLM disclosure is required for this project.
+- Confirm the paper includes enough reproducibility guidance, code/data availability information, and limitations discussion.
+- Check that the contribution is already clear by the end of the Introduction.
+
+## Minimal Submission Checklist
+
+Before submission, verify:
+
+- the venue-specific required sections are present,
+- the page budget is satisfied for the main body,
+- the contribution bullets do not overclaim,
+- citations, figures, tables, and references are internally consistent,
+- the PDF is anonymized and ready for reviewer consumption.

--- a/.claude/skills/guides/writing-principles.md
+++ b/.claude/skills/guides/writing-principles.md
@@ -1,0 +1,525 @@
+# Orchestra-Adapted Writing Principles
+
+Use this reference when `paper-plan` needs help shaping the paper's story or when `paper-write` needs stronger drafting and revision guidance.
+
+This is the expanded English counterpart to the detailed Chinese version. It is not a new workflow phase. Its purpose is to provide a stronger writing model on top of the existing `insleep` pipeline.
+
+## Contents
+
+- [When to Read](#when-to-read)
+- [The Narrative Principle](#the-narrative-principle)
+- [Time Allocation and Reviewer Reading Order](#time-allocation-and-reviewer-reading-order)
+- [How to Write the Abstract](#how-to-write-the-abstract)
+- [Introduction Structure](#introduction-structure)
+- [Sentence-Level Clarity](#sentence-level-clarity)
+- [Micro-Level Writing Tactics](#micro-level-writing-tactics)
+- [Word Choice and Precision](#word-choice-and-precision)
+- [Mathematical Writing](#mathematical-writing)
+- [Figure Design](#figure-design)
+- [Common Mistakes](#common-mistakes)
+- [Pre-Submission Checklist](#pre-submission-checklist)
+
+## When to Read
+
+- Read before locking the framing of the paper.
+- Read before drafting the Abstract and Introduction.
+- Read when Related Work feels like a literature dump.
+- Read when the prose feels generic, templated, or overly AI-shaped.
+- Read when the structure looks fine on paper but the draft still feels unconvincing.
+
+## The Narrative Principle
+
+### Neel Nanda's Core View
+
+A paper should be a **short, rigorous, evidence-backed technical story**, not a pile of experiments.
+
+By the end of the Introduction, the reader should clearly understand:
+
+- **The What**: the 1-3 specific claims the paper makes,
+- **The Why**: the evidence that supports those claims,
+- **The So What**: why the community should care.
+
+### Andrej Karpathy's Complement
+
+A strong paper “sells” **one thing** that was previously absent or non-obvious. The full paper should be organized around that single contribution.
+
+### Practical Rules
+
+- If the core contribution cannot be stated in one sentence, the framing has not converged.
+- Every section should serve the same story instead of launching a second one.
+- Experiments, related work, and discussion are there to support the main claim, not to operate as independent mini-papers.
+
+### One-Sentence Contribution Test
+
+If you cannot write something like the following, the framing is still too loose:
+
+- “We prove that X converges under assumption Y.”
+- “We show that method A improves B by 15% on benchmark C.”
+- “We identify failure mode D and propose mechanism E that removes it.”
+
+If the one-sentence contribution is hard to write, the usual causes are:
+
+- the contribution is still too vague,
+- the evidence is not yet tightly coupled to the claims,
+- or the paper does not yet know what story it is telling.
+
+## Time Allocation and Reviewer Reading Order
+
+### Where Effort Should Go
+
+A useful rule of thumb is to spend roughly the same amount of time on:
+
+1. the Abstract,
+2. the Introduction,
+3. the Figures,
+4. everything else combined.
+
+This is not an exaggeration. Many reviewers form a preliminary judgment before they read the full methods section carefully.
+
+### Common Reviewer Reading Order
+
+Most reviewers encounter the paper in this order:
+
+1. Title
+2. Abstract
+3. Introduction
+4. Figures, especially Figure 1
+5. The rest
+
+### Writing Implications
+
+- Put disproportionate effort into the title, abstract, introduction, and hero figure.
+- Do not bury the main contribution after Section 3.
+- Make the value of the paper legible before the reader reaches the full method.
+- If the first two pages are unclear, later brilliance may never be seen.
+
+## How to Write the Abstract
+
+### Sebastian Farquhar's Five-Sentence Formula
+
+Prefer a compact five-part abstract:
+
+1. What you achieved
+2. Why the problem is important and difficult
+3. How you approached it
+4. What evidence supports the claim
+5. What number, result, or guarantee the reader should remember
+
+### What a Good Abstract Should Do
+
+- Enter the paper's specific contribution in the first one or two sentences.
+- Include at least one explicit quantitative result.
+- Be understandable without the main text.
+- Avoid undefined acronyms.
+- Avoid depending on citations to explain itself.
+
+### A Good Abstract Sketch
+
+```text
+We prove that X converges linearly under assumption Y.
+This addresses a long-standing question about why optimization remains stable in an apparently non-convex setting.
+Our analysis reduces the training dynamics to Z, which yields a tractable theoretical structure.
+We validate the prediction on datasets A and B and observe close agreement between theory and experiment.
+Compared with prior methods, we reduce error by 15% and provide the first convergence guarantee in this setting.
+```
+
+### Openings to Delete
+
+If the first sentence could fit almost any ML paper, delete it.
+
+For example:
+
+- “Large language models have achieved remarkable success...”
+- “In recent years, deep learning has...”
+- “Neural networks have revolutionized...”
+
+The problem is not just that these openings sound stale. They carry **too little information** to help a reviewer judge the paper's specific contribution.
+
+## Introduction Structure
+
+### Basic Requirements
+
+In two-column conference papers, the Introduction is usually best at about 1-1.5 pages.
+
+It should satisfy the following:
+
+- the method should start appearing by page 2-3 at the latest,
+- the Introduction should include 2-4 contribution bullets,
+- the central story should already make sense before technical detail arrives.
+
+### Recommended Structure
+
+1. **Opening hook**
+   - What problem does the paper address?
+   - Why does it matter now?
+
+2. **Background / challenge**
+   - Why is the problem hard?
+   - What has prior work tried, and why is it insufficient?
+
+3. **Approach overview**
+   - What does this paper do differently?
+   - What is the key insight?
+
+4. **Contribution bullets**
+   - 2-4 items
+   - specific and falsifiable
+   - ideally no longer than 1-2 lines each
+
+5. **Results preview**
+   - surface the strongest result early
+   - tell the reader what is worth remembering
+
+6. **Optional roadmap**
+   - briefly describe the remaining sections
+
+### Contribution Bullets: Good vs Bad
+
+Good:
+
+- We prove that X converges in O(n log n) under assumption Y.
+- We introduce architecture Z, which reduces memory by 40%.
+- We improve method A by 15% on benchmark C.
+
+Bad:
+
+- We study problem X.
+- We perform extensive experiments.
+- We make several contributions to the field.
+
+The problem with the “bad” bullets is not grammar. It is that a reviewer cannot cleanly agree, disagree, or challenge them.
+
+## Sentence-Level Clarity
+
+### The Core Insight from Gopen and Swan
+
+Readers have strong structural expectations about prose. If you repeatedly violate those expectations, readers spend effort decoding the sentence instead of understanding the idea.
+
+### Seven Key Principles
+
+#### 1. Keep Subject and Verb Close
+
+Weak:
+
+```text
+The model, which was trained on 100M tokens and then fine-tuned with several domain-specific modifications, achieves strong results.
+```
+
+Strong:
+
+```text
+The model achieves strong results after training on 100M tokens and fine-tuning with domain-specific modifications.
+```
+
+#### 2. Put Important Information Near the End
+
+Weak:
+
+```text
+Accuracy improves by 15% when using attention.
+```
+
+Strong:
+
+```text
+When using attention, accuracy improves by 15%.
+```
+
+#### 3. Put Context at the Start
+
+Weak:
+
+```text
+A new attention mechanism is introduced to solve the alignment problem.
+```
+
+Strong:
+
+```text
+To address the alignment problem, we introduce a new attention mechanism.
+```
+
+#### 4. Move from Old to New
+
+Readers track arguments more easily when the sentence begins with what is already familiar and ends with what is newly important.
+
+#### 5. One Unit, One Function
+
+- A paragraph should ideally do one main job.
+- If a sentence is carrying two layers of logic at once, it probably wants to become two sentences.
+
+#### 6. Put Actions in Verbs
+
+Weak:
+
+```text
+We performed an analysis of the results.
+```
+
+Strong:
+
+```text
+We analyzed the results.
+```
+
+#### 7. Set the Stage Before New Material
+
+Before presenting an equation, theorem, or experimental result, tell the reader why it matters.
+
+### Fast Revision Questions
+
+When revising a paragraph, ask:
+
+- Is the subject separated from the verb by too much material?
+- Does the sentence begin with context?
+- Does the sentence end on the point that matters most?
+- Is this paragraph trying to do two jobs at once?
+
+## Micro-Level Writing Tactics
+
+### Reduce Ambiguous Pronouns
+
+When `this`, `it`, or `these` could be unclear, replace them with a specific noun.
+
+Weak:
+
+```text
+This shows the method is robust.
+```
+
+Strong:
+
+```text
+These ablation results show that the method is robust to label noise.
+```
+
+### Move Verbs Earlier
+
+Readers parse sentences faster when the main verb arrives early.
+
+### Remove Low-Information Fillers
+
+These words can usually be deleted:
+
+- actually
+- very
+- really
+- quite
+- basically
+- essentially
+- Importantly,
+- Notably,
+- It is worth noting that
+
+### Paragraph Shape
+
+A useful paragraph skeleton is:
+
+- first sentence: the point,
+- middle: support,
+- last sentence: reinforcement or transition.
+
+Do not bury the key sentence in the middle.
+
+## Word Choice and Precision
+
+### Zachary Lipton Style: Remove Needless Hedging
+
+Unless uncertainty is genuine, avoid overusing:
+
+- may
+- can
+- might
+- potentially
+
+Excessive hedging often reads less like rigor and more like self-doubt.
+
+### Replace Vague Terms with Specific Ones
+
+| Vague Term | Better Alternative |
+|-----------|--------------------|
+| performance | accuracy / F1 / latency / throughput |
+| improves | increases by X% / reduces by Y |
+| large | 1B parameters / 100M tokens |
+| fast | 3x faster / 50ms latency |
+| good results | 92% accuracy / 0.85 F1 |
+
+### Terminology Consistency
+
+Do not rename the same concept across the paper.
+
+For example, avoid mixing:
+
+- model / network / architecture
+- training / learning / optimization
+- sample / instance / example
+
+Choose the best term and keep it stable.
+
+### Vocabulary Signaling
+
+Some verbs make the work sound like a loose combination of existing pieces:
+
+- combine
+- modify
+- extend
+- expand
+
+Stronger alternatives are often:
+
+- develop
+- propose
+- introduce
+- characterize
+
+This is not about mechanical substitution. It is about how wording changes a reviewer's intuition about whether the work is a real contribution.
+
+## Mathematical Writing
+
+### Core Principle
+
+The goal of mathematical writing is not to sound sophisticated. It is to let the reader **follow** the argument.
+
+Prefer the following:
+
+1. state assumptions formally before the theorem,
+2. pair proofs and derivations with intuition,
+3. keep notation consistent,
+4. define symbols at first use.
+
+### Recommended Notation Habits
+
+```latex
+% Scalars: lowercase italic
+$x$, $y$, $\alpha$, $\beta$
+
+% Vectors: lowercase bold
+$\mathbf{x}$, $\mathbf{v}$
+
+% Matrices: uppercase bold
+$\mathbf{W}$, $\mathbf{X}$
+
+% Sets: uppercase calligraphic
+$\mathcal{X}$, $\mathcal{D}$
+
+% Named functions: roman
+$\mathrm{softmax}$, $\mathrm{ReLU}$
+```
+
+### Common Mathematical Writing Mistakes
+
+- presenting equations without telling the reader why they matter,
+- introducing assumptions too late,
+- reusing symbols with different meanings across sections,
+- moving all proof intuition to the appendix and leaving only bare statements in the main text.
+
+For theory papers especially, **intuition and rigor** should coexist.
+
+## Figure Design
+
+### Why Figure 1 Matters
+
+Figure 1 is often one of the first artifacts a reviewer studies after the abstract.
+
+It should usually do at least one of the following:
+
+- explain the core system or method idea,
+- show the strongest comparison that justifies the paper,
+- or provide the simplest visual summary of the main claim.
+
+### Design Principles
+
+1. **Figure 1 is crucial**
+2. **captions should be self-contained**
+3. **do not place a decorative title inside the figure**
+4. **plots should use vector graphics whenever possible**
+
+### Accessibility
+
+Account for color-vision deficiency.
+
+Do:
+
+- use colorblind-safe palettes,
+- avoid red-green pairings,
+- make sure the figure still works in grayscale,
+- use line styles and markers in addition to color.
+
+### Caption Rules
+
+- A reader should understand the point of the figure from the caption alone.
+- State what is being compared.
+- State what the reader should notice.
+- Do not make the caption depend on the surrounding paragraph for essential meaning.
+
+## Common Mistakes
+
+### Structural Mistakes
+
+| Mistake | Fix |
+|--------|-----|
+| Introduction longer than 1.5 pages | Move background to Related Work |
+| Method buried too late | Front-load the contribution and compress the intro |
+| Missing contribution bullets | Add 2-4 concrete claims |
+| Experiments not tied to claims | State what each experiment tests |
+
+### Writing Mistakes
+
+| Mistake | Fix |
+|--------|-----|
+| Generic abstract opening | Start from the paper's actual contribution |
+| Inconsistent terminology | Keep one name per concept |
+| Too much passive voice | Prefer active constructions |
+| Hedging everywhere | Keep hedging only where uncertainty is real |
+
+### Figure Mistakes
+
+| Mistake | Fix |
+|--------|-----|
+| Raster plots | Use PDF / EPS or other vector output |
+| Red-green color schemes | Switch to colorblind-safe palettes |
+| Titles inside figures | Move the title into the caption |
+| Captions that require the main text | Rewrite them to be self-contained |
+
+### Citation Mistakes
+
+| Mistake | Fix |
+|--------|-----|
+| Related Work as paper-by-paper summary | Reorganize by method family or research question |
+| Missing important references | Proactively expand the search |
+| AI-generated citations | Use a verification workflow |
+| Inconsistent key or style format | Normalize the bibliography |
+
+## Pre-Submission Checklist
+
+### Narrative
+
+- [ ] The contribution can be stated in one sentence.
+- [ ] The Introduction makes the What / Why / So What clear.
+- [ ] Every major experiment supports a clear claim.
+
+### Structure
+
+- [ ] The abstract follows the five-sentence formula.
+- [ ] The Introduction stays within about 1-1.5 pages.
+- [ ] The method starts by page 2-3.
+- [ ] There are 2-4 concrete contribution bullets.
+- [ ] Limitations are clearly stated.
+
+### Writing
+
+- [ ] Terminology is consistent.
+- [ ] There are no generic field-background openings.
+- [ ] Unnecessary hedging has been removed.
+- [ ] All key figures have self-contained captions.
+
+### Technical
+
+- [ ] Citations are verified.
+- [ ] Error bars and statistical reporting are clear.
+- [ ] Compute resources are documented.
+- [ ] Code / data availability is stated.
+
+## Final Sentence
+
+**A paper is not just a written record of experiments. It is a technical conclusion organized into a story that a reviewer is willing to believe.**

--- a/README.md
+++ b/README.md
@@ -1,329 +1,80 @@
-# AutoR
+# AutoR — Stage 07: Paper Production Pipeline
 
-AutoR is a terminal-first research workflow runner for long-form AI-assisted research. It takes a research goal, runs a fixed 8-stage pipeline with Claude Code, and requires explicit human approval after every stage before the workflow can continue.
+AutoR Stage 07 turns research results into submission-ready papers in a single Claude session. Claude handles everything — outlining, drafting, polishing, self-review, compilation, and packaging — while Python only validates that the final artifacts exist.
 
-Each run is isolated under `runs/<run_id>/`. AutoR is intentionally file-based: prompts, logs, stage outputs, and research artifacts are all written into the run directory so the workflow is inspectable, resumable, and auditable.
+## Pipeline
 
-## Overview
-
-AutoR uses a fixed stage order:
-
-1. `01_literature_survey`
-2. `02_hypothesis_generation`
-3. `03_study_design`
-4. `04_implementation`
-5. `05_experimentation`
-6. `06_analysis`
-7. `07_writing`
-8. `08_dissemination`
-
-Core constraints:
-
-- One primary Claude invocation per stage attempt. Repair and fallback invocations are operator-managed.
-- Every stage writes a draft summary to `stages/<stage>.tmp.md`.
-- AutoR validates the draft, then promotes it to `stages/<stage>.md`.
-- Human approval is mandatory after every validated stage.
-- Each stage keeps its own Claude conversation state.
-- `1/2/3/4` continue the current stage conversation with refinement feedback. Only `5` advances. `6` aborts.
-- Approved stage summaries are appended to `memory.md`.
-- `main.py` defaults to `--model sonnet`, but the model can be overridden per run.
-
-The main code lives in:
-
-- [main.py](main.py)
-- [src/manager.py](src/manager.py)
-- [src/operator.py](src/operator.py)
-- [src/utils.py](src/utils.py)
-- [src/prompts/](src/prompts)
-
-## Code Structure
+Content quality is finalized **before** compilation. The pipeline polishes prose and scores the draft first, then compiles to PDF.
 
 ```mermaid
 flowchart LR
-    A[main.py] --> B[src/manager.py]
-    B --> C[src/operator.py]
-    B --> D[src/utils.py]
-    B --> E[src/prompts/*]
-    C --> D
+    A[Outline] --> B[Drafting]
+    B --> C[Quality Polish]
+    C --> D[Self-Review]
+    D --> E[Compilation]
+    E --> F[Packaging]
 ```
 
-File boundaries:
+| Phase | What happens |
+|-------|-------------|
+| **Outline** | Read manifest, set up venue template, generate `math_commands.tex`, design paper skeleton |
+| **Drafting** | Write `sections/*.tex` and `references.bib` with DBLP/CrossRef verified entries |
+| **Quality Polish** | De-AI rewrite (70+ word list), reverse outline test, logic consistency check, citation pre-check, chktex lint, cleanup |
+| **Self-Review** | Score on 8 dimensions (1-10), classify issues as CRITICAL/MAJOR/MINOR, fix up to 2 rounds until overall >= 7.0, output `self_review.json` |
+| **Compilation** | `pdflatex` + `bibtex` with self-repair loop (up to 3 retries), post-compilation checks |
+| **Packaging** | Copy PDF, build `submission_bundle.zip`, write `build_log.txt`, `citation_verification.json`, `build_manifest.json`, stage summary |
 
-- [main.py](main.py): CLI entry point. Starts a new run or resumes an existing run.
-- [src/manager.py](src/manager.py): Owns the 8-stage loop, approval flow, repair flow, resume, redo-stage logic, and stage-level continuation policy.
-- [src/operator.py](src/operator.py): Invokes Claude CLI, streams output live, persists stage session IDs, resumes the same stage conversation for refinement, and falls back to a fresh session if resume fails.
-- [src/utils.py](src/utils.py): Stage metadata, prompt assembly, run paths, markdown validation, and artifact validation.
-- [src/prompts/](src/prompts): Per-stage prompt templates.
+## Design
 
-## Workspace Structure
+- **Claude does everything, Python only gates.** Consistent with Stages 1-6 and 8 — `manager.py` orchestrates, `operator.py` calls Claude CLI, `utils.py` validates artifacts, user approves.
+- **Polish before compile.** Writing quality iteration happens on `.tex` source, not on rendered PDF. Compilation is a formatting step, not a quality gate.
+- **Self-Review Scoring Loop.** Claude scores its own paper on 8 dimensions, fixes issues by severity (CRITICAL first), and must clear a 7.0 threshold with no CRITICAL issues before proceeding.
+- **Config-driven templates.** `registry.yaml` supports 9 venues (NeurIPS, ICLR, ICML, CVPR, ACL, AAAI, IEEE Journal/Conference). No hardcoded style files.
 
-Each run contains `user_input.txt`, `memory.md`, `prompt_cache/`, `operator_state/`, `stages/`, `workspace/`, `logs.txt`, and `logs_raw.jsonl`. The substantive research payload lives in `workspace/`.
+## Artifacts
 
-```mermaid
-flowchart TD
-    A[workspace/] --> B[literature/]
-    A --> C[code/]
-    A --> D[data/]
-    A --> E[results/]
-    A --> F[writing/]
-    A --> G[figures/]
-    A --> H[artifacts/]
-    A --> I[notes/]
-    A --> J[reviews/]
+Stage 07 produces 7 validated artifacts:
+
+| Artifact | Location |
+|----------|----------|
+| `main.tex` | `workspace/writing/` |
+| `references.bib` | `workspace/writing/` |
+| `sections/*.tex` | `workspace/writing/sections/` |
+| `paper.pdf` | `workspace/artifacts/` |
+| `build_log.txt` | `workspace/artifacts/` |
+| `citation_verification.json` | `workspace/artifacts/` |
+| `self_review.json` | `workspace/artifacts/` |
+
+## Project Structure
+
+```
+src/
+  prompts/07_writing.md    # Full prompt for Claude (375 lines)
+  manager.py               # Stage orchestration loop
+  operator.py              # Claude CLI invocation
+  utils.py                 # Artifact validation (7 checks for Stage 07)
+  writing_manifest.py      # Build figures/data manifest for prompt
+templates/
+  registry.yaml            # 9 venue configurations
+tests/
+  test_writing_pipeline.py # 20 tests (validation, manifest, registry)
+.claude/skills/
+  guides/                  # Shared writing knowledge
+    writing-principles.md
+    venue-checklists.md
+    citation-discipline.md
 ```
 
-Directory boundaries:
-
-- `literature/`: papers, benchmark notes, survey tables, reading artifacts.
-- `code/`: runnable pipeline code, scripts, configs, and method implementations.
-- `data/`: machine-readable datasets, manifests, processed splits, caches, and loaders.
-- `results/`: machine-readable metrics, predictions, ablations, tables, and evaluation outputs.
-- `writing/`: manuscript sources, LaTeX, section drafts, tables, and bibliography.
-- `figures/`: plots, diagrams, charts, and paper figures.
-- `artifacts/`: compiled PDFs and packaged deliverables.
-- `notes/`: temporary notes and setup material.
-- `reviews/`: critique notes, threat-to-validity notes, and readiness reviews.
-
-Other run state:
-
-- `memory.md`: approved cross-stage memory only.
-- `prompt_cache/`: exact prompts used for stage attempts and repairs.
-- `operator_state/`: per-stage Claude session IDs.
-- `stages/`: draft and promoted stage summaries.
-- `logs.txt` and `logs_raw.jsonl`: workflow logs and raw Claude stream output.
-
-## Workflow
-
-```mermaid
-flowchart TD
-    A[Start or resume run] --> S1[01 Literature Survey]
-    S1 --> H1{Human approval}
-    H1 -- Refine --> S1
-    H1 -- Approve --> S2[02 Hypothesis Generation]
-    H1 -- Abort --> X[Abort]
-
-    S2 --> H2{Human approval}
-    H2 -- Refine --> S2
-    H2 -- Approve --> S3[03 Study Design]
-    H2 -- Abort --> X
-
-    S3 --> H3{Human approval}
-    H3 -- Refine --> S3
-    H3 -- Approve --> S4[04 Implementation]
-    H3 -- Abort --> X
-
-    S4 --> H4{Human approval}
-    H4 -- Refine --> S4
-    H4 -- Approve --> S5[05 Experimentation]
-    H4 -- Abort --> X
-
-    S5 --> H5{Human approval}
-    H5 -- Refine --> S5
-    H5 -- Approve --> S6[06 Analysis]
-    H5 -- Abort --> X
-
-    S6 --> H6{Human approval}
-    H6 -- Refine --> S6
-    H6 -- Approve --> S7[07 Writing]
-    H6 -- Abort --> X
-
-    S7 --> H7{Human approval}
-    H7 -- Refine --> S7
-    H7 -- Approve --> S8[08 Dissemination]
-    H7 -- Abort --> X
-
-    S8 --> H8{Human approval}
-    H8 -- Refine --> S8
-    H8 -- Approve --> Z[Run complete]
-    H8 -- Abort --> X
-```
-
-## Stage Attempt Loop
-
-```mermaid
-flowchart TD
-    A[Build prompt from template + goal + memory + optional feedback] --> B[Start or resume stage session]
-    B --> C[Claude writes draft stage summary]
-    C --> D[Validate markdown and required artifacts]
-    D --> E{Valid?}
-    E -- No --> F[Repair, normalize, or rerun current stage]
-    F --> A
-    E -- Yes --> G[Promote draft to final stage summary]
-    G --> H{Human choice}
-    H -- 1 or 2 or 3 --> I[Continue current stage conversation with AI refinement]
-    I --> A
-    H -- 4 --> J[Continue current stage conversation with custom feedback]
-    J --> A
-    H -- 5 --> K[Append approved summary to memory.md]
-    K --> L[Continue to next stage]
-    H -- 6 --> X[Abort]
-```
-
-Stage-loop rules:
-
-- Claude never writes directly to the final stage file.
-- The final stage file exists only after validation succeeds.
-- The first attempt of a stage starts a fresh Claude session.
-- Later refinements reuse the same stage session whenever possible.
-- If validation still fails after repair and normalization, AutoR keeps working inside the same stage and falls back to a fresh session only if resume fails.
-- The stage loop is controlled by AutoR, not by Claude.
-
-## Prompt and Execution
-
-For each stage attempt, AutoR assembles a prompt from:
-
-1. the stage template from [src/prompts/](src/prompts)
-2. the required stage summary contract
-3. execution discipline and output-path constraints
-4. `user_input.txt`
-5. approved `memory.md`
-6. optional refinement feedback
-7. for continuation attempts, the current stage draft/final files and existing workspace state
-
-AutoR writes the assembled prompt to `runs/<run_id>/prompt_cache/`, stores per-stage session IDs in `runs/<run_id>/operator_state/`, and invokes Claude in streaming mode through [src/operator.py](src/operator.py).
-
-First attempt for a stage:
+## Environment
 
 ```bash
-claude --model <model> \
-  --permission-mode bypassPermissions \
-  --dangerously-skip-permissions \
-  --session-id <stage_session_id> \
-  -p @runs/<run_id>/prompt_cache/<stage>_attempt_<nn>.prompt.md \
-  --output-format stream-json \
-  --verbose
+conda activate autor_tex   # TeX Live, pdflatex, bibtex, chktex
+python -m pytest tests/    # 20 tests
 ```
 
-Continuation attempt for the same stage:
+## References
 
-```bash
-claude --model <model> \
-  --permission-mode bypassPermissions \
-  --dangerously-skip-permissions \
-  --resume <stage_session_id> \
-  -p @runs/<run_id>/prompt_cache/<stage>_attempt_<nn>.prompt.md \
-  --output-format stream-json \
-  --verbose
-```
+Techniques borrowed from these projects:
 
-Refinement attempts reuse the same `stage_session_id` instead of opening a new stage conversation.
-
-The streamed Claude output is shown live in the terminal and also captured in `logs_raw.jsonl`.
-
-## Validation
-
-AutoR validates both the stage markdown and the stage artifacts.
-
-Required stage markdown shape:
-
-```md
-# Stage X: <name>
-
-## Objective
-## Previously Approved Stage Summaries
-## What I Did
-## Key Results
-## Files Produced
-## Suggestions for Refinement
-## Your Options
-```
-
-Additional markdown requirements:
-
-- Exactly 3 numbered refinement suggestions.
-- The fixed 6 user options.
-- No unfinished placeholders such as `[In progress]`, `[Pending]`, `[TODO]`, or `[TBD]`.
-- Concrete file paths in `Files Produced`.
-
-Artifact requirements by stage:
-
-- Stage 03+: machine-readable data under `workspace/data/`
-- Stage 05+: machine-readable results under `workspace/results/`
-- Stage 06+: figure files under `workspace/figures/`
-- Stage 07+: NeurIPS-style LaTeX sources plus a compiled PDF under `workspace/writing/` or `workspace/artifacts/`
-- Stage 08+: review and readiness artifacts under `workspace/reviews/`
-
-A run with only markdown notes does not pass validation.
-
-## CLI
-
-Start a new run:
-
-```bash
-python main.py
-```
-
-Start a new run with an inline goal:
-
-```bash
-python main.py --goal "Your research goal here"
-```
-
-Run fake mode:
-
-```bash
-python main.py --fake-operator --goal "Smoke test"
-```
-
-Run with the default model explicitly:
-
-```bash
-python main.py --model sonnet
-```
-
-Run with a different Claude model alias:
-
-```bash
-python main.py --model opus
-```
-
-Resume the latest run:
-
-```bash
-python main.py --resume-run latest
-```
-
-Resume a specific run:
-
-```bash
-python main.py --resume-run 20260329_210252
-```
-
-Redo from a specific stage inside the same run:
-
-```bash
-python main.py --resume-run 20260329_210252 --redo-stage 03
-```
-
-`--resume-run ... --redo-stage ...` continues inside the existing run directory. It does not create a new run.
-
-Valid stage identifiers include `03`, `3`, and `03_study_design`.
-
-## Scope
-
-Included:
-
-- fixed 8-stage workflow
-- one primary Claude invocation per stage attempt
-- mandatory human approval after every stage
-- stage-local Claude conversation continuation within a stage
-- AI refine, custom refine, approve, and abort
-- isolated run directories
-- live Claude streaming output
-- repair passes and rerun fallback
-- draft-to-final stage promotion
-- resume and redo-stage support
-- artifact-level validation
-
-Out of scope:
-
-- multi-agent orchestration
-- database-backed state
-- web UI
-- concurrent stage execution
-- automatic reviewer scoring
-
-## Notes
-
-- `runs/` is gitignored.
-- AutoR implements the workflow control layer. Submission-grade output still depends on the environment, available tools, data access, model access, and the quality of the stage attempts.
+- [Auto-claude-code-research-in-sleep](https://github.com/JackHopkins/auto-claude-code-research-in-sleep) — Self-review scoring loop (2-round fix cycle, severity classification), writing principles (narrative principle, 5-sentence abstract, Gopen-Swan clarity), venue checklists
+- [awesome-ai-research-writing](https://github.com/mlsysops/awesome-ai-research-writing) — De-AI word list (70+ patterns), reviewer template (score + strengths + weaknesses), logic check prompt

--- a/src/_legacy/README.md
+++ b/src/_legacy/README.md
@@ -1,0 +1,28 @@
+# `_legacy/` — Deprecated Stage 07 Pipeline Modules
+
+These modules implemented the original Python-driven writing pipeline for Stage 07.
+They have been replaced by the prompt-driven architecture where Claude handles
+LaTeX compilation, citation verification, and submission packaging directly
+(same pattern as all other AutoR stages).
+
+## Contents
+
+| Module | Original Purpose |
+|---|---|
+| `writing_pipeline.py` | Orchestrated the multi-step writing pipeline |
+| `latex_build.py` | Called `pdflatex`/`bibtex` from Python |
+| `citation_verifier.py` | Verified BibTeX entries via DBLP/CrossRef |
+| `submission_packager.py` | Bundled submission files into a zip |
+
+## Why deprecated
+
+The "Claude does everything, Python only validates" principle means Stage 07
+now works like Stages 1-6 and 8: the prompt template (`prompts/07_writing.md`)
+instructs Claude to perform all writing, compilation, and packaging steps.
+Python code only validates the final artifacts via `validate_stage_artifacts()`.
+
+## Safe to delete
+
+These files have zero imports from the active codebase (`manager.py`,
+`operator.py`, `utils.py`). They can be removed entirely once confidence
+in the new pipeline is established.

--- a/src/_legacy/__init__.py
+++ b/src/_legacy/__init__.py
@@ -1,0 +1,7 @@
+# Legacy modules — deprecated as of Stage 07 redesign (2026-03).
+#
+# These modules implemented a Python-driven writing pipeline that has been
+# replaced by the prompt-driven approach where Claude handles compilation,
+# citation verification, and packaging directly.
+#
+# Kept for reference only.  Nothing in the active codebase imports from here.

--- a/src/_legacy/citation_verifier.py
+++ b/src/_legacy/citation_verifier.py
@@ -1,0 +1,156 @@
+"""Citation and figure reference consistency verifier for Stage 07."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+
+# Regex patterns validated by AI-Scientist-v2 and data-to-paper.
+CITE_PATTERN = re.compile(r"\\cite[tp]?\{([^}]+)\}")
+INCLUDEGRAPHICS_PATTERN = re.compile(r"\\includegraphics(?:\[[^\]]*\])?\{([^}]+)\}")
+BIB_ENTRY_PATTERN = re.compile(r"@\w+\{([^,]+),")
+LABEL_PATTERN = re.compile(r"\\label\{([^}]+)\}")
+REF_PATTERN = re.compile(r"\\(?:c?ref|Cref)\{([^}]+)\}")
+INPUT_PATTERN = re.compile(r"\\input\{([^}]+)\}")
+
+FIGURE_SUFFIXES = {".png", ".pdf", ".svg", ".jpg", ".jpeg", ".eps"}
+
+
+@dataclass
+class VerificationReport:
+    cite_keys_in_tex: set[str] = field(default_factory=set)
+    bib_keys: set[str] = field(default_factory=set)
+    missing_in_bib: set[str] = field(default_factory=set)
+    unused_in_bib: set[str] = field(default_factory=set)
+    figure_refs: set[str] = field(default_factory=set)
+    figures_available: set[str] = field(default_factory=set)
+    missing_figures: set[str] = field(default_factory=set)
+    unused_figures: set[str] = field(default_factory=set)
+    label_keys: set[str] = field(default_factory=set)
+    ref_keys: set[str] = field(default_factory=set)
+    undefined_refs: set[str] = field(default_factory=set)
+    overall_status: str = "pass"
+
+
+def verify_citations(
+    writing_dir: Path,
+    figures_dir: Path,
+    main_tex: str = "main.tex",
+) -> VerificationReport:
+    """Cross-check \\cite{} keys against .bib, and \\includegraphics against figures/."""
+    report = VerificationReport()
+
+    # Collect all .tex content (main + \\input'd files)
+    all_tex = _collect_all_tex(writing_dir, main_tex)
+
+    # Extract cite keys
+    for match in CITE_PATTERN.finditer(all_tex):
+        for key in match.group(1).split(","):
+            key = key.strip()
+            if key:
+                report.cite_keys_in_tex.add(key)
+
+    # Extract bib keys from all .bib files
+    for bib_path in writing_dir.glob("*.bib"):
+        bib_content = bib_path.read_text(encoding="utf-8", errors="replace")
+        for match in BIB_ENTRY_PATTERN.finditer(bib_content):
+            report.bib_keys.add(match.group(1).strip())
+
+    report.missing_in_bib = report.cite_keys_in_tex - report.bib_keys
+    report.unused_in_bib = report.bib_keys - report.cite_keys_in_tex
+
+    # Extract figure references
+    for match in INCLUDEGRAPHICS_PATTERN.finditer(all_tex):
+        ref = match.group(1).strip()
+        report.figure_refs.add(ref)
+
+    # Collect available figures
+    if figures_dir.exists():
+        for path in figures_dir.rglob("*"):
+            if path.is_file() and path.suffix.lower() in FIGURE_SUFFIXES:
+                report.figures_available.add(path.name)
+
+    # Normalize figure refs to filenames for comparison
+    ref_filenames = {Path(ref).name for ref in report.figure_refs}
+    report.missing_figures = ref_filenames - report.figures_available
+    report.unused_figures = report.figures_available - ref_filenames
+
+    # Extract labels and refs
+    for match in LABEL_PATTERN.finditer(all_tex):
+        report.label_keys.add(match.group(1).strip())
+    for match in REF_PATTERN.finditer(all_tex):
+        report.ref_keys.add(match.group(1).strip())
+    report.undefined_refs = report.ref_keys - report.label_keys
+
+    # Determine overall status
+    if report.missing_in_bib or report.missing_figures:
+        report.overall_status = "fail"
+    elif report.undefined_refs:
+        report.overall_status = "warn"
+
+    return report
+
+
+def write_verification_json(report: VerificationReport, output_path: Path) -> None:
+    """Write verification report to JSON."""
+    data = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "citations": {
+            "total_cite_keys": len(report.cite_keys_in_tex),
+            "total_bib_entries": len(report.bib_keys),
+            "missing_in_bib": sorted(report.missing_in_bib),
+            "unused_in_bib": sorted(report.unused_in_bib),
+        },
+        "figures": {
+            "total_referenced": len(report.figure_refs),
+            "total_available": len(report.figures_available),
+            "missing": sorted(report.missing_figures),
+            "unused": sorted(report.unused_figures),
+        },
+        "cross_references": {
+            "total_labels": len(report.label_keys),
+            "total_refs": len(report.ref_keys),
+            "undefined_refs": sorted(report.undefined_refs),
+        },
+        "overall_status": report.overall_status,
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _collect_all_tex(writing_dir: Path, main_tex: str) -> str:
+    """Recursively collect all .tex content starting from main_tex."""
+    parts: list[str] = []
+    visited: set[str] = set()
+    _collect_tex_recursive(writing_dir, main_tex, parts, visited)
+    return "\n".join(parts)
+
+
+def _collect_tex_recursive(
+    writing_dir: Path, tex_name: str, parts: list[str], visited: set[str]
+) -> None:
+    """Recursively collect .tex content, following \\input{} directives."""
+    if tex_name in visited:
+        return
+    visited.add(tex_name)
+
+    # Try with and without .tex extension
+    candidates = [
+        writing_dir / tex_name,
+        writing_dir / f"{tex_name}.tex",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            content = candidate.read_text(encoding="utf-8", errors="replace")
+            parts.append(content)
+            # Follow \\input{} directives
+            for match in INPUT_PATTERN.finditer(content):
+                child = match.group(1).strip()
+                _collect_tex_recursive(writing_dir, child, parts, visited)
+            return

--- a/src/_legacy/latex_build.py
+++ b/src/_legacy/latex_build.py
@@ -1,0 +1,190 @@
+"""LaTeX compilation service layer for Stage 07 writing pipeline."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class LatexError:
+    message: str
+    line_number: int | None = None
+    context_lines: str | None = None
+
+
+@dataclass
+class BuildResult:
+    success: bool
+    pdf_path: Path | None = None
+    log: str = ""
+    errors: list[LatexError] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    attempts: int = 0
+    chktex_output: str | None = None
+
+
+# Four-step compile sequence validated by AI-Scientist-v2, data-to-paper, CodeScientist, micromanubot.
+_COMPILE_STEPS = [
+    ("pdflatex", ["-interaction=nonstopmode"]),
+    ("bibtex", []),
+    ("pdflatex", ["-interaction=nonstopmode"]),
+    ("pdflatex", ["-interaction=nonstopmode"]),
+]
+
+_ERROR_PATTERN = re.compile(r"^! (.+)$", re.MULTILINE)
+_LINE_PATTERN = re.compile(r"l\.(\d+)")
+_OVERFLOW_PATTERN = re.compile(r"Overfull \\hbox \((.+?)pt too wide\)")
+
+
+def compile_latex(
+    working_dir: Path,
+    main_tex: str = "main.tex",
+    timeout: int = 60,
+) -> BuildResult:
+    """Execute the four-step pdflatex+bibtex compile sequence.
+
+    Success is determined by whether the output PDF exists and is non-empty,
+    not by process exit codes (pdflatex often returns non-zero but still
+    produces a usable PDF).
+    """
+    stem = Path(main_tex).stem
+    log_parts: list[str] = []
+    all_errors: list[LatexError] = []
+    all_warnings: list[str] = []
+
+    tex_content = ""
+    tex_path = working_dir / main_tex
+    if tex_path.exists():
+        tex_content = tex_path.read_text(encoding="utf-8", errors="replace")
+
+    for step_idx, (engine, extra_args) in enumerate(_COMPILE_STEPS):
+        if engine == "bibtex":
+            cmd = [engine, stem]
+        else:
+            cmd = [engine] + extra_args + [main_tex]
+
+        step_label = f"Step {step_idx + 1}: {' '.join(cmd)}"
+        log_parts.append(f"\n{'=' * 60}\n{step_label}\n{'=' * 60}")
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(working_dir),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            log_parts.append(proc.stdout)
+            if proc.stderr:
+                log_parts.append(f"STDERR:\n{proc.stderr}")
+
+            if engine == "pdflatex":
+                errors = extract_latex_errors(proc.stdout, tex_content)
+                all_errors.extend(errors)
+                warnings = _extract_overflow_warnings(proc.stdout)
+                all_warnings.extend(warnings)
+
+        except subprocess.TimeoutExpired:
+            log_parts.append(f"TIMEOUT after {timeout}s")
+            all_errors.append(LatexError(message=f"{engine} timed out after {timeout}s"))
+        except FileNotFoundError:
+            log_parts.append(f"ERROR: {engine} not found on PATH")
+            all_errors.append(LatexError(message=f"{engine} not found. Is TeX Live installed?"))
+            break
+
+    pdf_path = working_dir / f"{stem}.pdf"
+    success = pdf_path.exists() and pdf_path.stat().st_size > 0
+
+    full_log = "\n".join(log_parts)
+
+    return BuildResult(
+        success=success,
+        pdf_path=pdf_path if success else None,
+        log=full_log,
+        errors=all_errors,
+        warnings=all_warnings,
+        attempts=1,
+    )
+
+
+def run_chktex(
+    working_dir: Path,
+    main_tex: str = "main.tex",
+) -> str:
+    """Run chktex with the suppressed-warning set validated by AI-Scientist-v2."""
+    cmd = ["chktex", main_tex, "-q", "-n2", "-n24", "-n13", "-n1"]
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(working_dir),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return (proc.stdout + proc.stderr).strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ""
+
+
+def extract_latex_errors(pdflatex_output: str, tex_content: str = "") -> list[LatexError]:
+    """Extract structured errors from pdflatex stdout.
+
+    Pattern: lines starting with '! ' are errors, 'l.NNN' gives the line number.
+    """
+    errors: list[LatexError] = []
+    lines = pdflatex_output.splitlines()
+    tex_lines = tex_content.splitlines() if tex_content else []
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith("! "):
+            message = line[2:].strip()
+            # Look ahead up to 4 lines for line number
+            context_chunk = "\n".join(lines[i : i + 5])
+            line_match = _LINE_PATTERN.search(context_chunk)
+            line_number = int(line_match.group(1)) if line_match else None
+
+            context_lines = None
+            if line_number and tex_lines:
+                start = max(0, line_number - 2)
+                end = min(len(tex_lines), line_number + 1)
+                context_lines = "\n".join(
+                    f"{'>>>' if j + 1 == line_number else '   '} {j + 1}: {tex_lines[j]}"
+                    for j in range(start, end)
+                )
+
+            errors.append(LatexError(
+                message=message,
+                line_number=line_number,
+                context_lines=context_lines,
+            ))
+        i += 1
+
+    return errors
+
+
+def _extract_overflow_warnings(pdflatex_output: str) -> list[str]:
+    return [
+        f"Overfull hbox ({m.group(1)}pt too wide)"
+        for m in _OVERFLOW_PATTERN.finditer(pdflatex_output)
+    ]
+
+
+def format_build_errors_for_prompt(result: BuildResult) -> str:
+    """Format build errors into a string suitable for feeding back to an agent."""
+    parts: list[str] = []
+    if result.errors:
+        parts.append("## LaTeX Compilation Errors\n")
+        for err in result.errors:
+            parts.append(f"- {err.message}")
+            if err.line_number:
+                parts.append(f"  (line {err.line_number})")
+            if err.context_lines:
+                parts.append(f"  ```\n{err.context_lines}\n  ```")
+    if result.chktex_output:
+        parts.append(f"\n## chktex Lint Output\n```\n{result.chktex_output}\n```")
+    return "\n".join(parts)

--- a/src/_legacy/submission_packager.py
+++ b/src/_legacy/submission_packager.py
@@ -1,0 +1,79 @@
+"""Submission bundle packager for Stage 07 writing pipeline."""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from pathlib import Path
+
+KEEP_SUFFIXES = {
+    ".tex", ".sty", ".bst", ".bib", ".cls",
+    ".pdf", ".png", ".jpg", ".jpeg", ".eps", ".svg",
+}
+EXCLUDE_SUFFIXES = {
+    ".aux", ".log", ".out", ".fls", ".fdb_latexmk",
+    ".synctex.gz", ".blg", ".bbl", ".toc", ".lof", ".lot",
+    ".nav", ".snm", ".vrb",
+}
+EXCLUDE_DIRS = {"__pycache__", ".git", "__MACOSX", ".tmp"}
+
+
+def package_submission(
+    writing_dir: Path,
+    figures_dir: Path,
+    output_dir: Path,
+    pdf_path: Path | None = None,
+) -> Path | None:
+    """Generate submission_bundle.zip containing all files needed for submission.
+
+    Returns the path to the zip file, or None if packaging fails.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    zip_path = output_dir / "submission_bundle.zip"
+
+    try:
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            # Add writing directory files
+            _add_directory_to_zip(zf, writing_dir, "")
+
+            # Add figures
+            if figures_dir.exists():
+                _add_directory_to_zip(zf, figures_dir, "figures")
+
+            # Add compiled PDF if available and not already included
+            if pdf_path and pdf_path.exists():
+                arcname = pdf_path.name
+                if arcname not in zf.namelist():
+                    zf.write(pdf_path, arcname)
+
+        return zip_path
+    except Exception:
+        if zip_path.exists():
+            zip_path.unlink()
+        return None
+
+
+def _add_directory_to_zip(
+    zf: zipfile.ZipFile,
+    directory: Path,
+    prefix: str,
+) -> None:
+    """Add files from a directory to a zip, filtering by suffix."""
+    if not directory.exists():
+        return
+    for path in sorted(directory.rglob("*")):
+        if not path.is_file():
+            continue
+        # Skip excluded directories
+        if any(part in EXCLUDE_DIRS for part in path.parts):
+            continue
+        # Skip excluded suffixes
+        if path.suffix.lower() in EXCLUDE_SUFFIXES:
+            continue
+        # Only include known-good suffixes
+        if path.suffix.lower() not in KEEP_SUFFIXES:
+            continue
+
+        rel = path.relative_to(directory)
+        arcname = f"{prefix}/{rel}" if prefix else str(rel)
+        zf.write(path, arcname)

--- a/src/_legacy/writing_pipeline.py
+++ b/src/_legacy/writing_pipeline.py
@@ -1,0 +1,263 @@
+"""Stage 07 deterministic post-processing pipeline.
+
+After the agent finishes generating LaTeX fragments, this module runs
+the deterministic build → verify → package sequence. It is NOT a replacement
+for the agent writing step — it is the engineering layer that turns agent
+output into a compiled, verified paper package.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from src._legacy.citation_verifier import VerificationReport, verify_citations, write_verification_json
+from src._legacy.latex_build import BuildResult, compile_latex, run_chktex
+from src._legacy.submission_packager import package_submission
+from src.utils import RunPaths, append_log_entry
+from src.writing_manifest import build_writing_manifest
+
+
+TEMPLATE_DIR_NAME = "neurips_2025"
+
+# Files from the template that should be copied into writing_dir.
+_TEMPLATE_COPY_FILES = ["neurips_2025.sty", "main_template.tex"]
+
+# Section files expected after agent writing.
+EXPECTED_SECTIONS = [
+    "abstract", "introduction", "related_work",
+    "method", "experiments", "results", "conclusion",
+]
+
+
+@dataclass
+class WritingPipelineResult:
+    manifest: dict
+    build_result: BuildResult
+    verification: VerificationReport
+    bundle_path: Path | None
+    build_log_path: Path
+    errors: list[str]
+
+
+def run_writing_pipeline(paths: RunPaths) -> WritingPipelineResult:
+    """Execute the full deterministic post-processing pipeline for Stage 07.
+
+    Steps:
+    1. Build writing manifest from workspace artifacts
+    2. Set up NeurIPS template (copy .sty, generate main.tex if needed)
+    3. Ensure sections/ directory has at least stub files
+    4. Compile LaTeX → PDF
+    5. Run chktex lint
+    6. Verify citations and figure references
+    7. Package submission bundle
+    8. Write build artifacts (build_log.txt, build_manifest.json, citation_verification.json)
+    """
+    errors: list[str] = []
+
+    # Step 1: Build manifest
+    try:
+        manifest = build_writing_manifest(paths)
+    except Exception as exc:
+        manifest = {}
+        errors.append(f"Manifest generation failed: {exc}")
+
+    # Step 2: Set up template
+    try:
+        setup_template(paths.writing_dir)
+    except Exception as exc:
+        errors.append(f"Template setup failed: {exc}")
+
+    # Step 3: Ensure section stubs exist so pdflatex doesn't fail on missing \\input
+    _ensure_section_stubs(paths.writing_dir)
+
+    # Step 4: Ensure references.bib exists
+    bib_path = paths.writing_dir / "references.bib"
+    if not bib_path.exists():
+        bib_path.write_text("% Auto-generated empty bibliography\n", encoding="utf-8")
+
+    # Step 5: Compile LaTeX
+    build_result = compile_latex(paths.writing_dir, main_tex="main.tex")
+
+    # Step 6: Run chktex
+    chktex_output = run_chktex(paths.writing_dir, main_tex="main.tex")
+    build_result.chktex_output = chktex_output
+
+    # Step 7: Verify citations and figures
+    verification = verify_citations(
+        writing_dir=paths.writing_dir,
+        figures_dir=paths.figures_dir,
+        main_tex="main.tex",
+    )
+
+    # Step 8: Write build artifacts
+    paths.artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build log
+    build_log_path = paths.artifacts_dir / "build_log.txt"
+    log_content = _format_build_log(build_result, chktex_output, verification)
+    build_log_path.write_text(log_content, encoding="utf-8")
+
+    # Citation verification JSON
+    verification_json_path = paths.artifacts_dir / "citation_verification.json"
+    write_verification_json(verification, verification_json_path)
+
+    # Copy PDF to artifacts/
+    if build_result.success and build_result.pdf_path:
+        artifact_pdf = paths.artifacts_dir / "paper.pdf"
+        shutil.copy2(build_result.pdf_path, artifact_pdf)
+
+    # Step 9: Package submission bundle (best effort)
+    bundle_path = package_submission(
+        writing_dir=paths.writing_dir,
+        figures_dir=paths.figures_dir,
+        output_dir=paths.artifacts_dir,
+        pdf_path=build_result.pdf_path,
+    )
+
+    # Step 10: Write build manifest
+    _write_build_manifest(paths, build_result, verification, bundle_path)
+
+    if not build_result.success:
+        errors.append("LaTeX compilation did not produce a PDF.")
+
+    return WritingPipelineResult(
+        manifest=manifest,
+        build_result=build_result,
+        verification=verification,
+        bundle_path=bundle_path,
+        build_log_path=build_log_path,
+        errors=errors,
+    )
+
+
+def setup_template(writing_dir: Path) -> None:
+    """Copy NeurIPS template files into writing_dir and create main.tex if missing.
+
+    Also creates empty stub .tex files for any expected sections that don't
+    exist yet, so pdflatex won't fail on missing \\input{} files.
+    """
+    template_source = _find_template_dir()
+
+    writing_dir.mkdir(parents=True, exist_ok=True)
+    (writing_dir / "sections").mkdir(exist_ok=True)
+
+    # Copy .sty
+    sty_source = template_source / "neurips_2025.sty"
+    sty_dest = writing_dir / "neurips_2025.sty"
+    if sty_source.exists() and not sty_dest.exists():
+        shutil.copy2(sty_source, sty_dest)
+
+    # Create main.tex from template if it doesn't exist
+    main_dest = writing_dir / "main.tex"
+    if not main_dest.exists():
+        template_tex = template_source / "main_template.tex"
+        if template_tex.exists():
+            shutil.copy2(template_tex, main_dest)
+
+    # Create section stubs for any missing sections
+    _ensure_section_stubs(writing_dir)
+
+
+def _find_template_dir() -> Path:
+    """Locate the template directory relative to this source file."""
+    # templates/ is a sibling of src/ in the repo root
+    src_dir = Path(__file__).resolve().parent
+    repo_root = src_dir.parent
+    template_dir = repo_root / "templates" / TEMPLATE_DIR_NAME
+    if not template_dir.exists():
+        raise FileNotFoundError(f"Template directory not found: {template_dir}")
+    return template_dir
+
+
+def _ensure_section_stubs(writing_dir: Path) -> None:
+    """Create empty stub .tex files for any expected sections that don't exist.
+
+    This prevents pdflatex from failing on missing \\input{} files.
+    """
+    sections_dir = writing_dir / "sections"
+    sections_dir.mkdir(exist_ok=True)
+    for section_name in EXPECTED_SECTIONS:
+        section_file = sections_dir / f"{section_name}.tex"
+        if not section_file.exists():
+            section_file.write_text(
+                f"% TODO: {section_name} content\n",
+                encoding="utf-8",
+            )
+
+
+def _format_build_log(
+    build_result: BuildResult,
+    chktex_output: str,
+    verification: VerificationReport,
+) -> str:
+    """Format a human-readable build log."""
+    parts: list[str] = [
+        f"Build Log — {datetime.now().isoformat(timespec='seconds')}",
+        f"PDF generated: {build_result.success}",
+        f"PDF path: {build_result.pdf_path or '(none)'}",
+        "",
+    ]
+
+    if build_result.errors:
+        parts.append("=== LaTeX Errors ===")
+        for err in build_result.errors:
+            line_info = f" (line {err.line_number})" if err.line_number else ""
+            parts.append(f"  ! {err.message}{line_info}")
+            if err.context_lines:
+                parts.append(err.context_lines)
+        parts.append("")
+
+    if build_result.warnings:
+        parts.append("=== Warnings ===")
+        for warn in build_result.warnings:
+            parts.append(f"  {warn}")
+        parts.append("")
+
+    if chktex_output:
+        parts.append("=== chktex Output ===")
+        parts.append(chktex_output)
+        parts.append("")
+
+    parts.append("=== Citation Verification ===")
+    parts.append(f"  Status: {verification.overall_status}")
+    parts.append(f"  Cite keys in .tex: {len(verification.cite_keys_in_tex)}")
+    parts.append(f"  Entries in .bib: {len(verification.bib_keys)}")
+    if verification.missing_in_bib:
+        parts.append(f"  Missing in .bib: {sorted(verification.missing_in_bib)}")
+    if verification.missing_figures:
+        parts.append(f"  Missing figures: {sorted(verification.missing_figures)}")
+    if verification.undefined_refs:
+        parts.append(f"  Undefined refs: {sorted(verification.undefined_refs)}")
+
+    parts.append("")
+    parts.append("=== Full Compile Log ===")
+    parts.append(build_result.log)
+
+    return "\n".join(parts)
+
+
+def _write_build_manifest(
+    paths: RunPaths,
+    build_result: BuildResult,
+    verification: VerificationReport,
+    bundle_path: Path | None,
+) -> None:
+    """Write build_manifest.json summarizing the pipeline run."""
+    data = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "pdf_generated": build_result.success,
+        "pdf_path": str(build_result.pdf_path) if build_result.pdf_path else None,
+        "error_count": len(build_result.errors),
+        "warning_count": len(build_result.warnings),
+        "citation_status": verification.overall_status,
+        "bundle_path": str(bundle_path) if bundle_path else None,
+    }
+    manifest_path = paths.artifacts_dir / "build_manifest.json"
+    manifest_path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )

--- a/src/prompts/07_writing.md
+++ b/src/prompts/07_writing.md
@@ -4,34 +4,341 @@ You are executing the writing stage for a serious research workflow whose target
 
 ## Mission
 
-Turn the approved problem framing, method, evidence, and analysis into manuscript-quality written material aligned with real research communication standards.
+Turn the approved problem framing, method, evidence, and analysis into a **submission-ready paper package**. You are responsible for the entire pipeline: writing LaTeX, compiling to PDF, verifying citations, polishing prose, and packaging the submission bundle.
 
 ## Your Responsibilities
 
-- Draft or refine paper-ready writing grounded in the actual approved outputs.
-- Structure the narrative around the strongest evidence and most defensible claims.
-- Make contribution statements precise.
-- Align the writing with plausible publication expectations rather than generic blog-style exposition.
-- Ensure the manuscript-level narrative does not outrun the evidence.
-- Produce a conference-style paper package: NeurIPS LaTeX source, compiled PDF, figures, and tables integrated into the manuscript.
+- Draft paper-ready LaTeX section files grounded in the actual approved outputs.
+- Set up the venue template (download or copy official .sty/.cls files).
+- Compile the paper to PDF and fix any compilation errors.
+- Verify all citations and figure references are consistent.
+- Polish prose to remove AI writing artifacts.
+- Package the final submission bundle.
+- Produce structured verification artifacts (build_log, citation_verification).
+
+## TeX Environment
+
+The TeX toolchain is available via conda. Before running any LaTeX commands, ensure the PATH includes the TeX binaries:
+
+```bash
+export PATH="/Users/yifanzhou/miniconda3/envs/autor_tex/bin:$PATH"
+```
+
+Verify availability: `which pdflatex && which bibtex && which chktex`
+
+## Template Setup
+
+A template registry is available at the repo root: `templates/registry.yaml`. It lists supported venues with their official URLs, style packages, citation styles, and page limits.
+
+**To set up a template:**
+
+1. Read `templates/registry.yaml` to find the target venue configuration.
+2. Download the official style package from the `official_url`, OR copy pre-downloaded templates if available.
+3. Generate `main.tex` that uses the correct `\usepackage{...}` and `\input{sections/...}` structure.
+4. Generate `math_commands.tex` with paper-specific notation macros.
+
+If the official URL is unreachable, check for fallback templates under `workspace/agent_systems/Auto-claude-code-research-in-sleep/skills/paper-write/templates/`.
+
+**Default venue: NeurIPS 2025** (unless the run configuration specifies otherwise).
+
+## File Convention
+
+All your output must go under `{{WORKSPACE_WRITING_DIR}}`. The expected structure:
+
+```
+writing/
+├── main.tex                    ← YOU create this (based on venue template)
+├── math_commands.tex           ← YOU create this (shared math macros)
+├── references.bib              ← YOU create this (all BibTeX entries)
+├── sections/
+│   ├── abstract.tex            ← YOU create this
+│   ├── introduction.tex        ← YOU create this
+│   ├── related_work.tex        ← YOU create this
+│   ├── method.tex              ← YOU create this
+│   ├── experiments.tex         ← YOU create this
+│   ├── results.tex             ← YOU create this
+│   ├── conclusion.tex          ← YOU create this
+│   └── appendix.tex            ← YOU create this (optional)
+└── tables/
+    └── main_results.tex        ← YOU create this (optional)
+```
+
+## Available Workspace Artifacts
+
+Before writing, read `{{WORKSPACE_WRITING_DIR}}/manifest.json` if it exists. It lists:
+- Available figures under `{{WORKSPACE_FIGURES_DIR}}`
+- Available result files under `{{WORKSPACE_RESULTS_DIR}}`
+- Stage summaries from prior stages
+
+Use these real artifacts in your paper. **Do not fabricate data, figures, or results.**
+
+## Workflow — Step by Step
+
+Complete all steps in this order within a single session:
+
+### Phase 1: Outline
+
+1. Read `manifest.json` to understand available figures, results, and data.
+2. Read prior stage summaries to understand the research narrative.
+3. Set up the venue template (download/copy .sty + generate `main.tex`).
+4. Generate `math_commands.tex` with paper-specific notation.
+
+### Phase 2: Drafting
+
+5. Write `sections/*.tex` files — each is a pure LaTeX fragment (no `\documentclass`, no `\begin{document}`, no preamble). Just section content starting with `\section{...}`.
+   - `abstract.tex`: only the abstract text (no `\begin{abstract}` — the template handles that).
+   - Each section should meet its page target (intro ~1.5pp, related work ≥1pp, method ~2pp, experiments ~2.5pp, conclusion ~0.5pp).
+   - Figure references: `\includegraphics[width=\columnwidth]{filename.png}` — set `\graphicspath{{../figures/}}` in `main.tex`.
+   - Every `\cite{}` / `\citep{}` key must have a matching entry in `references.bib`.
+
+6. Write `references.bib` — **NEVER fabricate BibTeX entries from memory**. Use this verification chain:
+   - **Step A — DBLP** (best quality): `curl -s "https://dblp.org/search/publ/api?q=TITLE+AUTHOR&format=json&h=3"` → extract key → `curl -s "https://dblp.org/rec/{key}.bib"`
+   - **Step B — CrossRef DOI** (fallback): `curl -sLH "Accept: application/x-bibtex" "https://doi.org/{doi}"`
+   - **Step C — Mark [VERIFY]** (last resort): add `% [VERIFY]` comment. Do NOT fabricate.
+   - Only include entries that are actually `\cite`d in the paper (no bloat).
+
+### Phase 3: Quality Polish
+
+7. **De-AI polish** — scan all section files and fix AI writing patterns. The goal is natural academic prose, not mechanical word substitution. Only change text that genuinely reads as machine-generated.
+
+    **Words to replace** (when they add no precision over simpler alternatives):
+    delve, pivotal, landscape, tapestry, underscore, noteworthy, intriguingly, leverage, elucidate, utilize, facilitate, aforementioned, paradigm, synergy, holistic, novel (when overused), comprehensive (when vague), robust (when imprecise), seamless, cutting-edge, state-of-the-art (prefer "recent" or cite the actual method)
+
+    **Phrases to remove** (low-information fillers):
+    "It is worth noting that", "Importantly,", "Notably,", "It should be noted that", "First and foremost,", "In recent years,", "has attracted significant attention", "plays a crucial role"
+
+    **Structural patterns to fix**:
+    - Consecutive sentences starting with "This" or "We" — vary sentence openings
+    - Repetitive three-item lists ("X, Y, and Z") in consecutive paragraphs
+    - Generic field-background openings in the abstract (delete and start with the specific contribution)
+    - Bullet/list formatting in prose sections — convert to flowing paragraphs
+    - Excessive dash (—) usage — replace with commas, parentheses, or subordinate clauses
+
+    **修改阈值**: If a sentence already reads naturally and precisely, leave it alone. Do not change for the sake of changing. The goal is removing obvious machine artifacts, not rewriting everything.
+
+8. **Reverse outline test** — extract the first sentence of every paragraph, read them in sequence. They should form a coherent narrative. Fix any paragraph whose topic sentence doesn't advance the story.
+
+9. **Logic consistency check** — read the full paper and verify:
+    - No contradictory claims between sections (e.g., intro claims X, experiments show not-X)
+    - Core terminology is consistent throughout (do not rename the same concept across sections)
+    - Every experiment in the Experiments section maps to a claim stated in the Introduction
+    - Contribution bullets in the Introduction are specific and falsifiable (not "we study X" or "we perform experiments")
+
+10. **Pre-compilation citation & reference check** — verify before compiling:
+    - Every `\cite{key}` / `\citep{key}` / `\citet{key}` has a corresponding `@type{key,` entry in `references.bib`
+    - Every `\includegraphics{file}` references a file that exists under `{{WORKSPACE_FIGURES_DIR}}`
+    - Every `\ref{label}` has a corresponding `\label{label}` in some `.tex` file
+    - Fix any inconsistencies found
+
+11. Clean up stale files — check that every `.tex` file in `sections/` is `\input`ed by `main.tex`. Remove orphans.
+
+12. Clean up bib bloat — remove entries from `references.bib` that are not `\cite`d anywhere.
+
+### Phase 4: Self-Review Scoring Loop
+
+**After polishing, score your own paper before compiling.** This is a structured self-assessment — not a rewrite. Run up to 2 rounds. If the first round scores ≥ 7.0 overall with no CRITICAL issues, skip round 2 and proceed to compilation.
+
+13. **Score the paper** on these 8 dimensions (1-10 each):
+
+    | Dimension | What to evaluate | Score |
+    |-----------|-----------------|-------|
+    | **Narrative clarity** | Can the contribution be stated in one sentence? Is the What/Why/So What clear by end of Introduction? | _ /10 |
+    | **Claims-evidence alignment** | Does every claim in the abstract/intro have supporting evidence in experiments? Any overclaims? | _ /10 |
+    | **Technical rigor** | Are methods described precisely enough to reproduce? Are assumptions stated? Are proofs/derivations correct? | _ /10 |
+    | **Experiment design** | Are baselines fair and sufficient? Are ablations present for key design choices? Error bars? | _ /10 |
+    | **Writing quality** | Is prose clear, precise, and free of AI artifacts? Is terminology consistent? | _ /10 |
+    | **Structure & flow** | Does the paper follow a logical progression? Is the Introduction ≤1.5pp? Does the method start by page 2-3? | _ /10 |
+    | **References & figures** | Are citations real and relevant? Are figure captions self-contained? Are all refs/labels resolved? | _ /10 |
+    | **Completeness** | Are all sections substantively filled? No placeholder text? No [TODO] markers? | _ /10 |
+
+    Compute the **overall score** = average of 8 dimensions.
+
+14. **Classify issues by severity**:
+    - **CRITICAL** (must fix): contradictions, fabricated data/citations, missing key evidence, anonymity breach, placeholder text remaining
+    - **MAJOR** (should fix): overclaims, missing ablations, inconsistent terminology, weak related work, structural problems
+    - **MINOR** (fix if time permits): wording improvements, minor formatting, non-essential warnings
+
+15. **Fix issues** — apply fixes in severity order (CRITICAL → MAJOR → MINOR). Common fix patterns:
+
+    | Issue | Fix Pattern |
+    |-------|-------------|
+    | Overclaim | Soften: "validates" → "demonstrates", "achieves state-of-the-art" → "achieves competitive results" |
+    | Claim without evidence | Either add evidence reference or remove/weaken the claim |
+    | Inconsistent terminology | Pick the best term, search-and-replace globally across all .tex files |
+    | Missing experiment-claim link | Add a sentence in Experiments stating what claim this experiment tests |
+    | Weak contribution bullets | Rewrite as specific, falsifiable statements with quantitative results |
+    | Abstract starts with generic background | Delete generic opening, start with the paper's specific contribution |
+    | Related Work is paper-by-paper | Reorganize by method family or research question |
+
+    If fixes were applied, re-score and check whether another round is needed.
+
+16. **Log the self-review** — write `{{WORKSPACE_ARTIFACTS_DIR}}/self_review.json`:
+    ```json
+    {
+      "rounds": 1,
+      "scores": {
+        "narrative_clarity": 8,
+        "claims_evidence": 7,
+        "technical_rigor": 8,
+        "experiment_design": 7,
+        "writing_quality": 8,
+        "structure_flow": 8,
+        "references_figures": 9,
+        "completeness": 9
+      },
+      "overall_score": 8.0,
+      "critical_issues_found": 0,
+      "major_issues_found": 2,
+      "issues_fixed": ["softened overclaim in abstract", "added ablation reference in experiments"],
+      "final_verdict": "ready"
+    }
+    ```
+
+    **Verdict**: `"ready"` if overall ≥ 7.0 and 0 CRITICAL issues; `"needs_revision"` otherwise.
+
+### Phase 5: Compilation
+
+All text changes are now finalized. Compile the paper.
+
+17. Compile using the four-step sequence:
+    ```bash
+    cd {{WORKSPACE_WRITING_DIR}}
+    pdflatex -interaction=nonstopmode main.tex
+    bibtex main
+    pdflatex -interaction=nonstopmode main.tex
+    pdflatex -interaction=nonstopmode main.tex
+    ```
+
+18. **Self-repair loop** (up to 3 attempts): If compilation fails, read the error log and fix issues:
+    - Missing packages → install via `tlmgr` or remove unused `\usepackage`
+    - Undefined references → check `\label{}` exists in the correct environment
+    - Missing figures → check filename/extension, update `\includegraphics` path
+    - Citation undefined → add missing entry to `references.bib` or fix key
+    - BibTeX syntax errors → fix comma, braces, special characters
+    - Overfull hbox (>20pt) → rephrase text or adjust figure width
+    - After fixing, recompile with the full four-step sequence.
+    - **Success criterion**: PDF file exists and is > 100KB (not empty/corrupt). Do not rely on exit codes — pdflatex often returns non-zero but still produces usable PDFs.
+
+19. **Post-compilation checks**:
+    - Run `chktex main.tex -q -n2 -n24 -n13 -n1` — address significant warnings
+    - No "??" in PDF (undefined references — check compile log)
+    - No "[?]" in PDF (undefined citations — check compile log)
+    - No `[VERIFY]` markers left in text
+    - Page count within venue limit (main body to Conclusion end, excluding refs/appendix for ML venues)
+    - Anonymous mode: no author names, affiliations, or self-citations revealing identity
+    - All fonts embedded in PDF (`pdffonts main.pdf | grep -v "yes"` should return nothing)
+    - File size reasonable (< 50MB, preferred < 10MB)
+    - Self-review overall score ≥ 7.0
+    - Zero CRITICAL issues remaining
+
+### Phase 6: Packaging
+
+20. Copy the compiled PDF to `{{WORKSPACE_ARTIFACTS_DIR}}/paper.pdf`.
+
+21. Package `submission_bundle.zip` containing only submission files:
+    - **Include**: `.tex`, `.sty`, `.bst`, `.bib`, `.cls`, `.pdf`, `.png`, `.jpg`, `.jpeg`, `.eps`, `.svg`
+    - **Exclude**: `.aux`, `.log`, `.out`, `.fls`, `.fdb_latexmk`, `.synctex.gz`, `.blg`, `.bbl`, `.toc`
+
+22. Write `{{WORKSPACE_ARTIFACTS_DIR}}/build_log.txt` — structured build log:
+    ```
+    === Build Log ===
+    Timestamp: ...
+    Venue: ...
+    Compilation attempts: N
+    Self-review rounds: N
+    Self-review score: X.X/10
+    Final status: SUCCESS / FAILED
+    PDF pages: X (main body) + Y (references) + Z (appendix)
+    Warnings remaining: [list]
+    Errors fixed: [list]
+    ```
+
+23. Write `{{WORKSPACE_ARTIFACTS_DIR}}/citation_verification.json`:
+    ```json
+    {
+      "overall_status": "pass" | "fail",
+      "total_citations": N,
+      "verified_citations": N,
+      "unverified_citations": ["key1", "key2"],
+      "missing_figures": [],
+      "orphan_labels": [],
+      "orphan_refs": [],
+      "verify_markers_remaining": 0
+    }
+    ```
+
+24. Write `{{WORKSPACE_ARTIFACTS_DIR}}/build_manifest.json` with pipeline metadata.
+
+25. Write the stage summary markdown to `{{STAGE_OUTPUT_PATH}}`.
 
 ## Filesystem Requirements
 
 - All generated working files must remain under `{{WORKSPACE_ROOT}}`.
-- Put manuscript sections, outlines, abstracts, and response-ready prose under `{{WORKSPACE_WRITING_DIR}}`.
-- Produce a full NeurIPS-style LaTeX manuscript under `{{WORKSPACE_WRITING_DIR}}`.
-- Compile the manuscript to PDF and place the output under `{{WORKSPACE_WRITING_DIR}}` or `{{WORKSPACE_ARTIFACTS_DIR}}`.
-- Put supporting tables and figure references under `{{WORKSPACE_WRITING_DIR}}` or `{{WORKSPACE_FIGURES_DIR}}`.
-- Put revision notes under `{{WORKSPACE_REVIEWS_DIR}}` when useful.
+- Put manuscript sections and bibliography under `{{WORKSPACE_WRITING_DIR}}`.
+- Put compiled PDF, build log, and verification artifacts under `{{WORKSPACE_ARTIFACTS_DIR}}`.
+- Reference figures from `{{WORKSPACE_FIGURES_DIR}}` by filename only.
 - The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
 - The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
 
-## Quality Bar
+## Writing Quality Rules
 
-- Writing should be clear, technically serious, and appropriately cautious.
-- Claims should match the evidence.
-- The output should be useful as a real submission-ready manuscript package, not just generic commentary.
-- The target is a roughly 9-page conference paper body with rich figures and tables, not a toy note.
+### The Narrative Principle
+
+A paper is a **short, rigorous, evidence-backed technical story** — not a pile of experiments.
+
+- If the core contribution cannot be stated in one sentence, the framing has not converged.
+- Every section should serve the same story. Experiments, related work, and discussion support the main claim — they are not independent mini-papers.
+- Front-load the contribution: title, abstract, introduction, and Figure 1 should make the main claim clear before the reader reaches the method.
+
+### Abstract (Five-Sentence Formula)
+
+Write a compact abstract following this structure:
+1. What you achieved (the specific contribution)
+2. Why the problem is important and difficult
+3. How you approached it
+4. What evidence supports the claim
+5. What number, result, or guarantee the reader should remember
+
+**Do not** open with generic field background ("Large language models have achieved remarkable success..."). If the first sentence could fit any ML paper, delete it and start with the paper's specific contribution.
+
+### Introduction Structure
+
+- Keep the Introduction to ~1.5 pages. The method should start by page 2-3.
+- Include 2-4 contribution bullets that are **specific and falsifiable**:
+  - Good: "We prove that X converges in O(n log n) under assumption Y."
+  - Bad: "We study problem X." / "We perform extensive experiments."
+- Surface the strongest result early — tell the reader what is worth remembering.
+
+### Sentence-Level Clarity
+
+- **Keep subject and verb close** — do not separate them with long subordinate clauses.
+- **Put context at the start, new information at the end** — readers parse better when sentences move from familiar to new.
+- **Put actions in verbs** — "We analyzed the results" not "We performed an analysis of the results."
+- **One paragraph, one job** — if a paragraph tries to do two things, split it.
+- **Reduce ambiguous pronouns** — when "this", "it", "these" could refer to multiple things, replace with a specific noun.
+
+### Word Choice
+
+- Use precise terms: "accuracy" not "performance", "3x faster" not "fast", "92% F1" not "good results".
+- Claims must match the evidence — do not overclaim. Use hedging ("suggests", "indicates") only where uncertainty is genuine. But do not over-hedge — excessive "may", "might", "potentially" reads as self-doubt, not rigor.
+- Maintain consistent terminology — do not rename concepts across sections (e.g., do not mix "model" / "network" / "architecture" for the same thing).
+- Prefer verbs that signal contribution: "develop", "propose", "introduce", "characterize" over "combine", "modify", "extend".
+- Avoid possessive forms for method/model names: write "the performance of METHOD" not "METHOD's performance".
+- Never use contractions in academic writing (write "does not", not "doesn't").
+
+### Structure Targets
+
+- The target is a roughly 9-page conference paper body (for ML venues) with rich figures and tables.
+- Section page budgets: intro ~1.5pp, related work ≥1pp, method ~2pp, experiments ~2.5pp, conclusion ~0.5pp.
+- Keep related work ≥ 1 full page, organized by method family, not paper-by-paper.
+- Figure captions must be self-contained — a reader should understand the figure from its caption alone.
+
+### Mathematical Writing
+
+- State assumptions formally before any theorem.
+- Pair proofs with intuition — do not leave only bare statements in the main text.
+- Keep notation consistent: scalars ($x$), vectors ($\mathbf{x}$), matrices ($\mathbf{W}$), sets ($\mathcal{X}$).
+- Define every symbol at first use.
 
 ## Stage Output Requirements
 
@@ -42,14 +349,17 @@ Additional expectations for this stage:
 - `Key Results` should include:
   - what manuscript components were drafted
   - the central narrative and contribution framing
+  - compilation status and any remaining issues
+  - citation verification summary
   - places where the paper is currently strong or vulnerable
-  - what dissemination should emphasize
-- `Files Produced` should list manuscript drafts, sections, abstracts, or writing artifacts.
-- `Suggestions for Refinement` should focus on argument clarity, claim discipline, or paper structure.
+- `Files Produced` should list all .tex files, references.bib, paper.pdf, build_log.txt, citation_verification.json, self_review.json, and submission_bundle.zip.
+- `Key Results` should also include the self-review score breakdown and any issues fixed during the self-review loop.
+- `Suggestions for Refinement` should focus on argument clarity, claim discipline, paper structure, remaining [VERIFY] markers, or dimensions that scored below 7 in self-review.
 
 ## Important Constraints
 
-- Do not invent missing evidence in order to strengthen the story.
-- Do not stop at markdown-only drafts if a structured LaTeX paper and compiled PDF can be produced.
+- **Do not invent missing evidence** in order to strengthen the story.
+- **Do not fabricate BibTeX entries** from memory — always verify via DBLP/CrossRef or mark with [VERIFY].
+- **Do not fabricate experimental results, figures, or data.**
 - Do not control workflow progression.
 - Do not write outside the current run directory.

--- a/src/utils.py
+++ b/src/utils.py
@@ -484,21 +484,51 @@ def validate_stage_artifacts(stage: StageSpec, paths: RunPaths) -> list[str]:
             )
 
     if stage.number >= 7:
-        tex_files = [path for path in _existing_files(paths.writing_dir) if path.suffix.lower() in LATEX_SUFFIXES]
-        if not tex_files:
+        # Check main.tex exists (venue-agnostic — no longer hardcoded to NeurIPS)
+        main_tex = paths.writing_dir / "main.tex"
+        if not main_tex.exists():
             problems.append(
-                f"{stage.stage_title} requires LaTeX sources under workspace/writing."
-            )
-        elif not any(_looks_like_neurips_tex(path) for path in tex_files):
-            problems.append(
-                f"{stage.stage_title} requires a NeurIPS-style LaTeX manuscript in workspace/writing."
+                f"{stage.stage_title} requires main.tex under workspace/writing."
             )
 
+        # Check references.bib exists
+        bib_files = [p for p in _existing_files(paths.writing_dir) if p.suffix.lower() == ".bib"]
+        if not bib_files:
+            problems.append(
+                f"{stage.stage_title} requires references.bib under workspace/writing."
+            )
+
+        # Check sections/ directory has .tex files
+        sections_dir = paths.writing_dir / "sections"
+        if not sections_dir.exists() or not list(sections_dir.glob("*.tex")):
+            problems.append(
+                f"{stage.stage_title} requires section .tex files under workspace/writing/sections/."
+            )
+
+        # Check compiled PDF
         pdf_count = _count_files_with_suffixes(paths.writing_dir, PDF_SUFFIXES)
         pdf_count += _count_files_with_suffixes(paths.artifacts_dir, PDF_SUFFIXES)
         if pdf_count == 0:
             problems.append(
-                f"{stage.stage_title} requires a compiled PDF manuscript under workspace/writing or workspace/artifacts."
+                f"{stage.stage_title} requires a compiled PDF under workspace/writing or workspace/artifacts."
+            )
+
+        # Check build_log.txt exists
+        if not (paths.artifacts_dir / "build_log.txt").exists():
+            problems.append(
+                f"{stage.stage_title} requires build_log.txt under workspace/artifacts."
+            )
+
+        # Check citation_verification.json exists
+        if not (paths.artifacts_dir / "citation_verification.json").exists():
+            problems.append(
+                f"{stage.stage_title} requires citation_verification.json under workspace/artifacts."
+            )
+
+        # Check self_review.json exists
+        if not (paths.artifacts_dir / "self_review.json").exists():
+            problems.append(
+                f"{stage.stage_title} requires self_review.json under workspace/artifacts."
             )
 
     if stage.number >= 8:
@@ -611,13 +641,6 @@ def _count_files_with_suffixes(directory: Path, suffixes: set[str]) -> int:
 
 def _count_non_markdown_files(directory: Path) -> int:
     return sum(1 for path in _existing_files(directory) if path.suffix.lower() not in {".md", ".txt"})
-
-
-def _looks_like_neurips_tex(path: Path) -> bool:
-    if not path.exists() or path.suffix.lower() != ".tex":
-        return False
-    text = read_text(path).lower()
-    return "neurips" in text and "\\documentclass" in text
 
 
 def canonicalize_stage_markdown(

--- a/src/writing_manifest.py
+++ b/src/writing_manifest.py
@@ -1,0 +1,108 @@
+"""Artifact scanner and manifest generator for Stage 07 writing pipeline."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+from .utils import RunPaths
+
+FIGURE_SUFFIXES = {".png", ".pdf", ".svg", ".jpg", ".jpeg", ".eps"}
+RESULT_SUFFIXES = {".json", ".jsonl", ".csv", ".tsv", ".parquet", ".npz", ".npy"}
+
+
+def build_writing_manifest(paths: RunPaths) -> dict:
+    """Scan workspace directories and produce a structured writing manifest.
+
+    The manifest tells the agent what artifacts are available for the paper.
+    Written to workspace/writing/manifest.json.
+    """
+    manifest = {
+        "generated_at": datetime.now().isoformat(timespec="seconds"),
+        "figures": scan_figures(paths.figures_dir),
+        "result_files": scan_results(paths.results_dir),
+        "data_files": _scan_dir(paths.data_dir),
+        "stage_summaries": _collect_stage_summaries(paths),
+    }
+
+    paths.writing_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path = paths.writing_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def scan_figures(figures_dir: Path) -> list[dict]:
+    """Return list of figure metadata dicts."""
+    if not figures_dir.exists():
+        return []
+    results = []
+    for path in sorted(figures_dir.rglob("*")):
+        if path.is_file() and path.suffix.lower() in FIGURE_SUFFIXES:
+            results.append({
+                "filename": path.name,
+                "rel_path": f"figures/{path.relative_to(figures_dir)}",
+                "size_bytes": path.stat().st_size,
+            })
+    return results
+
+
+def scan_results(results_dir: Path) -> list[dict]:
+    """Return list of result file metadata dicts."""
+    if not results_dir.exists():
+        return []
+    results = []
+    for path in sorted(results_dir.rglob("*")):
+        if path.is_file() and path.suffix.lower() in RESULT_SUFFIXES:
+            results.append({
+                "filename": path.name,
+                "rel_path": f"results/{path.relative_to(results_dir)}",
+                "type": path.suffix.lstrip("."),
+            })
+    return results
+
+
+def _scan_dir(directory: Path) -> list[str]:
+    """Return list of relative paths for all files in a directory."""
+    if not directory.exists():
+        return []
+    return sorted(
+        str(path.relative_to(directory.parent))
+        for path in directory.rglob("*")
+        if path.is_file()
+    )
+
+
+def _collect_stage_summaries(paths: RunPaths) -> dict[str, str]:
+    """Collect paths to existing stage summaries."""
+    summaries = {}
+    if paths.stages_dir.exists():
+        for stage_file in sorted(paths.stages_dir.glob("*.md")):
+            if not stage_file.name.endswith(".tmp.md"):
+                summaries[stage_file.stem] = str(stage_file.relative_to(paths.run_root))
+    return summaries
+
+
+def format_manifest_for_prompt(manifest: dict) -> str:
+    """Format the manifest into a concise string for the agent prompt."""
+    parts: list[str] = []
+
+    figures = manifest.get("figures", [])
+    if figures:
+        parts.append("### Available Figures")
+        for fig in figures:
+            parts.append(f"- `{fig['rel_path']}` ({fig['size_bytes']} bytes)")
+
+    result_files = manifest.get("result_files", [])
+    if result_files:
+        parts.append("\n### Available Result Files")
+        for rf in result_files:
+            parts.append(f"- `{rf['rel_path']}` (type: {rf['type']})")
+
+    if not parts:
+        parts.append("No experiment artifacts found in workspace.")
+
+    return "\n".join(parts)

--- a/templates/registry.yaml
+++ b/templates/registry.yaml
@@ -1,0 +1,96 @@
+# Template Registry — config-driven venue templates for Stage 07
+#
+# Claude downloads/copies the official template at writing time based on
+# the target venue configured for the run.  The registry only stores
+# metadata; no vendored .sty files live in this repo.
+#
+# Fields:
+#   display_name   — human-readable venue name
+#   official_url   — URL to the official style package (zip)
+#   style_package  — LaTeX package name to \usepackage{...}
+#   bib_style      — BibTeX style (e.g. plainnat, IEEEtran)
+#   citation_style — natbib (\citep/\citet) or cite (\cite)
+#   page_limit     — main body page limit (to end of Conclusion)
+#   refs_in_limit  — whether references count toward page limit
+#   fallback_templates — path to pre-downloaded templates (relative to repo root)
+
+neurips_2025:
+  display_name: "NeurIPS 2025"
+  official_url: "https://media.neurips.cc/Conferences/NeurIPS2025/Styles.zip"
+  style_package: "neurips_2025"
+  bib_style: "plainnat"
+  citation_style: "natbib"
+  page_limit: 9
+  refs_in_limit: false
+
+neurips_2026:
+  display_name: "NeurIPS 2026"
+  official_url: "https://media.neurips.cc/Conferences/NeurIPS2026/Styles.zip"
+  style_package: "neurips_2026"
+  bib_style: "plainnat"
+  citation_style: "natbib"
+  page_limit: 9
+  refs_in_limit: false
+
+iclr_2026:
+  display_name: "ICLR 2026"
+  official_url: "https://github.com/ICLR/Master-Template/raw/master/iclr2026.zip"
+  style_package: "iclr2026_conference"
+  bib_style: "iclr2026_conference"
+  citation_style: "natbib"
+  page_limit: 9
+  refs_in_limit: false
+
+icml_2026:
+  display_name: "ICML 2026"
+  official_url: "https://icml.cc/Conferences/2026/Styles.zip"
+  style_package: "icml2026"
+  bib_style: "icml2026"
+  citation_style: "natbib"
+  page_limit: 8
+  refs_in_limit: false
+
+cvpr_2026:
+  display_name: "CVPR 2026"
+  official_url: "https://cvpr.thecvf.com/Conferences/2026/AuthorGuidelines"
+  style_package: "cvpr"
+  bib_style: "ieee_fullname"
+  citation_style: "natbib"
+  page_limit: 8
+  refs_in_limit: false
+
+acl_2026:
+  display_name: "ACL 2026"
+  official_url: "https://github.com/acl-org/acl-style-files"
+  style_package: "acl"
+  bib_style: "acl_natbib"
+  citation_style: "natbib"
+  page_limit: 8
+  refs_in_limit: false
+
+aaai_2026:
+  display_name: "AAAI 2026"
+  official_url: "https://aaai.org/conference/aaai/aaai-26/aaai-26-submission-instructions/"
+  style_package: "aaai2026"
+  bib_style: "aaai2026"
+  citation_style: "natbib"
+  page_limit: 7
+  refs_in_limit: true
+
+ieee_journal:
+  display_name: "IEEE Transactions / Letters"
+  official_url: "https://www.ieee.org/conferences/publishing/templates.html"
+  style_package: "IEEEtran"
+  bib_style: "IEEEtran"
+  citation_style: "cite"
+  page_limit: 14
+  refs_in_limit: true
+
+ieee_conference:
+  display_name: "IEEE Conference (ICC, GLOBECOM, etc.)"
+  official_url: "https://www.ieee.org/conferences/publishing/templates.html"
+  style_package: "IEEEtran"
+  bib_style: "IEEEtran"
+  citation_style: "cite"
+  page_limit: 6
+  refs_in_limit: true

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""AutoR test package."""

--- a/tests/test_writing_pipeline.py
+++ b/tests/test_writing_pipeline.py
@@ -1,0 +1,207 @@
+"""Tests for Stage 07 writing-related modules.
+
+Covers:
+- validate_stage_artifacts() for stage 07 (venue-agnostic)
+- writing_manifest module (still active)
+- templates/registry.yaml structure
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+from src.utils import RunPaths, StageSpec, build_run_paths, ensure_run_layout, validate_stage_artifacts
+from src.writing_manifest import build_writing_manifest, format_manifest_for_prompt, scan_figures
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+STAGE_07 = StageSpec(7, "07_writing", "Writing")
+
+
+@pytest.fixture
+def tmp_run(tmp_path: Path) -> RunPaths:
+    """Create a minimal run directory structure."""
+    run_root = tmp_path / "test_run"
+    paths = build_run_paths(run_root)
+    ensure_run_layout(paths)
+    # Create minimal prior-stage artifacts so Stage 07 validation doesn't fail on those
+    (paths.data_dir / "design.json").write_text('{"key": "value"}')
+    (paths.results_dir / "metrics.json").write_text('{"accuracy": 0.9}')
+    (paths.figures_dir / "accuracy.png").write_bytes(b"\x89PNG fake image data")
+    return paths
+
+
+def _populate_writing_dir(paths: RunPaths) -> None:
+    """Fill writing dir with the minimum artifacts that pass Stage 07 validation."""
+    sections_dir = paths.writing_dir / "sections"
+    sections_dir.mkdir(parents=True, exist_ok=True)
+
+    (paths.writing_dir / "main.tex").write_text(
+        "\\documentclass{article}\n\\begin{document}\nHello\n\\end{document}\n"
+    )
+    (paths.writing_dir / "references.bib").write_text(
+        "@article{test2024,\n  title={Test},\n  author={A},\n  year={2024},\n}\n"
+    )
+    (sections_dir / "introduction.tex").write_text("\\section{Introduction}\nContent.\n")
+    (sections_dir / "method.tex").write_text("\\section{Method}\nContent.\n")
+
+    # Compiled PDF (fake)
+    (paths.artifacts_dir / "paper.pdf").write_bytes(b"%PDF-1.4 fake")
+    (paths.artifacts_dir / "build_log.txt").write_text("=== Build Log ===\nFinal status: SUCCESS\n")
+    (paths.artifacts_dir / "citation_verification.json").write_text(
+        json.dumps({"overall_status": "pass", "total_citations": 1})
+    )
+    (paths.artifacts_dir / "self_review.json").write_text(
+        json.dumps({"overall_score": 8.0, "final_verdict": "ready", "rounds": 1})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 07 artifact validation tests (venue-agnostic)
+# ---------------------------------------------------------------------------
+
+class TestStage07Validation:
+    def test_complete_setup_passes(self, tmp_run: RunPaths) -> None:
+        _populate_writing_dir(tmp_run)
+        problems = validate_stage_artifacts(STAGE_07, tmp_run)
+        assert problems == []
+
+    def test_rejects_missing_main_tex(self, tmp_run: RunPaths) -> None:
+        _populate_writing_dir(tmp_run)
+        (tmp_run.writing_dir / "main.tex").unlink()
+        problems = validate_stage_artifacts(STAGE_07, tmp_run)
+        assert any("main.tex" in p for p in problems)
+
+    def test_rejects_missing_bib(self, tmp_run: RunPaths) -> None:
+        _populate_writing_dir(tmp_run)
+        (tmp_run.writing_dir / "references.bib").unlink()
+        problems = validate_stage_artifacts(STAGE_07, tmp_run)
+        assert any(".bib" in p.lower() or "references" in p.lower() for p in problems)
+
+    def test_rejects_missing_sections(self, tmp_run: RunPaths) -> None:
+        _populate_writing_dir(tmp_run)
+        import shutil
+        shutil.rmtree(tmp_run.writing_dir / "sections")
+        problems = validate_stage_artifacts(STAGE_07, tmp_run)
+        assert any("section" in p.lower() for p in problems)
+
+    def test_rejects_missing_pdf(self, tmp_run: RunPaths) -> None:
+        _populate_writing_dir(tmp_run)
+        (tmp_run.artifacts_dir / "paper.pdf").unlink()
+        problems = validate_stage_artifacts(STAGE_07, tmp_run)
+        assert any("pdf" in p.lower() for p in problems)
+
+    def test_rejects_missing_build_log(self, tmp_run: RunPaths) -> None:
+        _populate_writing_dir(tmp_run)
+        (tmp_run.artifacts_dir / "build_log.txt").unlink()
+        problems = validate_stage_artifacts(STAGE_07, tmp_run)
+        assert any("build_log" in p for p in problems)
+
+    def test_rejects_missing_citation_verification(self, tmp_run: RunPaths) -> None:
+        _populate_writing_dir(tmp_run)
+        (tmp_run.artifacts_dir / "citation_verification.json").unlink()
+        problems = validate_stage_artifacts(STAGE_07, tmp_run)
+        assert any("citation_verification" in p for p in problems)
+
+    def test_rejects_missing_self_review(self, tmp_run: RunPaths) -> None:
+        _populate_writing_dir(tmp_run)
+        (tmp_run.artifacts_dir / "self_review.json").unlink()
+        problems = validate_stage_artifacts(STAGE_07, tmp_run)
+        assert any("self_review" in p for p in problems)
+
+    def test_empty_writing_dir_returns_seven_errors(self, tmp_run: RunPaths) -> None:
+        problems = validate_stage_artifacts(STAGE_07, tmp_run)
+        # main.tex, .bib, sections/, PDF, build_log.txt, citation_verification.json, self_review.json
+        assert len(problems) == 7
+
+
+# ---------------------------------------------------------------------------
+# Writing manifest tests
+# ---------------------------------------------------------------------------
+
+class TestWritingManifest:
+    def test_scan_figures(self, tmp_run: RunPaths) -> None:
+        figures = scan_figures(tmp_run.figures_dir)
+        assert len(figures) == 1
+        assert figures[0]["filename"] == "accuracy.png"
+
+    def test_scan_figures_empty_dir(self, tmp_path: Path) -> None:
+        figures = scan_figures(tmp_path / "nonexistent")
+        assert figures == []
+
+    def test_build_manifest(self, tmp_run: RunPaths) -> None:
+        manifest = build_writing_manifest(tmp_run)
+
+        assert "figures" in manifest
+        assert "result_files" in manifest
+        assert len(manifest["figures"]) == 1
+        assert (tmp_run.writing_dir / "manifest.json").exists()
+
+        # Verify JSON is valid
+        raw = (tmp_run.writing_dir / "manifest.json").read_text()
+        parsed = json.loads(raw)
+        assert parsed["figures"] == manifest["figures"]
+
+    def test_format_for_prompt(self, tmp_run: RunPaths) -> None:
+        manifest = build_writing_manifest(tmp_run)
+        text = format_manifest_for_prompt(manifest)
+        assert "accuracy.png" in text
+        assert "metrics.json" in text
+
+    def test_format_empty_manifest(self) -> None:
+        text = format_manifest_for_prompt({"figures": [], "result_files": []})
+        assert "No experiment artifacts found" in text
+
+
+# ---------------------------------------------------------------------------
+# Template registry tests
+# ---------------------------------------------------------------------------
+
+REGISTRY_PATH = Path(__file__).resolve().parent.parent / "templates" / "registry.yaml"
+
+REQUIRED_FIELDS = {"display_name", "official_url", "style_package", "bib_style", "citation_style", "page_limit", "refs_in_limit"}
+
+
+class TestRegistryYaml:
+    @pytest.fixture(autouse=True)
+    def _load_registry(self) -> None:
+        assert REGISTRY_PATH.exists(), f"registry.yaml not found at {REGISTRY_PATH}"
+        yaml = YAML(typ="safe")
+        with open(REGISTRY_PATH) as f:
+            self.registry = yaml.load(f)
+
+    def test_is_non_empty_dict(self) -> None:
+        assert isinstance(self.registry, dict)
+        assert len(self.registry) >= 1
+
+    def test_all_entries_have_required_fields(self) -> None:
+        for venue_key, config in self.registry.items():
+            missing = REQUIRED_FIELDS - set(config.keys())
+            assert not missing, f"Venue '{venue_key}' missing fields: {missing}"
+
+    def test_page_limits_are_positive_ints(self) -> None:
+        for venue_key, config in self.registry.items():
+            assert isinstance(config["page_limit"], int), f"{venue_key}: page_limit must be int"
+            assert config["page_limit"] > 0, f"{venue_key}: page_limit must be positive"
+
+    def test_refs_in_limit_is_bool(self) -> None:
+        for venue_key, config in self.registry.items():
+            assert isinstance(config["refs_in_limit"], bool), f"{venue_key}: refs_in_limit must be bool"
+
+    def test_citation_style_is_valid(self) -> None:
+        valid_styles = {"natbib", "cite"}
+        for venue_key, config in self.registry.items():
+            assert config["citation_style"] in valid_styles, (
+                f"{venue_key}: citation_style must be one of {valid_styles}"
+            )
+
+    def test_neurips_2025_is_default(self) -> None:
+        assert "neurips_2025" in self.registry
+        assert self.registry["neurips_2025"]["page_limit"] == 9


### PR DESCRIPTION
## Summary

- Redesign Stage 07 from a Python-heavy pipeline into a prompt-driven single-session workflow (Claude does everything, Python only validates)
- 6-phase pipeline: Outline → Drafting → Quality Polish → Self-Review → Compilation → Packaging — content quality is finalized **before** compilation
- Self-review scoring loop with 8 dimensions, CRITICAL/MAJOR/MINOR severity classification, ≥7.0 threshold
- De-AI rewrite with 70+ word list, reverse outline test, DBLP three-level citation verification
- Config-driven template registry supporting 9 venues (NeurIPS, ICLR, ICML, CVPR, ACL, AAAI, IEEE, etc.)
- 7 validated artifacts including `self_review.json`
- Legacy pipeline modules moved to `src/_legacy/`
- 20 tests covering validation, manifest building, and registry config

## Key design decisions

- **Polish before compile**: writing quality iteration happens on `.tex` source, not on rendered PDF
- **Self-review before compile**: Claude scores and fixes its own draft before producing PDF
- **No Python pipeline code**: consistent with Stages 1–8 architecture (manager orchestrates → Claude executes → Python validates)

## References

Techniques borrowed from:
- [auto-claude-code-research-in-sleep](https://github.com/JackHopkins/auto-claude-code-research-in-sleep) — self-review loop, writing principles, venue checklists
- [awesome-ai-research-writing](https://github.com/mlsysops/awesome-ai-research-writing) — De-AI word list, reviewer template

## Test plan

- [x] `python -m pytest tests/` — 20/20 pass
- [ ] End-to-end run of Stage 07 on a real research project

🤖 Generated with [Claude Code](https://claude.com/claude-code)