### PR TITLE
Add project repo bootstrap to infer current state (fixes #22)

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,6 +73,12 @@ def parse_args() -> argparse.Namespace:
         "--rollback-stage",
         help="When resuming a run, roll back to this stage and mark downstream stages stale before continuing.",
     )
+    parser.add_argument(
+        "--project-root",
+        metavar="PATH",
+        help="Path to an existing project repository. AutoR will scan it to infer "
+             "current project state and recommend a re-entry stage.",
+    )
     return parser.parse_args()
 
 
@@ -194,11 +200,14 @@ def main() -> int:
     if not skip_intake and sys.stdin.isatty():
         resources = collect_resource_paths_from_ui(ui, initial_resources=args.resources)
 
+    project_root_arg = Path(args.project_root).expanduser().resolve() if args.project_root else None
+
     return 0 if manager.run(
         goal,
         venue=venue,
         resources=resources or None,
         skip_intake=skip_intake,
+        project_root=project_root_arg,
     ) else 1
 
 

--- a/src/manager.py
+++ b/src/manager.py
@@ -6,6 +6,14 @@ import sys
 from pathlib import Path
 from typing import TextIO
 
+from .project_bootstrap import (
+    format_project_context_for_prompt,
+    format_project_scan_for_prompt,
+    format_scan_stats_for_log,
+    project_bootstrap_exists,
+    save_project_bootstrap,
+    scan_project,
+)
 from .intake import (
     IntakeContext,
     ResourceEntry,
@@ -59,6 +67,7 @@ from .utils import (
     mark_stage_execution_started,
     parse_refinement_suggestions,
     read_text,
+    required_stage_output_template,
     truncate_text,
     validate_stage_artifacts,
     validate_stage_markdown,
@@ -90,6 +99,7 @@ class ResearchManager:
         venue: str | None = None,
         resources: list[ResourceEntry] | None = None,
         skip_intake: bool = False,
+        project_root: Path | None = None,
     ) -> bool:
         paths = self._create_run(user_goal, venue=venue, resources=resources)
         self.ui.show_run_started(paths.run_root.as_posix(), self.operator.model, venue or "default")
@@ -102,7 +112,17 @@ class ResearchManager:
                 self.ui.show_status("Run aborted.", level="warn")
                 return False
 
-        return self._run_from_paths(paths)
+        # Run project repo bootstrap if provided
+        bootstrap_start_stage: StageSpec | None = None
+        if project_root is not None:
+            bootstrap_result = self._run_project_bootstrap(paths, project_root)
+            if bootstrap_result is None:
+                append_log_entry(paths.logs, "run_aborted", "Run aborted during project bootstrap.")
+                self.ui.show_status("Run aborted.", level="warn")
+                return False
+            bootstrap_start_stage = bootstrap_result
+
+        return self._run_from_paths(paths, start_stage=bootstrap_start_stage)
 
     def resume_run(
         self,
@@ -359,6 +379,195 @@ class ResearchManager:
         intake_text = format_intake_for_prompt(ctx)
         if intake_text:
             append_approved_stage_summary(paths.memory, INTAKE_STAGE, stage_markdown)
+
+    # ------------------------------------------------------------------
+    # Project repo bootstrap (scan existing repo → infer stage)
+    # ------------------------------------------------------------------
+
+    PROJECT_BOOTSTRAP_STAGE = StageSpec(number=-1, slug="project_bootstrap", display_name="Project Repo Bootstrap")
+
+    def _run_project_bootstrap(self, paths: RunPaths, project_root: Path) -> StageSpec | None:
+        """Scan an existing project repo and run Claude to infer project state.
+
+        Returns the recommended start StageSpec, or None if the user aborts.
+        """
+        stage = self.PROJECT_BOOTSTRAP_STAGE
+
+        if project_bootstrap_exists(paths):
+            self.ui.show_status("Project bootstrap already exists, skipping scan.", level="info")
+            from .project_bootstrap import load_recommended_entry_stage
+            entry = load_recommended_entry_stage(paths)
+            if entry is not None:
+                for s in STAGES:
+                    if s.number == entry:
+                        return s
+            return None
+
+        self.ui.show_status(f"Scanning project repo: {project_root}", level="info")
+        try:
+            scan_result = scan_project(project_root)
+        except (FileNotFoundError, NotADirectoryError) as exc:
+            self.ui.show_status(f"Project bootstrap error: {exc}", level="error")
+            return None
+
+        self.ui.show_status(
+            f"Scanned {scan_result.total_files} files. "
+            f"Code: {scan_result.code_state.status}, "
+            f"Experiments: {scan_result.experiment_state.status}, "
+            f"Writing: {scan_result.writing_state.status}. "
+            f"Heuristic entry: Stage {scan_result.recommended_entry_stage:02d}.",
+            level="info",
+        )
+        append_log_entry(paths.logs, "project_bootstrap_start", format_scan_stats_for_log(scan_result))
+
+        # Save heuristic results so Claude can read them
+        save_project_bootstrap(paths, scan_result)
+
+        scan_prompt_section = format_project_scan_for_prompt(scan_result)
+
+        attempt_no = 1
+        revision_feedback: str | None = None
+        continue_session = False
+
+        while True:
+            self.ui.show_stage_start(stage.stage_title, attempt_no, continue_session)
+            prompt = self._build_project_bootstrap_prompt(
+                paths, stage, scan_prompt_section, project_root, revision_feedback, continue_session,
+            )
+            append_log_entry(paths.logs, f"project_bootstrap attempt {attempt_no} prompt", prompt)
+
+            result = self.operator.run_stage(stage, prompt, paths, attempt_no, continue_session=continue_session)
+            append_log_entry(
+                paths.logs,
+                f"project_bootstrap attempt {attempt_no} result",
+                (
+                    f"success: {result.success}\n"
+                    f"session_id: {result.session_id or '(unknown)'}\n"
+                    f"stage_file_path: {result.stage_file_path}\n\n"
+                    "stdout:\n"
+                    f"{result.stdout or '(empty)'}\n\n"
+                    "stderr:\n"
+                    f"{result.stderr or '(empty)'}"
+                ),
+            )
+
+            if not result.stage_file_path.exists():
+                self.ui.show_status(
+                    "Project bootstrap draft missing. Running repair attempt...",
+                    level="warn",
+                )
+                repair_result = self.operator.repair_stage_summary(
+                    stage=stage, original_prompt=prompt,
+                    original_result=result, paths=paths, attempt_no=attempt_no,
+                )
+                result = repair_result
+
+            if not result.stage_file_path.exists():
+                fallback_text = "\n\n".join(
+                    part for part in [result.stdout, result.stderr] if part
+                )
+                result = self._materialize_missing_stage_draft(
+                    paths=paths, stage=stage, attempt_no=attempt_no,
+                    source="project bootstrap attempt and repair", fallback_text=fallback_text,
+                )
+
+            stage_markdown = read_text(result.stage_file_path)
+            suggestions = parse_refinement_suggestions(stage_markdown)
+            self._display_stage_output(stage, stage_markdown)
+            choice = self._ask_choice(suggestions)
+            append_log_entry(paths.logs, f"project_bootstrap attempt {attempt_no} user_choice", f"choice: {choice}")
+
+            if choice in {"1", "2", "3"}:
+                selected = suggestions[int(choice) - 1]
+                revision_feedback = (
+                    "Continue the project bootstrap conversation and improve the stage assessments. "
+                    "Do not discard correct parts. Address this refinement request:\n"
+                    f"{selected}"
+                )
+                continue_session = True
+                attempt_no += 1
+                continue
+
+            if choice == "4":
+                custom_feedback = self._read_multiline_feedback()
+                revision_feedback = (
+                    "Continue the project bootstrap conversation and improve the stage assessments. "
+                    "Preserve correct parts unless the feedback requires changing them. "
+                    "Address this user feedback:\n"
+                    f"{custom_feedback}"
+                )
+                append_log_entry(paths.logs, f"project_bootstrap attempt {attempt_no} custom_feedback", custom_feedback)
+                continue_session = True
+                attempt_no += 1
+                continue
+
+            if choice == "5":
+                # Append bootstrap summary to memory
+                bootstrap_context = format_project_context_for_prompt(paths)
+                if bootstrap_context:
+                    append_approved_stage_summary(paths.memory, stage, stage_markdown)
+                append_log_entry(paths.logs, "project_bootstrap_approved", "Project bootstrap approved.")
+                self.ui.show_status("Approved project bootstrap.", level="success")
+
+                # Determine start stage from Claude's corrected assessments
+                from .project_bootstrap import load_recommended_entry_stage
+                entry = load_recommended_entry_stage(paths)
+                entry_stage_num = entry if entry is not None else scan_result.recommended_entry_stage
+                for s in STAGES:
+                    if s.number == entry_stage_num:
+                        self.ui.show_status(
+                            f"Starting from {s.stage_title} based on project bootstrap.",
+                            level="info",
+                        )
+                        return s
+                return STAGES[0]
+
+            if choice == "6":
+                return None
+
+    def _build_project_bootstrap_prompt(
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        scan_text: str,
+        project_root: Path,
+        revision_feedback: str | None,
+        continue_session: bool,
+    ) -> str:
+        template = load_prompt_template(self.prompt_dir, stage)
+        stage_template = format_stage_template(template, stage, paths)
+
+        if continue_session:
+            return build_continuation_prompt(
+                stage, stage_template, paths,
+                handoff_context="",
+                revision_feedback=revision_feedback,
+            )
+
+        user_request = read_text(paths.user_input)
+        project_section = (
+            f"# Existing Project Repository\n\n"
+            f"**Project root:** `{project_root}`\n\n"
+            f"{scan_text}"
+        )
+
+        sections = [
+            "# Stage Instructions",
+            stage_template.strip(),
+            "# Required Stage Summary Format",
+            (
+                "You must create or overwrite the stage summary markdown file using exactly the "
+                "top-level heading order below. Do not omit any section. Use exactly 3 numbered "
+                "refinement suggestions and exactly the fixed 6 option lines."
+            ),
+            "```md\n" + required_stage_output_template(stage).strip() + "\n```",
+            "# Original User Request",
+            user_request.strip(),
+            project_section,
+            "# Revision Feedback",
+            revision_feedback.strip() if revision_feedback else "None.",
+        ]
+        return "\n\n".join(sections).strip() + "\n"
 
     # ------------------------------------------------------------------
     # Regular stages (01–08)
@@ -715,6 +924,16 @@ class ResearchManager:
                 stage_template.rstrip()
                 + "\n\n## Writing Manifest\n\n"
                 + format_manifest_for_prompt(manifest)
+                + "\n"
+            )
+
+        # Inject project bootstrap context if available
+        project_context = format_project_context_for_prompt(paths)
+        if project_context and stage.number >= 1:
+            stage_template = (
+                stage_template.rstrip()
+                + "\n\n# Existing Project Context (from repo bootstrap)\n\n"
+                + project_context
                 + "\n"
             )
 

--- a/src/project_bootstrap.py
+++ b/src/project_bootstrap.py
@@ -1,0 +1,817 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .utils import RunPaths
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MAX_SCAN_FILES = 500
+_MAX_SCAN_DEPTH = 6
+_MAX_TEXT_PER_FILE = 4000
+
+# File classification sets
+_CODE_SUFFIXES = {".py", ".ipynb", ".r", ".jl", ".sh", ".js", ".ts", ".cpp", ".c", ".h", ".java", ".go", ".rs"}
+_CONFIG_SUFFIXES = {".yaml", ".yml", ".json", ".toml", ".cfg", ".ini"}
+_DATA_SUFFIXES = {".csv", ".tsv", ".parquet", ".jsonl", ".npz", ".npy", ".h5", ".hdf5", ".pkl", ".pickle"}
+_RESULT_SUFFIXES = {".csv", ".tsv", ".json", ".jsonl", ".npz", ".npy", ".pkl", ".log", ".txt"}
+_FIGURE_SUFFIXES = {".png", ".pdf", ".svg", ".jpg", ".jpeg", ".eps"}
+_TEX_SUFFIXES = {".tex", ".bib", ".bibtex", ".bbl", ".sty", ".cls"}
+_CHECKPOINT_SUFFIXES = {".pt", ".pth", ".ckpt", ".safetensors", ".bin", ".h5"}
+_LOG_SUFFIXES = {".log", ".txt", ".out", ".err"}
+
+# Directories to skip
+_SKIP_DIRS = {
+    ".git", "__pycache__", "node_modules", ".tox", ".mypy_cache",
+    ".pytest_cache", ".venv", "venv", "env", ".env", ".eggs",
+    "dist", "build", "egg-info", ".idea", ".vscode",
+}
+
+# Heuristic directory names for each category
+_CODE_DIRS = {"src", "lib", "models", "model", "modules", "core", "utils", "scripts"}
+_EXPERIMENT_DIRS = {"experiments", "exp", "configs", "config", "runs", "outputs", "output", "logs", "wandb", "mlruns", "tensorboard"}
+_RESULT_DIRS = {"results", "output", "outputs", "eval", "evaluation", "metrics", "benchmarks"}
+_FIGURE_DIRS = {"figures", "figs", "plots", "images", "imgs", "visualizations"}
+_WRITING_DIRS = {"paper", "papers", "draft", "drafts", "writing", "manuscript", "latex", "tex", "doc", "docs"}
+_DATA_DIRS = {"data", "datasets", "dataset", "raw", "processed", "cache"}
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FileEntry:
+    """A single file found during repo scanning."""
+    relative_path: str
+    category: str  # "code", "config", "data", "result", "figure", "writing", "checkpoint", "log", "other"
+    size_bytes: int
+    suffix: str
+
+
+@dataclass
+class CodeState:
+    """Summary of the code found in the repo."""
+    languages: list[str] = field(default_factory=list)
+    frameworks: list[str] = field(default_factory=list)
+    entry_points: list[str] = field(default_factory=list)
+    module_dirs: list[str] = field(default_factory=list)
+    dependency_files: list[str] = field(default_factory=list)
+    test_files: list[str] = field(default_factory=list)
+    total_code_files: int = 0
+    status: str = "not_started"  # "not_started", "partial", "complete"
+    evidence: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ExperimentState:
+    """Summary of experiments found in the repo."""
+    config_files: list[str] = field(default_factory=list)
+    result_files: list[str] = field(default_factory=list)
+    checkpoint_files: list[str] = field(default_factory=list)
+    log_files: list[str] = field(default_factory=list)
+    figure_files: list[str] = field(default_factory=list)
+    total_experiments_configured: int = 0
+    total_experiments_with_results: int = 0
+    status: str = "not_started"
+    evidence: list[str] = field(default_factory=list)
+
+
+@dataclass
+class WritingState:
+    """Summary of writing artifacts found in the repo."""
+    tex_files: list[str] = field(default_factory=list)
+    bib_files: list[str] = field(default_factory=list)
+    draft_pdfs: list[str] = field(default_factory=list)
+    sections_found: list[str] = field(default_factory=list)
+    total_tex_chars: int = 0
+    has_abstract: bool = False
+    has_introduction: bool = False
+    has_related_work: bool = False
+    has_method: bool = False
+    has_experiments: bool = False
+    has_conclusion: bool = False
+    status: str = "not_started"
+    evidence: list[str] = field(default_factory=list)
+
+
+@dataclass
+class StageAssessment:
+    """Per-stage assessment of completion."""
+    stage_number: int
+    stage_name: str
+    status: str  # "not_started", "partial", "complete"
+    confidence: str  # "high", "medium", "low"
+    evidence: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ProjectBootstrapResult:
+    """Complete result of scanning a project repo."""
+    project_root: str
+    scanned_at: str
+    total_files: int
+    code_state: CodeState
+    experiment_state: ExperimentState
+    writing_state: WritingState
+    stage_assessments: list[StageAssessment]
+    recommended_entry_stage: int  # stage number to start from
+    summary: str = ""
+    file_tree_sample: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Repo scanning
+# ---------------------------------------------------------------------------
+
+
+def scan_project(project_root: Path) -> ProjectBootstrapResult:
+    """Scan a project repository and classify its contents."""
+    project_root = project_root.expanduser().resolve()
+    if not project_root.exists():
+        raise FileNotFoundError(f"Project root not found: {project_root}")
+    if not project_root.is_dir():
+        raise NotADirectoryError(f"Project root is not a directory: {project_root}")
+
+    files = _collect_files(project_root)
+    file_tree_sample = _build_tree_sample(files, limit=80)
+
+    code_state = _analyze_code(files, project_root)
+    experiment_state = _analyze_experiments(files, project_root)
+    writing_state = _analyze_writing(files, project_root)
+
+    stage_assessments = _assess_stages(code_state, experiment_state, writing_state)
+    entry_stage = _recommend_entry_stage(stage_assessments)
+
+    return ProjectBootstrapResult(
+        project_root=str(project_root),
+        scanned_at=datetime.now().isoformat(timespec="seconds"),
+        total_files=len(files),
+        code_state=code_state,
+        experiment_state=experiment_state,
+        writing_state=writing_state,
+        stage_assessments=stage_assessments,
+        recommended_entry_stage=entry_stage,
+        file_tree_sample=file_tree_sample,
+    )
+
+
+def _collect_files(root: Path) -> list[FileEntry]:
+    """Walk the repo and classify each file."""
+    entries: list[FileEntry] = []
+    count = 0
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Skip hidden/build directories
+        dirnames[:] = [
+            d for d in dirnames
+            if d not in _SKIP_DIRS and not d.startswith(".")
+        ]
+
+        depth = Path(dirpath).relative_to(root).parts
+        if len(depth) > _MAX_SCAN_DEPTH:
+            dirnames.clear()
+            continue
+
+        for fname in filenames:
+            if fname.startswith("."):
+                continue
+            fpath = Path(dirpath) / fname
+            try:
+                size = fpath.stat().st_size
+            except OSError:
+                continue
+
+            rel = str(fpath.relative_to(root))
+            suffix = fpath.suffix.lower()
+            category = _classify_file(rel, suffix)
+            entries.append(FileEntry(
+                relative_path=rel,
+                category=category,
+                size_bytes=size,
+                suffix=suffix,
+            ))
+
+            count += 1
+            if count >= _MAX_SCAN_FILES:
+                return entries
+
+    return entries
+
+
+def _classify_file(relative_path: str, suffix: str) -> str:
+    """Classify a file by its suffix and path context."""
+    parts = Path(relative_path).parts
+    parent_dirs = {p.lower() for p in parts[:-1]}
+
+    # Checkpoints first (they overlap with data suffixes)
+    if suffix in _CHECKPOINT_SUFFIXES:
+        return "checkpoint"
+
+    # Writing context
+    if suffix in _TEX_SUFFIXES or parent_dirs & _WRITING_DIRS:
+        if suffix in {".tex", ".bib", ".bibtex", ".bbl", ".sty", ".cls"}:
+            return "writing"
+
+    # Figures
+    if suffix in _FIGURE_SUFFIXES and parent_dirs & _FIGURE_DIRS:
+        return "figure"
+
+    # Results (check dir context to distinguish from general data)
+    if suffix in _RESULT_SUFFIXES and parent_dirs & _RESULT_DIRS:
+        return "result"
+
+    # Code
+    if suffix in _CODE_SUFFIXES:
+        return "code"
+
+    # Config
+    if suffix in _CONFIG_SUFFIXES:
+        if parent_dirs & _EXPERIMENT_DIRS:
+            return "config"
+        return "config"
+
+    # Data
+    if suffix in _DATA_SUFFIXES:
+        return "data"
+
+    # Figures by suffix alone
+    if suffix in _FIGURE_SUFFIXES:
+        return "figure"
+
+    # Log files
+    if suffix in _LOG_SUFFIXES and parent_dirs & _EXPERIMENT_DIRS:
+        return "log"
+
+    return "other"
+
+
+def _build_tree_sample(files: list[FileEntry], limit: int = 80) -> list[str]:
+    """Build a directory-tree-like sample for prompt context."""
+    paths = sorted(f.relative_path for f in files)
+    return paths[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Code analysis
+# ---------------------------------------------------------------------------
+
+_FRAMEWORK_PATTERNS = {
+    "pytorch": re.compile(r"import torch|from torch"),
+    "tensorflow": re.compile(r"import tensorflow|from tensorflow"),
+    "jax": re.compile(r"import jax|from jax"),
+    "sklearn": re.compile(r"from sklearn|import sklearn"),
+    "huggingface": re.compile(r"from transformers|import transformers"),
+    "lightning": re.compile(r"import lightning|from lightning|import pytorch_lightning"),
+}
+
+_ENTRY_POINT_NAMES = {"main.py", "train.py", "run.py", "run_experiment.py", "evaluate.py", "eval.py", "inference.py"}
+_DEPENDENCY_FILES = {"requirements.txt", "setup.py", "pyproject.toml", "environment.yml", "Pipfile", "setup.cfg"}
+
+
+def _analyze_code(files: list[FileEntry], root: Path) -> CodeState:
+    code_files = [f for f in files if f.category == "code"]
+    if not code_files:
+        return CodeState(status="not_started", evidence=["No code files found"])
+
+    state = CodeState(total_code_files=len(code_files))
+
+    # Languages
+    lang_map = {".py": "Python", ".r": "R", ".jl": "Julia", ".cpp": "C++",
+                ".c": "C", ".java": "Java", ".go": "Go", ".rs": "Rust",
+                ".js": "JavaScript", ".ts": "TypeScript"}
+    seen_langs = set()
+    for f in code_files:
+        lang = lang_map.get(f.suffix)
+        if lang:
+            seen_langs.add(lang)
+    state.languages = sorted(seen_langs)
+
+    # Entry points
+    for f in code_files:
+        fname = Path(f.relative_path).name
+        if fname in _ENTRY_POINT_NAMES:
+            state.entry_points.append(f.relative_path)
+
+    # Dependencies
+    for f in files:
+        fname = Path(f.relative_path).name
+        if fname in _DEPENDENCY_FILES:
+            state.dependency_files.append(f.relative_path)
+
+    # Test files
+    for f in code_files:
+        name = Path(f.relative_path).name
+        if name.startswith("test_") or name.endswith("_test.py") or "tests/" in f.relative_path:
+            state.test_files.append(f.relative_path)
+
+    # Module directories
+    for f in code_files:
+        parts = Path(f.relative_path).parts
+        if len(parts) > 1:
+            top_dir = parts[0].lower()
+            if top_dir in _CODE_DIRS:
+                if parts[0] not in state.module_dirs:
+                    state.module_dirs.append(parts[0])
+
+    # Framework detection (sample first few .py files)
+    py_files = [f for f in code_files if f.suffix == ".py"]
+    for f in py_files[:20]:
+        try:
+            text = (root / f.relative_path).read_text(encoding="utf-8", errors="replace")[:2000]
+        except Exception:
+            continue
+        for framework, pattern in _FRAMEWORK_PATTERNS.items():
+            if pattern.search(text) and framework not in state.frameworks:
+                state.frameworks.append(framework)
+
+    # Status assessment
+    evidence = []
+    if state.total_code_files > 0:
+        evidence.append(f"{state.total_code_files} code files found")
+    if state.entry_points:
+        evidence.append(f"Entry points: {', '.join(state.entry_points)}")
+    if state.frameworks:
+        evidence.append(f"Frameworks: {', '.join(state.frameworks)}")
+    if state.dependency_files:
+        evidence.append(f"Dependencies declared: {', '.join(state.dependency_files)}")
+    if state.test_files:
+        evidence.append(f"{len(state.test_files)} test file(s)")
+
+    state.evidence = evidence
+
+    if state.entry_points and state.total_code_files >= 3 and state.dependency_files:
+        state.status = "complete"
+    elif state.total_code_files >= 2:
+        state.status = "partial"
+    else:
+        state.status = "not_started"
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Experiment analysis
+# ---------------------------------------------------------------------------
+
+
+def _analyze_experiments(files: list[FileEntry], root: Path) -> ExperimentState:
+    state = ExperimentState()
+
+    for f in files:
+        if f.category == "config" and _is_experiment_config(f):
+            state.config_files.append(f.relative_path)
+        elif f.category == "result":
+            state.result_files.append(f.relative_path)
+        elif f.category == "checkpoint":
+            state.checkpoint_files.append(f.relative_path)
+        elif f.category == "log":
+            state.log_files.append(f.relative_path)
+        elif f.category == "figure":
+            state.figure_files.append(f.relative_path)
+
+    state.total_experiments_configured = len(state.config_files)
+    state.total_experiments_with_results = len(state.result_files)
+
+    evidence = []
+    if state.config_files:
+        evidence.append(f"{len(state.config_files)} experiment config(s)")
+    if state.result_files:
+        evidence.append(f"{len(state.result_files)} result file(s)")
+    if state.checkpoint_files:
+        evidence.append(f"{len(state.checkpoint_files)} checkpoint(s)")
+    if state.log_files:
+        evidence.append(f"{len(state.log_files)} log file(s)")
+    if state.figure_files:
+        evidence.append(f"{len(state.figure_files)} figure(s)")
+    if not evidence:
+        evidence.append("No experiment artifacts found")
+
+    state.evidence = evidence
+
+    has_configs = bool(state.config_files)
+    has_results = bool(state.result_files) or bool(state.checkpoint_files)
+    has_figures = bool(state.figure_files)
+
+    if has_results and has_figures:
+        state.status = "complete"
+    elif has_results or has_configs:
+        state.status = "partial"
+    else:
+        state.status = "not_started"
+
+    return state
+
+
+def _is_experiment_config(f: FileEntry) -> bool:
+    """Heuristic: is this config file likely an experiment config?"""
+    parts = {p.lower() for p in Path(f.relative_path).parts}
+    return bool(parts & _EXPERIMENT_DIRS) or any(
+        kw in f.relative_path.lower()
+        for kw in ("experiment", "config", "hparam", "sweep")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Writing analysis
+# ---------------------------------------------------------------------------
+
+_TEX_SECTION_RE = re.compile(r"\\section\s*\{(.+?)\}")
+_TEX_ABSTRACT_RE = re.compile(r"\\begin\{abstract\}", re.IGNORECASE)
+
+_SECTION_MAP = {
+    "abstract": "has_abstract",
+    "introduction": "has_introduction",
+    "related work": "has_related_work",
+    "background": "has_related_work",
+    "method": "has_method",
+    "methodology": "has_method",
+    "approach": "has_method",
+    "model": "has_method",
+    "experiment": "has_experiments",
+    "evaluation": "has_experiments",
+    "result": "has_experiments",
+    "conclusion": "has_conclusion",
+    "discussion": "has_conclusion",
+}
+
+
+def _analyze_writing(files: list[FileEntry], root: Path) -> WritingState:
+    state = WritingState()
+
+    for f in files:
+        if f.category != "writing":
+            continue
+        if f.suffix in {".tex"}:
+            state.tex_files.append(f.relative_path)
+        elif f.suffix in {".bib", ".bibtex"}:
+            state.bib_files.append(f.relative_path)
+
+    # Check for draft PDFs in writing directories
+    for f in files:
+        if f.suffix == ".pdf":
+            parts = {p.lower() for p in Path(f.relative_path).parts}
+            if parts & _WRITING_DIRS or "draft" in f.relative_path.lower():
+                state.draft_pdfs.append(f.relative_path)
+
+    # Analyze .tex content
+    for tex_path in state.tex_files:
+        try:
+            text = (root / tex_path).read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            continue
+        state.total_tex_chars += len(text)
+
+        if _TEX_ABSTRACT_RE.search(text):
+            state.has_abstract = True
+
+        for match in _TEX_SECTION_RE.finditer(text):
+            section_name = match.group(1).strip()
+            state.sections_found.append(section_name)
+            section_lower = section_name.lower()
+            for keyword, attr in _SECTION_MAP.items():
+                if keyword in section_lower:
+                    setattr(state, attr, True)
+
+    evidence = []
+    if state.tex_files:
+        evidence.append(f"{len(state.tex_files)} .tex file(s), {state.total_tex_chars} chars total")
+    if state.bib_files:
+        evidence.append(f"{len(state.bib_files)} .bib file(s)")
+    if state.draft_pdfs:
+        evidence.append(f"{len(state.draft_pdfs)} draft PDF(s)")
+    if state.sections_found:
+        evidence.append(f"Sections: {', '.join(state.sections_found)}")
+    section_flags = []
+    for attr_name in ["has_abstract", "has_introduction", "has_related_work",
+                       "has_method", "has_experiments", "has_conclusion"]:
+        if getattr(state, attr_name):
+            section_flags.append(attr_name.replace("has_", ""))
+    if section_flags:
+        evidence.append(f"Sections with content: {', '.join(section_flags)}")
+    if not evidence:
+        evidence.append("No writing artifacts found")
+
+    state.evidence = evidence
+
+    if state.tex_files and state.total_tex_chars > 5000 and state.has_abstract and state.has_conclusion:
+        state.status = "complete"
+    elif state.tex_files and state.total_tex_chars > 1000:
+        state.status = "partial"
+    elif state.tex_files:
+        state.status = "partial"
+    else:
+        state.status = "not_started"
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Stage assessment
+# ---------------------------------------------------------------------------
+
+
+def _assess_stages(
+    code: CodeState,
+    experiments: ExperimentState,
+    writing: WritingState,
+) -> list[StageAssessment]:
+    """Map code/experiment/writing state to per-stage assessments."""
+    assessments = []
+
+    # Stage 01: Literature Survey — check for .bib files with substantial references
+    has_bib = bool(writing.bib_files)
+    has_related_work = writing.has_related_work
+    if has_bib and has_related_work:
+        s01 = StageAssessment(1, "Literature Survey", "complete", "medium",
+                              [f"Has .bib files: {', '.join(writing.bib_files)}",
+                               "Related work section found in .tex"])
+    elif has_bib:
+        s01 = StageAssessment(1, "Literature Survey", "partial", "low",
+                              [f"Has .bib files but no related work section in .tex"])
+    else:
+        s01 = StageAssessment(1, "Literature Survey", "not_started", "high",
+                              ["No .bib files or literature review found"])
+    assessments.append(s01)
+
+    # Stage 02: Hypothesis Generation — hard to infer, mark based on downstream evidence
+    if code.status in ("partial", "complete"):
+        s02 = StageAssessment(2, "Hypothesis Generation", "complete", "low",
+                              ["Inferred from downstream implementation work"])
+    else:
+        s02 = StageAssessment(2, "Hypothesis Generation", "not_started", "low",
+                              ["Cannot reliably infer hypothesis stage from repo artifacts"])
+    assessments.append(s02)
+
+    # Stage 03: Study Design — check for experiment configs
+    if experiments.config_files:
+        s03 = StageAssessment(3, "Study Design", "complete", "medium",
+                              [f"{len(experiments.config_files)} experiment config(s) found"] + experiments.config_files[:5])
+    elif code.status in ("partial", "complete"):
+        s03 = StageAssessment(3, "Study Design", "partial", "low",
+                              ["Code exists but no explicit experiment configs"])
+    else:
+        s03 = StageAssessment(3, "Study Design", "not_started", "medium",
+                              ["No experiment configurations found"])
+    assessments.append(s03)
+
+    # Stage 04: Implementation
+    s04 = StageAssessment(4, "Implementation", code.status,
+                          "high" if code.total_code_files > 10 else "medium",
+                          code.evidence)
+    assessments.append(s04)
+
+    # Stage 05: Experimentation
+    if experiments.result_files or experiments.checkpoint_files or experiments.log_files:
+        status = "complete" if experiments.result_files else "partial"
+        conf = "high" if experiments.result_files else "medium"
+        s05 = StageAssessment(5, "Experimentation", status, conf, experiments.evidence)
+    elif experiments.config_files:
+        s05 = StageAssessment(5, "Experimentation", "partial", "low",
+                              ["Configs exist but no results/logs found"])
+    else:
+        s05 = StageAssessment(5, "Experimentation", "not_started", "medium",
+                              ["No experiment artifacts found"])
+    assessments.append(s05)
+
+    # Stage 06: Analysis
+    has_analysis_figures = bool(experiments.figure_files)
+    has_results = bool(experiments.result_files)
+    if has_analysis_figures and has_results:
+        s06 = StageAssessment(6, "Analysis", "complete", "medium",
+                              [f"{len(experiments.figure_files)} figures",
+                               f"{len(experiments.result_files)} result files"])
+    elif has_analysis_figures or has_results:
+        s06 = StageAssessment(6, "Analysis", "partial", "low",
+                              experiments.evidence)
+    else:
+        s06 = StageAssessment(6, "Analysis", "not_started", "medium",
+                              ["No analysis artifacts found"])
+    assessments.append(s06)
+
+    # Stage 07: Writing
+    s07 = StageAssessment(7, "Writing", writing.status,
+                          "high" if writing.total_tex_chars > 10000 else "medium",
+                          writing.evidence)
+    assessments.append(s07)
+
+    # Stage 08: Dissemination
+    if writing.draft_pdfs and writing.status == "complete":
+        s08 = StageAssessment(8, "Dissemination", "partial", "low",
+                              ["Draft PDF exists; submission status unknown"])
+    else:
+        s08 = StageAssessment(8, "Dissemination", "not_started", "medium",
+                              ["No dissemination artifacts found"])
+    assessments.append(s08)
+
+    return assessments
+
+
+def _recommend_entry_stage(assessments: list[StageAssessment]) -> int:
+    """Find the best re-entry stage based on assessments.
+
+    If later stages are complete, don't recommend going back to an earlier
+    incomplete stage unless it has high confidence. The entry point is the
+    first stage that is not complete AND has no complete stages after it,
+    OR the first "partial"/"not_started" stage after the last complete one.
+    """
+    # Find the last complete stage
+    last_complete = 0
+    for a in assessments:
+        if a.status == "complete":
+            last_complete = a.stage_number
+
+    # Entry point: first non-complete stage at or after the last complete stage
+    for a in assessments:
+        if a.stage_number <= last_complete:
+            continue
+        if a.status != "complete":
+            return a.stage_number
+
+    # All complete — start at the last stage
+    if assessments:
+        return assessments[-1].stage_number
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Save / load artifacts
+# ---------------------------------------------------------------------------
+
+
+def save_project_bootstrap(paths: RunPaths, result: ProjectBootstrapResult) -> None:
+    """Write all bootstrap artifacts to workspace/bootstrap/."""
+    bdir = paths.bootstrap_dir
+    bdir.mkdir(parents=True, exist_ok=True)
+
+    _write_json(bdir / "project_state.json", asdict(result.code_state))
+    _write_json(bdir / "experiment_inventory.json", asdict(result.experiment_state))
+    _write_json(bdir / "writing_state.json", asdict(result.writing_state))
+    _write_json(bdir / "stage_assessments.json", [asdict(a) for a in result.stage_assessments])
+    _write_json(bdir / "scan_metadata.json", {
+        "project_root": result.project_root,
+        "scanned_at": result.scanned_at,
+        "total_files": result.total_files,
+        "recommended_entry_stage": result.recommended_entry_stage,
+    })
+
+    summary_text = result.summary or _generate_summary_text(result)
+    (bdir / "bootstrap_summary.md").write_text(summary_text.rstrip() + "\n", encoding="utf-8")
+
+
+def load_project_bootstrap_summary(paths: RunPaths) -> str | None:
+    summary_path = paths.bootstrap_dir / "bootstrap_summary.md"
+    if not summary_path.exists():
+        return None
+    return summary_path.read_text(encoding="utf-8").strip()
+
+
+def load_stage_assessments(paths: RunPaths) -> list[StageAssessment] | None:
+    sa_path = paths.bootstrap_dir / "stage_assessments.json"
+    if not sa_path.exists():
+        return None
+    try:
+        data = json.loads(sa_path.read_text(encoding="utf-8"))
+        return [StageAssessment(**a) for a in data]
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def load_recommended_entry_stage(paths: RunPaths) -> int | None:
+    meta_path = paths.bootstrap_dir / "scan_metadata.json"
+    if not meta_path.exists():
+        return None
+    try:
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+        return data.get("recommended_entry_stage")
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def project_bootstrap_exists(paths: RunPaths) -> bool:
+    return (paths.bootstrap_dir / "bootstrap_summary.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting
+# ---------------------------------------------------------------------------
+
+
+def format_project_scan_for_prompt(result: ProjectBootstrapResult) -> str:
+    """Format the scan results for Claude's bootstrap analysis prompt."""
+    parts: list[str] = []
+
+    # File tree sample
+    parts.append("## Repository File Tree (sample)")
+    parts.append("```")
+    parts.extend(result.file_tree_sample)
+    parts.append("```")
+
+    # Code state
+    parts.append("\n## Code Analysis")
+    for e in result.code_state.evidence:
+        parts.append(f"- {e}")
+
+    # Experiment state
+    parts.append("\n## Experiment Analysis")
+    for e in result.experiment_state.evidence:
+        parts.append(f"- {e}")
+
+    # Writing state
+    parts.append("\n## Writing Analysis")
+    for e in result.writing_state.evidence:
+        parts.append(f"- {e}")
+
+    # Stage assessments (heuristic, for Claude to review)
+    parts.append("\n## Heuristic Stage Assessments (for your review)")
+    parts.append("These are automated heuristic assessments. Review them against the actual repo content and adjust.")
+    for a in result.stage_assessments:
+        parts.append(f"\n### Stage {a.stage_number:02d}: {a.stage_name}")
+        parts.append(f"- **Status:** {a.status} (confidence: {a.confidence})")
+        for e in a.evidence:
+            parts.append(f"- {e}")
+
+    parts.append(f"\n**Heuristic recommended entry stage:** Stage {result.recommended_entry_stage:02d}")
+
+    return "\n".join(parts)
+
+
+def format_project_context_for_prompt(paths: RunPaths) -> str | None:
+    """Format the project bootstrap context for injection into stage prompts."""
+    if not project_bootstrap_exists(paths):
+        return None
+
+    parts: list[str] = []
+
+    summary = load_project_bootstrap_summary(paths)
+    if summary:
+        parts.append(f"## Project Bootstrap Summary\n\n{summary}")
+
+    assessments = load_stage_assessments(paths)
+    if assessments:
+        lines = ["## Project Stage Assessments"]
+        for a in assessments:
+            lines.append(f"- **Stage {a.stage_number:02d} ({a.stage_name}):** "
+                        f"{a.status} (confidence: {a.confidence})")
+        parts.append("\n".join(lines))
+
+    return "\n\n".join(parts) if parts else None
+
+
+def format_scan_stats_for_log(result: ProjectBootstrapResult) -> str:
+    """Format scan results for log entries."""
+    lines = [
+        f"Project root: {result.project_root}",
+        f"Scanned at: {result.scanned_at}",
+        f"Total files: {result.total_files}",
+        f"Code: {result.code_state.status} ({result.code_state.total_code_files} files)",
+        f"Experiments: {result.experiment_state.status}",
+        f"Writing: {result.writing_state.status}",
+        f"Recommended entry stage: {result.recommended_entry_stage}",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_summary_text(result: ProjectBootstrapResult) -> str:
+    """Generate a default summary from scan results (used if Claude hasn't written one yet)."""
+    lines = [
+        "# Project Bootstrap Summary",
+        "",
+        f"**Scanned:** {result.project_root}",
+        f"**Total files:** {result.total_files}",
+        "",
+        "## Stage Status",
+        "",
+    ]
+    for a in result.stage_assessments:
+        icon = {"complete": "[x]", "partial": "[-]", "not_started": "[ ]"}.get(a.status, "[ ]")
+        lines.append(f"- {icon} Stage {a.stage_number:02d}: {a.stage_name} — {a.status} ({a.confidence} confidence)")
+        for e in a.evidence:
+            lines.append(f"  - {e}")
+    lines.extend([
+        "",
+        f"**Recommended entry point:** Stage {result.recommended_entry_stage:02d}",
+    ])
+    return "\n".join(lines)
+
+
+def _write_json(path: Path, data: dict | list) -> None:
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )

--- a/src/prompts/project_bootstrap.md
+++ b/src/prompts/project_bootstrap.md
@@ -1,0 +1,94 @@
+# Bootstrap: Project State Inference
+
+You are analyzing an existing project repository to infer the current research state and determine the best re-entry point for the AutoR pipeline.
+
+The repository has already been scanned: files are classified, code/experiment/writing states are assessed with heuristic rules, and a preliminary stage assessment is provided. Your job is to **review, correct, and enrich** these heuristic assessments using the actual file content and your understanding of research workflows.
+
+## Mission
+
+From the pre-scanned repository data, produce four bootstrap artifacts that map the existing project onto AutoR's 8-stage research pipeline:
+
+1. A **project state summary** with corrected stage assessments
+2. An **experiment inventory** of what has been run and what remains
+3. A **writing state assessment** of the current manuscript progress
+4. A **recommended re-entry stage** with justification
+
+## Your Responsibilities
+
+### 1. Review and Correct Stage Assessments
+
+The heuristic scanner provides automated assessments. You should:
+- Read key files (entry points, configs, .tex files) to verify the heuristics
+- Upgrade or downgrade stage statuses based on actual content
+- Add evidence you find that the scanner missed
+- Pay attention to README, notes, and documentation that describe project status
+
+Write corrected assessments to `{{WORKSPACE_BOOTSTRAP_DIR}}/stage_assessments.json`:
+```json
+[
+  {
+    "stage_number": 1,
+    "stage_name": "Literature Survey",
+    "status": "complete|partial|not_started",
+    "confidence": "high|medium|low",
+    "evidence": ["specific evidence from repo"]
+  }
+]
+```
+
+### 2. Experiment Inventory → `{{WORKSPACE_BOOTSTRAP_DIR}}/experiment_inventory.json`
+
+If experiments exist, catalog them:
+```json
+{
+  "config_files": ["path/to/config1.yaml"],
+  "result_files": ["results/exp1.json"],
+  "checkpoint_files": ["checkpoints/best.pt"],
+  "log_files": ["logs/train.log"],
+  "figure_files": ["figures/accuracy.png"],
+  "total_experiments_configured": 5,
+  "total_experiments_with_results": 3,
+  "status": "partial",
+  "evidence": ["5 configs found, 3 with matching result files", "2 experiments appear incomplete"]
+}
+```
+
+### 3. Writing State → `{{WORKSPACE_BOOTSTRAP_DIR}}/writing_state.json`
+
+If .tex files exist, assess manuscript completeness:
+- Which sections have substantive content vs. placeholders?
+- How complete is each section (rough percentage)?
+- Are figures referenced in the text?
+
+### 4. Bootstrap Summary → `{{WORKSPACE_BOOTSTRAP_DIR}}/bootstrap_summary.md`
+
+A human-readable summary (300-500 words) covering:
+- What this project is about (inferred from code, README, paper)
+- Current state of implementation, experiments, and writing
+- What's done, what's in progress, what's missing
+- Recommended re-entry stage with justification
+- Risks or gaps (e.g., "data loading code exists but no dataset found in repo")
+
+## Filesystem Requirements
+
+- All bootstrap artifacts go under `{{WORKSPACE_BOOTSTRAP_DIR}}/`.
+- The stage summary draft must be written to `{{STAGE_OUTPUT_PATH}}`.
+- You may read files from the project repo to verify heuristic assessments, but do NOT modify the original repo.
+
+## Quality Bar
+
+- Stage assessments must be evidence-based. Cite specific files.
+- "complete" means genuinely done, not "some files exist." A stage with boilerplate or placeholder content is "partial."
+- The recommended entry stage should be the earliest stage that needs real work, not just the first incomplete one. If Stage 04 is complete but Stage 03 was skipped, recommend Stage 03.
+- If the heuristic assessments are wrong, override them with explanation.
+- If the repo is ambiguous (e.g., multiple sub-projects), flag this and focus on the part most aligned with the user's goal.
+
+## Stage Output Requirements
+
+The markdown at `{{STAGE_OUTPUT_PATH}}` must follow the required output structure exactly.
+
+- **Objective**: Infer the current project state from an existing repository.
+- **What I Did**: Describe which files you inspected and what you found.
+- **Key Results**: Corrected stage assessments with evidence, recommended entry stage.
+- **Files Produced**: List all bootstrap artifacts with their paths.
+- **Suggestions for Refinement**: Offer to re-examine specific stages, adjust assessments, or scan additional directories.

--- a/src/utils.py
+++ b/src/utils.py
@@ -52,6 +52,7 @@ class RunPaths:
     artifacts_dir: Path
     notes_dir: Path
     reviews_dir: Path
+    bootstrap_dir: Path
     intake_context: Path
 
     def stage_file(self, stage: StageSpec) -> Path:
@@ -176,6 +177,7 @@ def build_run_paths(run_root: Path) -> RunPaths:
         artifacts_dir=workspace_root / "artifacts",
         notes_dir=workspace_root / "notes",
         reviews_dir=workspace_root / "reviews",
+        bootstrap_dir=workspace_root / "bootstrap",
         intake_context=run_root / "intake_context.json",
     )
 
@@ -207,6 +209,7 @@ def workspace_dirs(paths: RunPaths) -> list[Path]:
         paths.artifacts_dir,
         paths.notes_dir,
         paths.reviews_dir,
+        paths.bootstrap_dir,
     ]
 
 
@@ -361,6 +364,7 @@ def format_stage_template(template: str, stage: StageSpec, paths: RunPaths) -> s
         "{{WORKSPACE_ARTIFACTS_DIR}}": str(paths.artifacts_dir.resolve()),
         "{{WORKSPACE_NOTES_DIR}}": str(paths.notes_dir.resolve()),
         "{{WORKSPACE_REVIEWS_DIR}}": str(paths.reviews_dir.resolve()),
+        "{{WORKSPACE_BOOTSTRAP_DIR}}": str(paths.bootstrap_dir.resolve()),
         "{{SELECTED_VENUE}}": selected_venue_key(paths),
     }
 

--- a/tests/test_project_bootstrap.py
+++ b/tests/test_project_bootstrap.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.project_bootstrap import (
+    CodeState,
+    ExperimentState,
+    FileEntry,
+    ProjectBootstrapResult,
+    StageAssessment,
+    WritingState,
+    format_project_context_for_prompt,
+    format_project_scan_for_prompt,
+    load_project_bootstrap_summary,
+    load_recommended_entry_stage,
+    load_stage_assessments,
+    project_bootstrap_exists,
+    save_project_bootstrap,
+    scan_project,
+)
+from src.utils import build_run_paths, ensure_run_layout
+
+
+def _make_run(tmp: Path):
+    run_root = tmp / "test_run"
+    paths = build_run_paths(run_root)
+    ensure_run_layout(paths)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+
+class ScanProjectTests(unittest.TestCase):
+    def test_scan_empty_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = scan_project(Path(tmp))
+            self.assertEqual(result.total_files, 0)
+            self.assertEqual(result.code_state.status, "not_started")
+
+    def test_scan_nonexistent_raises(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            scan_project(Path("/nonexistent"))
+
+    def test_scan_file_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            f = Path(tmp) / "file.txt"
+            f.write_text("hi")
+            with self.assertRaises(NotADirectoryError):
+                scan_project(f)
+
+    def test_scan_with_python_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "train.py").write_text("import torch\nprint('train')")
+            (root / "model.py").write_text("import torch.nn as nn")
+            (root / "utils.py").write_text("def helper(): pass")
+            (root / "requirements.txt").write_text("torch>=2.0")
+            result = scan_project(root)
+            self.assertEqual(result.code_state.status, "complete")
+            self.assertIn("Python", result.code_state.languages)
+            self.assertIn("pytorch", result.code_state.frameworks)
+            self.assertTrue(any("train.py" in ep for ep in result.code_state.entry_points))
+            self.assertTrue(any("requirements.txt" in d for d in result.code_state.dependency_files))
+
+    def test_scan_with_experiments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "configs").mkdir()
+            (root / "configs" / "exp1.yaml").write_text("lr: 0.01")
+            (root / "results").mkdir()
+            (root / "results" / "metrics.json").write_text('{"acc": 0.9}')
+            (root / "figures").mkdir()
+            (root / "figures" / "plot.png").write_bytes(b"PNG")
+            result = scan_project(root)
+            self.assertIn(result.experiment_state.status, ("partial", "complete"))
+            self.assertTrue(len(result.experiment_state.config_files) >= 1)
+
+    def test_scan_with_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paper_dir = root / "paper"
+            paper_dir.mkdir()
+            (paper_dir / "main.tex").write_text(
+                r"\begin{abstract}Our method\end{abstract}"
+                r"\section{Introduction}We study..."
+                r"\section{Method}Our approach..."
+                r"\section{Conclusion}In summary..."
+            )
+            (paper_dir / "refs.bib").write_text("@article{a, title={A}}")
+            result = scan_project(root)
+            self.assertIn(result.writing_state.status, ("partial", "complete"))
+            self.assertTrue(result.writing_state.has_introduction)
+            self.assertTrue(result.writing_state.has_method)
+            self.assertTrue(result.writing_state.has_conclusion)
+
+    def test_scan_skips_hidden_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            git_dir = root / ".git"
+            git_dir.mkdir()
+            (git_dir / "config").write_text("gitconfig")
+            (root / "code.py").write_text("x = 1")
+            result = scan_project(root)
+            self.assertEqual(result.total_files, 1)
+
+    def test_recommended_entry_stage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # Project with code but no experiments → entry at Stage 05
+            (root / "train.py").write_text("import torch")
+            (root / "model.py").write_text("class Model: pass")
+            (root / "data.py").write_text("def load(): pass")
+            (root / "utils.py").write_text("def f(): pass")
+            (root / "eval.py").write_text("def evaluate(): pass")
+            (root / "requirements.txt").write_text("torch")
+            result = scan_project(root)
+            # Should recommend a stage after implementation
+            self.assertGreaterEqual(result.recommended_entry_stage, 4)
+
+
+# ---------------------------------------------------------------------------
+# Stage assessment
+# ---------------------------------------------------------------------------
+
+
+class StageAssessmentTests(unittest.TestCase):
+    def test_all_not_started(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = scan_project(Path(tmp))
+            for a in result.stage_assessments:
+                self.assertEqual(a.status, "not_started")
+            self.assertEqual(result.recommended_entry_stage, 1)
+
+    def test_complete_code_moves_entry_past_stage4(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name in ["main.py", "model.py", "train.py", "data.py", "utils.py", "eval.py"]:
+                (root / name).write_text("# code")
+            (root / "requirements.txt").write_text("torch")
+            result = scan_project(root)
+            s04 = next(a for a in result.stage_assessments if a.stage_number == 4)
+            self.assertEqual(s04.status, "complete")
+            self.assertGreaterEqual(result.recommended_entry_stage, 5)
+
+
+# ---------------------------------------------------------------------------
+# Save / load
+# ---------------------------------------------------------------------------
+
+
+class SaveLoadTests(unittest.TestCase):
+    def _sample_result(self) -> ProjectBootstrapResult:
+        return ProjectBootstrapResult(
+            project_root="/tmp/my-project",
+            scanned_at="2026-04-04T10:00:00",
+            total_files=42,
+            code_state=CodeState(
+                languages=["Python"], frameworks=["pytorch"],
+                entry_points=["train.py"], total_code_files=15,
+                status="complete", evidence=["15 code files"],
+            ),
+            experiment_state=ExperimentState(
+                config_files=["configs/exp1.yaml"],
+                result_files=["results/metrics.json"],
+                status="partial", evidence=["1 config, 1 result"],
+            ),
+            writing_state=WritingState(
+                tex_files=["paper/main.tex"], bib_files=["paper/refs.bib"],
+                status="partial", evidence=["1 .tex file"],
+            ),
+            stage_assessments=[
+                StageAssessment(1, "Literature Survey", "partial", "medium", [".bib exists"]),
+                StageAssessment(4, "Implementation", "complete", "high", ["15 code files"]),
+                StageAssessment(5, "Experimentation", "partial", "medium", ["1 result"]),
+            ],
+            recommended_entry_stage=5,
+            file_tree_sample=["train.py", "model.py"],
+        )
+
+    def test_save_and_load(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _make_run(Path(tmp))
+            save_project_bootstrap(paths, self._sample_result())
+
+            self.assertTrue((paths.bootstrap_dir / "project_state.json").exists())
+            self.assertTrue((paths.bootstrap_dir / "experiment_inventory.json").exists())
+            self.assertTrue((paths.bootstrap_dir / "writing_state.json").exists())
+            self.assertTrue((paths.bootstrap_dir / "stage_assessments.json").exists())
+            self.assertTrue((paths.bootstrap_dir / "scan_metadata.json").exists())
+            self.assertTrue((paths.bootstrap_dir / "bootstrap_summary.md").exists())
+
+            summary = load_project_bootstrap_summary(paths)
+            self.assertIsNotNone(summary)
+            self.assertIn("Stage 05", summary)
+
+            assessments = load_stage_assessments(paths)
+            self.assertEqual(len(assessments), 3)
+
+            entry = load_recommended_entry_stage(paths)
+            self.assertEqual(entry, 5)
+
+    def test_project_bootstrap_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _make_run(Path(tmp))
+            self.assertFalse(project_bootstrap_exists(paths))
+            save_project_bootstrap(paths, self._sample_result())
+            self.assertTrue(project_bootstrap_exists(paths))
+
+    def test_load_missing_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _make_run(Path(tmp))
+            self.assertIsNone(load_project_bootstrap_summary(paths))
+            self.assertIsNone(load_stage_assessments(paths))
+            self.assertIsNone(load_recommended_entry_stage(paths))
+
+
+# ---------------------------------------------------------------------------
+# Prompt formatting
+# ---------------------------------------------------------------------------
+
+
+class FormatPromptTests(unittest.TestCase):
+    def _sample_result(self) -> ProjectBootstrapResult:
+        return SaveLoadTests._sample_result(self)
+
+    def test_format_scan_for_prompt(self) -> None:
+        result = self._sample_result()
+        text = format_project_scan_for_prompt(result)
+        self.assertIn("Repository File Tree", text)
+        self.assertIn("Code Analysis", text)
+        self.assertIn("Experiment Analysis", text)
+        self.assertIn("Writing Analysis", text)
+        self.assertIn("Stage Assessments", text)
+
+    def test_format_context_for_prompt_none_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _make_run(Path(tmp))
+            self.assertIsNone(format_project_context_for_prompt(paths))
+
+    def test_format_context_for_prompt_with_data(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = _make_run(Path(tmp))
+            save_project_bootstrap(paths, self._sample_result())
+            text = format_project_context_for_prompt(paths)
+            self.assertIsNotNone(text)
+            self.assertIn("Project Bootstrap Summary", text)
+            self.assertIn("Stage Assessments", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Closes #22

- Adds `--project-root /path/to/repo` CLI flag that scans an existing project repository before Stage 01
- Classifies repo files into code / config / data / result / figure / writing / checkpoint / log using suffix + directory heuristics
- Analyzes three dimensions:
  - **Code state:** languages, frameworks (PyTorch/TF/JAX/HF), entry points, dependencies, tests
  - **Experiment state:** configs, results, checkpoints, logs, figures
  - **Writing state:** .tex section analysis (abstract, intro, method, conclusion presence)
- Per-stage assessment (`complete` / `partial` / `not_started`) with evidence and confidence
- Smart entry stage recommendation: skips past completed stages (e.g., code done → start at Stage 05)
- Claude reviews heuristic assessments via existing approval loop, can correct and enrich
- Generates inspectable artifacts under `workspace/bootstrap/`:
  - `project_state.json` — code analysis
  - `experiment_inventory.json` — experiment artifacts
  - `writing_state.json` — manuscript progress
  - `stage_assessments.json` — per-stage status with evidence
  - `scan_metadata.json` — scan metadata + recommended entry stage
  - `bootstrap_summary.md` — human-readable overview
- Project context injected into all downstream stage prompts
- Fully opt-in: no `--project-root` flag means zero behavior change

### Files changed
- `src/project_bootstrap.py` — **NEW**: repo scanning, file classification, state analysis, stage assessment, I/O
- `src/prompts/project_bootstrap.md` — **NEW**: Claude prompt for reviewing and correcting stage assessments
- `tests/test_project_bootstrap.py` — **NEW**: 16 test cases
- `main.py` — `--project-root` CLI argument
- `src/manager.py` — `_run_project_bootstrap()`, `_build_project_bootstrap_prompt()`, context injection
- `src/utils.py` — `bootstrap_dir` in RunPaths

## Test plan
- [x] 16 new unit tests pass (`python -m pytest tests/test_project_bootstrap.py -v`)
- [x] Repo scanning: empty dir, nested dirs, hidden dir skipping, error handling
- [x] Code analysis: language detection, framework detection, entry points, dependency files
- [x] Experiment analysis: configs, results, figures classification
- [x] Writing analysis: .tex section extraction, section presence detection
- [x] Stage assessment: empty repo → all not_started, code-heavy repo → entry past Stage 04
- [x] Save/load round-trip for all artifact types
- [x] Prompt formatting for scan results and stage context
- [x] No regression in existing tests (intake, artifact index, foundry)
- [ ] E2E: `--project-root` with real project repo + fake operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)