### PR TITLE
Add paper corpus bootstrap for researcher profile extraction (fixes #21)

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,6 +73,12 @@ def parse_args() -> argparse.Namespace:
         "--rollback-stage",
         help="When resuming a run, roll back to this stage and mark downstream stages stale before continuing.",
     )
+    parser.add_argument(
+        "--paper-corpus",
+        metavar="PATH",
+        help="Path to a directory of the user's own prior papers (PDFs, LaTeX, BibTeX, notes). "
+             "AutoR will analyze them to build a researcher profile that seeds downstream stages.",
+    )
     return parser.parse_args()
 
 
@@ -194,11 +200,14 @@ def main() -> int:
     if not skip_intake and sys.stdin.isatty():
         resources = collect_resource_paths_from_ui(ui, initial_resources=args.resources)
 
+    paper_corpus = Path(args.paper_corpus).expanduser().resolve() if args.paper_corpus else None
+
     return 0 if manager.run(
         goal,
         venue=venue,
         resources=resources or None,
         skip_intake=skip_intake,
+        paper_corpus=paper_corpus,
     ) else 1
 
 

--- a/src/bootstrap.py
+++ b/src/bootstrap.py
@@ -1,0 +1,704 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .utils import RunPaths
+
+# ---------------------------------------------------------------------------
+# Suffix sets for corpus scanning
+# ---------------------------------------------------------------------------
+
+_CORPUS_SUFFIXES = {".pdf", ".tex", ".bib", ".bibtex", ".md", ".txt"}
+
+_MAX_CHARS_PER_FILE = 8000
+_MAX_FILES = 50
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BibEntry:
+    """A single parsed BibTeX entry."""
+    cite_key: str
+    entry_type: str  # article, inproceedings, book, etc.
+    title: str = ""
+    authors: str = ""
+    year: str = ""
+    venue: str = ""  # journal, booktitle, or publisher
+    doi: str = ""
+
+
+@dataclass
+class PaperMetadata:
+    """Per-paper metadata extracted before Claude analysis."""
+    source_path: str
+    file_type: str  # "pdf", "tex", "bib", "notes"
+    title: str = ""
+    abstract: str = ""
+    sections: list[str] = field(default_factory=list)  # section headings found
+    bib_entries: list[BibEntry] = field(default_factory=list)
+    extracted_text: str = ""
+    char_count: int = 0
+
+
+@dataclass
+class CorpusManifest:
+    """Summary of what was scanned and how."""
+    corpus_path: str
+    scanned_at: str
+    total_files_found: int
+    files_processed: int
+    files_skipped: int
+    skipped_reasons: list[str] = field(default_factory=list)
+    papers: list[PaperMetadata] = field(default_factory=list)
+
+    @property
+    def unique_bib_entries(self) -> list[BibEntry]:
+        """Deduplicated bibliography entries across all papers."""
+        seen: set[str] = set()
+        entries: list[BibEntry] = []
+        for paper in self.papers:
+            for bib in paper.bib_entries:
+                key = bib.cite_key.lower()
+                if key not in seen:
+                    seen.add(key)
+                    entries.append(bib)
+        return entries
+
+    @property
+    def stats(self) -> dict[str, int | str]:
+        type_counts = {}
+        for p in self.papers:
+            type_counts[p.file_type] = type_counts.get(p.file_type, 0) + 1
+        years = [e.year for p in self.papers for e in p.bib_entries if e.year.isdigit()]
+        return {
+            "total_papers": len(self.papers),
+            "by_type": type_counts,
+            "unique_references": len(self.unique_bib_entries),
+            "year_range": f"{min(years)}–{max(years)}" if years else "unknown",
+        }
+
+
+@dataclass
+class ResearchProfile:
+    themes: list[str] = field(default_factory=list)
+    terminology: list[str] = field(default_factory=list)
+    methods: list[str] = field(default_factory=list)
+    venues: list[str] = field(default_factory=list)
+    confidence: str = ""  # "high", "medium", "low" based on corpus size
+    summary: str = ""
+
+
+@dataclass
+class CitationNeighborhood:
+    frequently_cited: list[dict[str, str]] = field(default_factory=list)
+    related_authors: list[str] = field(default_factory=list)
+    key_venues: list[str] = field(default_factory=list)
+    seed_papers: list[dict[str, str]] = field(default_factory=list)  # high-priority refs for Stage 01
+
+
+@dataclass
+class StyleProfile:
+    """Structured writing style analysis (not just free text)."""
+    voice: str = ""           # "passive", "active", "mixed"
+    person: str = ""          # "first_plural", "first_singular", "impersonal"
+    formality: str = ""       # "formal", "semi-formal"
+    avg_section_count: int = 0
+    section_ordering: list[str] = field(default_factory=list)  # typical section sequence
+    abstract_pattern: str = ""  # e.g. "problem-method-result-impact"
+    notation_conventions: list[str] = field(default_factory=list)
+    paragraph_style: str = ""   # e.g. "topic-sentence-first", "long-form-argument"
+    notes: str = ""             # free-form additional observations
+
+
+@dataclass
+class BootstrapResult:
+    profile: ResearchProfile
+    citation_neighborhood: CitationNeighborhood
+    style_profile: StyleProfile
+    summary: str
+    corpus_manifest: CorpusManifest
+
+
+# ---------------------------------------------------------------------------
+# BibTeX parsing
+# ---------------------------------------------------------------------------
+
+_BIB_ENTRY_RE = re.compile(
+    r"@(\w+)\s*\{\s*([^,\s]+)\s*,(.+?)\n\s*\}",
+    re.DOTALL,
+)
+_BIB_FIELD_RE = re.compile(
+    r"(\w+)\s*=\s*[{\"](.+?)[}\"]",
+    re.DOTALL,
+)
+
+
+def parse_bibtex(text: str) -> list[BibEntry]:
+    """Parse BibTeX text into structured entries."""
+    entries: list[BibEntry] = []
+    for match in _BIB_ENTRY_RE.finditer(text):
+        entry_type = match.group(1).lower()
+        cite_key = match.group(2).strip()
+        body = match.group(3)
+
+        fields: dict[str, str] = {}
+        for fm in _BIB_FIELD_RE.finditer(body):
+            key = fm.group(1).lower().strip()
+            val = fm.group(2).strip()
+            # Clean up LaTeX artifacts
+            val = re.sub(r"[{}]", "", val).strip()
+            fields[key] = val
+
+        venue = fields.get("journal") or fields.get("booktitle") or fields.get("publisher", "")
+        entries.append(BibEntry(
+            cite_key=cite_key,
+            entry_type=entry_type,
+            title=fields.get("title", ""),
+            authors=fields.get("author", ""),
+            year=fields.get("year", ""),
+            venue=venue,
+            doi=fields.get("doi", ""),
+        ))
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# TeX section extraction
+# ---------------------------------------------------------------------------
+
+_TEX_TITLE_RE = re.compile(r"\\title\s*(?:\[.*?\])?\s*\{(.+?)\}", re.DOTALL)
+_TEX_ABSTRACT_RE = re.compile(
+    r"\\begin\{abstract\}(.+?)\\end\{abstract\}",
+    re.DOTALL,
+)
+_TEX_SECTION_RE = re.compile(r"\\(?:section|subsection)\s*\{(.+?)\}")
+_TEX_PREAMBLE_END_RE = re.compile(r"\\begin\{document\}")
+
+
+def extract_tex_metadata(text: str) -> tuple[str, str, list[str], str]:
+    """Extract title, abstract, section headings, and body from a .tex file.
+
+    Returns (title, abstract, section_headings, body_text).
+    The body_text excludes the preamble.
+    """
+    title = ""
+    title_match = _TEX_TITLE_RE.search(text)
+    if title_match:
+        title = _clean_latex(title_match.group(1))
+
+    abstract = ""
+    abstract_match = _TEX_ABSTRACT_RE.search(text)
+    if abstract_match:
+        abstract = _clean_latex(abstract_match.group(1))
+
+    sections = [_clean_latex(m.group(1)) for m in _TEX_SECTION_RE.finditer(text)]
+
+    # Strip preamble for the body text sent to Claude
+    body = text
+    preamble_end = _TEX_PREAMBLE_END_RE.search(text)
+    if preamble_end:
+        body = text[preamble_end.end():]
+
+    return title, abstract, sections, body.strip()
+
+
+def _clean_latex(text: str) -> str:
+    """Remove common LaTeX commands from extracted text."""
+    text = re.sub(r"\\[a-zA-Z]+\{([^}]*)\}", r"\1", text)
+    text = re.sub(r"[{}\\]", "", text)
+    return " ".join(text.split()).strip()
+
+
+# ---------------------------------------------------------------------------
+# Corpus scanning (enhanced)
+# ---------------------------------------------------------------------------
+
+
+def scan_corpus(corpus_path: Path) -> CorpusManifest:
+    """Scan a directory for paper-related files with structured extraction.
+
+    Returns a CorpusManifest with per-paper metadata and pre-parsed bibliography.
+    """
+    corpus_path = corpus_path.expanduser().resolve()
+    if not corpus_path.exists():
+        raise FileNotFoundError(f"Paper corpus path not found: {corpus_path}")
+    if not corpus_path.is_dir():
+        raise NotADirectoryError(f"Paper corpus path is not a directory: {corpus_path}")
+
+    all_files: list[Path] = []
+    for suffix in _CORPUS_SUFFIXES:
+        all_files.extend(corpus_path.rglob(f"*{suffix}"))
+    all_files = sorted(set(all_files))
+
+    manifest = CorpusManifest(
+        corpus_path=str(corpus_path),
+        scanned_at=datetime.now().isoformat(timespec="seconds"),
+        total_files_found=len(all_files),
+        files_processed=0,
+        files_skipped=0,
+    )
+
+    for fpath in all_files[:_MAX_FILES]:
+        paper = _process_file(fpath)
+        if paper is None:
+            manifest.files_skipped += 1
+            manifest.skipped_reasons.append(f"{fpath.name}: empty or unreadable")
+            continue
+        manifest.papers.append(paper)
+        manifest.files_processed += 1
+
+    if len(all_files) > _MAX_FILES:
+        manifest.files_skipped += len(all_files) - _MAX_FILES
+        manifest.skipped_reasons.append(
+            f"Corpus exceeds {_MAX_FILES} file limit; {len(all_files) - _MAX_FILES} file(s) skipped."
+        )
+
+    return manifest
+
+
+def _process_file(path: Path) -> PaperMetadata | None:
+    """Extract metadata and text from a single corpus file."""
+    suffix = path.suffix.lower()
+
+    if suffix == ".pdf":
+        text = _extract_pdf_text(path)
+        if not text.strip():
+            return None
+        return PaperMetadata(
+            source_path=str(path),
+            file_type="pdf",
+            extracted_text=text[:_MAX_CHARS_PER_FILE],
+            char_count=len(text),
+        )
+
+    if suffix == ".tex":
+        raw = _read_text_safe(path)
+        if not raw.strip():
+            return None
+        title, abstract, sections, body = extract_tex_metadata(raw)
+        return PaperMetadata(
+            source_path=str(path),
+            file_type="tex",
+            title=title,
+            abstract=abstract,
+            sections=sections,
+            extracted_text=body[:_MAX_CHARS_PER_FILE],
+            char_count=len(body),
+        )
+
+    if suffix in {".bib", ".bibtex"}:
+        raw = _read_text_safe(path)
+        if not raw.strip():
+            return None
+        bib_entries = parse_bibtex(raw)
+        return PaperMetadata(
+            source_path=str(path),
+            file_type="bib",
+            bib_entries=bib_entries,
+            extracted_text=raw[:_MAX_CHARS_PER_FILE],
+            char_count=len(raw),
+        )
+
+    # notes (md, txt)
+    raw = _read_text_safe(path)
+    if not raw.strip():
+        return None
+    return PaperMetadata(
+        source_path=str(path),
+        file_type="notes",
+        extracted_text=raw[:_MAX_CHARS_PER_FILE],
+        char_count=len(raw),
+    )
+
+
+def _read_text_safe(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return ""
+
+
+def _extract_pdf_text(path: Path) -> str:
+    """Extract text from a PDF using PyMuPDF (fitz). Returns empty string if unavailable."""
+    try:
+        import fitz  # PyMuPDF
+    except ImportError:
+        return f"[PDF file: {path.name} — install PyMuPDF (`pip install pymupdf`) for text extraction]"
+
+    try:
+        doc = fitz.open(str(path))
+        pages = []
+        for page in doc:
+            pages.append(page.get_text())
+        doc.close()
+        return "\n\n".join(pages)
+    except Exception as exc:
+        return f"[PDF extraction failed for {path.name}: {exc}]"
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting for Claude (structured, not raw dump)
+# ---------------------------------------------------------------------------
+
+
+def format_corpus_for_prompt(manifest: CorpusManifest) -> str:
+    """Format the scanned corpus as structured prompt sections for Claude."""
+    if not manifest.papers:
+        return "_No corpus files found._"
+
+    parts: list[str] = []
+
+    # Corpus overview
+    stats = manifest.stats
+    overview_lines = [
+        "## Corpus Overview",
+        f"- **Papers scanned:** {stats['total_papers']}",
+        f"- **File types:** {', '.join(f'{k}: {v}' for k, v in stats['by_type'].items())}",
+        f"- **Unique references (from .bib):** {stats['unique_references']}",
+        f"- **Year range:** {stats['year_range']}",
+    ]
+    parts.append("\n".join(overview_lines))
+
+    # Pre-parsed bibliography (structured, not raw text)
+    bib_entries = manifest.unique_bib_entries
+    if bib_entries:
+        bib_lines = ["## Pre-Parsed Bibliography", ""]
+        for entry in bib_entries[:80]:
+            line = f"- [{entry.cite_key}] "
+            if entry.authors:
+                line += f"{entry.authors}. "
+            if entry.title:
+                line += f'"{entry.title}" '
+            if entry.venue:
+                line += f"*{entry.venue}* "
+            if entry.year:
+                line += f"({entry.year})"
+            bib_lines.append(line.strip())
+        if len(bib_entries) > 80:
+            bib_lines.append(f"- ... and {len(bib_entries) - 80} more entries")
+        parts.append("\n".join(bib_lines))
+
+    # Per-paper content (with metadata headers, not just raw dump)
+    for i, paper in enumerate(manifest.papers, 1):
+        if paper.file_type == "bib":
+            continue  # already shown above as structured data
+        header_lines = [f"### Paper {i}: {Path(paper.source_path).name} ({paper.file_type})"]
+        if paper.title:
+            header_lines.append(f"**Title:** {paper.title}")
+        if paper.abstract:
+            header_lines.append(f"**Abstract:** {paper.abstract}")
+        if paper.sections:
+            header_lines.append(f"**Sections:** {' → '.join(paper.sections)}")
+        header = "\n".join(header_lines)
+        parts.append(f"{header}\n\n```\n{paper.extracted_text}\n```")
+
+    return "\n\n".join(parts)
+
+
+def format_corpus_stats_for_log(manifest: CorpusManifest) -> str:
+    """Format corpus scan results for log entries."""
+    lines = [
+        f"Corpus path: {manifest.corpus_path}",
+        f"Scanned at: {manifest.scanned_at}",
+        f"Total files found: {manifest.total_files_found}",
+        f"Files processed: {manifest.files_processed}",
+        f"Files skipped: {manifest.files_skipped}",
+    ]
+    if manifest.skipped_reasons:
+        lines.append("Skip reasons:")
+        lines.extend(f"  - {r}" for r in manifest.skipped_reasons)
+    lines.append("Papers:")
+    for p in manifest.papers:
+        title = f" ({p.title})" if p.title else ""
+        lines.append(f"  - {Path(p.source_path).name} [{p.file_type}]{title} ({p.char_count} chars)")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Profile artifact I/O
+# ---------------------------------------------------------------------------
+
+
+def save_bootstrap_result(paths: RunPaths, result: BootstrapResult) -> None:
+    """Write all bootstrap profile artifacts to workspace/profile/."""
+    profile_dir = paths.profile_dir
+    profile_dir.mkdir(parents=True, exist_ok=True)
+
+    # research_profile.json
+    _write_json(profile_dir / "research_profile.json", asdict(result.profile))
+
+    # citation_neighborhood.json
+    _write_json(profile_dir / "citation_neighborhood.json", asdict(result.citation_neighborhood))
+
+    # style_profile.json (structured)
+    _write_json(profile_dir / "style_profile.json", asdict(result.style_profile))
+
+    # style_notes.md (human-readable rendering of style_profile)
+    _write_style_notes_md(profile_dir / "style_notes.md", result.style_profile)
+
+    # bootstrap_summary.md
+    (profile_dir / "bootstrap_summary.md").write_text(
+        result.summary.rstrip() + "\n", encoding="utf-8",
+    )
+
+    # corpus_manifest.json (what was scanned)
+    _write_json(profile_dir / "corpus_manifest.json", asdict(result.corpus_manifest))
+
+
+def _write_style_notes_md(path: Path, style: StyleProfile) -> None:
+    """Render a StyleProfile as human-readable markdown."""
+    lines = ["# Writing Style Profile", ""]
+    if style.voice:
+        lines.append(f"- **Voice:** {style.voice}")
+    if style.person:
+        lines.append(f"- **Person:** {style.person}")
+    if style.formality:
+        lines.append(f"- **Formality:** {style.formality}")
+    if style.section_ordering:
+        lines.append(f"- **Typical section order:** {' → '.join(style.section_ordering)}")
+    if style.avg_section_count:
+        lines.append(f"- **Avg section count:** {style.avg_section_count}")
+    if style.abstract_pattern:
+        lines.append(f"- **Abstract pattern:** {style.abstract_pattern}")
+    if style.paragraph_style:
+        lines.append(f"- **Paragraph style:** {style.paragraph_style}")
+    if style.notation_conventions:
+        lines.append("- **Notation conventions:**")
+        for conv in style.notation_conventions:
+            lines.append(f"  - {conv}")
+    if style.notes:
+        lines.extend(["", "## Additional Observations", "", style.notes])
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def load_bootstrap_summary(paths: RunPaths) -> str | None:
+    summary_path = paths.profile_dir / "bootstrap_summary.md"
+    if not summary_path.exists():
+        return None
+    return summary_path.read_text(encoding="utf-8").strip()
+
+
+def load_research_profile(paths: RunPaths) -> ResearchProfile | None:
+    profile_path = paths.profile_dir / "research_profile.json"
+    if not profile_path.exists():
+        return None
+    try:
+        data = json.loads(profile_path.read_text(encoding="utf-8"))
+        return ResearchProfile(**data)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def load_citation_neighborhood(paths: RunPaths) -> CitationNeighborhood | None:
+    cn_path = paths.profile_dir / "citation_neighborhood.json"
+    if not cn_path.exists():
+        return None
+    try:
+        data = json.loads(cn_path.read_text(encoding="utf-8"))
+        return CitationNeighborhood(**data)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def load_style_profile(paths: RunPaths) -> StyleProfile | None:
+    style_path = paths.profile_dir / "style_profile.json"
+    if not style_path.exists():
+        return None
+    try:
+        data = json.loads(style_path.read_text(encoding="utf-8"))
+        return StyleProfile(**data)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def load_corpus_manifest(paths: RunPaths) -> CorpusManifest | None:
+    manifest_path = paths.profile_dir / "corpus_manifest.json"
+    if not manifest_path.exists():
+        return None
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        papers = [PaperMetadata(**p) for p in data.pop("papers", [])]
+        for p in papers:
+            p.bib_entries = [BibEntry(**b) if isinstance(b, dict) else b for b in p.bib_entries]
+        manifest = CorpusManifest(**data, papers=papers)
+        return manifest
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def bootstrap_profile_exists(paths: RunPaths) -> bool:
+    return (paths.profile_dir / "bootstrap_summary.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Stage-specific profile formatting
+# ---------------------------------------------------------------------------
+
+
+def format_profile_for_prompt(paths: RunPaths, stage_slug: str | None = None) -> str | None:
+    """Format the bootstrap profile for injection into stage prompts.
+
+    Different stages get different emphasis:
+    - Stage 01 (literature_survey): citation neighborhood + seed papers
+    - Stage 07 (writing): full style profile + writing conventions
+    - Other stages: general research profile + summary
+    """
+    if not bootstrap_profile_exists(paths):
+        return None
+
+    parts: list[str] = []
+
+    # Always include the summary
+    summary = load_bootstrap_summary(paths)
+    if summary:
+        parts.append(f"## Researcher Profile Summary\n\n{summary}")
+
+    # Always include the general profile
+    profile = load_research_profile(paths)
+    if profile:
+        lines = ["## Research Profile"]
+        if profile.themes:
+            lines.append(f"- **Themes:** {', '.join(profile.themes)}")
+        if profile.terminology:
+            lines.append(f"- **Key terminology:** {', '.join(profile.terminology)}")
+        if profile.methods:
+            lines.append(f"- **Methods:** {', '.join(profile.methods)}")
+        if profile.venues:
+            lines.append(f"- **Venues:** {', '.join(profile.venues)}")
+        if profile.confidence:
+            lines.append(f"- **Profile confidence:** {profile.confidence}")
+        parts.append("\n".join(lines))
+
+    # Stage-specific sections
+    if stage_slug == "01_literature_survey":
+        parts.extend(_format_citation_context(paths, expanded=True))
+    elif stage_slug == "07_writing":
+        parts.extend(_format_style_context(paths, expanded=True))
+        parts.extend(_format_citation_context(paths, expanded=False))
+    else:
+        parts.extend(_format_citation_context(paths, expanded=False))
+        parts.extend(_format_style_context(paths, expanded=False))
+
+    return "\n\n".join(parts) if parts else None
+
+
+def _format_citation_context(paths: RunPaths, expanded: bool) -> list[str]:
+    """Format citation neighborhood. Expanded mode shows seed papers and full details."""
+    cn = load_citation_neighborhood(paths)
+    if not cn:
+        return []
+
+    lines = ["## Citation Neighborhood"]
+    if cn.seed_papers and expanded:
+        lines.append("\n**Seed papers for literature search** (high-priority starting points):")
+        for ref in cn.seed_papers:
+            title = ref.get("title", "Unknown")
+            authors = ref.get("authors", "")
+            year = ref.get("year", "")
+            line = f"- {title}"
+            if authors:
+                line += f" — {authors}"
+            if year:
+                line += f" ({year})"
+            lines.append(line)
+
+    if cn.frequently_cited:
+        limit = 25 if expanded else 10
+        lines.append(f"\n**Frequently cited** (top {min(limit, len(cn.frequently_cited))}):")
+        for ref in cn.frequently_cited[:limit]:
+            title = ref.get("title", "Unknown")
+            authors = ref.get("authors", "")
+            year = ref.get("year", "")
+            line = f"- {title}"
+            if authors:
+                line += f" ({authors}"
+                if year:
+                    line += f", {year}"
+                line += ")"
+            elif year:
+                line += f" ({year})"
+            lines.append(line)
+
+    if cn.related_authors:
+        limit = 20 if expanded else 10
+        lines.append(f"\n**Related authors:** {', '.join(cn.related_authors[:limit])}")
+    if cn.key_venues:
+        lines.append(f"**Key venues:** {', '.join(cn.key_venues)}")
+
+    return ["\n".join(lines)]
+
+
+def _format_style_context(paths: RunPaths, expanded: bool) -> list[str]:
+    """Format writing style profile. Expanded mode includes full detail for Stage 07."""
+    style = load_style_profile(paths)
+    if not style:
+        # Fall back to reading style_notes.md directly
+        style_path = paths.profile_dir / "style_notes.md"
+        if style_path.exists():
+            text = style_path.read_text(encoding="utf-8").strip()
+            if text:
+                return [f"## Writing Style Notes\n\n{text}"]
+        return []
+
+    if not expanded:
+        # Compact: just the key facts
+        lines = ["## Writing Style (compact)"]
+        attrs = []
+        if style.voice:
+            attrs.append(f"voice: {style.voice}")
+        if style.person:
+            attrs.append(f"person: {style.person}")
+        if style.formality:
+            attrs.append(f"formality: {style.formality}")
+        if attrs:
+            lines.append(f"- {', '.join(attrs)}")
+        if style.section_ordering:
+            lines.append(f"- Typical sections: {' → '.join(style.section_ordering)}")
+        return ["\n".join(lines)]
+
+    # Expanded: full detail for writing stage
+    lines = ["## Writing Style Profile (detailed)"]
+    if style.voice:
+        lines.append(f"- **Voice:** {style.voice}")
+    if style.person:
+        lines.append(f"- **Person:** {style.person}")
+    if style.formality:
+        lines.append(f"- **Formality:** {style.formality}")
+    if style.section_ordering:
+        lines.append(f"- **Section ordering:** {' → '.join(style.section_ordering)}")
+    if style.avg_section_count:
+        lines.append(f"- **Average section count:** {style.avg_section_count}")
+    if style.abstract_pattern:
+        lines.append(f"- **Abstract pattern:** {style.abstract_pattern}")
+    if style.paragraph_style:
+        lines.append(f"- **Paragraph style:** {style.paragraph_style}")
+    if style.notation_conventions:
+        lines.append("- **Notation conventions:**")
+        for conv in style.notation_conventions:
+            lines.append(f"  - {conv}")
+    if style.notes:
+        lines.extend(["", "### Additional Style Observations", "", style.notes])
+
+    return ["\n".join(lines)]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )

--- a/src/manager.py
+++ b/src/manager.py
@@ -6,6 +6,14 @@ import sys
 from pathlib import Path
 from typing import TextIO
 
+from .bootstrap import (
+    bootstrap_profile_exists,
+    format_corpus_for_prompt,
+    format_corpus_stats_for_log,
+    format_profile_for_prompt,
+    save_bootstrap_result,
+    scan_corpus,
+)
 from .intake import (
     IntakeContext,
     ResourceEntry,
@@ -59,6 +67,7 @@ from .utils import (
     mark_stage_execution_started,
     parse_refinement_suggestions,
     read_text,
+    required_stage_output_template,
     truncate_text,
     validate_stage_artifacts,
     validate_stage_markdown,
@@ -90,6 +99,7 @@ class ResearchManager:
         venue: str | None = None,
         resources: list[ResourceEntry] | None = None,
         skip_intake: bool = False,
+        paper_corpus: Path | None = None,
     ) -> bool:
         paths = self._create_run(user_goal, venue=venue, resources=resources)
         self.ui.show_run_started(paths.run_root.as_posix(), self.operator.model, venue or "default")
@@ -99,6 +109,14 @@ class ResearchManager:
             intake_approved = self._run_intake(paths)
             if not intake_approved:
                 append_log_entry(paths.logs, "run_aborted", "Run aborted during intake.")
+                self.ui.show_status("Run aborted.", level="warn")
+                return False
+
+        # Run bootstrap from paper corpus if provided
+        if paper_corpus is not None:
+            bootstrap_approved = self._run_bootstrap(paths, paper_corpus)
+            if not bootstrap_approved:
+                append_log_entry(paths.logs, "run_aborted", "Run aborted during bootstrap.")
                 self.ui.show_status("Run aborted.", level="warn")
                 return False
 
@@ -359,6 +377,173 @@ class ResearchManager:
         intake_text = format_intake_for_prompt(ctx)
         if intake_text:
             append_approved_stage_summary(paths.memory, INTAKE_STAGE, stage_markdown)
+
+    # ------------------------------------------------------------------
+    # Bootstrap stage (paper corpus → researcher profile)
+    # ------------------------------------------------------------------
+
+    BOOTSTRAP_STAGE = StageSpec(number=-1, slug="bootstrap", display_name="Paper Corpus Bootstrap")
+
+    def _run_bootstrap(self, paths: RunPaths, corpus_path: Path) -> bool:
+        """Scan the user's paper corpus and run Claude to extract a researcher profile.
+
+        Uses the same operator + approval loop so the user can review and refine
+        the extracted profile before downstream stages use it as context.
+        """
+        stage = self.BOOTSTRAP_STAGE
+
+        if bootstrap_profile_exists(paths):
+            self.ui.show_status("Bootstrap profile already exists, skipping.", level="info")
+            return True
+
+        self.ui.show_status(f"Scanning paper corpus: {corpus_path}", level="info")
+        try:
+            corpus_manifest = scan_corpus(corpus_path)
+        except (FileNotFoundError, NotADirectoryError) as exc:
+            self.ui.show_status(f"Bootstrap error: {exc}", level="error")
+            return False
+
+        if not corpus_manifest.papers:
+            self.ui.show_status("No extractable files found in paper corpus. Skipping bootstrap.", level="warn")
+            return True
+
+        stats = corpus_manifest.stats
+        self.ui.show_status(
+            f"Found {stats['total_papers']} paper(s), {stats['unique_references']} unique references. "
+            f"Running profile extraction...",
+            level="info",
+        )
+        append_log_entry(paths.logs, "bootstrap_start", format_corpus_stats_for_log(corpus_manifest))
+
+        corpus_prompt_section = format_corpus_for_prompt(corpus_manifest)
+
+        attempt_no = 1
+        revision_feedback: str | None = None
+        continue_session = False
+
+        while True:
+            self.ui.show_stage_start(stage.stage_title, attempt_no, continue_session)
+            prompt = self._build_bootstrap_prompt(paths, stage, corpus_prompt_section, revision_feedback, continue_session)
+            append_log_entry(paths.logs, f"bootstrap attempt {attempt_no} prompt", prompt)
+
+            result = self.operator.run_stage(stage, prompt, paths, attempt_no, continue_session=continue_session)
+            append_log_entry(
+                paths.logs,
+                f"bootstrap attempt {attempt_no} result",
+                (
+                    f"success: {result.success}\n"
+                    f"session_id: {result.session_id or '(unknown)'}\n"
+                    f"stage_file_path: {result.stage_file_path}\n\n"
+                    "stdout:\n"
+                    f"{result.stdout or '(empty)'}\n\n"
+                    "stderr:\n"
+                    f"{result.stderr or '(empty)'}"
+                ),
+            )
+
+            if not result.stage_file_path.exists():
+                self.ui.show_status(
+                    "Bootstrap summary draft missing. Running repair attempt...",
+                    level="warn",
+                )
+                repair_result = self.operator.repair_stage_summary(
+                    stage=stage, original_prompt=prompt,
+                    original_result=result, paths=paths, attempt_no=attempt_no,
+                )
+                result = repair_result
+
+            if not result.stage_file_path.exists():
+                fallback_text = "\n\n".join(
+                    part for part in [result.stdout, result.stderr] if part
+                )
+                result = self._materialize_missing_stage_draft(
+                    paths=paths, stage=stage, attempt_no=attempt_no,
+                    source="bootstrap attempt and repair", fallback_text=fallback_text,
+                )
+
+            stage_markdown = read_text(result.stage_file_path)
+
+            suggestions = parse_refinement_suggestions(stage_markdown)
+            self._display_stage_output(stage, stage_markdown)
+            choice = self._ask_choice(suggestions)
+            append_log_entry(paths.logs, f"bootstrap attempt {attempt_no} user_choice", f"choice: {choice}")
+
+            if choice in {"1", "2", "3"}:
+                selected = suggestions[int(choice) - 1]
+                revision_feedback = (
+                    "Continue the bootstrap conversation and improve the researcher profile. "
+                    "Do not discard correct completed parts. Address this refinement request:\n"
+                    f"{selected}"
+                )
+                continue_session = True
+                attempt_no += 1
+                continue
+
+            if choice == "4":
+                custom_feedback = self._read_multiline_feedback()
+                revision_feedback = (
+                    "Continue the bootstrap conversation and improve the researcher profile. "
+                    "Preserve correct parts unless the feedback requires changing them. "
+                    "Address this user feedback:\n"
+                    f"{custom_feedback}"
+                )
+                append_log_entry(paths.logs, f"bootstrap attempt {attempt_no} custom_feedback", custom_feedback)
+                continue_session = True
+                attempt_no += 1
+                continue
+
+            if choice == "5":
+                # Approve: profile artifacts should already be in workspace/profile/
+                # Append bootstrap summary to memory for downstream stages
+                summary = format_profile_for_prompt(paths)
+                if summary:
+                    append_approved_stage_summary(paths.memory, stage, stage_markdown)
+                append_log_entry(paths.logs, "bootstrap_approved", "Bootstrap profile approved.")
+                self.ui.show_status("Approved bootstrap profile.", level="success")
+                return True
+
+            if choice == "6":
+                return False
+
+    def _build_bootstrap_prompt(
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        corpus_text: str,
+        revision_feedback: str | None,
+        continue_session: bool,
+    ) -> str:
+        """Build the prompt for the bootstrap stage."""
+        template = load_prompt_template(self.prompt_dir, stage)
+        stage_template = format_stage_template(template, stage, paths)
+
+        if continue_session:
+            return build_continuation_prompt(
+                stage, stage_template, paths,
+                handoff_context="",
+                revision_feedback=revision_feedback,
+            )
+
+        user_request = read_text(paths.user_input)
+        corpus_section = f"# User's Paper Corpus\n\n{corpus_text}"
+
+        sections = [
+            "# Stage Instructions",
+            stage_template.strip(),
+            "# Required Stage Summary Format",
+            (
+                "You must create or overwrite the stage summary markdown file using exactly the "
+                "top-level heading order below. Do not omit any section. Use exactly 3 numbered "
+                "refinement suggestions and exactly the fixed 6 option lines."
+            ),
+            "```md\n" + required_stage_output_template(stage).strip() + "\n```",
+            "# Original User Request",
+            user_request.strip(),
+            corpus_section,
+            "# Revision Feedback",
+            revision_feedback.strip() if revision_feedback else "None.",
+        ]
+        return "\n\n".join(sections).strip() + "\n"
 
     # ------------------------------------------------------------------
     # Regular stages (01–08)
@@ -715,6 +900,16 @@ class ResearchManager:
                 stage_template.rstrip()
                 + "\n\n## Writing Manifest\n\n"
                 + format_manifest_for_prompt(manifest)
+                + "\n"
+            )
+
+        # Inject bootstrap researcher profile if available (stage-specific)
+        profile_text = format_profile_for_prompt(paths, stage_slug=stage.slug)
+        if profile_text and stage.number >= 1:
+            stage_template = (
+                stage_template.rstrip()
+                + "\n\n# Researcher Profile (from paper corpus bootstrap)\n\n"
+                + profile_text
                 + "\n"
             )
 

--- a/src/prompts/bootstrap.md
+++ b/src/prompts/bootstrap.md
@@ -1,0 +1,105 @@
+# Bootstrap: Research Profile Extraction
+
+You are analyzing a researcher's prior paper corpus to build a structured research profile. This profile will seed all downstream stages of the AutoR research workflow with aligned context.
+
+The corpus has already been pre-processed: BibTeX entries are parsed into structured data, LaTeX files have their titles/abstracts/section headings extracted, and a corpus overview with statistics is provided. Use this structured data as ground truth — do not re-interpret raw BibTeX syntax or guess at metadata that has already been extracted.
+
+## Mission
+
+From the pre-processed corpus, produce four profile artifacts that capture the researcher's identity:
+
+1. A **research profile** (themes, terminology, methods, venues)
+2. A **citation neighborhood** (key references, related authors, seed papers for literature search)
+3. A **structured style profile** (writing conventions, section patterns, notation)
+4. A **bootstrap summary** (human-readable overview)
+
+## Your Responsibilities
+
+### 1. Research Profile → `{{WORKSPACE_PROFILE_DIR}}/research_profile.json`
+
+Analyze across all papers to identify:
+- **Themes:** Recurring research topics (be specific: "multi-agent reinforcement learning" not just "AI")
+- **Terminology:** Domain vocabulary the researcher consistently uses
+- **Methods:** Preferred experimental/analytical approaches
+- **Venues:** Publication outlets (extracted from .bib data and paper content)
+- **Confidence:** "high" if 5+ papers, "medium" if 2-4, "low" if 1
+
+```json
+{
+  "themes": ["specific theme 1", "specific theme 2"],
+  "terminology": ["term1", "term2"],
+  "methods": ["method1", "method2"],
+  "venues": ["venue1", "venue2"],
+  "confidence": "high|medium|low",
+  "summary": "One-paragraph summary grounded in actual corpus content."
+}
+```
+
+### 2. Citation Neighborhood → `{{WORKSPACE_PROFILE_DIR}}/citation_neighborhood.json`
+
+Use the pre-parsed bibliography entries to identify:
+- **frequently_cited:** Papers that appear across multiple documents (cross-reference the .bib data)
+- **related_authors:** Researchers who appear repeatedly as co-authors or cited authors
+- **key_venues:** Conferences/journals the researcher publishes in or cites frequently
+- **seed_papers:** 5-10 highest-signal references that should be the starting point for Stage 01 literature survey — these are the papers most central to the researcher's work
+
+```json
+{
+  "frequently_cited": [{"title": "...", "authors": "...", "year": "...", "venue": "..."}],
+  "related_authors": ["author1", "author2"],
+  "key_venues": ["venue1", "venue2"],
+  "seed_papers": [{"title": "...", "authors": "...", "year": "...", "why": "reason this is a key seed"}]
+}
+```
+
+### 3. Style Profile → `{{WORKSPACE_PROFILE_DIR}}/style_profile.json`
+
+Analyze the writing patterns across papers. Be concrete and evidence-based:
+
+```json
+{
+  "voice": "passive|active|mixed",
+  "person": "first_plural|first_singular|impersonal",
+  "formality": "formal|semi-formal",
+  "avg_section_count": 7,
+  "section_ordering": ["Introduction", "Related Work", "Method", "Experiments", "Results", "Discussion", "Conclusion"],
+  "abstract_pattern": "problem-method-result-impact",
+  "notation_conventions": ["boldface for vectors", "calligraphic for sets"],
+  "paragraph_style": "topic-sentence-first",
+  "notes": "Additional observations about distinctive writing patterns."
+}
+```
+
+Also write a human-readable version to `{{WORKSPACE_PROFILE_DIR}}/style_notes.md`.
+
+### 4. Bootstrap Summary → `{{WORKSPACE_PROFILE_DIR}}/bootstrap_summary.md`
+
+A concise, human-readable summary (300-500 words) covering:
+- Who this researcher is (based on evidence from the corpus)
+- Their core research direction and methodology
+- Their position in the field (based on citation patterns)
+- Confidence assessment and what additional papers would strengthen the profile
+
+## Filesystem Requirements
+
+- All profile artifacts go under `{{WORKSPACE_PROFILE_DIR}}/`.
+- The stage summary draft must be written to `{{STAGE_OUTPUT_PATH}}`.
+
+## Quality Bar
+
+- Every claim must be grounded in the actual corpus — cite which paper(s) support each theme/method/style observation.
+- Themes should be specific enough to distinguish this researcher from others in the same broad field.
+- Citation neighborhood should prioritize cross-paper references (papers cited in 2+ of the researcher's works).
+- Style analysis must be based on observed patterns, not generic academic writing norms.
+- Seed papers should be the references most likely to lead Stage 01 to relevant literature, with a "why" explaining each choice.
+- If the corpus is small, explicitly flag which extractions are low-confidence.
+
+## Stage Output Requirements
+
+The markdown at `{{STAGE_OUTPUT_PATH}}` must follow the required output structure exactly.
+
+- **Objective**: Extract a researcher profile from the user's prior paper corpus.
+- **What I Did**: For each paper, describe what was analyzed and what was extracted. Reference pre-parsed metadata.
+- **Key Results**: Summarize the profile with evidence. Include corpus statistics and confidence assessment.
+- **Files Produced**: List all profile artifacts with their paths.
+- **Suggestions for Refinement**: Offer specific improvements — e.g., "Theme X was only found in one paper — confirm if this is a research direction or a one-off", "Add papers from 2023-2024 to strengthen the temporal coverage".

--- a/src/utils.py
+++ b/src/utils.py
@@ -52,6 +52,7 @@ class RunPaths:
     artifacts_dir: Path
     notes_dir: Path
     reviews_dir: Path
+    profile_dir: Path
     intake_context: Path
 
     def stage_file(self, stage: StageSpec) -> Path:
@@ -176,6 +177,7 @@ def build_run_paths(run_root: Path) -> RunPaths:
         artifacts_dir=workspace_root / "artifacts",
         notes_dir=workspace_root / "notes",
         reviews_dir=workspace_root / "reviews",
+        profile_dir=workspace_root / "profile",
         intake_context=run_root / "intake_context.json",
     )
 
@@ -207,6 +209,7 @@ def workspace_dirs(paths: RunPaths) -> list[Path]:
         paths.artifacts_dir,
         paths.notes_dir,
         paths.reviews_dir,
+        paths.profile_dir,
     ]
 
 
