### PR TITLE
Add dissemination readiness check: structured warnings before final approve

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -29,6 +29,7 @@ from .utils import (
     read_attempt_count,
     read_text,
     truncate_text,
+    validate_dissemination_readiness,
     validate_stage_artifacts,
     validate_stage_markdown,
     write_attempt_count,
@@ -370,6 +371,18 @@ class ResearchManager:
                 continue
 
             if choice == "5":
+                if stage.number == 8:
+                    readiness_warnings = validate_dissemination_readiness(paths)
+                    if readiness_warnings:
+                        self._print(f"\n{'=' * 60}")
+                        self._print(f"Readiness warnings ({len(readiness_warnings)}):")
+                        for w in readiness_warnings:
+                            self._print(f"  - {w}")
+                        self._print(f"{'=' * 60}")
+                        confirm = input("Type 'yes' to approve despite warnings, or anything else to go back: ").strip()
+                        if confirm.lower() != "yes":
+                            continue
+
                 append_approved_stage_summary(paths.memory, stage, stage_markdown)
                 append_log_entry(
                     paths.logs,

--- a/src/prompts/08_dissemination.md
+++ b/src/prompts/08_dissemination.md
@@ -44,6 +44,30 @@ Additional expectations for this stage:
 - `Files Produced` should list release, packaging, or communication artifacts.
 - `Suggestions for Refinement` should focus on readiness, packaging quality, clarity of communication, or risk reduction before publication or release.
 
+## Required Readiness Report
+
+You must produce `{{WORKSPACE_REVIEWS_DIR}}/readiness_report.json` with the following structure:
+
+```json
+{
+  "ready": false,
+  "blocking_gaps": [
+    "Missing NodeFormer baseline comparison"
+  ],
+  "warnings": [
+    "Abstract may exceed venue word limit"
+  ],
+  "assets": [
+    {"path": "workspace/artifacts/paper.pdf", "status": "ready"},
+    {"path": "workspace/code/", "status": "needs_cleanup"}
+  ]
+}
+```
+
+Be honest. If there are blocking gaps that would prevent acceptance at the target venue,
+list them in `blocking_gaps`. AutoR will show these to the user before final approval.
+Set `ready` to `true` only if `blocking_gaps` is empty.
+
 ## Important Constraints
 
 - Do not present unfinished work as publication-ready if it is not.

--- a/src/utils.py
+++ b/src/utils.py
@@ -692,6 +692,36 @@ def validate_stage_artifacts(stage: StageSpec, paths: RunPaths) -> list[str]:
     return problems
 
 
+def validate_dissemination_readiness(paths: RunPaths) -> list[str]:
+    warnings: list[str] = []
+
+    pdf_count = _count_files_with_suffixes(paths.writing_dir, PDF_SUFFIXES)
+    pdf_count += _count_files_with_suffixes(paths.artifacts_dir, PDF_SUFFIXES)
+    if pdf_count == 0:
+        warnings.append("No compiled PDF found in workspace/writing or workspace/artifacts.")
+
+    if not (paths.writing_dir / "main.tex").exists():
+        warnings.append("No main.tex found in workspace/writing.")
+
+    review_files = _existing_files(paths.reviews_dir)
+    if not review_files:
+        warnings.append("No review/readiness files found in workspace/reviews.")
+
+    report_path = paths.reviews_dir / "readiness_report.json"
+    if report_path.exists():
+        try:
+            report = json.loads(read_text(report_path))
+            blocking = report.get("blocking_gaps", [])
+            for gap in blocking:
+                warnings.append(f"Blocking gap: {gap}")
+        except (json.JSONDecodeError, KeyError):
+            warnings.append("readiness_report.json exists but could not be parsed.")
+    else:
+        warnings.append("No readiness_report.json found. Stage 08 should produce this file.")
+
+    return warnings
+
+
 def render_approved_stage_entry(stage: StageSpec, stage_markdown: str) -> str:
     objective = extract_markdown_section(stage_markdown, "Objective") or "Not provided."
     what_i_did = extract_markdown_section(stage_markdown, "What I Did") or "Not provided."

--- a/tests/test_dissemination.py
+++ b/tests/test_dissemination.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.utils import (
+    DEFAULT_VENUE,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    validate_dissemination_readiness,
+    write_text,
+)
+
+
+class TestDisseminationReadiness(unittest.TestCase):
+    def _build_paths(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        run_root = Path(tmp_dir.name) / "run"
+        paths = build_run_paths(run_root)
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Test goal")
+        write_text(paths.memory, "# Approved Run Memory\n\n## Approved Stage Summaries\n\n_None yet._\n")
+        ensure_run_config(paths, model="sonnet", venue=DEFAULT_VENUE)
+        return paths
+
+    def test_no_pdf_returns_warning(self) -> None:
+        paths = self._build_paths()
+        warnings = validate_dissemination_readiness(paths)
+        self.assertTrue(any("PDF" in w for w in warnings))
+
+    def test_no_main_tex_returns_warning(self) -> None:
+        paths = self._build_paths()
+        warnings = validate_dissemination_readiness(paths)
+        self.assertTrue(any("main.tex" in w for w in warnings))
+
+    def test_no_review_files_returns_warning(self) -> None:
+        paths = self._build_paths()
+        warnings = validate_dissemination_readiness(paths)
+        self.assertTrue(any("review" in w.lower() for w in warnings))
+
+    def test_missing_readiness_report_returns_warning(self) -> None:
+        paths = self._build_paths()
+        warnings = validate_dissemination_readiness(paths)
+        self.assertTrue(any("readiness_report.json" in w for w in warnings))
+
+    def test_readiness_report_blocking_gaps_surfaced(self) -> None:
+        paths = self._build_paths()
+        # Create all required files
+        write_text(paths.writing_dir / "main.tex", "\\documentclass{article}")
+        (paths.artifacts_dir / "paper.pdf").write_bytes(b"%PDF-1.4")
+        write_text(paths.reviews_dir / "checklist.md", "# Checklist\n- Done")
+        write_text(
+            paths.reviews_dir / "readiness_report.json",
+            json.dumps({
+                "ready": False,
+                "blocking_gaps": ["Missing GloGNN baseline", "No Pei 2020 splits"],
+                "warnings": [],
+                "assets": [],
+            }),
+        )
+        warnings = validate_dissemination_readiness(paths)
+        self.assertTrue(any("GloGNN" in w for w in warnings))
+        self.assertTrue(any("Pei 2020" in w for w in warnings))
+
+    def test_all_present_ready_true_returns_no_blocking(self) -> None:
+        paths = self._build_paths()
+        write_text(paths.writing_dir / "main.tex", "\\documentclass{article}")
+        (paths.artifacts_dir / "paper.pdf").write_bytes(b"%PDF-1.4")
+        write_text(paths.reviews_dir / "checklist.md", "# Checklist\n- Done")
+        write_text(
+            paths.reviews_dir / "readiness_report.json",
+            json.dumps({
+                "ready": True,
+                "blocking_gaps": [],
+                "warnings": [],
+                "assets": [],
+            }),
+        )
+        warnings = validate_dissemination_readiness(paths)
+        self.assertEqual(warnings, [])
+
+    def test_malformed_json_returns_warning(self) -> None:
+        paths = self._build_paths()
+        write_text(paths.writing_dir / "main.tex", "\\documentclass{article}")
+        (paths.artifacts_dir / "paper.pdf").write_bytes(b"%PDF-1.4")
+        write_text(paths.reviews_dir / "checklist.md", "# Checklist")
+        write_text(paths.reviews_dir / "readiness_report.json", "not valid json{{{")
+        warnings = validate_dissemination_readiness(paths)
+        self.assertTrue(any("could not be parsed" in w for w in warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `validate_dissemination_readiness()` checking PDF, main.tex, reviews, and `readiness_report.json`
- Stage 08 approve now shows readiness warnings and requires `yes` confirmation
- `readiness_report.json` blocking gaps are surfaced as warnings to the user
- Prompt requires `readiness_report.json` with `blocking_gaps`/`warnings` schema

## Context
Example run's Stage 08 identified 4 blocking gaps (missing baselines, missing splits, abstract too long, no figure scripts) but the user could approve without any warning. The system now surfaces these as structured warnings before final approval.

Depends on #14.

## Test plan
- [x] 7 new tests in `tests/test_dissemination.py` — all passing
- [ ] Manual: `--fake-operator` full run → Stage 08 approve → verify warning display

🤖 Generated with [Claude Code](https://claude.com/claude-code)