### PR TITLE
Harden writing pipeline: warning vs error distinction, flexible file structure

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -215,7 +215,13 @@ class ResearchManager:
                 )
 
             stage_markdown = read_text(result.stage_file_path)
-            validation_errors = validate_stage_markdown(stage_markdown) + validate_stage_artifacts(stage, paths)
+            all_issues = validate_stage_markdown(stage_markdown) + validate_stage_artifacts(stage, paths)
+            validation_warnings = [e for e in all_issues if e.startswith("[warning]")]
+            validation_errors = [e for e in all_issues if not e.startswith("[warning]")]
+            if validation_warnings:
+                self._print(f"Warnings for {stage.stage_title}:")
+                for w in validation_warnings:
+                    self._print(f"  {w}")
             if validation_errors:
                 self._print(
                     f"Stage summary for {stage.stage_title} was incomplete. Running repair attempt..."
@@ -261,7 +267,8 @@ class ResearchManager:
                     )
 
                 stage_markdown = read_text(repair_result.stage_file_path)
-                validation_errors = validate_stage_markdown(stage_markdown) + validate_stage_artifacts(stage, paths)
+                all_issues = validate_stage_markdown(stage_markdown) + validate_stage_artifacts(stage, paths)
+                validation_errors = [e for e in all_issues if not e.startswith("[warning]")]
                 if validation_errors:
                     self._print(
                         f"Repair output for {stage.stage_title} is still incomplete. Normalizing locally..."

--- a/src/prompts/07_writing.md
+++ b/src/prompts/07_writing.md
@@ -34,15 +34,15 @@ Expected behavior:
 
 ## File Convention
 
-All writing output must stay under `{{WORKSPACE_WRITING_DIR}}`. The expected structure is:
+All writing output must stay under `{{WORKSPACE_WRITING_DIR}}`. The recommended structure is:
 
 ```text
 writing/
-├── main.tex
+├── main.tex              (required)
 ├── math_commands.tex
-├── references.bib
+├── references.bib        (preferred over inline bibliography)
 ├── manifest.json
-├── sections/
+├── sections/             (optional — single-file main.tex is acceptable)
 │   ├── abstract.tex
 │   ├── introduction.tex
 │   ├── related_work.tex
@@ -55,13 +55,30 @@ writing/
     └── main_results.tex
 ```
 
-Additional generated artifacts should go under `{{WORKSPACE_ARTIFACTS_DIR}}`, such as:
+A single-file `main.tex` containing all sections is acceptable, especially for shorter papers.
+If you use a single file, you do not need to create the `sections/` directory.
 
-- `paper.pdf`
-- `build_log.txt`
-- `citation_verification.json`
-- `self_review.json`
-- `submission_bundle.zip`
+### Bibliography
+
+Prefer generating a `references.bib` file with BibTeX entries and using `\bibliography{references}` in `main.tex`. This is more flexible for venue changes and easier to verify.
+
+If generating a `.bib` file is not feasible, use `\begin{thebibliography}` as a fallback. Both formats pass validation.
+
+### Required Artifacts
+
+The following artifacts must go under `{{WORKSPACE_ARTIFACTS_DIR}}`:
+
+- `paper.pdf` — compiled manuscript (required)
+- `build_log.txt` — redirect or save LaTeX compilation output here
+- `citation_verification.json` — verify each citation matches a bibliography entry:
+  ```json
+  {"citations": [{"key": "xu2019", "in_bib": true, "in_text": true}], "unresolved": []}
+  ```
+- `self_review.json` — rate each section's completeness:
+  ```json
+  {"sections": [{"name": "Introduction", "complete": true, "issues": []}], "overall_score": 4}
+  ```
+- `submission_bundle.zip` (optional)
 
 ## Available Workspace Artifacts
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -647,11 +647,12 @@ def validate_stage_artifacts(stage: StageSpec, paths: RunPaths) -> list[str]:
             )
 
         sections_dir = paths.writing_dir / "sections"
-        section_tex_files = list(sections_dir.glob("*.tex")) if sections_dir.exists() else []
-        if not section_tex_files:
-            problems.append(
-                f"{stage.stage_title} requires section .tex files under workspace/writing/sections."
-            )
+        if sections_dir.exists():
+            section_tex_files = list(sections_dir.glob("*.tex"))
+            if not section_tex_files:
+                problems.append(
+                    f"[warning] {stage.stage_title}: workspace/writing/sections/ exists but contains no .tex files."
+                )
 
         pdf_count = _count_files_with_suffixes(paths.writing_dir, PDF_SUFFIXES)
         pdf_count += _count_files_with_suffixes(paths.artifacts_dir, PDF_SUFFIXES)
@@ -661,18 +662,24 @@ def validate_stage_artifacts(stage: StageSpec, paths: RunPaths) -> list[str]:
             )
 
         if not (paths.artifacts_dir / "build_log.txt").exists():