@@ -361,6 +364,7 @@ def format_stage_template(template: str, stage: StageSpec, paths: RunPaths) -> s
         "{{WORKSPACE_ARTIFACTS_DIR}}": str(paths.artifacts_dir.resolve()),
         "{{WORKSPACE_NOTES_DIR}}": str(paths.notes_dir.resolve()),
         "{{WORKSPACE_REVIEWS_DIR}}": str(paths.reviews_dir.resolve()),
+        "{{WORKSPACE_PROFILE_DIR}}": str(paths.profile_dir.resolve()),
         "{{SELECTED_VENUE}}": selected_venue_key(paths),
     }
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.bootstrap import (
+    BibEntry,
+    BootstrapResult,
+    CitationNeighborhood,
+    CorpusManifest,
+    PaperMetadata,
+    ResearchProfile,
+    StyleProfile,
+    bootstrap_profile_exists,
+    extract_tex_metadata,
+    format_corpus_for_prompt,
+    format_profile_for_prompt,
+    load_bootstrap_summary,
+    load_citation_neighborhood,
+    load_corpus_manifest,
+    load_research_profile,
+    load_style_profile,
+    parse_bibtex,
+    save_bootstrap_result,
+    scan_corpus,
+)
+from src.utils import build_run_paths, ensure_run_layout
+
+
+def _make_run(tmp: Path) -> "src.utils.RunPaths":
+    from src.utils import build_run_paths, ensure_run_layout
+    run_root = tmp / "test_run"
+    paths = build_run_paths(run_root)
+    ensure_run_layout(paths)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# BibTeX parsing
+# ---------------------------------------------------------------------------
+
+
+class ParseBibtexTests(unittest.TestCase):
+    def test_parse_single_entry(self) -> None:
+        bib = """@article{vaswani2017attention,
+  title={Attention Is All You Need},
+  author={Vaswani, Ashish and Shazeer, Noam},
+  journal={NeurIPS},
+  year={2017}
+}"""
+        entries = parse_bibtex(bib)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].cite_key, "vaswani2017attention")
+        self.assertEqual(entries[0].entry_type, "article")
+        self.assertIn("Attention", entries[0].title)
+        self.assertIn("Vaswani", entries[0].authors)
+        self.assertEqual(entries[0].year, "2017")
+        self.assertEqual(entries[0].venue, "NeurIPS")
+
+    def test_parse_inproceedings(self) -> None:
+        bib = """@inproceedings{brown2020gpt3,
+  title={Language Models are Few-Shot Learners},
+  author={Brown, Tom and Mann, Benjamin},
+  booktitle={NeurIPS},
+  year={2020}
+}"""
+        entries = parse_bibtex(bib)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].venue, "NeurIPS")
+
+    def test_parse_multiple_entries(self) -> None:
+        bib = """@article{a, title={Paper A}, author={Alice}, year={2020}, journal={ICML}
+}
+@article{b, title={Paper B}, author={Bob}, year={2021}, journal={NeurIPS}
+}"""
+        entries = parse_bibtex(bib)
+        self.assertEqual(len(entries), 2)
+
+    def test_parse_empty_returns_empty(self) -> None:
+        self.assertEqual(parse_bibtex(""), [])
+        self.assertEqual(parse_bibtex("no bibtex here"), [])
+
+    def test_parse_with_doi(self) -> None:
+        bib = """@article{foo,
+  title={Foo},
+  author={Bar},
+  doi={10.1234/foo},
+  year={2022},
+  journal={Nature}
+}"""
+        entries = parse_bibtex(bib)
+        self.assertEqual(entries[0].doi, "10.1234/foo")
+
+
+# ---------------------------------------------------------------------------
+# TeX extraction
+# ---------------------------------------------------------------------------
+
+
+class ExtractTexMetadataTests(unittest.TestCase):
+    def test_extract_title_and_abstract(self) -> None:
+        tex = r"""
+\documentclass{article}
+\title{My Great Paper}
+\begin{document}
+\begin{abstract}
+This paper does great things.
+\end{abstract}
+\section{Introduction}
+Hello world.
+\section{Method}
+We do stuff.
+\end{document}
+"""
+        title, abstract, sections, body = extract_tex_metadata(tex)
+        self.assertEqual(title, "My Great Paper")
+        self.assertIn("great things", abstract)
+        self.assertEqual(sections, ["Introduction", "Method"])
+        self.assertNotIn("documentclass", body)
+
+    def test_no_abstract(self) -> None:
+        tex = r"\title{Simple}\begin{document}\section{Intro}Content\end{document}"
+        title, abstract, sections, body = extract_tex_metadata(tex)
+        self.assertEqual(title, "Simple")
+        self.assertEqual(abstract, "")
+
+    def test_empty_tex(self) -> None:
+        title, abstract, sections, body = extract_tex_metadata("")
+        self.assertEqual(title, "")
+        self.assertEqual(abstract, "")
+        self.assertEqual(sections, [])
+
+
+# ---------------------------------------------------------------------------
+# Corpus scanning
+# ---------------------------------------------------------------------------
+
+
+class ScanCorpusTests(unittest.TestCase):
+    def test_scan_empty_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = scan_corpus(Path(tmp))
+            self.assertEqual(len(manifest.papers), 0)
+            self.assertEqual(manifest.files_processed, 0)
+
+    def test_scan_with_tex_and_bib(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "paper.tex").write_text(
+                r"\title{Test}\begin{document}\section{Intro}Hello\end{document}",
+                encoding="utf-8",
+            )
+            (tmp_path / "refs.bib").write_text(
+                '@article{foo, title={Foo}, author={Alice}, year={2020}, journal={ICML}\n}',
+                encoding="utf-8",
+            )
+            manifest = scan_corpus(tmp_path)
+            types = {p.file_type for p in manifest.papers}
+            self.assertIn("tex", types)
+            self.assertIn("bib", types)
+            # .tex paper should have extracted title
+            tex_paper = next(p for p in manifest.papers if p.file_type == "tex")
+            self.assertEqual(tex_paper.title, "Test")
+
+    def test_scan_bib_has_parsed_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "refs.bib").write_text(
+                '@article{a, title={Paper A}, author={Alice}, year={2020}, journal={ICML}\n}\n'
+                '@article{b, title={Paper B}, author={Bob}, year={2021}, journal={NeurIPS}\n}',
+                encoding="utf-8",
+            )
+            manifest = scan_corpus(tmp_path)
+            bib_paper = manifest.papers[0]
+            self.assertEqual(len(bib_paper.bib_entries), 2)
+            self.assertEqual(manifest.stats["unique_references"], 2)
+
+    def test_scan_nonexistent_dir_raises(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            scan_corpus(Path("/nonexistent/path"))
+
+    def test_scan_file_instead_of_dir_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Path(tmp) / "file.txt"
+            f.write_text("hello", encoding="utf-8")
+            with self.assertRaises(NotADirectoryError):
+                scan_corpus(f)
+
+    def test_scan_nested_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sub = Path(tmp) / "subdir"
+            sub.mkdir()
+            (sub / "paper.tex").write_text(
+                r"\begin{document}Content\end{document}", encoding="utf-8",
+            )
+            manifest = scan_corpus(Path(tmp))
+            self.assertEqual(len(manifest.papers), 1)
+
+    def test_manifest_stats(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "a.tex").write_text(r"\begin{document}A\end{document}", encoding="utf-8")
+            (tmp_path / "b.md").write_text("# Notes", encoding="utf-8")
+            manifest = scan_corpus(tmp_path)
+            stats = manifest.stats
+            self.assertEqual(stats["total_papers"], 2)
+            self.assertIn("tex", stats["by_type"])
+            self.assertIn("notes", stats["by_type"])
+
+
+# ---------------------------------------------------------------------------
+# Corpus prompt formatting
+# ---------------------------------------------------------------------------
+
+
+class FormatCorpusTests(unittest.TestCase):
+    def test_empty_manifest(self) -> None:
+        manifest = CorpusManifest(
+            corpus_path="/tmp", scanned_at="now",
+            total_files_found=0, files_processed=0, files_skipped=0,
+        )
+        result = format_corpus_for_prompt(manifest)
+        self.assertIn("No corpus files", result)
+
+    def test_format_includes_overview(self) -> None:
+        manifest = CorpusManifest(
+            corpus_path="/tmp", scanned_at="now",
+            total_files_found=2, files_processed=2, files_skipped=0,
+            papers=[
+                PaperMetadata(
+                    source_path="/tmp/a.tex", file_type="tex",
+                    title="Paper A", abstract="Abstract A",
+                    sections=["Intro", "Method"], extracted_text="body", char_count=100,
+                ),
+                PaperMetadata(
+                    source_path="/tmp/refs.bib", file_type="bib",
+                    bib_entries=[BibEntry(cite_key="x", entry_type="article", title="X", authors="Y", year="2020", venue="ICML")],
+                    extracted_text="@article{...}", char_count=50,
+                ),
+            ],
+        )
+        result = format_corpus_for_prompt(manifest)
+        self.assertIn("Corpus Overview", result)
+        self.assertIn("Paper A", result)
+        self.assertIn("Pre-Parsed Bibliography", result)
+
+    def test_bib_entries_shown_structured(self) -> None:
+        manifest = CorpusManifest(
+            corpus_path="/tmp", scanned_at="now",
+            total_files_found=1, files_processed=1, files_skipped=0,
+            papers=[
+                PaperMetadata(
+                    source_path="/tmp/refs.bib", file_type="bib",
+                    bib_entries=[BibEntry(cite_key="key1", entry_type="article", title="Title One", authors="Author A", year="2021", venue="NeurIPS")],
+                    extracted_text="raw", char_count=10,
+                ),
+            ],
+        )
+        result = format_corpus_for_prompt(manifest)
+        self.assertIn("[key1]", result)
+        self.assertIn("Title One", result)
+        self.assertIn("Author A", result)
+
+
+# ---------------------------------------------------------------------------
+# Save / Load profile
+# ---------------------------------------------------------------------------
+
+
+class SaveLoadProfileTests(unittest.TestCase):
+    def _sample_result(self) -> BootstrapResult:
+        return BootstrapResult(
+            profile=ResearchProfile(
+                themes=["NLP", "reasoning"],
+                terminology=["chain-of-thought", "in-context learning"],
+                methods=["fine-tuning", "prompting"],
+                venues=["NeurIPS", "ACL"],
+                confidence="high",
+                summary="Researcher focused on NLP reasoning.",
+            ),
+            citation_neighborhood=CitationNeighborhood(
+                frequently_cited=[{"title": "Attention Is All You Need", "authors": "Vaswani et al.", "year": "2017"}],
+                related_authors=["Wei et al.", "Brown et al."],
+                key_venues=["NeurIPS", "ICML"],
+                seed_papers=[{"title": "Chain-of-Thought Prompting", "authors": "Wei et al.", "year": "2022", "why": "foundational to their method"}],
+            ),
+            style_profile=StyleProfile(
+                voice="passive",
+                person="first_plural",
+                formality="formal",
+                avg_section_count=7,
+                section_ordering=["Introduction", "Related Work", "Method", "Experiments", "Conclusion"],
+                abstract_pattern="problem-method-result",
+                notation_conventions=["boldface for vectors"],
+                paragraph_style="topic-sentence-first",
+                notes="Uses formal academic tone throughout.",
+            ),
+            summary="NLP researcher focused on reasoning with LLMs.",
+            corpus_manifest=CorpusManifest(
+                corpus_path="/tmp/papers", scanned_at="2026-04-04T10:00:00",
+                total_files_found=5, files_processed=5, files_skipped=0,
+            ),
+        )
+
+    def test_save_and_load_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _make_run(Path(tmp))
+            save_bootstrap_result(paths, self._sample_result())
+
+            self.assertTrue((paths.profile_dir / "research_profile.json").exists())
+            self.assertTrue((paths.profile_dir / "citation_neighborhood.json").exists())
+            self.assertTrue((paths.profile_dir / "style_profile.json").exists())
+            self.assertTrue((paths.profile_dir / "style_notes.md").exists())
+            self.assertTrue((paths.profile_dir / "bootstrap_summary.md").exists())
+            self.assertTrue((paths.profile_dir / "corpus_manifest.json").exists())
+
+            profile = load_research_profile(paths)
+            self.assertIn("NLP", profile.themes)
+            self.assertEqual(profile.confidence, "high")
+
+            cn = load_citation_neighborhood(paths)
+            self.assertEqual(len(cn.seed_papers), 1)
+
+            style = load_style_profile(paths)
+            self.assertEqual(style.voice, "passive")
+            self.assertEqual(style.person, "first_plural")
+
+            summary = load_bootstrap_summary(paths)
+            self.assertIn("NLP", summary)
+
+            cm = load_corpus_manifest(paths)
+            self.assertEqual(cm.files_processed, 5)
+
+    def test_bootstrap_profile_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _make_run(Path(tmp))
+            self.assertFalse(bootstrap_profile_exists(paths))
+            save_bootstrap_result(paths, self._sample_result())
+            self.assertTrue(bootstrap_profile_exists(paths))
+
+    def test_load_missing_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _make_run(Path(tmp))
+            self.assertIsNone(load_research_profile(paths))
+            self.assertIsNone(load_citation_neighborhood(paths))
+            self.assertIsNone(load_style_profile(paths))
+            self.assertIsNone(load_bootstrap_summary(paths))
+            self.assertIsNone(load_corpus_manifest(paths))
+
+
+# ---------------------------------------------------------------------------
+# Stage-specific prompt formatting
+# ---------------------------------------------------------------------------
+
+
+class FormatProfileForPromptTests(unittest.TestCase):
+    def _setup(self, tmp: Path) -> "src.utils.RunPaths":
+        paths = _make_run(tmp)
+        save_bootstrap_result(paths, SaveLoadProfileTests._sample_result(self))
+        return paths
+
+    def test_no_profile_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _make_run(Path(tmp))
+            self.assertIsNone(format_profile_for_prompt(paths))
+
+    def test_default_includes_all_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._setup(Path(tmp))
+            text = format_profile_for_prompt(paths)
+            self.assertIn("Researcher Profile Summary", text)
+            self.assertIn("Research Profile", text)
+
+    def test_stage01_gets_expanded_citations(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._setup(Path(tmp))
+            text = format_profile_for_prompt(paths, stage_slug="01_literature_survey")
+            self.assertIn("Seed papers for literature search", text)
+            self.assertIn("Chain-of-Thought Prompting", text)
+
+    def test_stage07_gets_expanded_style(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._setup(Path(tmp))
+            text = format_profile_for_prompt(paths, stage_slug="07_writing")
+            self.assertIn("Writing Style Profile (detailed)", text)
+            self.assertIn("passive", text)
+            self.assertIn("first_plural", text)
+            self.assertIn("topic-sentence-first", text)
+
+    def test_other_stage_gets_compact_style(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._setup(Path(tmp))
+            text = format_profile_for_prompt(paths, stage_slug="03_study_design")
+            self.assertIn("Writing Style (compact)", text)
+            self.assertNotIn("Writing Style Profile (detailed)", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Closes #21

- Adds `--paper-corpus /path/to/papers` CLI flag that scans a researcher's prior publications before Stage 01
- Extracts structured metadata: BibTeX parsing (cite_key, title, authors, year, venue, doi), LaTeX section extraction (title, abstract, section headings), corpus statistics
- Generates inspectable profile artifacts under `workspace/profile/`:
  - `research_profile.json` — themes, terminology, methods, venues, confidence level
  - `citation_neighborhood.json` — frequently cited papers, related authors, seed papers for Stage 01
  - `style_profile.json` + `style_notes.md` — voice, person, formality, section ordering, notation conventions
  - `bootstrap_summary.md` — human-readable researcher profile summary
  - `corpus_manifest.json` — what was scanned, file counts, skip reasons
- Stage-specific context injection: Stage 01 gets expanded citation seeds, Stage 07 gets full style profile, other stages get compact profile
- Human-in-the-loop approval via existing operator + approval loop
- Fully opt-in: no `--paper-corpus` flag means zero behavior change

### Files changed
- `src/bootstrap.py` — **NEW**: corpus scanning, BibTeX/TeX parsing, profile data model, serialization, stage-specific prompt formatting
- `src/prompts/bootstrap.md` — **NEW**: Claude prompt template for profile extraction
- `tests/test_bootstrap.py` — **NEW**: 26 test cases
- `main.py` — `--paper-corpus` CLI argument
- `src/manager.py` — `_run_bootstrap()`, `_build_bootstrap_prompt()`, profile injection into stage prompts
- `src/utils.py` — `profile_dir` in RunPaths

## Test plan
- [x] 26 new unit tests pass (`python -m pytest tests/test_bootstrap.py -v`)
- [x] BibTeX parsing: single/multiple entries, inproceedings, DOI extraction, empty input
- [x] TeX extraction: title, abstract, section headings, preamble stripping
- [x] Corpus scanning: empty dir, nested dirs, mixed file types, error handling
- [x] Profile save/load round-trip for all artifact types
- [x] Stage-specific prompt formatting (Stage 01 citations, Stage 07 style, compact for others)
- [x] No regression in existing tests (intake, artifact index, foundry)
- [ ] E2E: `--paper-corpus` with real PDF corpus + fake operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)