### PR TITLE
Add CodexOperator skeleton for future Codex CLI integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--operator",
-        choices=["claude"],
+        choices=["claude", "codex"],
         default="claude",
         help="Operator backend. Default: claude.",
     )
@@ -157,6 +157,9 @@ def create_operator(backend: str, model: str, fake_mode: bool, ui: TerminalUI) -
     if backend == "claude":
         from src.operator import ClaudeOperator
         return ClaudeOperator(model=model, fake_mode=fake_mode, ui=ui)
+    if backend == "codex":
+        from src.operator_codex import CodexOperator
+        return CodexOperator(model=model)
     raise ValueError(f"Unknown operator backend: {backend}")
 
 

--- a/src/operator_codex.py
+++ b/src/operator_codex.py
@@ -1,0 +1,51 @@
+"""Codex CLI operator skeleton.
+
+This is a placeholder for future Codex CLI integration.
+It implements the OperatorBase interface but raises NotImplementedError
+for all operations.
+"""
+from __future__ import annotations
+
+from .operator_base import OperatorBase
+from .utils import OperatorResult, RunPaths, StageSpec
+
+
+class CodexOperator(OperatorBase):
+    """Operator backed by the Codex CLI (placeholder).
+
+    To implement a real Codex operator, override run_stage() and
+    repair_stage_summary() with subprocess calls to the codex CLI.
+    """
+
+    def __init__(self, model: str = "codex-mini") -> None:
+        self._model = model
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def run_stage(
+        self,
+        stage: StageSpec,
+        prompt: str,
+        paths: RunPaths,
+        attempt_no: int,
+        continue_session: bool = False,
+    ) -> OperatorResult:
+        raise NotImplementedError(
+            "CodexOperator is a placeholder. "
+            "Implement run_stage() to call the Codex CLI."
+        )
+
+    def repair_stage_summary(
+        self,
+        stage: StageSpec,
+        original_prompt: str,
+        original_result: OperatorResult,
+        paths: RunPaths,
+        attempt_no: int,
+    ) -> OperatorResult:
+        raise NotImplementedError(
+            "CodexOperator is a placeholder. "
+            "Implement repair_stage_summary() to call the Codex CLI."
+        )

--- a/src/operator_codex.py
+++ b/src/operator_codex.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from .operator_base import OperatorBase
 from .utils import OperatorResult, RunPaths, StageSpec
 
-
 class CodexOperator(OperatorBase):
     """Operator backed by the Codex CLI (placeholder).
 

--- a/tests/test_operator_codex.py
+++ b/tests/test_operator_codex.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.operator_codex import CodexOperator
+from src.operator_base import OperatorBase
+from src.utils import OperatorResult, StageSpec
+
+
+class TestCodexOperator:
+    def test_is_operator_base(self):
+        op = CodexOperator()
+        assert isinstance(op, OperatorBase)
+
+    def test_default_model(self):
+        op = CodexOperator()
+        assert op.model == "codex-mini"
+
+    def test_custom_model(self):
+        op = CodexOperator(model="o3")
+        assert op.model == "o3"
+
+    def test_run_stage_raises_not_implemented(self):
+        op = CodexOperator()
+        stage = StageSpec(number=1, slug="01_literature_survey", display_name="Literature Survey")
+        with pytest.raises(NotImplementedError, match="CodexOperator"):
+            op.run_stage(stage, "test", None, 1)
+
+    def test_repair_stage_summary_raises_not_implemented(self):
+        op = CodexOperator()
+        stage = StageSpec(number=1, slug="01_literature_survey", display_name="Literature Survey")
+        dummy_result = OperatorResult(
+            success=False, exit_code=1, stdout="", stderr="",
+            stage_file_path=Path("/tmp/x.md"),
+        )
+        with pytest.raises(NotImplementedError, match="CodexOperator"):
+            op.repair_stage_summary(stage, "test", dummy_result, None, 1)


### PR DESCRIPTION
## Summary
- Add `src/operator_codex.py`: `CodexOperator(OperatorBase)` skeleton with `NotImplementedError` for both methods
- Default model is `codex-mini`, configurable via constructor
- Add `"codex"` to `--operator` CLI choices and `create_operator()` factory
- Pre-wires the extension point for future Codex CLI integration without affecting current behavior

## Context
With the `OperatorBase` ABC in place (#26), adding new operator backends is straightforward — implement the ABC and register in the factory. This PR establishes the pattern with a Codex skeleton. To make it functional, a future PR only needs to fill in `run_stage()` with subprocess calls to the Codex CLI.

Depends on #26. Independent of #27 and #28.

## Files changed

| File | Change |
|------|--------|
| `src/operator_codex.py` | **NEW**: `CodexOperator(OperatorBase)` skeleton (~50 lines) |
| `tests/test_operator_codex.py` | **NEW**: 5 tests |
| `main.py` | Add `"codex"` to `--operator` choices, add codex branch to `create_operator()` |

## Test plan
- [x] 5 new tests in `tests/test_operator_codex.py`:
  - `CodexOperator` is instance of `OperatorBase`
  - Default model is `"codex-mini"`
  - Custom model (`"o3"`) works
  - `run_stage()` raises `NotImplementedError` matching `"CodexOperator"`
  - `repair_stage_summary()` raises `NotImplementedError` matching `"CodexOperator"`
- [x] Existing tests unaffected — `--operator` defaults to `"claude"`, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)