-            problems.append(
-                f"{stage.stage_title} requires build_log.txt under workspace/artifacts."
-            )
+            if pdf_count > 0:
+                problems.append(
+                    f"[warning] {stage.stage_title}: build_log.txt missing under workspace/artifacts. "
+                    "PDF exists so compilation likely succeeded."
+                )
+            else:
+                problems.append(
+                    f"{stage.stage_title} requires build_log.txt under workspace/artifacts."
+                )
 
         if not (paths.artifacts_dir / "citation_verification.json").exists():
             problems.append(
-                f"{stage.stage_title} requires citation_verification.json under workspace/artifacts."
+                f"[warning] {stage.stage_title}: citation_verification.json missing under workspace/artifacts."
             )
 
         if not (paths.artifacts_dir / "self_review.json").exists():
             problems.append(
-                f"{stage.stage_title} requires self_review.json under workspace/artifacts."
+                f"[warning] {stage.stage_title}: self_review.json missing under workspace/artifacts."
             )
 
     if stage.number >= 8:

--- a/tests/test_writing_pipeline.py
+++ b/tests/test_writing_pipeline.py
@@ -208,19 +208,59 @@ class WritingPipelineTests(unittest.TestCase):
         problems = validate_stage_artifacts(STAGE_07, paths)
         self.assertTrue(any("Expected venue: nature" in problem for problem in problems))
 
-    def test_stage07_validation_requires_build_log(self) -> None:
+    def test_stage07_missing_build_log_with_pdf_is_warning(self) -> None:
         _, paths = self._build_paths()
         self._populate_valid_stage07_outputs(paths)
         (paths.artifacts_dir / "build_log.txt").unlink()
         problems = validate_stage_artifacts(STAGE_07, paths)
-        self.assertTrue(any("build_log.txt" in problem for problem in problems))
+        build_log_issues = [p for p in problems if "build_log.txt" in p]
+        self.assertTrue(len(build_log_issues) > 0)
+        self.assertTrue(all(p.startswith("[warning]") for p in build_log_issues))
 
-    def test_stage07_validation_requires_self_review(self) -> None:
+    def test_stage07_missing_build_log_without_pdf_is_error(self) -> None:
+        _, paths = self._build_paths()
+        self._populate_valid_stage07_outputs(paths)
+        (paths.artifacts_dir / "build_log.txt").unlink()
+        (paths.artifacts_dir / "paper.pdf").unlink()
+        # Also remove any PDF in writing dir
+        for f in paths.writing_dir.glob("*.pdf"):
+            f.unlink()
+        problems = validate_stage_artifacts(STAGE_07, paths)
+        pdf_errors = [p for p in problems if "PDF" in p and not p.startswith("[warning]")]
+        self.assertTrue(len(pdf_errors) > 0)
+
+    def test_stage07_missing_self_review_is_warning(self) -> None:
         _, paths = self._build_paths()
         self._populate_valid_stage07_outputs(paths)
         (paths.artifacts_dir / "self_review.json").unlink()
         problems = validate_stage_artifacts(STAGE_07, paths)
-        self.assertTrue(any("self_review.json" in problem for problem in problems))
+        sr_issues = [p for p in problems if "self_review.json" in p]
+        self.assertTrue(len(sr_issues) > 0)
+        self.assertTrue(all(p.startswith("[warning]") for p in sr_issues))
+
+    def test_stage07_single_file_main_tex_without_sections_passes(self) -> None:
+        _, paths = self._build_paths()
+        self._populate_valid_stage07_outputs(paths)
+        # Remove sections/ directory entirely
+        import shutil
+        sections_dir = paths.writing_dir / "sections"
+        if sections_dir.exists():
+            shutil.rmtree(sections_dir)
+        problems = validate_stage_artifacts(STAGE_07, paths)
+        errors = [p for p in problems if not p.startswith("[warning]")]
+        self.assertEqual(errors, [], f"Unexpected errors: {errors}")
+
+    def test_stage07_empty_sections_dir_is_warning(self) -> None:
+        _, paths = self._build_paths()
+        self._populate_valid_stage07_outputs(paths)
+        # Remove all .tex files from sections/ but keep directory
+        sections_dir = paths.writing_dir / "sections"
+        for f in sections_dir.glob("*.tex"):
+            f.unlink()
+        problems = validate_stage_artifacts(STAGE_07, paths)
+        section_issues = [p for p in problems if "sections/" in p]
+        self.assertTrue(len(section_issues) > 0)
+        self.assertTrue(all(p.startswith("[warning]") for p in section_issues))
 
     def test_scan_figures_returns_expected_metadata(self) -> None:
         _, paths = self._build_paths()


### PR DESCRIPTION
## Summary
- `sections/` directory no longer required — single-file `main.tex` is valid
- `build_log.txt` missing with PDF present is now a warning, not a blocking error
- `citation_verification.json` and `self_review.json` missing are now warnings
- Manager separates `[warning]` from errors: warnings display but don't trigger repair
- Prompt updated with explicit `.bib` guidance and JSON schema for verification artifacts

## Context
Example run produced a single-file `main.tex` without `sections/`, used inline `\begin{thebibliography}` instead of `.bib`, and lacked `build_log.txt`. Validation triggered unnecessary repair cycles for issues that weren't real blockers.

Depends on #13.

## Test plan
- [x] 5 new tests + 2 updated tests in `tests/test_writing_pipeline.py` — all passing
- [ ] Verify existing `test_stage07_validation_passes_with_expected_outputs` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)