### PR TITLE
chore: normalize line endings and ignore agentspace/

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize line endings for all text files in the repo.
+# Without this, Windows editors that auto-convert to CRLF cause every file
+# to show as fully modified in WSL/Linux working trees.
+* text=auto eol=lf
+
+# Explicitly mark known binary types so they aren't touched.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tar binary
+*.whl binary

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ AGENTS.md
 .codex
 docs/
 examples/
+agentspace/


### PR DESCRIPTION
## Summary

- Add `.gitattributes` with `* text=auto eol=lf` so text files are stored with LF in the index regardless of which editor or OS the contributor uses
- Mark known binary types (`*.png`, `*.jpg`, `*.pdf`, `*.zip`, `*.gz`, `*.whl`, etc.) explicitly so they aren't touched
- Add `agentspace/` to `.gitignore` for local per-day working notes

## Why

When the project is opened in a Windows editor that auto-converts to CRLF, every text file shows as fully modified in WSL/Linux working trees — a single re-save can produce a 50-file / 10000-line phantom diff that swamps real changes. `* text=auto eol=lf` makes git normalize on add/commit so this can't happen again.

Existing contributors should also set:

```bash
git config --local core.autocrlf input
```

(This is automatic for new clones once `.gitattributes` is in place; setting it explicitly is just belt-and-suspenders.)

## Test plan

- [ ] CI passes
- [ ] On a clone, `file main.py` reports LF line terminators
- [ ] Opening any file in a Windows editor that re-saves with CRLF, then `git status` should still show clean (or only the real diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)