### PR TITLE
fix: prevent ENAMETOOLONG crash when extracting path refs from stage fallback text 

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1160,9 +1160,13 @@ def _extract_path_references(text: str) -> list[str]:
     seen: set[str] = set()
     paths: list[str] = []
 
-    for candidate in re.findall(r"`([^`]+)`", text):
+    for candidate in re.findall(r"`([^`\n\r]+)`", text):
         normalized = candidate.strip()
         if not normalized:
+            continue
+
+        # Reject multi-line or excessively long strings — not valid file paths
+        if "\n" in normalized or "\r" in normalized or len(normalized) > 512:
             continue
 
         if not (
@@ -1202,16 +1206,19 @@ def _listed_file_exists(run_root: Path, listed_path: str) -> bool:
     affected.
     """
     candidate = Path(listed_path)
-    if candidate.is_absolute():
-        return candidate.exists()
-    # 1. Run-root-relative (canonical AutoR form)
-    via_root = run_root / candidate
-    if via_root.exists():
-        return True
-    # 2. Workspace-relative fallback
-    via_workspace = run_root / "workspace" / candidate
-    if via_workspace.exists():
-        return True
+    try:
+        if candidate.is_absolute():
+            return candidate.exists()
+        # 1. Run-root-relative (canonical AutoR form)
+        via_root = run_root / candidate
+        if via_root.exists():
+            return True
+        # 2. Workspace-relative fallback
+        via_workspace = run_root / "workspace" / candidate
+        if via_workspace.exists():
+            return True
+    except OSError:
+        return False
     return False
 
 


### PR DESCRIPTION
## Problem
When resuming a run that had previously attempted Stage 07 (writing), AutoR crashed immediately with:

```
Error: [Errno 36] File name too long:
'/runs/<run_id>/using verified metadata where possible. If the venue prefers
inline references for submission, keep references auditable...\n<line>\tCitation
discipline:\n\t- Never fabricate BibTeX entries from memory.\n\t- Prefer DBLP
lookup first.\n\t- Use DOI / CrossRef as fallback...'
```

## Root Cause
`_extract_path_references` in `src/utils.py` uses the regex `([^`]+)` to find backtick-quoted file paths.
In Python's `re` module, `[^`]` matches any character including newlines, so the regex can match across line boundaries.

When a stage attempt fails, AutoR passes Claude's captured stdout as `fallback_text` to `canonicalize_stage_markdown`.
This stdout can contain large chunks of the assembled prompt (e.g., read back via a tool call), which embeds the Stage 07 template text.
A mismatched or widely-spaced pair of backticks in that content causes the regex to extract a multi-line, multi-hundred-character string as a "file path".

That string is then passed to `_listed_file_exists`, which calls `run_root / Path(that_string)` and triggers an OS `stat` call — which fails with `ENAMETOOLONG (errno 36)`, crashing the entire resume.

## Fix
Two changes in `src/utils.py`:

1. **`_extract_path_references`**:
   - Change regex from `([^`]+)` to `([^`\n\r]+)` to prevent cross-line matching.
   - Add a `len > 512` guard as a secondary filter.

2. **`_listed_file_exists`**:
   - Wrap all `Path.exists()` calls in `try/except OSError` so any OS-level path error returns `False` instead of propagating.

## Testing
- Reproduced locally by resuming a run that had previously failed mid-Stage 07.
- Confirmed the crash is eliminated after the fix.
- Existing path validation logic is unaffected — the regex change only removes matches that were never valid file paths.