### PR TITLE
Add Socratic intake stage to support richer input types (fixes #16)

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from src.intake import ResourceEntry, classify_resource, collect_resource_paths_from_ui
 from src.manager import ResearchManager
 from src.operator import ClaudeOperator
 from src.terminal_ui import TerminalUI
@@ -55,6 +56,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--redo-stage",
         help="When resuming a run, restart from this stage slug or stage number (for example '06_analysis' or '6').",
+    )
+    parser.add_argument(
+        "--resources",
+        nargs="+",
+        metavar="PATH",
+        help="Paths to resource files or directories to include in the run "
+             "(PDFs, code repos, datasets, .bib files, notes).",
+    )
+    parser.add_argument(
+        "--skip-intake",
+        action="store_true",
+        help="Skip the Claude-driven Socratic intake stage.",
     )
     return parser.parse_args()
 
@@ -111,6 +124,24 @@ def read_user_goal() -> str:
     return goal
 
 
+def _build_resource_entries(paths: list[str]) -> list[ResourceEntry]:
+    """Classify CLI --resources into ResourceEntry objects."""
+    entries: list[ResourceEntry] = []
+    for p in paths:
+        path = Path(p).expanduser().resolve()
+        rtype, ddir = classify_resource(path)
+        entries.append(
+            ResourceEntry(
+                source_path=str(path),
+                resource_type=rtype,
+                dest_dir=ddir,
+                dest_relative="",
+                description="",
+            )
+        )
+    return entries
+
+
 def main() -> int:
     args = parse_args()
     repo_root = Path(__file__).resolve().parent
@@ -144,8 +175,23 @@ def main() -> int:
         operator=operator,
         ui=ui,
     )
+
     goal = args.goal.strip() if args.goal else read_user_goal()
-    return 0 if manager.run(goal, venue=venue) else 1
+    skip_intake = args.skip_intake or not sys.stdin.isatty()
+
+    # Collect resources: from --resources flag, and optionally from interactive prompt
+    resources: list[ResourceEntry] = []
+    if args.resources:
+        resources = _build_resource_entries(args.resources)
+    if not skip_intake and sys.stdin.isatty():
+        resources = collect_resource_paths_from_ui(ui, initial_resources=args.resources)
+
+    return 0 if manager.run(
+        goal,
+        venue=venue,
+        resources=resources or None,
+        skip_intake=skip_intake,
+    ) else 1
 
 
 if __name__ == "__main__":

