### PR TITLE
Bound automatic recovery and detect repeated validation failures

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -60,6 +60,7 @@ from .utils import (
     DEFAULT_REFINEMENT_SUGGESTIONS,
     FIXED_STAGE_OPTIONS,
     INTAKE_STAGE,
+    MAX_STAGE_ATTEMPTS,
     STAGES,
     RunPaths,
     StageSpec,
@@ -313,6 +314,14 @@ class ResearchManager:
         mark_stage_execution_started(paths, stage)
 
         while True:
+            if attempt_no > MAX_STAGE_ATTEMPTS:
+                self.ui.show_status(
+                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts. Escalating to user.",
+                    level="error",
+                )
+                append_log_entry(paths.logs, f"{stage.slug} max_attempts_exceeded",
+                                 f"Stopped after {MAX_STAGE_ATTEMPTS} attempts.")
+                return False
             self.ui.show_stage_start(stage.stage_title, attempt_no, continue_session)
             prompt = self._build_stage_prompt(paths, stage, revision_feedback, continue_session)
             append_log_entry(paths.logs, f"{stage.slug} attempt {attempt_no} prompt", prompt)
@@ -476,6 +485,14 @@ class ResearchManager:
         continue_session = False
 
         while True:
+            if attempt_no > MAX_STAGE_ATTEMPTS:
+                self.ui.show_status(
+                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts. Escalating to user.",
+                    level="error",
+                )
+                append_log_entry(paths.logs, f"project_bootstrap max_attempts_exceeded",
+                                 f"Stopped after {MAX_STAGE_ATTEMPTS} attempts.")
+                return None
             self.ui.show_stage_start(stage.stage_title, attempt_no, continue_session)
             prompt = self._build_project_bootstrap_prompt(
                 paths, stage, scan_prompt_section, project_root, revision_feedback, continue_session,
@@ -625,6 +642,14 @@ class ResearchManager:
         continue_session = False
 
         while True:
+            if attempt_no > MAX_STAGE_ATTEMPTS:
+                self.ui.show_status(
+                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts. Escalating to user.",
+                    level="error",
+                )
+                append_log_entry(paths.logs, f"bootstrap max_attempts_exceeded",
+                                 f"Stopped after {MAX_STAGE_ATTEMPTS} attempts.")
+                return False
             self.ui.show_stage_start(stage.stage_title, attempt_no, continue_session)
             prompt = self._build_bootstrap_prompt(paths, stage, corpus_prompt_section, revision_feedback, continue_session)
             append_log_entry(paths.logs, f"bootstrap attempt {attempt_no} prompt", prompt)
@@ -905,13 +930,25 @@ class ResearchManager:
         attempt_no = read_attempt_count(paths, stage) + 1
         revision_feedback: str | None = None
         continue_session = False
+        last_validation_errors: list[str] = []
         mark_stage_execution_started(paths, stage)
 
         while True:
+            if attempt_no > MAX_STAGE_ATTEMPTS:
+                self.ui.show_status(
+                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts. Escalating to user.",
+                    level="error",
+                )
+                append_log_entry(paths.logs, f"{stage.slug} max_attempts_exceeded",
+                                 f"Stopped after {MAX_STAGE_ATTEMPTS} attempts. "
+                                 f"Last errors: {last_validation_errors}")
+                return False
             mark_stage_running_manifest(paths, stage, attempt_no)
             write_attempt_count(paths, stage, attempt_no)
             self._print(f"\nRunning {stage.stage_title} (attempt {attempt_no})...")
-            prompt = self._build_stage_prompt(paths, stage, revision_feedback, continue_session)
+            prompt = self._build_stage_prompt(paths, stage, revision_feedback, continue_session,
+                                             attempt_no=attempt_no,
+                                             previous_validation_errors=last_validation_errors or None)
             append_log_entry(
                 paths.logs,
                 f"{stage.slug} attempt {attempt_no} prompt",
@@ -1089,6 +1126,7 @@ class ResearchManager:
                             "Keep all correct work already completed, but produce a fully complete stage summary "
                             "with no placeholder markers and ensure every required section is substantively filled."
                         )
+                        last_validation_errors = list(validation_errors)
                         continue_session = True
                         attempt_no += 1
                         continue
@@ -1242,6 +1280,8 @@ class ResearchManager:
         stage: StageSpec,
         revision_feedback: str | None,
         continue_session: bool,
+        attempt_no: int = 1,
+        previous_validation_errors: list[str] | None = None,
     ) -> str:
         template = load_prompt_template(self.prompt_dir, stage)
         stage_template = format_stage_template(template, stage, paths)
@@ -1312,6 +1352,8 @@ class ResearchManager:
             return build_continuation_prompt(
                 stage, stage_template, paths, handoff_context, revision_feedback,
                 intake_context_text=intake_context_text,
+                attempt_no=attempt_no,
+                previous_validation_errors=previous_validation_errors,
             )
 
         user_request = read_text(paths.user_input)

--- a/src/manager.py
+++ b/src/manager.py
@@ -928,21 +928,30 @@ class ResearchManager:
 
     def _run_stage(self, paths: RunPaths, stage: StageSpec) -> bool:
         attempt_no = read_attempt_count(paths, stage) + 1
+        loop_attempts = 0
         revision_feedback: str | None = None
         continue_session = False
         last_validation_errors: list[str] = []
         mark_stage_execution_started(paths, stage)
 
         while True:
-            if attempt_no > MAX_STAGE_ATTEMPTS:
+            if loop_attempts >= MAX_STAGE_ATTEMPTS:
+                error = (
+                    f"Exceeded {MAX_STAGE_ATTEMPTS} attempts in the current stage run. "
+                    f"Last validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
+                )
                 self.ui.show_status(
-                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts. Escalating to user.",
+                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts in this run.",
                     level="error",
                 )
-                append_log_entry(paths.logs, f"{stage.slug} max_attempts_exceeded",
-                                 f"Stopped after {MAX_STAGE_ATTEMPTS} attempts. "
-                                 f"Last errors: {last_validation_errors}")
+                append_log_entry(
+                    paths.logs,
+                    f"{stage.slug} max_attempts_exceeded",
+                    error,
+                )
+                mark_stage_failed_manifest(paths, stage, error)
                 return False
+            loop_attempts += 1
             mark_stage_running_manifest(paths, stage, attempt_no)
             write_attempt_count(paths, stage, attempt_no)
             self._print(f"\nRunning {stage.stage_title} (attempt {attempt_no})...")

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,6 +10,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_REGISTRY_PATH = REPO_ROOT / "templates" / "registry.yaml"
 DEFAULT_VENUE = "neurips_2025"
+MAX_STAGE_ATTEMPTS = 5
 
 
 @dataclass(frozen=True)
@@ -460,6 +461,8 @@ def build_continuation_prompt(
     handoff_context: str,
     revision_feedback: str | None,
     intake_context_text: str | None = None,
+    attempt_no: int = 1,
+    previous_validation_errors: list[str] | None = None,
 ) -> str:
     current_draft = paths.stage_tmp_file(stage)
     current_final = paths.stage_file(stage)
@@ -504,6 +507,19 @@ def build_continuation_prompt(
         sections.extend([
             "# Intake Context (User-Provided Resources and Clarifications)",
             intake_context_text.strip(),
+        ])
+    if attempt_no >= 3 and previous_validation_errors:
+        error_list = "\n".join(f"- {e}" for e in previous_validation_errors)
+        sections.extend([
+            "# Recovery Context",
+            (
+                f"This is attempt {attempt_no}. The following validation errors have persisted "
+                f"from the previous attempt:\n{error_list}\n\n"
+                "If you believe these errors cannot be resolved within the current stage "
+                "(e.g. missing external files, impossible constraints), state that clearly "
+                "in your stage summary under ## What I Did so the human reviewer can decide "
+                "how to proceed."
+            ),
         ])
     sections.extend([
         "# Stage Handoff Context",

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -12,15 +12,15 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from src.manager import ResearchManager
+from src.manifest import load_run_manifest
 from src.operator import ClaudeOperator
 from src.terminal_ui import TerminalUI
 from src.utils import (
     MAX_STAGE_ATTEMPTS,
     STAGES,
-    StageSpec,
     build_continuation_prompt,
     build_run_paths,
     create_run_root,
@@ -151,20 +151,85 @@ class TestRunStageMaxAttempts(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_run_stage_returns_false_after_max_attempts(self):
-        """Simulate a stage that always produces invalid output.
+    def _write_valid_stage_draft(self, stage) -> Path:
+        produced = self.paths.notes_dir / f"{stage.slug}_note.md"
+        produced.parent.mkdir(parents=True, exist_ok=True)
+        produced.write_text("note", encoding="utf-8")
+        draft_path = self.paths.stage_tmp_file(stage)
+        draft_path.write_text(
+            "\n".join(
+                [
+                    f"# {stage.stage_title}",
+                    "",
+                    "## Objective",
+                    "Complete the stage.",
+                    "",
+                    "## Previously Approved Stage Summaries",
+                    "_None yet._",
+                    "",
+                    "## What I Did",
+                    "Did the required work.",
+                    "",
+                    "## Key Results",
+                    "Obtained a concrete result.",
+                    "",
+                    "## Files Produced",
+                    f"- `workspace/notes/{stage.slug}_note.md` - Supporting note",
+                    "",
+                    "## Suggestions for Refinement",
+                    "1. Tighten the scope.",
+                    "2. Strengthen the evidence.",
+                    "3. Clarify the assumptions.",
+                    "",
+                    "## Your Options",
+                    "1. Use suggestion 1",
+                    "2. Use suggestion 2",
+                    "3. Use suggestion 3",
+                    "4. Refine with your own feedback",
+                    "5. Approve and continue",
+                    "6. Abort",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return draft_path
 
-        We patch the attempt counter to start just below the limit so the
-        loop hits the ceiling quickly without running MAX_STAGE_ATTEMPTS
-        real fake-operator calls.
-        """
+    def test_run_stage_uses_fresh_window_despite_historical_attempt_count(self):
         from src.utils import write_attempt_count
         stage = STAGES[0]
-        # Set attempt counter so next attempt_no = MAX_STAGE_ATTEMPTS + 1
         write_attempt_count(self.paths, stage, MAX_STAGE_ATTEMPTS)
+        draft_path = self._write_valid_stage_draft(stage)
+        self.operator.run_stage = MagicMock(
+            return_value=MagicMock(
+                success=True,
+                exit_code=0,
+                session_id="session-1",
+                stage_file_path=draft_path,
+                stdout="",
+                stderr="",
+            )
+        )
+        self.manager._display_stage_output = MagicMock()
+        self.manager._ask_choice = MagicMock(return_value="5")
 
         result = self.manager._run_stage(self.paths, stage)
+        self.assertTrue(result)
+        self.operator.run_stage.assert_called_once()
+        self.assertTrue(self.paths.stage_file(stage).exists())
+
+    def test_run_stage_marks_manifest_failed_when_attempt_window_is_exhausted(self):
+        stage = STAGES[0]
+
+        with patch("src.manager.MAX_STAGE_ATTEMPTS", 0):
+            result = self.manager._run_stage(self.paths, stage)
+
         self.assertFalse(result)
+        manifest = load_run_manifest(self.paths.run_manifest)
+        self.assertIsNotNone(manifest)
+        stage_entry = next(entry for entry in manifest.stages if entry.slug == stage.slug)
+        self.assertEqual(stage_entry.status, "failed")
+        self.assertIn("Exceeded 0 attempts", stage_entry.last_error or "")
 
 
 if __name__ == "__main__":

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -1,0 +1,171 @@
+"""Tests for bounded automatic recovery (Issue #35).
+
+Validates that:
+- MAX_STAGE_ATTEMPTS is enforced on all retry loops.
+- Recovery context is injected into continuation prompts after repeated failures.
+- Normal first-attempt prompts do not include recovery context.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.manager import ResearchManager
+from src.operator import ClaudeOperator
+from src.terminal_ui import TerminalUI
+from src.utils import (
+    MAX_STAGE_ATTEMPTS,
+    STAGES,
+    StageSpec,
+    build_continuation_prompt,
+    build_run_paths,
+    create_run_root,
+    ensure_run_layout,
+    format_stage_template,
+    initialize_memory,
+    initialize_run_config,
+    load_prompt_template,
+    write_text,
+)
+
+
+class TestMaxStageAttemptsConstant(unittest.TestCase):
+    def test_max_stage_attempts_is_positive_integer(self):
+        self.assertIsInstance(MAX_STAGE_ATTEMPTS, int)
+        self.assertGreater(MAX_STAGE_ATTEMPTS, 0)
+
+    def test_default_value_is_five(self):
+        self.assertEqual(MAX_STAGE_ATTEMPTS, 5)
+
+
+class TestRecoveryContextInContinuationPrompt(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.runs_dir = Path(self.tmp) / "runs"
+        self.runs_dir.mkdir()
+        self.run_root = create_run_root(self.runs_dir)
+        self.paths = build_run_paths(self.run_root)
+        ensure_run_layout(self.paths)
+        initialize_run_config(self.paths, model="sonnet", venue="neurips_2025")
+        initialize_memory(self.paths, "Test goal")
+        write_text(self.paths.user_input, "Test goal")
+
+        self.stage = STAGES[0]
+        repo_root = Path(__file__).resolve().parent.parent
+        prompt_dir = repo_root / "src" / "prompts"
+        template = load_prompt_template(prompt_dir, self.stage)
+        self.stage_template = format_stage_template(template, self.stage, self.paths)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_no_recovery_context_on_first_attempt(self):
+        prompt = build_continuation_prompt(
+            self.stage, self.stage_template, self.paths,
+            handoff_context="", revision_feedback=None,
+            attempt_no=1,
+            previous_validation_errors=["missing ## Key Results"],
+        )
+        self.assertNotIn("# Recovery Context", prompt)
+
+    def test_no_recovery_context_on_second_attempt(self):
+        prompt = build_continuation_prompt(
+            self.stage, self.stage_template, self.paths,
+            handoff_context="", revision_feedback=None,
+            attempt_no=2,
+            previous_validation_errors=["missing ## Key Results"],
+        )
+        self.assertNotIn("# Recovery Context", prompt)
+
+    def test_recovery_context_on_third_attempt(self):
+        errors = ["missing ## Key Results", "missing ## Files Produced"]
+        prompt = build_continuation_prompt(
+            self.stage, self.stage_template, self.paths,
+            handoff_context="", revision_feedback=None,
+            attempt_no=3,
+            previous_validation_errors=errors,
+        )
+        self.assertIn("# Recovery Context", prompt)
+        self.assertIn("attempt 3", prompt)
+        self.assertIn("missing ## Key Results", prompt)
+        self.assertIn("missing ## Files Produced", prompt)
+
+    def test_recovery_context_mentions_human_reviewer(self):
+        prompt = build_continuation_prompt(
+            self.stage, self.stage_template, self.paths,
+            handoff_context="", revision_feedback=None,
+            attempt_no=4,
+            previous_validation_errors=["missing section"],
+        )
+        self.assertIn("human reviewer", prompt)
+
+    def test_no_recovery_context_without_errors(self):
+        prompt = build_continuation_prompt(
+            self.stage, self.stage_template, self.paths,
+            handoff_context="", revision_feedback=None,
+            attempt_no=5,
+            previous_validation_errors=None,
+        )
+        self.assertNotIn("# Recovery Context", prompt)
+
+    def test_no_recovery_context_with_empty_errors(self):
+        prompt = build_continuation_prompt(
+            self.stage, self.stage_template, self.paths,
+            handoff_context="", revision_feedback=None,
+            attempt_no=5,
+            previous_validation_errors=[],
+        )
+        self.assertNotIn("# Recovery Context", prompt)
+
+
+class TestRunStageMaxAttempts(unittest.TestCase):
+    """Test that _run_stage stops after MAX_STAGE_ATTEMPTS."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.runs_dir = Path(self.tmp) / "runs"
+        self.runs_dir.mkdir()
+        self.run_root = create_run_root(self.runs_dir)
+        self.paths = build_run_paths(self.run_root)
+        ensure_run_layout(self.paths)
+        initialize_run_config(self.paths, model="sonnet", venue="neurips_2025")
+        initialize_memory(self.paths, "Test goal")
+        write_text(self.paths.user_input, "Test goal")
+
+        self.repo_root = Path(__file__).resolve().parent.parent
+        self.ui = TerminalUI()
+        self.operator = ClaudeOperator(
+            model="sonnet", fake_mode=True, ui=self.ui,
+        )
+        self.manager = ResearchManager(
+            project_root=self.repo_root,
+            runs_dir=self.runs_dir,
+            operator=self.operator,
+            ui=self.ui,
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_run_stage_returns_false_after_max_attempts(self):
+        """Simulate a stage that always produces invalid output.
+
+        We patch the attempt counter to start just below the limit so the
+        loop hits the ceiling quickly without running MAX_STAGE_ATTEMPTS
+        real fake-operator calls.
+        """
+        from src.utils import write_attempt_count
+        stage = STAGES[0]
+        # Set attempt counter so next attempt_no = MAX_STAGE_ATTEMPTS + 1
+        write_attempt_count(self.paths, stage, MAX_STAGE_ATTEMPTS)
+
+        result = self.manager._run_stage(self.paths, stage)
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `MAX_STAGE_ATTEMPTS = 5` hard ceiling to all 4 `while True` stage loops in `manager.py`, preventing runaway retries
- Inject `# Recovery Context` into continuation prompts from the 3rd attempt onward, giving Claude visibility into previous validation errors so it can decide whether to fix or escalate to the human reviewer
- Add 9 tests covering the constant, recovery context injection conditions, and max-attempt enforcement

Closes #35

## Test plan
- [x] 152 tests pass (`python -m unittest discover -s tests -v`)
- [x] `py_compile` passes on all modified files
- [x] CLI smoke test (`--fake-operator --goal "smoke test" --skip-intake`) runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)