--- a/src/intake.py
+++ b/src/intake.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .terminal_ui import TerminalUI
+    from .utils import RunPaths
+
+# ---------------------------------------------------------------------------
+# Suffix sets (reuse from utils where possible, add code-oriented ones)
+# ---------------------------------------------------------------------------
+
+PDF_SUFFIXES = {".pdf"}
+BIB_SUFFIXES = {".bib", ".bibtex"}
+CODE_SUFFIXES = {".py", ".ipynb", ".r", ".jl", ".sh", ".js", ".ts", ".cpp", ".c", ".h", ".java", ".go", ".rs"}
+DATA_SUFFIXES = {".json", ".jsonl", ".csv", ".tsv", ".parquet", ".yaml", ".yml", ".npz", ".npy"}
+NOTES_SUFFIXES = {".md", ".txt", ".rst", ".org"}
+TEX_SUFFIXES = {".tex"}
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QATurn:
+    question: str
+    answer: str
+
+
+@dataclass(frozen=True)
+class ResourceEntry:
+    source_path: str
+    resource_type: str  # "pdf", "bib", "code", "dataset", "notes", "other"
+    dest_dir: str  # workspace subdirectory name: "literature", "code", "data", "notes", "artifacts"
+    dest_relative: str  # relative path within workspace after copy
+    description: str
+
+
+@dataclass(frozen=True)
+class IntakeContext:
+    goal: str
+    original_goal: str
+    resources: list[ResourceEntry] = field(default_factory=list)
+    qa_transcript: list[QATurn] = field(default_factory=list)
+    notes: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Resource classification
+# ---------------------------------------------------------------------------
+
+
+def classify_resource(path: Path) -> tuple[str, str]:
+    """Return (resource_type, dest_dir) based on file suffix or directory heuristic."""
+    if path.is_dir():
+        # Heuristic: if directory contains code-like files, treat as code
+        code_files = list(path.rglob("*.py")) + list(path.rglob("*.ipynb"))
+        if code_files:
+            return "code", "code"
+        return "other", "artifacts"
+
+    suffix = path.suffix.lower()
+    if suffix in PDF_SUFFIXES:
+        return "pdf", "literature"
+    if suffix in BIB_SUFFIXES:
+        return "bib", "literature"
+    if suffix in CODE_SUFFIXES:
+        return "code", "code"
+    if suffix in DATA_SUFFIXES:
+        return "dataset", "data"
+    if suffix in NOTES_SUFFIXES:
+        return "notes", "notes"
+    if suffix in TEX_SUFFIXES:
+        return "tex", "writing"
+    return "other", "artifacts"
+
+
+# ---------------------------------------------------------------------------
+# Resource ingestion
+# ---------------------------------------------------------------------------
+
+_DEST_DIR_MAP = {
+    "literature": "literature_dir",
+    "code": "code_dir",
+    "data": "data_dir",
+    "notes": "notes_dir",
+    "writing": "writing_dir",
+    "artifacts": "artifacts_dir",
+}
+
+
+def ingest_resources(
+    resources: list[ResourceEntry],
+    paths: RunPaths,
+) -> list[ResourceEntry]:
+    """Copy each resource into the appropriate workspace directory.
+
+    Returns a new list of ResourceEntry with ``dest_relative`` filled in.
+    Missing source files are skipped with a warning printed to stderr.
+    """
+    import sys
+
+    updated: list[ResourceEntry] = []
+    for entry in resources:
+        src = Path(entry.source_path).expanduser().resolve()
+        if not src.exists():
+            print(f"Warning: resource not found, skipping: {src}", file=sys.stderr)
+            continue
+
+        attr = _DEST_DIR_MAP.get(entry.dest_dir, "artifacts_dir")
+        dest_parent: Path = getattr(paths, attr)
+        dest_parent.mkdir(parents=True, exist_ok=True)
+
+        if src.is_dir():
+            dest = dest_parent / src.name
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(src, dest)
+        else:
+            dest = dest_parent / src.name
+            shutil.copy2(src, dest)
+
+        rel = dest.relative_to(paths.workspace_root)
+        updated.append(
+            ResourceEntry(
+                source_path=entry.source_path,
+                resource_type=entry.resource_type,
+                dest_dir=entry.dest_dir,
+                dest_relative=str(rel),
+                description=entry.description,
+            )
+        )
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+def save_intake_context(paths: RunPaths, context: IntakeContext) -> Path:
+    """Write *context* to ``intake_context.json`` under the run root."""
+    dest = paths.intake_context
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(
+        json.dumps(asdict(context), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return dest
+
+
+def load_intake_context(paths: RunPaths) -> IntakeContext | None:
+    """Load an IntakeContext from disk. Returns ``None`` for legacy runs."""
+    if not paths.intake_context.exists():
+        return None
+    raw = json.loads(paths.intake_context.read_text(encoding="utf-8"))
+    return IntakeContext(
+        goal=raw["goal"],
+        original_goal=raw["original_goal"],
+        resources=[ResourceEntry(**r) for r in raw.get("resources", [])],
+        qa_transcript=[QATurn(**t) for t in raw.get("qa_transcript", [])],
+        notes=raw.get("notes", ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting
+# ---------------------------------------------------------------------------
+
+_MAX_RESOURCES_IN_PROMPT = 20
+
+
+def format_intake_for_prompt(context: IntakeContext) -> str:
+    """Format the intake context as a markdown section for stage prompts."""
+    parts: list[str] = []
+
+    if context.resources:
+        lines = ["## User-Provided Resources", ""]
+        shown = context.resources[:_MAX_RESOURCES_IN_PROMPT]
+        for r in shown:
+            desc = f" - {r.description}" if r.description else ""
+            lines.append(f"- `workspace/{r.dest_relative}` ({r.resource_type}){desc}")
+        remaining = len(context.resources) - len(shown)
+        if remaining > 0:
+            lines.append(f"- ... and {remaining} more resource(s) (see intake_context.json)")
+        parts.append("\n".join(lines))
+
+    if context.qa_transcript:
+        qa_lines = ["## User Clarifications", ""]
+        for turn in context.qa_transcript:
+            qa_lines.append(f"**Q: {turn.question}**")
+            qa_lines.append(f"A: {turn.answer}")
+            qa_lines.append("")
+        parts.append("\n".join(qa_lines).rstrip())
+
+    if context.notes:
+        parts.append(f"## Additional Notes\n\n{context.notes}")
+
+    return "\n\n".join(parts).strip() if parts else ""
+
+
+def format_resources_for_intake_prompt(resources: list[ResourceEntry]) -> str:
+    """Format pre-loaded resources as a section for the intake stage prompt."""
+    if not resources:
+        return "_No resources pre-loaded._"
+    lines = []
+    for r in resources:
+        rel = r.dest_relative or r.source_path
+        desc = f" - {r.description}" if r.description else ""
+        lines.append(f"- `{rel}` ({r.resource_type}){desc}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Convenience builders (non-interactive, for --skip-intake backward compat)
+# ---------------------------------------------------------------------------
+
+
+def build_intake_from_goal(goal: str) -> IntakeContext:
+    """Build a minimal IntakeContext from a plain goal string (backward compat)."""
+    return IntakeContext(goal=goal, original_goal=goal)
+
+
+def build_intake_from_resources(
+    goal: str,
+    resource_paths: list[str],
+) -> IntakeContext:
+    """Build an IntakeContext from a goal and a list of file/dir paths.
+
+    Used when ``--resources`` is provided without the interactive session.
+    """
+    entries: list[ResourceEntry] = []
+    for p in resource_paths:
+        path = Path(p).expanduser().resolve()
+        rtype, ddir = classify_resource(path)
+        entries.append(
+            ResourceEntry(
+                source_path=str(path),
+                resource_type=rtype,
+                dest_dir=ddir,
+                dest_relative="",  # filled in during ingest
+                description="",
+            )
+        )
+    return IntakeContext(
+        goal=goal,
+        original_goal=goal,
+        resources=entries,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Collect resource paths from UI (used before Claude-driven intake stage)
+# ---------------------------------------------------------------------------
+
+
+def collect_resource_paths_from_ui(
+    ui: TerminalUI,
+    initial_resources: list[str] | None = None,
+) -> list[ResourceEntry]:
+    """Prompt the user for resource file paths via the terminal UI.
+
+    Returns a list of :class:`ResourceEntry` objects ready for ingestion.
+    This runs *before* the Claude-driven intake stage so that resources
+    are already in the workspace when the operator executes.
+    """
+    entries: list[ResourceEntry] = []
+
+    # Seed from --resources if provided
+    if initial_resources:
+        for p in initial_resources:
+            path = Path(p).expanduser().resolve()
+            rtype, ddir = classify_resource(path)
+            entries.append(
+                ResourceEntry(
+                    source_path=str(path),
+                    resource_type=rtype,
+                    dest_dir=ddir,
+                    dest_relative="",
+                    description="",
+                )
+            )
+        ui.show_status(f"Pre-loaded {len(entries)} resource(s) from --resources.", level="info")
+
+    if ui.ask_yes_no(
+        "Do you have existing resources to include? (PDFs, code, datasets, .bib files, notes)",
+        default=bool(entries),
+    ):
+        new_entries = ui.ask_resource_paths()
+        for src_path, desc in new_entries:
+            path = Path(src_path).expanduser().resolve()
+            rtype, ddir = classify_resource(path)
+            entries.append(
+                ResourceEntry(
+                    source_path=str(path),
+                    resource_type=rtype,
+                    dest_dir=ddir,
+                    dest_relative="",
+                    description=desc,
+                )
+            )
+
+    return entries

--- a/src/manager.py
+++ b/src/manager.py
@@ -5,10 +5,20 @@ import sys
 from pathlib import Path
 from typing import TextIO
 
+from .intake import (
+    IntakeContext,
+    ResourceEntry,
+    format_intake_for_prompt,
+    format_resources_for_intake_prompt,
+    ingest_resources,
+    load_intake_context,
+    save_intake_context,
+)
 from .operator import ClaudeOperator
 from .terminal_ui import TerminalUI
 from .writing_manifest import build_writing_manifest, format_manifest_for_prompt
 from .utils import (
+    INTAKE_STAGE,
     STAGES,
     RunPaths,
     StageSpec,
@@ -55,9 +65,24 @@ class ResearchManager:
         self.ui = ui or TerminalUI(output_stream=output_stream)
         self._redo_start_stage: StageSpec | None = None
 
-    def run(self, user_goal: str, venue: str | None = None) -> bool:
-        paths = self._create_run(user_goal, venue=venue)
+    def run(
+        self,
+        user_goal: str,
+        venue: str | None = None,
+        resources: list[ResourceEntry] | None = None,
+        skip_intake: bool = False,
+    ) -> bool:
+        paths = self._create_run(user_goal, venue=venue, resources=resources)
         self.ui.show_run_started(paths.run_root.as_posix(), self.operator.model, venue or "default")
+
+        # Run Claude-driven intake stage unless skipped
+        if not skip_intake:
+            intake_approved = self._run_intake(paths)
+            if not intake_approved:
+                append_log_entry(paths.logs, "run_aborted", "Run aborted during intake.")
+                self.ui.show_status("Run aborted.", level="warn")
+                return False
+
         return self._run_from_paths(paths)
 
     def resume_run(
@@ -114,12 +139,26 @@ class ResearchManager:
         finally:
             self._redo_start_stage = previous_redo_start
 
-    def _create_run(self, user_goal: str, venue: str | None = None) -> RunPaths:
+    def _create_run(
+        self,
+        user_goal: str,
+        venue: str | None = None,
+        resources: list[ResourceEntry] | None = None,
+    ) -> RunPaths:
         run_root = create_run_root(self.runs_dir)
         paths = build_run_paths(run_root)
         ensure_run_layout(paths)
         write_text(paths.user_input, user_goal)
-        initialize_memory(paths, user_goal)
+
+        # Ingest any pre-provided resources into workspace
+        intake_summary: str | None = None
+        if resources:
+            updated = ingest_resources(resources, paths)
+            ctx = IntakeContext(goal=user_goal, original_goal=user_goal, resources=updated)
+            save_intake_context(paths, ctx)
+            intake_summary = format_intake_for_prompt(ctx)
+
+        initialize_memory(paths, user_goal, intake_summary=intake_summary)
         config = initialize_run_config(paths, model=self.operator.model, venue=venue)
         append_log_entry(paths.logs, "run_start", f"Run root: {paths.run_root}")
         append_log_entry(
@@ -147,6 +186,146 @@ class ResearchManager:
             pending.append(stage)
 
         return pending
+
+    # ------------------------------------------------------------------
+    # Intake stage (Claude-driven Socratic Q&A, runs before Stage 01)
+    # ------------------------------------------------------------------
+
+    def _run_intake(self, paths: RunPaths) -> bool:
+        """Run the Claude-driven intake stage.
+
+        Uses the same operator + approval loop pattern as ``_run_stage``
+        so that Claude generates Socratic questions and the user refines
+        via the standard suggestion / custom-feedback / approve mechanism.
+
+        On approval the intake summary is saved to ``intake_context.json``
+        and appended to run memory so all downstream stages can see it.
+        """
+        stage = INTAKE_STAGE
+
+        # Skip if intake was already approved (e.g. on resume)
+        intake_stage_file = paths.stage_file(stage)
+        if intake_stage_file.exists():
+            self.ui.show_status("Intake already approved, skipping.", level="info")
+            return True
+
+        attempt_no = 1
+        revision_feedback: str | None = None
+        continue_session = False
+        mark_stage_execution_started(paths, stage)
+
+        while True:
+            self.ui.show_stage_start(stage.stage_title, attempt_no, continue_session)
+            prompt = self._build_stage_prompt(paths, stage, revision_feedback, continue_session)
+            append_log_entry(paths.logs, f"{stage.slug} attempt {attempt_no} prompt", prompt)
+
+            result = self.operator.run_stage(stage, prompt, paths, attempt_no, continue_session=continue_session)
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} attempt {attempt_no} result",
+                (
+                    f"success: {result.success}\n"
+                    f"exit_code: {result.exit_code}\n"
+                    f"session_id: {result.session_id or '(unknown)'}\n"
+                    f"stage_file_path: {result.stage_file_path}\n\n"
+                    "stdout:\n"
+                    f"{result.stdout or '(empty)'}\n\n"
+                    "stderr:\n"
+                    f"{result.stderr or '(empty)'}"
+                ),
+            )
+
+            # If no stage file was produced, try repair (same as regular stages)
+            if not result.stage_file_path.exists():
+                self.ui.show_status(
+                    f"Stage summary draft missing for {stage.stage_title}. Running repair attempt...",
+                    level="warn",
+                )
+                repair_result = self.operator.repair_stage_summary(
+                    stage=stage, original_prompt=prompt,
+                    original_result=result, paths=paths, attempt_no=attempt_no,
+                )
+                result = repair_result
+
+            if not result.stage_file_path.exists():
+                fallback_text = "\n\n".join(
+                    part for part in [result.stdout, result.stderr] if part
+                )
+                result = self._materialize_missing_stage_draft(
+                    paths=paths, stage=stage, attempt_no=attempt_no,
+                    source="intake attempt and repair", fallback_text=fallback_text,
+                )
+
+            stage_markdown = read_text(result.stage_file_path)
+
+            # Show output and let user choose (same approval loop as _run_stage)
+            suggestions = parse_refinement_suggestions(stage_markdown)
+            self._display_stage_output(stage, stage_markdown)
+            choice = self._ask_choice(suggestions)
+            append_log_entry(paths.logs, f"{stage.slug} attempt {attempt_no} user_choice", f"choice: {choice}")
+
+            if choice in {"1", "2", "3"}:
+                selected = suggestions[int(choice) - 1]
+                revision_feedback = (
+                    "Continue the current stage conversation and improve the existing work. "
+                    "Do not discard correct completed parts. Address this refinement request:\n"
+                    f"{selected}"
+                )
+                continue_session = True
+                attempt_no += 1
+                continue
+
+            if choice == "4":
+                custom_feedback = self._read_multiline_feedback()
+                revision_feedback = (
+                    "Continue the current stage conversation and improve the existing work. "
+                    "Preserve correct completed parts unless the feedback requires changing them. "
+                    "Address this user feedback:\n"
+                    f"{custom_feedback}"
+                )
+                append_log_entry(paths.logs, f"{stage.slug} attempt {attempt_no} custom_feedback", custom_feedback)
+                continue_session = True
+                attempt_no += 1
+                continue
+
+            if choice == "5":
+                # Promote and save intake context
+                final_path = paths.stage_file(stage)
+                shutil.copyfile(result.stage_file_path, final_path)
+                append_log_entry(
+                    paths.logs,
+                    f"{stage.slug} attempt {attempt_no} promoted",
+                    f"Promoted intake summary.\ndraft: {result.stage_file_path}\nfinal: {final_path}",
+                )
+                self._save_intake_from_approved_stage(paths, stage_markdown)
+                self.ui.show_status(f"Approved {stage.stage_title}.", level="success")
+                return True
+
+            if choice == "6":
+                return False
+
+    def _save_intake_from_approved_stage(self, paths: RunPaths, stage_markdown: str) -> None:
+        """Persist the approved intake stage output into intake_context.json and memory."""
+        existing_ctx = load_intake_context(paths)
+        goal = read_text(paths.user_input).strip()
+
+        # Merge: keep any pre-ingested resources, store the stage output as notes
+        ctx = IntakeContext(
+            goal=goal,
+            original_goal=existing_ctx.original_goal if existing_ctx else goal,
+            resources=existing_ctx.resources if existing_ctx else [],
+            notes=stage_markdown,
+        )
+        save_intake_context(paths, ctx)
+
+        # Append intake summary to memory so downstream stages see it
+        intake_text = format_intake_for_prompt(ctx)
+        if intake_text:
+            append_approved_stage_summary(paths.memory, INTAKE_STAGE, stage_markdown)
+
+    # ------------------------------------------------------------------
+    # Regular stages (01–08)
+    # ------------------------------------------------------------------
 
     def _run_stage(self, paths: RunPaths, stage: StageSpec) -> bool:
         attempt_no = 1
@@ -393,6 +572,10 @@ class ResearchManager:
             if choice == "6":
                 return False
 
+    # ------------------------------------------------------------------
+    # Prompt building
+    # ------------------------------------------------------------------
+
     def _build_stage_prompt(
         self,
         paths: RunPaths,
@@ -408,6 +591,18 @@ class ResearchManager:
             + format_venue_for_prompt(paths)
             + "\n"
         )
+
+        # Append pre-loaded resource inventory for the intake stage
+        if stage.slug == "00_intake":
+            ctx = load_intake_context(paths)
+            if ctx and ctx.resources:
+                stage_template = (
+                    stage_template.rstrip()
+                    + "\n\n## Pre-Loaded Resources (already in workspace)\n\n"
+                    + format_resources_for_intake_prompt(ctx.resources)
+                    + "\n"
+                )
+
         if stage.slug == "07_writing":
             manifest = build_writing_manifest(paths)
             stage_template = (
@@ -416,14 +611,33 @@ class ResearchManager:
                 + format_manifest_for_prompt(manifest)
                 + "\n"
             )
+
         approved_memory = read_text(paths.memory)
         if self._redo_start_stage is not None and stage.number >= self._redo_start_stage.number:
             approved_memory = filtered_approved_memory(approved_memory, max_stage_number=stage.number - 1)
+
+        # Inject intake context for regular stages (01+)
+        intake_context_text: str | None = None
+        if stage.number > 0:
+            ctx = load_intake_context(paths)
+            if ctx:
+                intake_context_text = format_intake_for_prompt(ctx)
+
         if continue_session:
-            return build_continuation_prompt(stage, stage_template, paths, approved_memory, revision_feedback)
+            return build_continuation_prompt(
+                stage, stage_template, paths, approved_memory, revision_feedback,
+                intake_context_text=intake_context_text,
+            )
 
         user_request = read_text(paths.user_input)
-        return build_prompt(stage, stage_template, user_request, approved_memory, revision_feedback)
+        return build_prompt(
+            stage, stage_template, user_request, approved_memory, revision_feedback,
+            intake_context_text=intake_context_text,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
 
     def _display_stage_output(self, stage: StageSpec, markdown: str) -> None:
         self.ui.show_stage_document(stage.stage_title, markdown)

--- a/src/manager.py
+++ b/src/manager.py
@@ -13,7 +13,8 @@ from .intake import (
     format_resources_for_intake_prompt,
     ingest_resources,
     load_intake_context,
-    save_intake_context,
+    save_intake_context
+)
 from .artifact_index import format_artifact_index_for_prompt, write_artifact_index
 from .experiment_manifest import format_experiment_manifest_for_prompt, write_experiment_manifest
 from .manifest import (

--- a/src/prompts/00_intake.md
+++ b/src/prompts/00_intake.md
@@ -1,0 +1,46 @@
+# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
+
+You are executing the research intake stage for a serious research workflow. Your role is to act as a Socratic interviewer: analyze the user's research goal and any resources they have provided, then produce a clear, structured research brief that will guide all downstream stages.
+
+## Mission
+
+Given the user's research goal (and any pre-loaded resources), produce a thorough intake brief that clarifies the research direction, inventories available resources, identifies gaps, and suggests an efficient path through the pipeline.
+
+## Your Responsibilities
+
+- Carefully read and analyze the user's stated research goal.
+- If the user has pre-loaded resources (PDFs, code, datasets, .bib files, notes), examine them and summarize what each contributes.
+- Identify ambiguities, missing context, or implicit assumptions in the goal that later stages would need resolved.
+- Suggest which pipeline stages can leverage pre-existing resources and which will need to start from scratch.
+- Propose a concrete, actionable research direction based on the goal and available materials.
+- If resources are sufficient to skip or accelerate certain stages (e.g., literature already surveyed, dataset already available), note this explicitly.
+
+## Filesystem Requirements
+
+- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
+- Put intake analysis notes under `{{WORKSPACE_NOTES_DIR}}`.
+- If you catalog or index user-provided resources, put the index under `{{WORKSPACE_NOTES_DIR}}`.
+- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
+- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
+
+## Quality Bar
+
+- Be specific, not generic. Reference the user's actual goal and actual resources.
+- Ask precise clarifying questions in the Suggestions for Refinement, not vague ones.
+- Identify what the user likely needs to provide or decide before downstream stages can succeed.
+- If the user's goal is well-defined and resources are sufficient, say so clearly rather than inventing unnecessary questions.
+
+## Stage Output Requirements
+
+The markdown at `{{STAGE_OUTPUT_PATH}}` must follow the required output structure exactly.
+
+Additional expectations for this stage:
+
+- **Objective**: State that this stage clarifies the research direction and inventories available resources.
+- **What I Did**: Describe your analysis of the goal and any provided resources.
+- **Key Results**: Include:
+  - A refined, precise statement of the research direction.
+  - An inventory of user-provided resources with brief descriptions of each.
+  - An assessment of which pipeline stages (01-08) are well-supported by existing resources and which need full execution.
+  - Any critical ambiguities or decisions the user should resolve before proceeding.
+- **Suggestions for Refinement**: Frame these as Socratic questions or actionable clarifications the user might want to address. For example: clarify scope, specify target venue, confirm baseline methods, or provide additional resources.

--- a/src/terminal_ui.py
+++ b/src/terminal_ui.py
@@ -172,6 +172,75 @@ class TerminalUI:
             lines.append(line.rstrip())
         return "\n".join(lines).strip()
 
+    # ------------------------------------------------------------------
+    # Intake session helpers
+    # ------------------------------------------------------------------
+
+    def read_single_line(self, prompt: str) -> str:
+        """Read a single line of input with a styled prompt."""
+        return self._read_line(self._style(prompt, self.BOLD, self.FG_CYAN))
+
+    def ask_yes_no(self, question: str, default: bool = True) -> bool:
+        """Ask a yes/no question. Returns *default* on empty input."""
+        hint = "[Y/n]" if default else "[y/N]"
+        answer = self._read_line(
+            self._style(f"  {question} {hint} ", self.BOLD, self.FG_CYAN)
+        ).strip().lower()
+        if not answer:
+            return default
+        return answer in {"y", "yes"}
+
+    def ask_resource_paths(self) -> list[tuple[str, str]]:
+        """Collect file/directory paths and descriptions interactively.
+
+        Returns list of ``(path, description)`` tuples.
+        The user enters an empty path to stop.
+        """
+        self.panel(
+            "Add Resources",
+            [
+                "Enter file or directory paths one at a time.",
+                "For each path, you can add a short description.",
+                "Press Enter on an empty path to finish.",
+            ],
+            color=self.FG_MAGENTA,
+        )
+        entries: list[tuple[str, str]] = []
+        idx = 1
+        while True:
+            path = self._read_line(
+                self._style(f"  Path {idx} (empty to finish): ", self.BOLD, self.FG_MAGENTA)
+            ).strip()
+            if not path:
+                break
+            desc = self._read_line(
+                self._style("  Description (optional): ", self.DIM, self.FG_WHITE)
+            ).strip()
+            entries.append((path, desc))
+            idx += 1
+        return entries
+
+    def show_intake_summary(self, context: object) -> None:
+        """Display a summary panel for an IntakeContext."""
+        # Import here to avoid circular imports
+        from .intake import IntakeContext
+        assert isinstance(context, IntakeContext)
+
+        body: list[str] = [f"Goal: {context.goal}"]
+        if context.resources:
+            body.append(f"Resources: {len(context.resources)} file(s)")
+            for r in context.resources:
+                label = f"  - [{r.resource_type}] {r.source_path}"
+                if r.description:
+                    label += f" ({r.description})"
+                body.append(label)
+        if context.qa_transcript:
+            body.append("")
+            for turn in context.qa_transcript:
+                body.append(f"Q: {turn.question}")
+                body.append(f"A: {turn.answer}")
+        self.panel("Intake Summary", body, color=self.FG_GREEN)
+
     def panel(self, title: str, body: list[str] | str, color: str = "") -> None:
         lines = self._panel_lines(title, body, color=color)
         self.write("\n".join(lines) + "\n")

--- a/src/utils.py
+++ b/src/utils.py
@@ -48,6 +48,7 @@ class RunPaths:
     artifacts_dir: Path
     notes_dir: Path
     reviews_dir: Path
+    intake_context: Path
 
     def stage_file(self, stage: StageSpec) -> Path:
         return self.stages_dir / stage.filename
@@ -71,6 +72,8 @@ class OperatorResult:
     stage_file_path: Path
     session_id: str | None = None
 
+
+INTAKE_STAGE = StageSpec(0, "00_intake", "Research Intake")
 
 STAGES: list[StageSpec] = [
     StageSpec(1, "01_literature_survey", "Literature Survey"),
@@ -162,6 +165,7 @@ def build_run_paths(run_root: Path) -> RunPaths:
         artifacts_dir=workspace_root / "artifacts",
         notes_dir=workspace_root / "notes",
         reviews_dir=workspace_root / "reviews",
+        intake_context=run_root / "intake_context.json",
     )
 
 
@@ -219,8 +223,8 @@ def append_jsonl(path: Path, payload: dict[str, Any]) -> None:
     append_text(path, json.dumps(payload, ensure_ascii=True) + "\n")
 
 
-def initialize_memory(paths: RunPaths, user_goal: str) -> None:
-    write_text(paths.memory, build_memory_text(user_goal, []))
+def initialize_memory(paths: RunPaths, user_goal: str, intake_summary: str | None = None) -> None:
+    write_text(paths.memory, build_memory_text(user_goal, [], intake_summary=intake_summary))
 
 
 def initialize_run_config(paths: RunPaths, model: str, venue: str | None = None) -> dict[str, Any]:
@@ -382,6 +386,7 @@ def build_prompt(
     user_request: str,
     approved_memory: str,
     revision_feedback: str | None,
+    intake_context_text: str | None = None,
 ) -> str:
     sections = [
         "# Stage Instructions",
@@ -407,11 +412,18 @@ def build_prompt(
         ),
         "# Original User Request",
         user_request.strip(),
+    ]
+    if intake_context_text:
+        sections.extend([
+            "# Intake Context (User-Provided Resources and Clarifications)",
+            intake_context_text.strip(),
+        ])
+    sections.extend([
         "# Approved Memory",
         approved_memory.strip() or "_None yet._",
         "# Revision Feedback",
         revision_feedback.strip() if revision_feedback else "None.",
-    ]
+    ])
     return "\n\n".join(sections).strip() + "\n"
 
 
@@ -421,6 +433,7 @@ def build_continuation_prompt(
     paths: RunPaths,
     approved_memory: str,
     revision_feedback: str | None,
+    intake_context_text: str | None = None,
 ) -> str:
     current_draft = paths.stage_tmp_file(stage)
     current_final = paths.stage_file(stage)
@@ -452,13 +465,20 @@ def build_continuation_prompt(
             "8. Do not leave placeholder text such as [In progress], [Pending], [TODO], [TBD], or similar unfinished markers.\n"
             "9. If the existing stage work is partially correct, keep the correct parts and extend them rather than replacing them blindly."
         ),
+    ]
+    if intake_context_text:
+        sections.extend([
+            "# Intake Context (User-Provided Resources and Clarifications)",
+            intake_context_text.strip(),
+        ])
+    sections.extend([
         "# Approved Memory",
         approved_memory.strip() or "_None yet._",
         "# New Feedback",
         revision_feedback.strip()
         if revision_feedback
         else "Continue improving the current stage output and fix the issues from the previous attempt.",
-    ]
+    ])
     return "\n\n".join(sections).strip() + "\n"
 
 
@@ -749,17 +769,29 @@ def render_approved_stage_entry(stage: StageSpec, stage_markdown: str) -> str:
     )
 
 
-def build_memory_text(user_goal: str, approved_entries: list[str]) -> str:
+def build_memory_text(
+    user_goal: str,
+    approved_entries: list[str],
+    intake_summary: str | None = None,
+) -> str:
     approved_block = "\n\n".join(entry.strip() for entry in approved_entries if entry.strip())
     if not approved_block:
         approved_block = "_None yet._"
-    return (
-        "# Approved Run Memory\n\n"
+    parts = [
+        "# Approved Run Memory\n",
         "## Original User Goal\n"
-        f"{(user_goal or '').strip()}\n\n"
+        f"{(user_goal or '').strip()}\n",
+    ]
+    if intake_summary:
+        parts.append(
+            "## Intake Resources and Clarifications\n"
+            f"{intake_summary.strip()}\n"
+        )
+    parts.append(
         "## Approved Stage Summaries\n\n"
         f"{approved_block}\n"
     )
+    return "\n".join(parts)
 
 
 def approved_stage_entries(memory_text: str) -> list[tuple[int, str]]:

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.intake import (
+    IntakeContext,
+    QATurn,
+    ResourceEntry,
+    build_intake_from_goal,
+    build_intake_from_resources,
+    classify_resource,
+    format_intake_for_prompt,
+    ingest_resources,
+    load_intake_context,
+    save_intake_context,
+)
+from src.utils import (
+    STAGES,
+    build_prompt,
+    build_run_paths,
+    ensure_run_layout,
+    initialize_memory,
+    write_text,
+)
+
+
+class ClassifyResourceTests(unittest.TestCase):
+    def test_pdf(self) -> None:
+        rtype, ddir = classify_resource(Path("paper.pdf"))
+        self.assertEqual(rtype, "pdf")
+        self.assertEqual(ddir, "literature")
+
+    def test_bib(self) -> None:
+        rtype, ddir = classify_resource(Path("refs.bib"))
+        self.assertEqual(rtype, "bib")
+        self.assertEqual(ddir, "literature")
+
+    def test_bibtex_suffix(self) -> None:
+        rtype, ddir = classify_resource(Path("refs.bibtex"))
+        self.assertEqual(rtype, "bib")
+        self.assertEqual(ddir, "literature")
+
+    def test_python_code(self) -> None:
+        rtype, ddir = classify_resource(Path("model.py"))
+        self.assertEqual(rtype, "code")
+        self.assertEqual(ddir, "code")
+
+    def test_csv_dataset(self) -> None:
+        rtype, ddir = classify_resource(Path("data.csv"))
+        self.assertEqual(rtype, "dataset")
+        self.assertEqual(ddir, "data")
+
+    def test_markdown_notes(self) -> None:
+        rtype, ddir = classify_resource(Path("notes.md"))
+        self.assertEqual(rtype, "notes")
+        self.assertEqual(ddir, "notes")
+
+    def test_tex(self) -> None:
+        rtype, ddir = classify_resource(Path("main.tex"))
+        self.assertEqual(rtype, "tex")
+        self.assertEqual(ddir, "writing")
+
+    def test_unknown_suffix(self) -> None:
+        rtype, ddir = classify_resource(Path("mystery.xyz"))
+        self.assertEqual(rtype, "other")
+        self.assertEqual(ddir, "artifacts")
+
+    def test_directory_with_code(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name) / "repo"
+        d.mkdir()
+        (d / "train.py").write_text("pass")
+        rtype, ddir = classify_resource(d)
+        self.assertEqual(rtype, "code")
+        self.assertEqual(ddir, "code")
+
+    def test_directory_without_code(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        d = Path(tmp.name) / "stuff"
+        d.mkdir()
+        (d / "readme.txt").write_text("hi")
+        rtype, ddir = classify_resource(d)
+        self.assertEqual(rtype, "other")
+        self.assertEqual(ddir, "artifacts")
+
+
+class IngestResourcesTests(unittest.TestCase):
+    def _build_paths(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        run_root = Path(tmp_dir.name) / "run"
+        paths = build_run_paths(run_root)
+        ensure_run_layout(paths)
+        return paths, tmp_dir.name
+
+    def test_copies_file_to_workspace(self) -> None:
+        paths, base = self._build_paths()
+        src = Path(base) / "paper.pdf"
+        src.write_bytes(b"%PDF-1.4 fake")
+
+        entries = [
+            ResourceEntry(
+                source_path=str(src),
+                resource_type="pdf",
+                dest_dir="literature",
+                dest_relative="",
+                description="A test paper",
+            )
+        ]
+        updated = ingest_resources(entries, paths)
+
+        self.assertEqual(len(updated), 1)
+        self.assertEqual(updated[0].dest_relative, "literature/paper.pdf")
+        self.assertTrue((paths.literature_dir / "paper.pdf").exists())
+
+    def test_copies_directory_to_workspace(self) -> None:
+        paths, base = self._build_paths()
+        src_dir = Path(base) / "my_repo"
+        src_dir.mkdir()
+        (src_dir / "main.py").write_text("print('hi')")
+
+        entries = [
+            ResourceEntry(
+                source_path=str(src_dir),
+                resource_type="code",
+                dest_dir="code",
+                dest_relative="",
+                description="Code repo",
+            )
+        ]
+        updated = ingest_resources(entries, paths)
+
+        self.assertEqual(len(updated), 1)
+        self.assertTrue((paths.code_dir / "my_repo" / "main.py").exists())
+
+    def test_skips_missing_source(self) -> None:
+        paths, _ = self._build_paths()
+        entries = [
+            ResourceEntry(
+                source_path="/nonexistent/file.pdf",
+                resource_type="pdf",
+                dest_dir="literature",
+                dest_relative="",
+                description="missing",
+            )
+        ]
+        updated = ingest_resources(entries, paths)
+        self.assertEqual(len(updated), 0)
+
+
+class SerializationTests(unittest.TestCase):
+    def _build_paths(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        run_root = Path(tmp_dir.name) / "run"
+        paths = build_run_paths(run_root)
+        ensure_run_layout(paths)
+        return paths
+
+    def test_roundtrip(self) -> None:
+        paths = self._build_paths()
+        ctx = IntakeContext(
+            goal="Study transformers",
+            original_goal="transformers",
+            resources=[
+                ResourceEntry("a.pdf", "pdf", "literature", "literature/a.pdf", "Paper A"),
+            ],
+            qa_transcript=[
+                QATurn("What type?", "Empirical study"),
+            ],
+            notes="some notes",
+        )
+        save_intake_context(paths, ctx)
+        loaded = load_intake_context(paths)
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded.goal, "Study transformers")
+        self.assertEqual(loaded.original_goal, "transformers")
+        self.assertEqual(len(loaded.resources), 1)
+        self.assertEqual(loaded.resources[0].source_path, "a.pdf")
+        self.assertEqual(len(loaded.qa_transcript), 1)
+        self.assertEqual(loaded.qa_transcript[0].answer, "Empirical study")
+        self.assertEqual(loaded.notes, "some notes")
+
+    def test_load_missing_returns_none(self) -> None:
+        paths = self._build_paths()
+        self.assertIsNone(load_intake_context(paths))
+
+
+class FormatIntakeForPromptTests(unittest.TestCase):
+    def test_includes_resources_and_qa(self) -> None:
+        ctx = IntakeContext(
+            goal="Study X",
+            original_goal="X",
+            resources=[
+                ResourceEntry("a.pdf", "pdf", "literature", "literature/a.pdf", "Paper A"),
+            ],
+            qa_transcript=[
+                QATurn("What type?", "Survey"),
+            ],
+        )
+        text = format_intake_for_prompt(ctx)
+        self.assertIn("literature/a.pdf", text)
+        self.assertIn("Paper A", text)
+        self.assertIn("What type?", text)
+        self.assertIn("Survey", text)
+
+    def test_empty_context(self) -> None:
+        ctx = IntakeContext(goal="X", original_goal="X")
+        text = format_intake_for_prompt(ctx)
+        self.assertEqual(text, "")
+
+
+class BuildIntakeHelpersTests(unittest.TestCase):
+    def test_build_from_goal(self) -> None:
+        ctx = build_intake_from_goal("Test goal")
+        self.assertEqual(ctx.goal, "Test goal")
+        self.assertEqual(ctx.original_goal, "Test goal")
+        self.assertEqual(ctx.resources, [])
+
+    def test_build_from_resources(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        pdf = Path(tmp.name) / "test.pdf"
+        pdf.write_bytes(b"%PDF")
+        csv = Path(tmp.name) / "data.csv"
+        csv.write_text("a,b\n1,2")
+
+        ctx = build_intake_from_resources("Goal", [str(pdf), str(csv)])
+        self.assertEqual(ctx.goal, "Goal")
+        self.assertEqual(len(ctx.resources), 2)
+        types = {r.resource_type for r in ctx.resources}
+        self.assertIn("pdf", types)
+        self.assertIn("dataset", types)
+
+
+class PromptIntegrationTests(unittest.TestCase):
+    def test_prompt_includes_intake_section_when_present(self) -> None:
+        stage = STAGES[0]
+        prompt = build_prompt(
+            stage=stage,
+            stage_template="template content",
+            user_request="research goal",
+            approved_memory="",
+            revision_feedback=None,
+            intake_context_text="## Resources\n- paper.pdf",
+        )
+        self.assertIn("# Intake Context", prompt)
+        self.assertIn("paper.pdf", prompt)
+
+    def test_prompt_excludes_intake_section_when_absent(self) -> None:
+        stage = STAGES[0]
+        prompt = build_prompt(
+            stage=stage,
+            stage_template="template content",
+            user_request="research goal",
+            approved_memory="",
+            revision_feedback=None,
+        )
+        self.assertNotIn("Intake Context", prompt)
+
+
+class MemoryIntakeTests(unittest.TestCase):
+    def _build_paths(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        run_root = Path(tmp_dir.name) / "run"
+        paths = build_run_paths(run_root)
+        ensure_run_layout(paths)
+        return paths
+
+    def test_memory_includes_intake_summary(self) -> None:
+        paths = self._build_paths()
+        initialize_memory(paths, "my goal", intake_summary="Resources: paper.pdf")
+        memory = paths.memory.read_text(encoding="utf-8")
+        self.assertIn("Intake Resources", memory)
+        self.assertIn("paper.pdf", memory)
+
+    def test_memory_without_intake(self) -> None:
+        paths = self._build_paths()
+        initialize_memory(paths, "my goal")
+        memory = paths.memory.read_text(encoding="utf-8")
+        self.assertNotIn("Intake Resources", memory)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #16

- Adds a **Claude-driven Stage 00 (Research Intake)** that runs before Stage 01, using the same operator + approval loop as all other stages
- Supports user-provided resources: **PDFs, code repos, datasets, .bib files, notes** — auto-classified and copied into workspace
- Claude analyzes the goal and resources via **Socratic Q&A**, producing a research brief with stage-readiness assessment
- New CLI flags: `--resources PATH [PATH ...]` and `--skip-intake`
- Fully backward compatible: `--skip-intake` or piped stdin preserves old behavior; all 48 tests pass (23 new + 25 existing unchanged)

## What this addresses from the issue

| Issue request | Implementation |
|---|---|
| Support PDFs, code, datasets, notes, bib | `classify_resource()` handles all types, copies to correct workspace dirs |
| Skip steps if resources provided | Claude's intake output includes per-stage readiness assessment |
| Start from actual research materials | Resources are in workspace before any stage runs |
| Socratic Q&A style | Claude generates context-aware questions via `src/prompts/00_intake.md` |

## Files changed

- `src/intake.py` — **NEW**: dataclasses, resource classification/ingestion, serialization
- `src/prompts/00_intake.md` — **NEW**: Claude prompt template for Socratic intake
- `tests/test_intake.py` — **NEW**: 23 test cases
- `main.py` — `--resources`, `--skip-intake` flags
- `src/manager.py` — `_run_intake()`, intake context injection into prompts
- `src/terminal_ui.py` — `ask_yes_no()`, `ask_resource_paths()`, `show_intake_summary()`
- `src/utils.py` — `INTAKE_STAGE`, `intake_context` in `RunPaths`

## Test plan

- [x] All 48 unit tests pass (`python -m unittest discover tests/ -v`)
- [x] Integration tests: resource classification, ingestion, serialization round-trip, prompt injection
- [x] E2E: `--skip-intake` backward compatibility with fake-operator
- [x] Manual test: interactive intake with PDF resource, Claude analyzes and produces Socratic Q&A

🤖 Generated with [Claude Code](https://claude.com/claude-code)