### PR TITLE
ui_upgrade

### DIFF
--- a/src/frontend/static/app.js
+++ b/src/frontend/static/app.js
@@ -2081,6 +2081,11 @@ function readHashPage() {
 
 function setConnection(text) {
   elements.connectionStatus.textContent = text;
+  const t = (text || "").toLowerCase();
+  let status = "connecting";
+  if (t.includes("error")) status = "error";
+  else if (t.includes("idle") || t.includes("ready") || t.includes("connected") || t.includes("ok")) status = "ok";
+  elements.connectionStatus.dataset.status = status;
 }
 
 async function safeAction(promise) {

--- a/src/frontend/static/index.html
+++ b/src/frontend/static/index.html
@@ -4,312 +4,335 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>AutoR Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="/studio/styles.css" />
   </head>
   <body>
     <div class="app-shell" data-view="hub">
+      <!-- =========== TOPBAR =========== -->
       <header class="topbar">
-        <div class="topbar-lead">
-          <button id="back-to-hub" class="button button-ghost hub-only-hidden" type="button">← Projects</button>
-          <div>
-            <p class="eyebrow">AutoR Studio</p>
-            <h1>Research Control Workspace</h1>
-            <p class="topbar-copy">
-              Every project is human-in-the-loop. Pick a project to open its dedicated workspace for review, files, paper, and history.
-            </p>
+        <div class="topbar-brand">
+          <button id="back-to-hub" class="back-link" type="button" aria-label="Back to projects">
+            <span aria-hidden="true">←</span>
+            <span>Projects</span>
+          </button>
+          <div class="brand-mark">
+            <span class="brand-glyph" aria-hidden="true">A/R</span>
+            <div class="brand-text">
+              <span class="brand-name">AutoR Studio</span>
+              <span class="brand-tag">Research Control · Human in the loop</span>
+            </div>
           </div>
         </div>
         <div class="topbar-actions">
-          <span id="connection-status" class="badge">Connecting</span>
-          <button id="reload-button" class="button button-secondary" type="button">Reload</button>
+          <span id="connection-status" class="status-pill" data-status="connecting">Connecting</span>
+          <button id="reload-button" class="btn btn-ghost" type="button">↻ Reload</button>
         </div>
       </header>
 
       <!-- ============ HUB VIEW ============ -->
       <main class="hub-view">
-        <section class="panel hub-create">
-          <div class="panel-header">
+        <section class="hub-poster">
+          <div class="hub-poster-text">
+            <p class="kicker">A research control workspace</p>
+            <h1 class="display-headline">
+              Run experiments<br />
+              <em>read like papers.</em>
+            </h1>
+            <p class="lede">
+              Every project is human-in-the-loop. Each run is a small lab
+              notebook — staged, reviewed, and traceable from intake to
+              manuscript.
+            </p>
+          </div>
+
+          <form id="project-form" class="hub-create-card" novalidate>
+            <p class="kicker">Start a new project</p>
+            <label class="field">
+              <span class="field-label">Title</span>
+              <input
+                id="project-title"
+                name="title"
+                type="text"
+                placeholder="Sparse MoE Routing Study"
+                autocomplete="off"
+                required
+              />
+            </label>
+            <label class="field">
+              <span class="field-label">Thesis</span>
+              <textarea
+                id="project-thesis"
+                name="thesis"
+                rows="3"
+                placeholder="Probe routing dynamics, training stability, and paper-ready ablations."
+                required
+              ></textarea>
+            </label>
+            <button class="btn btn-primary btn-block" type="submit">
+              Create project →
+            </button>
+          </form>
+        </section>
+
+        <section class="hub-section">
+          <header class="section-header">
             <div>
-              <p class="eyebrow">Start</p>
-              <h2>New Project</h2>
+              <p class="kicker">Index</p>
+              <h2 class="section-title">Projects</h2>
             </div>
-            <span class="meta">Human-in-the-loop by default</span>
-          </div>
-          <div class="panel-body">
-            <form id="project-form" class="project-form project-form-inline">
-              <label>
-                <span>Title</span>
-                <input id="project-title" name="title" type="text" placeholder="Sparse MoE Study" required />
-              </label>
-              <label>
-                <span>Thesis</span>
-                <textarea
-                  id="project-thesis"
-                  name="thesis"
-                  rows="2"
-                  placeholder="Track routing, stability, and paper packaging."
-                  required
-                ></textarea>
-              </label>
-              <button class="button button-primary" type="submit">Create Project</button>
-            </form>
-          </div>
+            <span id="project-count" class="meta-counter">0</span>
+          </header>
+          <div id="projects-list" class="projects-grid"></div>
         </section>
-
-        <section class="panel">
-          <div class="panel-header">
-            <h2>Projects</h2>
-            <span id="project-count" class="meta">0</span>
-          </div>
-          <div class="panel-body">
-            <div id="projects-list" class="projects-grid"></div>
-          </div>
-        </section>
-
       </main>
 
       <!-- ============ WORKSPACE VIEW ============ -->
       <main class="workspace-view">
-        <section class="panel workspace-header">
-          <div class="workspace-header-body">
-            <div class="workspace-title">
-              <p id="active-project-label" class="eyebrow">No project selected</p>
-              <h2 id="run-title">No run selected</h2>
-              <p id="run-goal" class="workspace-goal">Select a run to inspect stage output, files, and manuscript artifacts.</p>
+        <section class="workspace-header">
+          <div class="workspace-header-row">
+            <div class="workspace-crumb">
+              <span id="active-project-label" class="crumb-eyebrow">No project selected</span>
+              <h2 id="run-title" class="crumb-title">No run selected</h2>
             </div>
-            <div class="workspace-actions">
-              <span id="run-status" class="badge badge-status">Idle</span>
+            <div class="workspace-header-meta">
+              <span id="run-status" class="status-pill" data-status="idle">Idle</span>
             </div>
           </div>
+          <p id="run-goal" class="workspace-goal">
+            Select a run to inspect stage output, files, and manuscript artifacts.
+          </p>
           <nav class="page-nav" aria-label="Studio pages">
-            <button class="page-link is-active" data-page="overview" type="button">Overview</button>
-            <button class="page-link" data-page="review" type="button">Human Review</button>
-            <button class="page-link" data-page="history" type="button">Versions</button>
-            <button class="page-link" data-page="notebook" type="button">Notebook</button>
+            <button class="page-link is-active" data-page="overview" type="button">
+              <span>Overview</span>
+            </button>
+            <button class="page-link" data-page="review" type="button">
+              <span>Human Review</span>
+            </button>
+            <button class="page-link" data-page="history" type="button">
+              <span>Versions</span>
+            </button>
+            <button class="page-link" data-page="notebook" type="button">
+              <span>Notebook</span>
+            </button>
           </nav>
         </section>
 
+        <!-- ============ OVERVIEW ============ -->
         <section id="page-overview" class="page is-active">
-          <div class="page-grid overview-grid">
-            <section class="panel panel-full live-panel">
-              <div class="panel-header">
-                <div class="live-header">
+          <article class="hero-panel">
+            <div class="hero-head">
+              <div class="hero-head-text">
+                <p class="kicker">
                   <span id="live-indicator" class="live-dot" aria-hidden="true"></span>
-                  <div>
-                    <p class="eyebrow">Current run</p>
-                    <h2 id="live-stage-title">No run selected</h2>
-                  </div>
-                </div>
-                <span id="live-status-chip" class="status-chip status-idle">Idle</span>
+                  Currently on
+                </p>
+                <h2 id="live-stage-title" class="hero-title">No run selected</h2>
               </div>
-              <div class="panel-body">
-                <ol id="stage-strip" class="stage-strip" aria-label="Pipeline progress"></ol>
-                <div class="live-progress-row">
-                  <div class="live-progress">
-                    <div class="live-progress-label">
-                      <span id="live-progress-text">0 / 0 stages approved</span>
-                      <span id="live-attempt-text" class="meta"></span>
-                    </div>
-                    <div class="live-progress-bar">
-                      <div id="live-progress-fill" class="live-progress-fill"></div>
-                    </div>
-                  </div>
-                  <div class="live-actions">
-                    <button id="live-approve" class="button button-primary" type="button" disabled>
-                      ✅ Approve
-                    </button>
-                    <button id="live-feedback-quick" class="button button-secondary" type="button" disabled>
-                      ✍︎ Review
-                    </button>
-                  </div>
-                </div>
-                <p id="live-last-event" class="live-last-event">Waiting for activity…</p>
-                <ol id="live-ticker" class="live-ticker" aria-label="Recent runner events"></ol>
-              </div>
-            </section>
+              <span id="live-status-chip" class="status-chip" data-status="idle">Idle</span>
+            </div>
 
-            <section class="panel panel-full">
-              <div class="panel-header">
-                <h2>Project Thesis</h2>
+            <ol id="stage-strip" class="stage-strip" aria-label="Pipeline progress"></ol>
+
+            <div class="hero-progress-row">
+              <div class="hero-progress">
+                <div class="hero-progress-meta">
+                  <span id="live-progress-text" class="hero-progress-text">0 / 0 stages approved</span>
+                  <span id="live-attempt-text" class="meta"></span>
+                </div>
+                <div class="hero-progress-bar">
+                  <div id="live-progress-fill" class="hero-progress-fill"></div>
+                </div>
+              </div>
+              <div class="hero-actions">
+                <button id="live-approve" class="btn btn-primary" type="button" disabled>
+                  Approve &amp; continue
+                </button>
+                <button id="live-feedback-quick" class="btn btn-ghost" type="button" disabled>
+                  Send feedback
+                </button>
+              </div>
+            </div>
+
+            <p id="live-last-event" class="hero-last-event">Waiting for activity…</p>
+            <ol id="live-ticker" class="live-ticker" aria-label="Recent runner events"></ol>
+          </article>
+
+          <div class="overview-grid">
+            <section class="card-panel">
+              <header class="card-header">
+                <p class="kicker">Project thesis</p>
                 <span id="project-meta" class="meta">No project</span>
-              </div>
-              <div class="panel-body">
-                <div id="project-brief" class="copy-block empty-state">
-                  Project context appears here after you select a project.
-                </div>
+              </header>
+              <div id="project-brief" class="prose-block empty-state">
+                Project context appears here after you select a project.
               </div>
             </section>
 
-            <section class="panel panel-full">
-              <div class="panel-header">
-                <h2>Activity</h2>
+            <section class="card-panel">
+              <header class="card-header">
+                <p class="kicker">Activity</p>
                 <span id="activity-count" class="meta">0 events</span>
-              </div>
-              <div class="panel-body">
-                <ol id="activity-feed" class="activity-feed"></ol>
-              </div>
+              </header>
+              <ol id="activity-feed" class="activity-feed"></ol>
             </section>
 
-            <section class="panel">
-              <div class="panel-header">
-                <h2>Stage Rail</h2>
+            <section class="card-panel">
+              <header class="card-header">
+                <p class="kicker">Stage rail</p>
                 <span id="stage-count" class="meta">0</span>
-              </div>
-              <div class="panel-body">
-                <div id="stage-rail" class="stage-rail"></div>
-              </div>
+              </header>
+              <div id="stage-rail" class="stage-rail"></div>
             </section>
 
-            <section class="panel">
-              <div class="panel-header">
-                <div>
-                  <p class="eyebrow">Current focus</p>
-                  <h2 id="overview-stage-title">Stage snapshot</h2>
-                </div>
-                <span id="overview-stage-meta" class="meta"></span>
-              </div>
-              <div class="panel-body">
-                <article id="overview-stage-summary" class="document-body empty-state">
-                  Select a stage to inspect the current summary.
-                </article>
-              </div>
-            </section>
-
-            <section class="panel panel-full">
-              <div class="panel-header">
-                <h2>Run Summary</h2>
-                <span id="artifact-total" class="meta">0 artifacts</span>
-              </div>
-              <div class="panel-body split-stack">
-                <dl id="run-summary" class="summary-list"></dl>
-                <section class="inspector-block">
-                  <h3>Artifacts</h3>
-                  <ul id="artifact-summary" class="artifact-summary"></ul>
-                </section>
-              </div>
+            <section class="card-panel">
+              <header class="card-header">
+                <p class="kicker">
+                  Current focus
+                  <span id="overview-stage-meta" class="meta inline"></span>
+                </p>
+                <h3 id="overview-stage-title" class="card-title">Stage snapshot</h3>
+              </header>
+              <article id="overview-stage-summary" class="prose-block empty-state">
+                Select a stage to inspect the current summary.
+              </article>
             </section>
           </div>
+
+          <section class="card-panel run-summary-strip">
+            <header class="card-header">
+              <p class="kicker">Run summary</p>
+              <span id="artifact-total" class="meta">0 artifacts</span>
+            </header>
+            <div class="run-summary-body">
+              <dl id="run-summary" class="summary-list"></dl>
+              <div class="summary-divider" aria-hidden="true"></div>
+              <div class="summary-artifacts">
+                <p class="kicker">Artifacts</p>
+                <ul id="artifact-summary" class="artifact-summary"></ul>
+              </div>
+            </div>
+          </section>
         </section>
 
+        <!-- ============ HUMAN REVIEW ============ -->
         <section id="page-review" class="page">
-          <!-- Pipeline state strip shared with Overview -->
-          <section class="panel panel-full review-strip-panel">
-            <ol id="review-stage-strip" class="stage-strip" aria-label="Pipeline progress"></ol>
-          </section>
+          <ol id="review-stage-strip" class="stage-strip review-strip" aria-label="Pipeline progress"></ol>
 
-          <div class="page-grid review-grid">
-            <section class="panel">
-              <div class="panel-body review-body">
-
-                <!-- Hero: "You are reviewing X" — content + actions together -->
-                <section id="review-hero" class="review-hero">
-                  <div class="review-hero-head">
-                    <div>
-                      <p class="eyebrow">You are reviewing</p>
-                      <h2 id="review-hero-title">No stage selected</h2>
-                      <p id="review-hero-sub" class="review-hero-sub">Pick a run to inspect a stage.</p>
-                    </div>
-                    <span id="review-hero-chip" class="status-chip status-idle">idle</span>
-                  </div>
-
-                  <div id="review-hero-tldr" class="review-hero-tldr"></div>
-
-                  <ul id="review-hero-files" class="review-hero-files"></ul>
-
-                  <div class="hitl-actions">
-                    <button id="approve-stage-button" class="button button-primary" type="button">
-                      ✅ Approve &amp; Continue
-                    </button>
-                    <button id="send-feedback-button" class="button button-secondary" type="button">
-                      ✍︎ Send Feedback &amp; Re-run
-                    </button>
-                  </div>
-
-                  <label class="feedback-inline-label">
-                    <span>Your feedback (optional — used when you click Send Feedback &amp; Re-run)</span>
-                    <textarea
-                      id="iteration-feedback-quick"
-                      rows="3"
-                      placeholder="Tighten the claims, keep the previous experiment results, and revise the writing narrative."
-                    ></textarea>
-                  </label>
-                  <p id="review-next" class="review-next"></p>
-                </section>
-
-                <!-- The full stage markdown, prominent directly below the hero -->
-                <section class="review-doc-section">
-                  <header class="session-section-header">
-                    <h3 id="document-title">Stage document</h3>
-                    <span id="document-meta" class="meta"></span>
-                  </header>
-                  <p id="review-stage-label" class="eyebrow review-stage-label">Human Review</p>
-                  <article id="stage-document" class="document-body empty-state">
-                    Select a stage to inspect the human-readable summary.
-                  </article>
-                </section>
-
-                <!-- Previous approved stages accordion — see the full chain at any time -->
-                <section class="review-previous-section">
-                  <header class="session-section-header">
-                    <h3>Previous Stages</h3>
-                    <span id="review-previous-count" class="meta">0 approved</span>
-                  </header>
-                  <div id="review-previous-list" class="review-previous-list"></div>
-                </section>
+          <article id="review-hero" class="review-hero">
+            <header class="review-hero-head">
+              <div>
+                <p class="kicker">You are reviewing</p>
+                <h2 id="review-hero-title" class="review-hero-title">No stage selected</h2>
+                <p id="review-hero-sub" class="review-hero-sub">
+                  Pick a run to inspect a stage.
+                </p>
               </div>
+              <span id="review-hero-chip" class="status-chip" data-status="idle">idle</span>
+            </header>
+
+            <div id="review-hero-tldr" class="review-hero-tldr"></div>
+
+            <ul id="review-hero-files" class="review-hero-files"></ul>
+
+            <div class="review-hero-actions">
+              <button id="approve-stage-button" class="btn btn-primary" type="button">
+                Approve &amp; continue
+              </button>
+              <button id="send-feedback-button" class="btn btn-ghost" type="button">
+                Send feedback &amp; re-run
+              </button>
+            </div>
+
+            <label class="field review-feedback-field">
+              <span class="field-label">
+                Your feedback
+                <span class="field-hint">used when you click Send feedback &amp; re-run</span>
+              </span>
+              <textarea
+                id="iteration-feedback-quick"
+                rows="3"
+                placeholder="Tighten the claims, keep the previous experiment results, and revise the writing narrative."
+              ></textarea>
+            </label>
+            <p id="review-next" class="review-next"></p>
+          </article>
+
+          <div class="review-grid">
+            <section class="card-panel">
+              <header class="card-header">
+                <p class="kicker">
+                  <span id="review-stage-label" class="kicker inline">Human review</span>
+                  · <span id="document-meta" class="meta inline"></span>
+                </p>
+                <h3 id="document-title" class="card-title">Stage document</h3>
+              </header>
+              <article id="stage-document" class="prose-block document-body empty-state">
+                Select a stage to inspect the human-readable summary.
+              </article>
+
+              <section class="review-previous-section">
+                <header class="card-subheader">
+                  <h4 class="card-subtitle">Previous stages</h4>
+                  <span id="review-previous-count" class="meta">0 approved</span>
+                </header>
+                <div id="review-previous-list" class="review-previous-list"></div>
+              </section>
             </section>
 
-            <aside class="panel">
-              <div class="panel-header">
-                <div>
-                  <p class="eyebrow">Live runner activity</p>
-                  <h2>Progress Monitor</h2>
-                </div>
+            <aside class="card-panel">
+              <header class="card-header">
+                <p class="kicker">Live runner</p>
                 <span id="session-event-count" class="meta">0 events</span>
+              </header>
+
+              <div id="review-progress-summary" class="review-progress-summary">
+                <span class="live-dot"></span>
+                <span id="review-progress-text">Waiting for activity…</span>
               </div>
-              <div class="panel-body split-stack">
-                <div id="review-progress-summary" class="review-progress-summary">
-                  <span class="live-dot"></span>
-                  <span id="review-progress-text">Waiting for activity…</span>
+
+              <section class="card-subsection">
+                <h4 class="card-subtitle">Interaction trace</h4>
+                <div id="stage-session-view" class="session-container">
+                  <div class="empty-state">Pick a stage to see the interaction trace.</div>
                 </div>
+              </section>
 
-                <section class="session-section">
-                  <div id="stage-session-view" class="session-container">
-                    <div class="session-empty">Pick a stage to see the interaction trace.</div>
-                  </div>
-                </section>
+              <section class="card-subsection">
+                <h4 class="card-subtitle">Review checklist</h4>
+                <ul class="reviewer-checklist">
+                  <li>Scan <b>What I Did</b> — does it match the goal?</li>
+                  <li>Check <b>Key Results</b> — do they look sane?</li>
+                  <li>Open one or two <b>Files Produced</b> to confirm.</li>
+                  <li>If unsure, drop a note in feedback and Re-run.</li>
+                </ul>
+              </section>
 
-                <section class="inspector-block">
-                  <h3>Review Checklist</h3>
-                  <ul id="reviewer-actions-primary" class="reviewer-checklist">
-                    <li>Scan <b>What I Did</b> — does it match the goal?</li>
-                    <li>Check <b>Key Results</b> — do they look sane?</li>
-                    <li>Open one or two <b>Files Produced</b> to confirm.</li>
-                    <li>If unsure, drop a note in the feedback box and Re-run.</li>
-                  </ul>
-                </section>
-
-                <details class="iteration-advanced">
-                  <summary>Advanced: manual iteration brief</summary>
-                  <p class="hitl-hint">
-                    Use this form only if you need to generate a structured execution brief for a specific scope (file, subtree, or manuscript). The two buttons above cover the common case.
-                  </p>
-
+              <details class="iteration-advanced">
+                <summary>Advanced — manual iteration brief</summary>
+                <p class="hint-block">
+                  Generates a structured execution brief for a specific scope. The two buttons above cover the common case.
+                </p>
                 <form id="iteration-form" class="iteration-form">
-                  <label>
-                    <span>Mode</span>
+                  <label class="field">
+                    <span class="field-label">Mode</span>
                     <select id="iteration-mode" name="mode">
                       <option value="continue">Continue</option>
                       <option value="redo">Redo</option>
                       <option value="branch">Branch</option>
                     </select>
                   </label>
-                  <label>
-                    <span>Stage</span>
+                  <label class="field">
+                    <span class="field-label">Stage</span>
                     <select id="iteration-stage" name="base_stage_slug"></select>
                   </label>
-                  <label>
-                    <span>Scope type</span>
+                  <label class="field">
+                    <span class="field-label">Scope type</span>
                     <select id="iteration-scope-type" name="scope_type">
                       <option value="stage">Stage</option>
                       <option value="file">File</option>
@@ -317,8 +340,8 @@
                       <option value="manuscript">Manuscript</option>
                     </select>
                   </label>
-                  <label>
-                    <span>Scope value</span>
+                  <label class="field">
+                    <span class="field-label">Scope value</span>
                     <input
                       id="iteration-scope-value"
                       name="scope_value"
@@ -326,92 +349,84 @@
                       placeholder="workspace/writing/sections/method.tex"
                     />
                   </label>
-                  <label>
-                    <span>Human feedback</span>
+                  <label class="field">
+                    <span class="field-label">Human feedback</span>
                     <textarea
                       id="iteration-feedback"
                       name="user_feedback"
-                      rows="5"
+                      rows="4"
                       placeholder="Tighten the claims, keep the previous experiment results, and revise the writing narrative."
                     ></textarea>
                   </label>
-                  <button class="button button-primary" type="submit">Generate Execution Brief</button>
+                  <button class="btn btn-primary" type="submit">Generate execution brief</button>
                 </form>
-
-                <section class="inspector-block">
-                  <h3>Execution Brief</h3>
-                  <div id="iteration-plan" class="plan-output empty-state">No iteration brief generated yet.</div>
+                <section class="card-subsection">
+                  <h4 class="card-subtitle">Execution brief</h4>
+                  <div id="iteration-plan" class="prose-block empty-state">
+                    No iteration brief generated yet.
+                  </div>
                 </section>
-                </details>
-              </div>
+              </details>
             </aside>
           </div>
         </section>
 
+        <!-- ============ VERSIONS ============ -->
         <section id="page-history" class="page">
-          <div class="page-grid history-grid">
-            <section class="panel">
-              <div class="panel-header">
-                <div>
-                  <p class="eyebrow">Project versions</p>
-                  <h2>Derived Checkpoints</h2>
-                </div>
+          <div class="versions-grid">
+            <section class="card-panel versions-rail-panel">
+              <header class="card-header">
+                <p class="kicker">Project versions</p>
                 <span id="version-count" class="meta">0</span>
-              </div>
-              <div class="panel-body">
-                <div class="banner subtle">
-                  This first history slice is read-only. It derives checkpoints from the run manifest and approved stages before named milestones are wired in.
-                </div>
-                <div id="version-list" class="version-list"></div>
-              </div>
+              </header>
+              <p class="hint-block subtle">
+                This first slice is read-only — checkpoints are derived from the run manifest and approved stages until named milestones are wired in.
+              </p>
+              <ol id="version-list" class="version-rail"></ol>
             </section>
 
-            <section class="panel">
-              <div class="panel-header">
-                <div>
-                  <p class="eyebrow">Checkpoint details</p>
-                  <h2 id="history-title">Version detail</h2>
-                </div>
-                <span id="history-meta" class="meta"></span>
+            <section class="card-panel">
+              <header class="card-header">
+                <p class="kicker">
+                  Checkpoint detail
+                  <span id="history-meta" class="meta inline"></span>
+                </p>
+                <h3 id="history-title" class="card-title">Version detail</h3>
+              </header>
+              <div id="history-summary" class="prose-block empty-state">
+                Select a checkpoint to inspect its stage summary and changed artifacts.
               </div>
-              <div class="panel-body split-stack">
-                <div id="history-summary" class="copy-block empty-state">
-                  Select a checkpoint to inspect its stage summary and changed artifacts.
-                </div>
-                <section class="inspector-block">
-                  <h3>Artifacts At This Checkpoint</h3>
-                  <ul id="history-artifacts" class="artifact-summary"></ul>
-                </section>
-                <section class="inspector-block">
-                  <h3>Stage Summary</h3>
-                  <article id="history-stage-preview" class="document-body empty-state">
-                    Select a checkpoint to preview its associated stage summary.
-                  </article>
-                </section>
-              </div>
+
+              <section class="card-subsection">
+                <h4 class="card-subtitle">Artifacts at this checkpoint</h4>
+                <ul id="history-artifacts" class="artifact-summary"></ul>
+              </section>
+
+              <section class="card-subsection">
+                <h4 class="card-subtitle">Stage summary</h4>
+                <article id="history-stage-preview" class="prose-block document-body empty-state">
+                  Select a checkpoint to preview its associated stage summary.
+                </article>
+              </section>
             </section>
 
-            <aside class="panel">
-              <div class="panel-header">
-                <div>
-                  <p class="eyebrow">Execution trace</p>
-                  <h2>Timeline</h2>
-                </div>
+            <aside class="card-panel">
+              <header class="card-header">
+                <p class="kicker">Execution timeline</p>
                 <span id="trace-count" class="meta">0 events</span>
-              </div>
-              <div class="panel-body">
-                <div id="trace-timeline" class="trace-timeline"></div>
-              </div>
+              </header>
+              <ol id="trace-timeline" class="trace-rail"></ol>
             </aside>
           </div>
         </section>
 
+        <!-- ============ NOTEBOOK ============ -->
         <section id="page-notebook" class="page">
           <div class="notebook-layout">
             <aside class="notebook-sources" aria-label="Notebook sources">
               <header class="notebook-col-header">
-                <p class="eyebrow">Sources</p>
-                <h3 id="notebook-project-title">Project</h3>
+                <p class="kicker">Sources</p>
+                <h3 id="notebook-project-title" class="notebook-col-title">Project</h3>
               </header>
               <div class="notebook-sources-body" id="notebook-sources-body">
                 <div class="empty-state">Pick a run to populate sources.</div>
@@ -421,24 +436,31 @@
             <section class="notebook-center" aria-label="Claude Code conversation">
               <header class="notebook-col-header notebook-center-header">
                 <div>
-                  <p class="eyebrow">Coordinator</p>
-                  <h3>Claude Code</h3>
+                  <p class="kicker">Coordinator</p>
+                  <h3 class="notebook-col-title">Claude Code</h3>
                 </div>
                 <div class="notebook-center-actions">
-                  <span id="notebook-status-chip" class="status-chip status-idle">Idle</span>
-                  <button id="notebook-reset-button" class="button button-ghost" type="button" title="Start a fresh Claude Code session for this run">Reset session</button>
+                  <span id="notebook-status-chip" class="status-chip" data-status="idle">Idle</span>
+                  <button
+                    id="notebook-reset-button"
+                    class="btn btn-ghost btn-small"
+                    type="button"
+                    title="Start a fresh Claude Code session for this run"
+                  >
+                    Reset session
+                  </button>
                 </div>
               </header>
               <ol id="notebook-events" class="notebook-events" aria-live="polite"></ol>
-              <form id="notebook-form" class="notebook-input-row">
+              <form id="notebook-form" class="notebook-composer">
                 <textarea
                   id="notebook-input"
                   rows="3"
                   placeholder="Ask Claude to inspect a stage, edit a file, compile the paper, or plan the next step. Shift+Enter for newline."
                 ></textarea>
-                <div class="notebook-input-actions">
-                  <span class="notebook-input-hint">Enter to send · Shift+Enter for newline</span>
-                  <button id="notebook-send-button" class="button button-primary" type="submit">Send</button>
+                <div class="notebook-composer-actions">
+                  <span class="notebook-composer-hint">Enter to send · Shift+Enter for newline</span>
+                  <button id="notebook-send-button" class="btn btn-primary" type="submit">Send</button>
                 </div>
               </form>
             </section>
@@ -446,17 +468,13 @@
             <aside class="notebook-viewer" aria-label="Viewer">
               <header class="notebook-col-header notebook-viewer-header">
                 <div>
-                  <p class="eyebrow">Viewer</p>
-                  <h3 id="notebook-viewer-title">Nothing open</h3>
+                  <p class="kicker">Viewer</p>
+                  <h3 id="notebook-viewer-title" class="notebook-col-title">Nothing open</h3>
                 </div>
                 <span id="notebook-viewer-meta" class="meta"></span>
               </header>
               <div class="notebook-viewer-toolbar">
                 <span id="notebook-viewer-path" class="notebook-path-breadcrumb">—</span>
-                <div class="pill-row">
-                  <span class="pill pill-disabled">Open in VS Code (planned)</span>
-                  <span class="pill pill-disabled">Open in Overleaf (planned)</span>
-                </div>
               </div>
               <div id="notebook-viewer-body" class="notebook-viewer-body empty-state">
                 Click a file in the left rail, or a tool chip in the conversation, to preview it here.

--- a/src/frontend/static/index.html
+++ b/src/frontend/static/index.html
@@ -39,7 +39,7 @@
       <main class="hub-view">
         <section class="hub-poster">
           <div class="hub-poster-text">
-            <p class="kicker">A research control workspace</p>
+            <p class="kicker">A Research Control Workspace</p>
             <h1 class="display-headline">
               Run experiments<br />
               <em>read like papers.</em>

--- a/src/frontend/static/styles.css
+++ b/src/frontend/static/styles.css
@@ -1,1147 +1,827 @@
+/* =====================================================================
+   AutoR Studio — Editorial Research Console
+   ===================================================================== */
+
 :root {
-  --bg: #f6f2ea;
-  --surface: #eef3f6;
-  --card: #fbfcfd;
+  /* Surfaces */
+  --bg: #f4efe5;
+  --bg-elev: #faf7f0;
+  --surface: #eef0ec;
+  --card: #ffffff;
   --card-strong: #ffffff;
-  --ink: #18222d;
-  --muted: #5b6875;
-  --line: #d8e0e7;
-  --accent: #1f7a6a;
-  --accent-soft: #dff1ec;
-  --warning: #b9822e;
-  --warning-soft: rgba(185, 130, 46, 0.14);
-  --danger: #c65a46;
-  --danger-soft: rgba(198, 90, 70, 0.14);
-  --shadow: 0 12px 40px rgba(24, 34, 45, 0.08);
-  --shadow-soft: 0 6px 24px rgba(24, 34, 45, 0.06);
-  --radius: 18px;
+  --paper: #fdfaf3;
+
+  /* Ink */
+  --ink: #1a2128;
+  --ink-soft: #38434f;
+  --muted: #6a7682;
+  --line: #e3dccd;
+  --line-strong: #c8c0ad;
+  --rule: #d6cfbe;
+
+  /* Accent + semantic */
+  --accent: #1f6f60;
+  --accent-strong: #14564a;
+  --accent-soft: #d8ebe6;
+  --warning: #b07321;
+  --warning-soft: rgba(176, 115, 33, 0.14);
+  --danger: #b04a36;
+  --danger-soft: rgba(176, 74, 54, 0.14);
+  --info: #355d8a;
+  --info-soft: rgba(53, 93, 138, 0.12);
+
+  /* Effects */
+  --shadow: 0 16px 48px -28px rgba(20, 30, 40, 0.45);
+  --shadow-soft: 0 4px 14px -10px rgba(20, 30, 40, 0.25);
+  --shadow-pressed: 0 1px 0 rgba(20, 30, 40, 0.06);
+
+  /* Geometry */
+  --radius: 14px;
+  --radius-sm: 10px;
+  --radius-lg: 22px;
+
+  /* Type */
+  --font-sans: "IBM Plex Sans", "Inter", "Segoe UI", system-ui, sans-serif;
+  --font-serif: "Source Serif 4", "Iowan Old Style", Georgia, serif;
+  --font-mono: "JetBrains Mono", "SFMono-Regular", ui-monospace, monospace;
+
+  /* Color compat aliases (used in legacy notebook CSS rules) */
+  --color-card: var(--card);
+  --color-divider: var(--line);
+  --color-surface: var(--surface);
+  --color-ink: var(--ink);
+  --color-muted: var(--muted);
 }
 
-* {
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; }
 
-html,
-body {
+html, body {
   margin: 0;
   min-height: 100%;
   background:
-    radial-gradient(circle at top left, rgba(31, 122, 106, 0.08), transparent 28%),
-    radial-gradient(circle at bottom right, rgba(185, 130, 46, 0.08), transparent 24%),
+    radial-gradient(1200px 600px at 12% -10%, rgba(31, 111, 96, 0.06), transparent 55%),
+    radial-gradient(900px 500px at 110% 8%, rgba(176, 115, 33, 0.05), transparent 55%),
     var(--bg);
   color: var(--ink);
-  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-body {
-  padding: 24px;
-}
+body { padding: 28px 36px 56px; }
 
-.app-shell {
-  max-width: 1600px;
-  margin: 0 auto;
-}
+.app-shell { max-width: 1480px; margin: 0 auto; }
 
-/* ---------- View switching ---------- */
+/* View switching */
 .app-shell[data-view="hub"] .workspace-view,
-.app-shell[data-view="workspace"] .hub-view {
-  display: none;
-}
-.app-shell[data-view="hub"] #back-to-hub {
-  display: none;
-}
+.app-shell[data-view="workspace"] .hub-view { display: none; }
+.app-shell[data-view="hub"] #back-to-hub { display: none; }
 
-.hub-view,
-.workspace-view {
+.hub-view, .workspace-view {
   display: grid;
-  gap: 20px;
+  gap: 28px;
   align-content: start;
+  animation: shell-fade 320ms ease both;
+}
+@keyframes shell-fade {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
-/* ---------- Topbar ---------- */
+/* =====================================================================
+   Topbar
+   ===================================================================== */
+
 .topbar {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: flex-start;
   gap: 24px;
-  margin-bottom: 20px;
+  padding: 6px 0 22px;
+  margin-bottom: 4px;
+  border-bottom: 1px solid var(--rule);
 }
 
-.topbar-lead {
+.topbar-brand {
   display: flex;
-  align-items: flex-start;
-  gap: 14px;
+  align-items: center;
+  gap: 18px;
   min-width: 0;
 }
 
-.topbar h1,
-.panel-header h2,
-.workspace-title h2,
-.inspector-block h3 {
-  margin: 0;
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px 6px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--card);
+  color: var(--ink-soft);
+  font: 500 12px/1 var(--font-sans);
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: border-color 140ms ease, color 140ms ease, transform 140ms ease;
+}
+.back-link:hover { border-color: var(--accent); color: var(--accent); transform: translateX(-1px); }
+
+.brand-mark {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
 }
 
-.topbar-copy,
-.workspace-goal,
-.copy-block,
-.banner {
-  line-height: 1.6;
-}
-
-.topbar-copy {
-  margin: 8px 0 0;
-  max-width: 720px;
-  color: var(--muted);
-}
-
-.eyebrow {
-  margin: 0 0 6px;
-  color: var(--muted);
+.brand-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--font-mono);
+  font-weight: 600;
   font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: -0.02em;
+}
+
+.brand-text { display: flex; flex-direction: column; line-height: 1.15; min-width: 0; }
+.brand-name {
+  font-family: var(--font-serif);
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+.brand-tag {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--muted);
   text-transform: uppercase;
+  margin-top: 2px;
 }
 
 .topbar-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   flex-shrink: 0;
 }
 
-/* ---------- Panels ---------- */
-.panel {
-  background: rgba(251, 252, 253, 0.92);
-  border: 1px solid rgba(216, 224, 231, 0.95);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(10px);
-  min-width: 0;
-}
-
-.panel-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 18px 20px 14px;
-  border-bottom: 1px solid var(--line);
-}
-
-.panel-header h2 {
-  font-size: 18px;
-  word-break: break-word;
-}
-
-.panel-body {
-  padding: 18px 20px 20px;
-  min-width: 0;
-}
-
-.split-stack {
-  display: grid;
-  gap: 20px;
-  min-width: 0;
-}
-
-/* ---------- Workspace header ---------- */
-.workspace-header .panel-body,
-.workspace-header-body {
-  padding: 0;
-}
-
-.workspace-header {
-  padding: 18px 20px 20px;
-}
-
-.workspace-header-body {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 20px;
-}
-
-.workspace-title {
-  display: grid;
-  gap: 6px;
-  min-width: 0;
-}
-
-.workspace-title h2 {
-  font-size: 22px;
-  word-break: break-word;
-}
-
-.workspace-goal {
-  margin: 0;
-  color: var(--muted);
-  max-width: 720px;
-  overflow-wrap: anywhere;
-}
-
-.workspace-actions {
-  flex-shrink: 0;
-}
-
-.page-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 16px;
-}
-
-.page-link {
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--card);
-  color: var(--muted);
-  font: inherit;
-  font-size: 13px;
-  font-weight: 700;
-  padding: 9px 14px;
-  cursor: pointer;
-  transition: border-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
-}
-
-.page-link:hover,
-.page-link.is-active {
-  border-color: var(--accent);
-  color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(31, 122, 106, 0.12);
-}
-
-.page {
-  display: none;
-}
-
-.page.is-active {
-  display: block;
-}
-
-.page-grid {
-  display: grid;
-  gap: 20px;
-  min-width: 0;
-}
-
-/* ---------- Overview grid ---------- */
-.overview-grid {
-  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-}
-
-.panel-full {
-  grid-column: 1 / -1;
-}
-
-.review-grid,
-.paper-grid {
-  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
-}
-
-.history-grid {
-  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr) minmax(300px, 360px);
-}
-
-.files-grid {
-  grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
-}
-
-/* ---------- Hub: projects/runs grid ---------- */
-.projects-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 14px;
-}
-
-.runs-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 12px;
-}
-
-.hub-create .project-form-inline {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 14px;
-  margin-bottom: 0;
-}
-
-.hub-create .project-form-inline label {
-  min-width: 0;
-}
-
-.hub-create .project-form-inline button {
-  height: 42px;
-  justify-self: end;
-  min-width: 180px;
-}
-
-.hub-create .project-form-inline textarea {
-  min-height: 64px;
-}
-
-/* ---------- Stage rail / lists (workspace sidebars removed) ---------- */
-.runs-list,
-.stage-rail,
-.file-tree,
-.version-list,
-.trace-timeline {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-width: 0;
-}
-
-/* ---------- Document / copy blocks ---------- */
-.document-body {
-  min-height: 240px;
-  max-height: 68vh;
-  overflow: auto;
-  border: 1px solid rgba(216, 224, 231, 0.9);
-  border-radius: 16px;
-  background: var(--card-strong);
-  box-shadow: var(--shadow-soft);
-  padding: 18px 20px;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.document-body.empty-state,
-.copy-block.empty-state,
-.paper-frame-container.empty-state {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  color: var(--muted);
-}
-
-.copy-block {
-  border: 1px dashed var(--line);
-  border-radius: 16px;
-  padding: 18px 20px;
-  background: rgba(255, 255, 255, 0.72);
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.copy-block p {
-  margin: 0 0 8px;
-}
-.copy-block p:last-child {
-  margin-bottom: 0;
-}
-
-/* ---------- Cards ---------- */
-.run-card,
-.project-card,
-.stage-item,
-.version-card {
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  padding: 14px 16px;
-  background: var(--card);
-  text-align: left;
-  min-width: 0;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.projects-grid .project-card,
-.runs-grid .run-card {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.run-card,
-.project-card,
-.stage-item,
-.version-card,
-.tree-label {
-  transition: transform 120ms ease, border-color 120ms ease, box-shadow 120ms ease, color 120ms ease;
-}
-
-.run-card,
-.project-card,
-.stage-item,
-.version-card {
-  cursor: pointer;
-  font: inherit;
-  color: inherit;
-}
-
-.run-card:hover,
-.project-card:hover,
-.stage-item:hover,
-.version-card:hover {
-  border-color: rgba(31, 122, 106, 0.45);
-}
-
-.run-card.is-active,
-.project-card.is-active,
-.stage-item.is-active,
-.version-card.is-active {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(31, 122, 106, 0.12);
-}
-
-.project-card-header,
-.run-card-title,
-.stage-title,
-.version-card-title {
-  font-weight: 700;
-}
-
-.project-card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.project-card-title {
-  font-size: 15px;
-}
-
-.version-card-header,
-.trace-title-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.project-card-thesis,
-.run-card-meta,
-.stage-meta,
-.meta {
-  color: var(--muted);
-  font-size: 13px;
-  overflow-wrap: anywhere;
-}
-
-.project-card-thesis {
-  margin: 4px 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.tag-row,
-.pill-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.tag,
-.mode-chip,
-.stage-status,
-.pill {
-  display: inline-flex;
-  align-items: center;
-  padding: 4px 8px;
-  border-radius: 999px;
-  background: var(--surface);
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.mode-chip,
-.badge-status {
-  background: var(--accent-soft);
-  color: var(--accent);
-}
-
-.stage-status.status-approved {
-  background: var(--accent-soft);
-  color: var(--accent);
-}
-
-.stage-status.status-human_review,
-.stage-status.status-running {
-  background: var(--warning-soft);
-  color: var(--warning);
-}
-
-.stage-status.status-failed,
-.stage-status.status-stale {
-  background: var(--danger-soft);
-  color: var(--danger);
-}
-
-.summary-list {
-  display: grid;
-  grid-template-columns: minmax(90px, 130px) minmax(0, 1fr);
-  gap: 8px 12px;
-  margin: 0;
-}
-
-.summary-list dt {
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.summary-list dd {
-  margin: 0;
-  font-size: 14px;
-  min-width: 0;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.artifact-summary {
-  margin: 0;
-  padding-left: 18px;
-}
-
-.artifact-summary li {
-  margin-bottom: 8px;
-  line-height: 1.5;
-  overflow-wrap: anywhere;
-}
-
-.tree-node {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-
-.tree-label {
-  border: 1px solid transparent;
-  border-radius: 10px;
-  background: none;
-  text-align: left;
-  padding: 6px 8px;
-  color: var(--ink);
-  font-size: 13px;
-  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
-  cursor: pointer;
-  overflow-wrap: anywhere;
-  word-break: break-all;
-}
-
-.tree-label:hover,
-.tree-label.is-active {
-  color: var(--accent);
-  border-color: rgba(31, 122, 106, 0.22);
-  background: rgba(31, 122, 106, 0.05);
-}
-
-.tree-children {
-  margin-left: 14px;
-  padding-left: 10px;
-  border-left: 1px solid var(--line);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-
-.badge,
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  font-size: 13px;
-  font-weight: 700;
-}
-
-.badge {
-  padding: 7px 12px;
-  background: var(--surface);
-  color: var(--muted);
-}
-
-.button {
-  border: none;
-  padding: 9px 14px;
-  cursor: pointer;
-}
-
-.button-primary {
-  background: var(--accent);
-  color: white;
-}
-
-.button-secondary {
-  background: var(--surface);
-  color: var(--ink);
-}
-
-.button-ghost {
-  background: transparent;
-  color: var(--muted);
-  border: 1px solid var(--line);
-}
-
-.button-ghost:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-
-.button:hover {
-  filter: brightness(0.98);
-}
-
-.attach-row {
-  margin-bottom: 16px;
-}
-
-.hitl-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 10px;
-}
-
-.hitl-actions .button {
-  flex: 1 1 auto;
-  padding: 11px 16px;
-}
-
-.hitl-hint {
-  margin: 0 0 14px;
-  color: var(--muted);
-  font-size: 12px;
-  line-height: 1.5;
-}
-
-/* ---------- Live status panel ---------- */
-.live-panel {
-  border: 1px solid rgba(31, 122, 106, 0.22);
-  background: linear-gradient(135deg, rgba(31, 122, 106, 0.06), rgba(255, 255, 255, 0.9));
-}
-
-.live-header {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  min-width: 0;
-}
-
-.live-header h2 {
-  font-size: 20px;
-  word-break: break-word;
-}
-
-.live-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 999px;
-  background: #8a95a1;
-  box-shadow: 0 0 0 0 rgba(138, 149, 161, 0);
-  flex-shrink: 0;
-}
-
-.live-dot.is-live {
-  background: var(--accent);
-  animation: live-pulse 1.6s ease-in-out infinite;
-}
-
-.live-dot.is-review {
-  background: var(--warning);
-  animation: live-pulse-warn 1.6s ease-in-out infinite;
-}
-
-.live-dot.is-done {
-  background: var(--accent);
-}
-
-.live-dot.is-failed {
-  background: var(--danger);
-}
-
-@keyframes live-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(31, 122, 106, 0.55); }
-  50%      { box-shadow: 0 0 0 8px rgba(31, 122, 106, 0); }
-}
-
-@keyframes live-pulse-warn {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(185, 130, 46, 0.55); }
-  50%      { box-shadow: 0 0 0 8px rgba(185, 130, 46, 0); }
-}
-
-.status-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  font-size: 12px;
-  font-weight: 700;
+/* =====================================================================
+   Type primitives
+   ===================================================================== */
+
+.kicker {
+  margin: 0 0 10px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  background: var(--surface);
   color: var(--muted);
-  white-space: nowrap;
+}
+.kicker.inline { display: inline; margin: 0; }
+
+/* Backwards compat with old eyebrow class still emitted by JS */
+.eyebrow {
+  margin: 0 0 6px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
 
-.status-chip.status-running    { background: var(--warning-soft); color: var(--warning); }
-.status-chip.status-human_review,
-.status-chip.status-review     { background: rgba(80, 130, 200, 0.14); color: #3a6aa8; }
-.status-chip.status-completed,
-.status-chip.status-approved   { background: var(--accent-soft); color: var(--accent); }
-.status-chip.status-failed,
-.status-chip.status-stale      { background: var(--danger-soft); color: var(--danger); }
-.status-chip.status-pending,
-.status-chip.status-idle       { background: var(--surface); color: var(--muted); }
+.meta {
+  font-family: var(--font-mono);
+  color: var(--muted);
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+}
+.meta.inline { font-family: var(--font-mono); }
 
-.live-progress-row {
+.meta-counter {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--muted);
+  background: var(--surface);
+  padding: 4px 10px;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+}
+
+/* =====================================================================
+   Hub view — editorial poster
+   ===================================================================== */
+
+.hub-view { gap: 36px; }
+
+.hub-poster {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 18px;
-  align-items: center;
-  margin-bottom: 14px;
+  grid-template-columns: minmax(0, 1.35fr) minmax(360px, 0.85fr);
+  gap: 56px;
+  padding: 42px 8px 12px;
+  align-items: start;
 }
 
-.live-progress {
-  min-width: 0;
+.hub-poster-text { max-width: 640px; }
+
+.display-headline {
+  margin: 14px 0 20px;
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: clamp(40px, 5.4vw, 64px);
+  line-height: 1.04;
+  letter-spacing: -0.018em;
+  color: var(--ink);
+}
+.display-headline em {
+  font-style: italic;
+  color: var(--accent-strong);
+  font-weight: 500;
 }
 
-.live-progress-label {
+.lede {
+  margin: 0;
+  font-size: 16.5px;
+  line-height: 1.65;
+  color: var(--ink-soft);
+  max-width: 540px;
+}
+
+.hub-create-card {
+  position: relative;
+  background: var(--card);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  padding: 26px 24px 24px;
+  display: grid;
+  gap: 14px;
+  box-shadow: var(--shadow);
+}
+.hub-create-card::before {
+  content: "";
+  position: absolute;
+  inset: -10px;
+  border-radius: calc(var(--radius-lg) + 10px);
+  border: 1px dashed var(--line-strong);
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.hub-section { display: grid; gap: 16px; }
+
+.section-header {
   display: flex;
+  align-items: flex-end;
   justify-content: space-between;
+  gap: 18px;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 14px;
+}
+
+.section-title {
+  margin: 4px 0 0;
+  font-family: var(--font-serif);
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* =====================================================================
+   Form fields
+   ===================================================================== */
+
+.field { display: grid; gap: 6px; min-width: 0; }
+.field-label {
+  display: flex;
   align-items: baseline;
   gap: 8px;
-  margin-bottom: 8px;
-  font-size: 13px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
   color: var(--muted);
-  font-weight: 700;
+  font-weight: 600;
+}
+.field-hint {
+  font-family: var(--font-sans);
+  font-size: 11px;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--muted);
+  font-weight: 400;
 }
 
-.live-progress-bar {
-  height: 10px;
-  background: rgba(216, 224, 231, 0.7);
+input, textarea, select {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 11px 13px;
+  font: 14px/1.45 var(--font-sans);
+  color: var(--ink);
+  background: var(--card);
+  min-width: 0;
+  transition: border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
+}
+input::placeholder, textarea::placeholder { color: var(--muted); opacity: 0.85; }
+input:focus, textarea:focus, select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(31, 111, 96, 0.16);
+}
+textarea { resize: vertical; line-height: 1.55; }
+
+/* =====================================================================
+   Buttons (.btn current + .button legacy compat)
+   ===================================================================== */
+
+.btn, .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 1px solid transparent;
   border-radius: 999px;
-  overflow: hidden;
+  font: 600 13px/1 var(--font-sans);
+  padding: 10px 16px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease,
+              transform 140ms ease, box-shadow 140ms ease;
+}
+.btn:focus-visible, .button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(31, 111, 96, 0.25);
 }
 
-.live-progress-fill {
-  height: 100%;
-  width: 0%;
-  background: linear-gradient(90deg, var(--accent) 0%, #2ea58e 100%);
-  border-radius: 999px;
-  transition: width 400ms ease;
+.btn-primary, .button-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
-
-.live-actions {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
+.btn-primary:hover:not(:disabled),
+.button-primary:hover:not(:disabled) {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px -8px rgba(20, 86, 74, 0.5);
 }
-
-.live-actions .button[disabled] {
-  opacity: 0.4;
+.btn-primary:disabled, .button-primary:disabled {
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
-.live-last-event {
-  margin: 0;
-  padding: 10px 14px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px dashed var(--line);
-  color: var(--muted);
-  font-size: 13px;
-  overflow-wrap: anywhere;
+.btn-ghost, .button-ghost, .button-secondary {
+  background: var(--card);
+  color: var(--ink-soft);
+  border-color: var(--line-strong);
 }
-
-/* ---------- Activity feed ---------- */
-.activity-feed {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  max-height: 340px;
-  overflow: auto;
-}
-
-.activity-feed li {
-  display: grid;
-  grid-template-columns: 10px minmax(0, 1fr) auto;
-  gap: 10px;
-  align-items: center;
-  padding: 10px 12px;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  background: var(--card-strong);
-  transition: border-color 120ms ease;
-}
-
-.activity-feed li.is-running   { border-left: 3px solid var(--warning); }
-.activity-feed li.is-review    { border-left: 3px solid #3a6aa8; }
-.activity-feed li.is-approved  { border-left: 3px solid var(--accent); }
-.activity-feed li.is-failed    { border-left: 3px solid var(--danger); }
-.activity-feed li.is-pending   { border-left: 3px solid #cfd6dd; }
-
-.activity-feed .activity-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: #cfd6dd;
-}
-.activity-feed li.is-running .activity-dot { background: var(--warning); }
-.activity-feed li.is-review .activity-dot { background: #3a6aa8; }
-.activity-feed li.is-approved .activity-dot { background: var(--accent); }
-.activity-feed li.is-failed .activity-dot { background: var(--danger); }
-
-.activity-feed .activity-main {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-.activity-feed .activity-title {
-  font-weight: 700;
-  font-size: 13px;
-}
-
-.activity-feed .activity-detail {
-  font-size: 12px;
-  color: var(--muted);
-}
-
-.activity-feed .activity-time {
-  font-size: 11px;
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-/* ---------- Enhanced stage rail ---------- */
-.stage-rail .stage-item {
-  display: grid;
-  grid-template-columns: 28px minmax(0, 1fr);
-  grid-template-rows: auto auto;
-  grid-template-areas:
-    "num body"
-    "num chip";
-  gap: 4px 10px;
-  align-items: center;
-  padding: 10px 12px;
-}
-.stage-rail .stage-item .stage-number { grid-area: num; }
-.stage-rail .stage-item .stage-body   { grid-area: body; }
-.stage-rail .stage-item .status-chip  {
-  grid-area: chip;
-  justify-self: start;
-  padding: 3px 8px;
-  font-size: 11px;
-}
-.stage-rail .stage-item .stage-title {
-  font-size: 13px;
-  line-height: 1.3;
-}
-.stage-rail .stage-item .stage-meta {
-  font-size: 11px;
-}
-
-.stage-number {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 999px;
-  background: var(--surface);
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.stage-item.is-running  .stage-number { background: var(--warning-soft); color: var(--warning); }
-.stage-item.is-review   .stage-number { background: rgba(80, 130, 200, 0.14); color: #3a6aa8; }
-.stage-item.is-approved .stage-number { background: var(--accent-soft); color: var(--accent); }
-.stage-item.is-failed   .stage-number { background: var(--danger-soft); color: var(--danger); }
-
-.stage-item.is-current {
-  box-shadow: 0 0 0 2px rgba(31, 122, 106, 0.22), var(--shadow-soft);
-}
-
-.stage-item .stage-body {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-/* Connect the workspace header status badge to the same status-chip look. */
-.badge-status.status-running    { background: var(--warning-soft); color: var(--warning); }
-.badge-status.status-human_review { background: rgba(80, 130, 200, 0.14); color: #3a6aa8; }
-.badge-status.status-completed  { background: var(--accent-soft); color: var(--accent); }
-.badge-status.status-failed     { background: var(--danger-soft); color: var(--danger); }
-
-/* ---------- Session viewer ---------- */
-.session-empty {
-  padding: 16px;
-  text-align: center;
-  color: var(--muted);
-  font-style: italic;
-}
-
-.session-event-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  max-height: 68vh;
-  overflow: auto;
-}
-
-.session-event {
-  border-left: 3px solid var(--line);
-  border-radius: 10px;
-  background: var(--card-strong);
-  padding: 10px 12px;
-  box-shadow: var(--shadow-soft);
-  overflow-wrap: anywhere;
-}
-
-.session-event-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--muted);
-  margin-bottom: 6px;
-}
-
-.session-event-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 999px;
-  background: var(--surface);
-  font-size: 12px;
-}
-
-.session-event-label {
-  flex: 1;
-}
-
-.session-event-time {
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-
-.session-event-body {
-  font-size: 13px;
-  line-height: 1.55;
-  color: var(--ink);
-  white-space: pre-wrap;
-}
-
-.session-tool-call {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.session-tool-name {
-  display: inline-block;
-  align-self: flex-start;
-  padding: 3px 8px;
-  border-radius: 999px;
-  background: rgba(31, 122, 106, 0.12);
+.btn-ghost:hover:not(:disabled),
+.button-ghost:hover:not(:disabled),
+.button-secondary:hover:not(:disabled) {
+  border-color: var(--accent);
   color: var(--accent);
-  font-size: 11px;
-  font-weight: 700;
-  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  background: var(--card);
 }
+.btn-ghost:disabled, .button-ghost:disabled { opacity: 0.4; cursor: not-allowed; }
 
-.session-tool-input,
-.session-tool-output {
-  margin: 0;
-  border-radius: 10px;
-  background: #13212d;
-  color: #eff6fb;
-  padding: 10px 12px;
-  font-size: 12px;
-  line-height: 1.45;
-  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
-  overflow: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
+.btn-block { width: 100%; }
+.btn-small { padding: 6px 12px; font-size: 12px; }
 
-.event-system     { border-left-color: #8a95a1; }
-.event-assistant  { border-left-color: var(--accent); background: rgba(31, 122, 106, 0.04); }
-.event-user       { border-left-color: #3a6aa8; }
-.event-tool-use   { border-left-color: var(--warning); }
-.event-tool-result{ border-left-color: #5d7182; }
-.event-approval   { border-left-color: var(--accent); background: var(--accent-soft); }
-.event-feedback   { border-left-color: var(--warning); background: var(--warning-soft); }
-
-/* ---------- Toast notifications ---------- */
-.toast-stack {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  z-index: 9999;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  pointer-events: none;
-}
-.toast {
-  min-width: 240px;
-  max-width: 420px;
-  padding: 12px 16px;
-  border-radius: 12px;
-  background: var(--card-strong);
-  color: var(--ink);
-  font-size: 13px;
-  font-weight: 600;
-  box-shadow: var(--shadow);
-  border-left: 3px solid var(--accent);
-  transform: translateX(24px);
-  opacity: 0;
-  transition: transform 220ms ease, opacity 220ms ease;
-  pointer-events: auto;
-  overflow-wrap: anywhere;
-}
-.toast.toast-visible {
-  transform: translateX(0);
-  opacity: 1;
-}
-.toast.toast-success { border-left-color: var(--accent); }
-.toast.toast-warn    { border-left-color: var(--warning); background: var(--warning-soft); color: var(--warning); }
-.toast.toast-error   { border-left-color: var(--danger);  background: var(--danger-soft); color: var(--danger); }
-.toast.toast-info    { border-left-color: #3a6aa8; }
-
-/* ---------- Button loading state ---------- */
-.button.is-loading {
+.btn.is-loading, .button.is-loading {
   position: relative;
   cursor: wait;
   opacity: 0.75;
 }
-.button.is-loading::before {
+.btn.is-loading::before, .button.is-loading::before {
   content: "";
   display: inline-block;
   width: 10px;
   height: 10px;
-  margin-right: 8px;
+  margin-right: 6px;
   border: 2px solid currentColor;
   border-top-color: transparent;
   border-radius: 999px;
   animation: btn-spin 0.7s linear infinite;
   vertical-align: -1px;
 }
-@keyframes btn-spin {
-  to { transform: rotate(360deg); }
-}
+@keyframes btn-spin { to { transform: rotate(360deg); } }
 
-/* ---------- Projects hub polish ---------- */
-.projects-empty {
-  grid-column: 1 / -1;
-  text-align: center;
-  padding: 28px 20px;
+/* =====================================================================
+   Status pills + chips + dots
+   ===================================================================== */
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px 5px 10px;
+  border-radius: 999px;
+  font: 600 11px/1 var(--font-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: var(--surface);
   color: var(--muted);
-  border: 1px dashed var(--line);
-  border-radius: 16px;
+  border: 1px solid var(--line);
 }
-.projects-empty p { margin: 6px 0; }
+.status-pill::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.65;
+}
+.status-pill[data-status="ok"], .status-pill[data-status="connected"] {
+  background: var(--accent-soft); color: var(--accent); border-color: rgba(31, 111, 96, 0.25);
+}
+.status-pill[data-status="connecting"] {
+  background: var(--warning-soft); color: var(--warning); border-color: rgba(176, 115, 33, 0.25);
+}
+.status-pill[data-status="error"] {
+  background: var(--danger-soft); color: var(--danger); border-color: rgba(176, 74, 54, 0.25);
+}
+.status-pill[data-status="running"] { background: var(--warning-soft); color: var(--warning); border-color: rgba(176, 115, 33, 0.25); }
+.status-pill[data-status="human_review"] { background: var(--info-soft); color: var(--info); border-color: rgba(53, 93, 138, 0.25); }
+.status-pill[data-status="completed"], .status-pill[data-status="approved"] { background: var(--accent-soft); color: var(--accent); border-color: rgba(31, 111, 96, 0.25); }
+.status-pill[data-status="failed"] { background: var(--danger-soft); color: var(--danger); border-color: rgba(176, 74, 54, 0.25); }
 
-.project-card-footer {
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font: 600 10.5px/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--surface);
+  color: var(--muted);
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.status-chip.status-running    { background: var(--warning-soft); color: var(--warning); }
+.status-chip.status-human_review,
+.status-chip.status-review     { background: var(--info-soft); color: var(--info); }
+.status-chip.status-completed,
+.status-chip.status-approved   { background: var(--accent-soft); color: var(--accent); }
+.status-chip.status-failed,
+.status-chip.status-stale      { background: var(--danger-soft); color: var(--danger); }
+.status-chip.status-pending,
+.status-chip.status-idle       { background: var(--surface); color: var(--muted); }
+.status-chip.status-error      { background: var(--danger-soft); color: var(--danger); }
+
+/* Legacy badge classes JS still injects */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font: 600 11px/1 var(--font-mono);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.badge-status.status-running    { background: var(--warning-soft); color: var(--warning); }
+.badge-status.status-human_review { background: var(--info-soft); color: var(--info); }
+.badge-status.status-completed  { background: var(--accent-soft); color: var(--accent); }
+.badge-status.status-failed     { background: var(--danger-soft); color: var(--danger); }
+.badge-status.status-idle       { background: var(--surface); color: var(--muted); }
+
+.live-dot {
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--muted);
+  flex-shrink: 0;
+  vertical-align: -1px;
+  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+}
+.live-dot.is-live    { background: var(--warning); animation: live-pulse 1.6s ease-in-out infinite; }
+.live-dot.is-review  { background: var(--info);    animation: live-pulse-info 1.6s ease-in-out infinite; }
+.live-dot.is-done    { background: var(--accent); }
+.live-dot.is-failed  { background: var(--danger); }
+@keyframes live-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(176, 115, 33, 0.55); }
+  50%      { box-shadow: 0 0 0 7px rgba(176, 115, 33, 0); }
+}
+@keyframes live-pulse-info {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(53, 93, 138, 0.55); }
+  50%      { box-shadow: 0 0 0 7px rgba(53, 93, 138, 0); }
+}
+
+/* =====================================================================
+   Workspace shell — header + underline tabs
+   ===================================================================== */
+
+.workspace-header {
+  display: grid;
+  gap: 10px;
+  padding: 14px 4px 0;
+}
+
+.workspace-header-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 12px;
-  margin-top: 4px;
+  gap: 18px;
+  flex-wrap: wrap;
 }
 
-.project-progress {
-  display: flex;
+.workspace-crumb { display: grid; gap: 4px; min-width: 0; }
+.crumb-eyebrow {
+  display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
-
-.progress-ring .ring-bg {
-  fill: none;
-  stroke: rgba(216, 224, 231, 0.65);
-  stroke-width: 5;
-}
-.progress-ring .ring-fill {
-  fill: none;
-  stroke: var(--accent);
-  stroke-width: 5;
-  stroke-linecap: round;
-  transform: rotate(-90deg);
-  transform-origin: 50% 50%;
-  transition: stroke-dashoffset 400ms ease;
-}
-.progress-ring .ring-label {
-  font-size: 10px;
-  font-weight: 700;
-  fill: var(--ink);
-}
-
-.project-progress-label {
-  display: flex;
-  flex-direction: column;
-  line-height: 1.1;
-}
-.project-progress-pct {
-  font-weight: 700;
-  font-size: 14px;
+.crumb-eyebrow::after { content: "›"; opacity: 0.6; }
+.crumb-title {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.012em;
   color: var(--ink);
 }
-.project-progress-sub {
-  font-size: 11px;
+
+.workspace-header-meta { display: flex; gap: 10px; align-items: center; }
+
+.workspace-goal {
+  margin: 0;
+  color: var(--ink-soft);
+  max-width: 720px;
+  font-size: 13.5px;
+  line-height: 1.55;
+}
+
+.page-nav {
+  display: flex;
+  gap: 0;
+  margin-top: 8px;
+  border-bottom: 1px solid var(--rule);
+  padding-bottom: 0;
+}
+.page-link {
+  position: relative;
+  background: transparent;
+  border: none;
+  padding: 14px 18px 12px;
+  margin: 0;
+  font: 500 13px/1 var(--font-sans);
+  color: var(--muted);
+  cursor: pointer;
+  letter-spacing: -0.005em;
+  transition: color 140ms ease;
+}
+.page-link::after {
+  content: "";
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: -1px;
+  height: 2px;
+  background: transparent;
+  border-radius: 2px 2px 0 0;
+  transition: background 180ms ease;
+}
+.page-link:hover { color: var(--ink-soft); }
+.page-link.is-active { color: var(--ink); font-weight: 600; }
+.page-link.is-active::after { background: var(--accent); }
+
+.page { display: none; }
+.page.is-active {
+  display: grid;
+  gap: 22px;
+  animation: page-fade 240ms ease both;
+}
+@keyframes page-fade {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* =====================================================================
+   Card panel — generic surface
+   ===================================================================== */
+
+.card-panel {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 18px 20px 20px;
+  min-width: 0;
+  box-shadow: var(--shadow-soft);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+  padding-bottom: 14px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+.card-header > div:first-child { min-width: 0; }
+.card-title {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+.card-subheader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin: 22px 0 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px dashed var(--line);
+}
+.card-subtitle {
+  margin: 0;
+  font: 600 12px/1 var(--font-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.card-subsection { margin-top: 22px; }
+.card-subsection > h4.card-subtitle { margin-bottom: 10px; }
+
+.prose-block {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  padding: 16px 18px;
+  line-height: 1.62;
+  color: var(--ink-soft);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.prose-block.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--muted);
+  font-style: italic;
+  min-height: 80px;
+}
+
+.empty-state {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.hint-block {
+  margin: 0 0 12px;
+  padding: 10px 14px;
+  background: var(--surface);
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+.hint-block.subtle { background: var(--paper); border: 1px dashed var(--line); }
+
+/* =====================================================================
+   Hero panel (Overview "currently on")
+   ===================================================================== */
+
+.hero-panel {
+  position: relative;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(180deg, var(--paper) 0%, var(--card) 100%);
+  padding: 24px 26px 22px;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+.hero-panel::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--warning));
+  opacity: 0.85;
+}
+
+.hero-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.hero-head-text { min-width: 0; }
+.hero-head .kicker { display: inline-flex; align-items: center; gap: 6px; }
+.hero-title {
+  margin: 4px 0 0;
+  font-family: var(--font-serif);
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  word-break: break-word;
+}
+
+.hero-progress-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 22px;
+  align-items: center;
+  margin-top: 6px;
+  margin-bottom: 14px;
+}
+.hero-progress { min-width: 0; }
+.hero-progress-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 8px;
+  font: 600 12px/1 var(--font-mono);
+  letter-spacing: 0.04em;
   color: var(--muted);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
 }
+.hero-progress-text { color: var(--ink); }
+.hero-progress-bar {
+  height: 6px;
+  background: rgba(196, 184, 162, 0.4);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.hero-progress-fill {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent) 0%, #2a8c79 100%);
+  border-radius: 999px;
+  transition: width 480ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 
-.project-card-time {
-  font-size: 11px;
+.hero-last-event {
+  margin: 12px 0 0;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px dashed var(--line);
   color: var(--muted);
-  font-variant-numeric: tabular-nums;
-  text-align: right;
-  white-space: nowrap;
+  font-size: 12.5px;
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
 }
 
-/* ---------- Horizontal stage strip ---------- */
+/* =====================================================================
+   Stage strip (horizontal pipeline)
+   ===================================================================== */
+
 .stage-strip {
   list-style: none;
-  margin: 0 0 18px;
+  margin: 0 0 16px;
   padding: 0;
   display: grid;
-  grid-template-columns: repeat(8, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(78px, 1fr));
   gap: 6px;
 }
 .stage-strip-pill {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 10px 6px 8px;
-  border-radius: 10px;
+  gap: 6px;
+  padding: 9px 6px 8px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--line);
-  background: var(--card-strong);
+  background: var(--card);
   cursor: pointer;
-  transition: transform 120ms ease, border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
   min-width: 0;
   overflow: hidden;
 }
 .stage-strip-pill:hover {
-  border-color: rgba(31, 122, 106, 0.4);
+  border-color: var(--accent);
   transform: translateY(-1px);
+  box-shadow: var(--shadow-soft);
 }
 .stage-strip-num {
   display: inline-flex;
@@ -1152,13 +832,11 @@ body {
   border-radius: 999px;
   background: var(--surface);
   color: var(--muted);
-  font-size: 11px;
-  font-weight: 800;
+  font: 700 11px/1 var(--font-mono);
 }
 .stage-strip-label {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+  font: 600 9.5px/1 var(--font-mono);
+  letter-spacing: 0.06em;
   color: var(--muted);
   white-space: nowrap;
   overflow: hidden;
@@ -1167,95 +845,431 @@ body {
   text-transform: uppercase;
 }
 .stage-strip-pill.state-done {
-  background: rgba(31, 122, 106, 0.08);
-  border-color: rgba(31, 122, 106, 0.4);
+  background: var(--accent-soft);
+  border-color: rgba(31, 111, 96, 0.4);
 }
-.stage-strip-pill.state-done .stage-strip-num {
-  background: var(--accent);
-  color: white;
-}
-.stage-strip-pill.state-done .stage-strip-label { color: var(--accent); }
+.stage-strip-pill.state-done .stage-strip-num { background: var(--accent); color: #fff; }
+.stage-strip-pill.state-done .stage-strip-label { color: var(--accent-strong); }
 .stage-strip-pill.state-running {
   background: var(--warning-soft);
-  border-color: rgba(185, 130, 46, 0.55);
-  box-shadow: 0 0 0 3px rgba(185, 130, 46, 0.18);
+  border-color: rgba(176, 115, 33, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(176, 115, 33, 0.18);
 }
 .stage-strip-pill.state-running .stage-strip-num {
   background: var(--warning);
-  color: white;
-  animation: strip-pulse 1.3s ease-in-out infinite;
+  color: #fff;
+  animation: strip-pulse 1.4s ease-in-out infinite;
 }
 .stage-strip-pill.state-review {
-  background: rgba(80, 130, 200, 0.09);
-  border-color: rgba(80, 130, 200, 0.45);
-  box-shadow: 0 0 0 3px rgba(80, 130, 200, 0.14);
+  background: var(--info-soft);
+  border-color: rgba(53, 93, 138, 0.4);
 }
 .stage-strip-pill.state-review .stage-strip-num {
-  background: #3a6aa8;
-  color: white;
+  background: var(--info);
+  color: #fff;
   animation: strip-pulse 1.6s ease-in-out infinite;
 }
-.stage-strip-pill.state-review .stage-strip-label { color: #3a6aa8; }
+.stage-strip-pill.state-review .stage-strip-label { color: var(--info); }
 .stage-strip-pill.state-failed {
   background: var(--danger-soft);
-  border-color: rgba(198, 90, 70, 0.5);
+  border-color: rgba(176, 74, 54, 0.5);
 }
-.stage-strip-pill.state-failed .stage-strip-num {
-  background: var(--danger);
-  color: white;
+.stage-strip-pill.state-failed .stage-strip-num { background: var(--danger); color: #fff; }
+.stage-strip-pill.is-selected {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 @keyframes strip-pulse {
   0%, 100% { transform: scale(1); }
-  50%      { transform: scale(1.08); }
+  50%      { transform: scale(1.1); }
 }
 
-/* ---------- Review page hero card ---------- */
-.review-body {
+.review-strip {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  margin-bottom: 0;
+  box-shadow: var(--shadow-soft);
+}
+.review-strip.stage-strip { margin-bottom: 0; }
+
+/* =====================================================================
+   Live ticker + activity feed
+   ===================================================================== */
+
+.live-ticker {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 12px 0 0;
+  border-top: 1px dashed var(--line);
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 4px;
+  max-height: 200px;
+  overflow: hidden;
+}
+.live-ticker-item {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--muted);
+  padding: 5px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.live-ticker-item:first-child {
+  background: rgba(31, 111, 96, 0.05);
+  color: var(--ink);
+}
+.live-ticker-icon { width: 18px; text-align: center; font-size: 11px; }
+.live-ticker-body { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.live-ticker-body code {
+  background: rgba(31, 111, 96, 0.12);
+  color: var(--accent);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 10.5px;
+}
+.live-ticker-time { font-size: 10px; font-variant-numeric: tabular-nums; }
+.live-ticker-item.event-approval { background: var(--accent-soft); color: var(--accent); }
+.live-ticker-item.event-feedback { background: var(--warning-soft); color: var(--warning); }
+
+.activity-feed {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 320px;
+  overflow: auto;
+}
+.activity-feed li {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  border: 1px solid var(--line);
+}
+.activity-feed li.is-running   { border-left: 3px solid var(--warning); }
+.activity-feed li.is-review    { border-left: 3px solid var(--info); }
+.activity-feed li.is-approved  { border-left: 3px solid var(--accent); }
+.activity-feed li.is-failed    { border-left: 3px solid var(--danger); }
+.activity-feed li.is-pending   { border-left: 3px solid var(--line-strong); }
+.activity-dot { display: none; }
+.activity-feed .activity-main { min-width: 0; overflow-wrap: anywhere; }
+.activity-feed .activity-title { font-weight: 600; font-size: 13px; color: var(--ink); }
+.activity-feed .activity-detail { font-size: 11.5px; color: var(--muted); margin-top: 2px; }
+.activity-feed .activity-time {
+  font-size: 10.5px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* =====================================================================
+   Overview grid + run summary strip
+   ===================================================================== */
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 18px;
+}
+
+.run-summary-strip { padding: 18px 22px 20px; }
+.run-summary-body {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) 1px minmax(0, 1.5fr);
+  gap: 24px;
+  align-items: start;
+}
+.summary-divider { background: var(--line); align-self: stretch; }
+.summary-list {
+  display: grid;
+  grid-template-columns: minmax(90px, 130px) minmax(0, 1fr);
+  gap: 10px 14px;
+  margin: 0;
+}
+.summary-list dt {
+  font: 600 11px/1.5 var(--font-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.summary-list dd {
+  margin: 0;
+  font-size: 13px;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+.summary-artifacts .kicker { margin-bottom: 8px; }
+.artifact-summary { margin: 0; padding-left: 18px; font-size: 13px; color: var(--ink-soft); }
+.artifact-summary li { margin-bottom: 6px; line-height: 1.55; overflow-wrap: anywhere; }
+
+/* Stage rail (left of overview-grid) */
+.stage-rail { display: flex; flex-direction: column; gap: 8px; }
+.stage-rail .stage-item {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  grid-template-rows: auto;
+  gap: 4px 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
+}
+.stage-rail .stage-item:hover { border-color: var(--accent); transform: translateY(-1px); }
+.stage-rail .stage-item.is-active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.stage-rail .stage-item.is-current {
+  box-shadow: 0 0 0 2px rgba(31, 111, 96, 0.18);
+}
+.stage-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font: 700 11px/1 var(--font-mono);
+}
+.stage-item.is-running  .stage-number { background: var(--warning-soft); color: var(--warning); }
+.stage-item.is-review   .stage-number { background: var(--info-soft); color: var(--info); }
+.stage-item.is-approved .stage-number { background: var(--accent-soft); color: var(--accent); }
+.stage-item.is-failed   .stage-number { background: var(--danger-soft); color: var(--danger); }
+.stage-item .stage-body { min-width: 0; overflow-wrap: anywhere; }
+.stage-title { font-weight: 600; font-size: 13px; color: var(--ink); line-height: 1.35; }
+.stage-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+.stage-rail .stage-item .status-chip { font-size: 9.5px; padding: 3px 8px; }
+
+/* =====================================================================
+   Hub: project cards
+   ===================================================================== */
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+  padding: 4px 0;
+}
+
+.projects-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--muted);
+  border: 1px dashed var(--line);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.4);
+}
+.projects-empty p { margin: 4px 0; }
+
+.project-card, .run-card, .version-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 18px 20px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--card);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  transition: border-color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+.project-card::before, .version-card::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0;
+  width: 3px;
+  height: 100%;
+  background: var(--rule);
+  border-radius: var(--radius) 0 0 var(--radius);
+  transition: background 160ms ease;
+}
+.project-card:hover, .run-card:hover, .version-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow);
+}
+.project-card:hover::before, .version-card:hover::before { background: var(--accent); }
+.project-card.is-active, .run-card.is-active, .version-card.is-active {
+  border-color: var(--accent);
+  box-shadow: var(--shadow);
+}
+.project-card.is-active::before, .version-card.is-active::before { background: var(--accent); }
+
+.project-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.project-card-title, .run-card-title, .version-card-title {
+  font-family: var(--font-serif);
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: -0.005em;
+}
+.project-card-thesis {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 13px;
+  line-height: 1.55;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.run-card-meta { color: var(--muted); font-size: 12px; font-family: var(--font-mono); }
+
+.project-card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--line);
+}
+.project-progress { display: flex; align-items: center; gap: 10px; }
+.progress-ring .ring-bg { fill: none; stroke: rgba(214, 207, 190, 0.65); stroke-width: 5; }
+.progress-ring .ring-fill {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 5;
+  stroke-linecap: round;
+  transform: rotate(-90deg);
+  transform-origin: 50% 50%;
+  transition: stroke-dashoffset 480ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.progress-ring .ring-label { font-size: 10px; font-weight: 700; fill: var(--ink); }
+.project-progress-label { display: flex; flex-direction: column; line-height: 1.2; }
+.project-progress-pct { font-weight: 700; font-size: 13px; color: var(--ink); }
+.project-progress-sub {
+  font: 600 10px/1 var(--font-mono);
+  color: var(--muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+.project-card-time {
+  font: 500 10.5px/1 var(--font-mono);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.tag-row, .pill-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.tag, .mode-chip, .stage-status, .pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font: 600 10.5px/1.4 var(--font-mono);
+  letter-spacing: 0.04em;
+}
+.mode-chip { background: var(--accent-soft); color: var(--accent); }
+.pill-disabled { opacity: 0.55; }
+.stage-status.status-approved { background: var(--accent-soft); color: var(--accent); }
+.stage-status.status-human_review,
+.stage-status.status-running { background: var(--warning-soft); color: var(--warning); }
+.stage-status.status-failed,
+.stage-status.status-stale   { background: var(--danger-soft); color: var(--danger); }
+
+/* =====================================================================
+   Review page
+   ===================================================================== */
+
+.review-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(320px, 0.85fr);
+  gap: 18px;
 }
 
 .review-hero {
-  border: 1px solid rgba(31, 122, 106, 0.28);
-  border-radius: 18px;
-  background: linear-gradient(135deg, rgba(31, 122, 106, 0.08), rgba(255, 255, 255, 0.92));
-  padding: 20px 22px;
+  position: relative;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, var(--paper), var(--card));
+  padding: 24px 26px 22px;
   box-shadow: var(--shadow);
+  overflow: hidden;
 }
+.review-hero::before {
+  content: "";
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--info), var(--accent));
+}
+
 .review-hero-head {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 14px;
-  margin-bottom: 12px;
+  gap: 16px;
+  margin-bottom: 14px;
 }
-.review-hero-head h2 {
-  margin: 0 0 4px;
-  font-size: 22px;
-  word-break: break-word;
+.review-hero-title {
+  margin: 4px 0 6px;
+  font-family: var(--font-serif);
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
 }
-.review-hero-sub {
-  margin: 0;
-  color: var(--muted);
-  font-size: 13px;
-}
+.review-hero-sub { margin: 0; color: var(--muted); font-size: 13.5px; }
+
 .review-hero-tldr {
   border-left: 3px solid var(--accent);
-  background: var(--card-strong);
-  padding: 12px 16px;
-  border-radius: 8px;
-  font-size: 14px;
-  line-height: 1.55;
+  background: var(--card);
+  padding: 14px 18px;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  font-size: 14.5px;
+  line-height: 1.6;
   color: var(--ink);
   margin-bottom: 14px;
   overflow-wrap: anywhere;
+  font-family: var(--font-serif);
 }
 .review-hero-tldr:empty { display: none; }
 
 .review-hero-files {
   list-style: none;
-  margin: 0 0 14px;
+  margin: 0 0 16px;
   padding: 0;
   display: flex;
   flex-wrap: wrap;
@@ -1267,19 +1281,29 @@ body {
   align-items: center;
   gap: 6px;
   padding: 5px 10px;
-  background: rgba(255, 255, 255, 0.7);
+  background: var(--card);
   border: 1px solid var(--line);
   border-radius: 999px;
-  font-size: 11px;
+  font: 500 11px/1 var(--font-mono);
+  color: var(--ink-soft);
   overflow-wrap: anywhere;
 }
-.review-hero-files li code {
-  background: none;
-  color: var(--ink);
-  padding: 0;
-  font-size: 11px;
+.review-hero-files .file-icon { font-size: 11px; opacity: 0.75; }
+
+.review-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 14px;
 }
-.review-hero-files .file-icon { font-size: 12px; }
+.review-hero-actions .btn,
+.review-hero-actions .button {
+  font-size: 13.5px;
+  padding: 12px 18px;
+}
+
+.review-feedback-field { display: grid; gap: 6px; }
+.review-feedback-field textarea { min-height: 84px; }
 
 .review-next {
   margin: 10px 0 0;
@@ -1289,53 +1313,12 @@ body {
 }
 .review-next:empty { display: none; }
 
-.review-hero .hitl-actions .button {
-  font-size: 14px;
-  padding: 13px 18px;
-}
-
-.review-doc-section { margin-top: 4px; }
-.review-stage-label { margin-top: 4px; }
-
-.reviewer-checklist {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.reviewer-checklist li {
-  padding: 10px 12px;
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  font-size: 13px;
-  line-height: 1.5;
-}
-
-/* Review page shared stage strip panel */
-.review-strip-panel {
-  padding: 14px 20px;
-  margin-bottom: 20px;
-}
-.review-strip-panel .stage-strip { margin: 0; }
-.stage-strip-pill.is-selected {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
-
-/* Previous stages accordion */
-.review-previous-section { margin-top: 22px; }
-.review-previous-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
+.review-previous-section { margin-top: 18px; padding-top: 18px; border-top: 1px dashed var(--line); }
+.review-previous-list { display: flex; flex-direction: column; gap: 8px; }
 .previous-stage-item {
   border: 1px solid var(--line);
-  border-radius: 12px;
-  background: var(--card-strong);
+  border-radius: var(--radius-sm);
+  background: var(--card);
   overflow: hidden;
 }
 .previous-stage-item > summary {
@@ -1351,7 +1334,7 @@ body {
 .previous-stage-item > summary::before {
   content: "▸";
   display: inline-block;
-  transition: transform 120ms ease;
+  transition: transform 160ms ease;
   color: var(--muted);
   width: 12px;
 }
@@ -1360,115 +1343,68 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   border-radius: 999px;
   background: var(--accent-soft);
   color: var(--accent);
-  font-size: 11px;
-  font-weight: 800;
+  font: 700 11px/1 var(--font-mono);
   flex-shrink: 0;
 }
-.prev-title { font-weight: 700; flex: 1; min-width: 0; overflow-wrap: anywhere; }
-.prev-meta { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.prev-title { font-weight: 600; flex: 1; min-width: 0; overflow-wrap: anywhere; }
+.prev-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--muted); white-space: nowrap; }
 .prev-body { padding: 10px 16px 14px; }
 .prev-load-btn { font-size: 12px; padding: 6px 12px; }
 
-/* Live progress summary in the Review right-sidebar */
 .review-progress-summary {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.85);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
   border: 1px solid var(--line);
-  font-size: 12px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
   color: var(--ink);
   overflow-wrap: anywhere;
-  font-variant-numeric: tabular-nums;
 }
 
-/* ---------- Overview live ticker ---------- */
-.live-ticker {
+.reviewer-checklist {
   list-style: none;
-  margin: 12px 0 0;
+  margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  max-height: 180px;
-  overflow: hidden;
-  border-top: 1px dashed var(--line);
-  padding-top: 10px;
-}
-.live-ticker-item {
-  display: grid;
-  grid-template-columns: 18px minmax(0, 1fr) auto;
   gap: 8px;
-  align-items: center;
-  font-size: 12px;
-  color: var(--muted);
-  padding: 4px 8px;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.55);
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
 }
-.live-ticker-item:first-child {
-  background: rgba(31, 122, 106, 0.06);
-  color: var(--ink);
+.reviewer-checklist li {
+  padding: 10px 12px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--ink-soft);
 }
-.live-ticker-icon {
-  font-size: 12px;
-  width: 18px;
-  text-align: center;
-}
-.live-ticker-body {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.live-ticker-body code {
-  background: rgba(31, 122, 106, 0.12);
+.reviewer-checklist li::before {
+  content: "□";
+  margin-right: 8px;
   color: var(--accent);
-  padding: 1px 5px;
-  border-radius: 4px;
-  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
-  font-size: 11px;
+  font-weight: 700;
 }
-.live-ticker-time {
-  font-size: 10px;
-  font-variant-numeric: tabular-nums;
-  color: var(--muted);
-}
-.live-ticker-item.event-approval { background: var(--accent-soft); color: var(--accent); }
-.live-ticker-item.event-feedback { background: var(--warning-soft); color: var(--warning); }
 
-/* ---------- Review page: inline feedback + advanced details ---------- */
-.feedback-inline-label {
-  display: grid;
-  gap: 6px;
-  margin-bottom: 14px;
-  font-size: 13px;
-  color: var(--muted);
-}
-.feedback-inline-label textarea {
-  min-height: 72px;
-}
 .iteration-advanced {
-  margin-top: 14px;
+  margin-top: 18px;
+  padding-top: 14px;
   border-top: 1px dashed var(--line);
-  padding-top: 12px;
 }
 .iteration-advanced > summary {
   cursor: pointer;
-  font-size: 12px;
-  font-weight: 700;
+  font: 600 11px/1 var(--font-mono);
   color: var(--muted);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.1em;
   list-style: none;
   padding: 6px 0;
 }
@@ -1476,398 +1412,455 @@ body {
 .iteration-advanced > summary::before {
   content: "▸ ";
   display: inline-block;
-  transition: transform 150ms ease;
+  transition: transform 160ms ease;
 }
-.iteration-advanced[open] > summary::before {
-  content: "▾ ";
-}
+.iteration-advanced[open] > summary::before { content: "▾ "; }
 
-.session-section { margin-top: 18px; }
-.session-section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: 10px;
-}
-.session-section-header h3 { margin: 0; font-size: 15px; }
-
-.project-form,
 .iteration-form {
   display: grid;
   gap: 12px;
-  margin-bottom: 18px;
+  margin: 14px 0 6px;
 }
 
-.project-form label,
-.iteration-form label {
+/* =====================================================================
+   Versions / history — vertical timeline rail
+   ===================================================================== */
+
+.versions-grid {
   display: grid;
-  gap: 6px;
-  font-size: 13px;
-  color: var(--muted);
-  min-width: 0;
+  grid-template-columns: minmax(280px, 0.85fr) minmax(0, 1.4fr) minmax(280px, 0.95fr);
+  gap: 18px;
 }
 
-input,
-textarea,
-select {
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 10px 12px;
-  font: inherit;
-  color: var(--ink);
-  background: var(--card-strong);
-  min-width: 0;
-  max-width: 100%;
-}
-
-textarea {
-  resize: vertical;
-}
-
-.banner {
-  border-radius: 16px;
-  padding: 14px 16px;
-  background: linear-gradient(135deg, rgba(31, 122, 106, 0.1), rgba(31, 122, 106, 0.04));
-  border: 1px solid rgba(31, 122, 106, 0.16);
-  overflow-wrap: anywhere;
-}
-
-.banner.subtle {
-  background: rgba(238, 243, 246, 0.85);
-  border-color: rgba(216, 224, 231, 0.95);
-}
-
-.plan-output {
-  border: 1px solid rgba(31, 122, 106, 0.16);
-  border-radius: 16px;
-  background: var(--card-strong);
-  padding: 16px;
-  line-height: 1.6;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
-.plan-summary {
-  margin: 0 0 12px;
-  font-weight: 700;
-}
-
-.plan-grid {
-  display: grid;
-  grid-template-columns: minmax(90px, 130px) minmax(0, 1fr);
-  gap: 8px 12px;
-  margin-bottom: 14px;
-}
-
-.plan-grid div {
-  color: var(--muted);
-  font-size: 13px;
-  overflow-wrap: anywhere;
-}
-
-.plan-grid strong {
-  color: var(--ink);
-  font-size: 14px;
-}
-
-.brief-block,
-.document-body pre {
+.version-rail {
+  list-style: none;
   margin: 0;
-  border-radius: 14px;
-  background: #13212d;
-  color: #eff6fb;
+  padding: 8px 0 0 16px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-left: 1px dashed var(--line-strong);
+}
+
+.version-card {
+  margin-left: -22px;
+  padding-left: 24px;
+}
+.version-card::before {
+  content: "";
+  position: absolute;
+  left: 0; top: auto;
+  width: 12px;
+  height: 12px;
+  margin-top: 14px;
+  border-radius: 999px;
+  background: var(--card);
+  border: 2px solid var(--line-strong);
+  box-shadow: 0 0 0 2px var(--card);
+  transition: border-color 160ms ease, background 160ms ease;
+}
+.version-card:hover::before,
+.version-card.is-active::before {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+.version-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Trace timeline (versions right rail) */
+.trace-rail {
+  list-style: none;
+  margin: 0;
+  padding: 6px 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.trace-item {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+.trace-time {
+  font-family: var(--font-mono);
+  color: var(--muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding-top: 12px;
+  text-align: right;
+}
+.trace-card {
+  border-left: 3px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--paper);
+  padding: 10px 14px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.trace-item.status-success .trace-card { border-left-color: var(--accent); }
+.trace-item.status-warning .trace-card { border-left-color: var(--warning); }
+.trace-item.status-neutral .trace-card { border-left-color: var(--muted); }
+.trace-title { font-weight: 600; font-size: 13px; color: var(--ink); }
+.trace-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+/* =====================================================================
+   Document body / Markdown
+   ===================================================================== */
+
+.document-body {
+  min-height: 240px;
+  max-height: 70vh;
   overflow: auto;
-  padding: 16px;
-  font-size: 13px;
-  line-height: 1.6;
-  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+  background: var(--paper);
+}
+.document-body.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--muted);
+}
+
+.markdown-body {
+  font-family: var(--font-serif);
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+.markdown-body h1, .markdown-body h2, .markdown-body h3,
+.markdown-body h4, .markdown-body h5, .markdown-body h6 {
+  margin: 1.4em 0 0.5em;
+  font-family: var(--font-sans);
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  line-height: 1.3;
+}
+.markdown-body h1 { font-size: 1.7em; }
+.markdown-body h2 { font-size: 1.35em; }
+.markdown-body h3 { font-size: 1.15em; }
+.markdown-body h1:first-child,
+.markdown-body h2:first-child,
+.markdown-body h3:first-child { margin-top: 0; }
+.markdown-body p, .markdown-body ul, .markdown-body ol, .markdown-body blockquote {
+  margin: 0 0 1em;
+}
+.markdown-body ul, .markdown-body ol { padding-left: 1.4em; }
+.markdown-body code {
+  border-radius: 4px;
+  background: rgba(20, 30, 40, 0.06);
+  padding: 0.1em 0.36em;
+  font-size: 0.88em;
+  font-family: var(--font-mono);
+  word-break: break-all;
+}
+.markdown-body pre { overflow: auto; }
+.markdown-body blockquote {
+  border-left: 3px solid var(--accent);
+  margin-left: 0;
+  padding-left: 16px;
+  color: var(--ink-soft);
+  font-style: italic;
+}
+
+.brief-block, .document-body pre {
+  margin: 0;
+  border-radius: var(--radius-sm);
+  background: #0f1924;
+  color: #e3edf2;
+  overflow: auto;
+  padding: 16px 18px;
+  font: 12.5px/1.6 var(--font-mono);
   white-space: pre-wrap;
   word-break: break-word;
 }
 
-.markdown-body {
-  font-family: "Source Serif 4", Georgia, serif;
-  line-height: 1.72;
-  color: var(--ink);
+/* =====================================================================
+   Plan / iteration brief output
+   ===================================================================== */
+
+.plan-summary { margin: 0 0 12px; font-weight: 600; color: var(--ink); }
+.plan-grid {
+  display: grid;
+  grid-template-columns: minmax(90px, 130px) minmax(0, 1fr);
+  gap: 8px 14px;
+  margin-bottom: 14px;
+}
+.plan-grid div {
+  font-family: var(--font-mono);
+  color: var(--muted);
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   overflow-wrap: anywhere;
 }
-
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
-  margin: 1.2em 0 0.55em;
-  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
-  line-height: 1.3;
+.plan-grid strong {
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 600;
 }
 
-.markdown-body h1:first-child,
-.markdown-body h2:first-child,
-.markdown-body h3:first-child {
-  margin-top: 0;
+/* =====================================================================
+   Session viewer (Review right rail interaction trace)
+   ===================================================================== */
+
+.session-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--muted);
+  font-style: italic;
+  font-size: 12.5px;
 }
 
-.markdown-body p,
-.markdown-body ul,
-.markdown-body ol,
-.markdown-body blockquote {
-  margin: 0 0 1em;
-}
-
-.markdown-body ul,
-.markdown-body ol {
-  padding-left: 1.35em;
-}
-
-.markdown-body code {
-  border-radius: 8px;
-  background: rgba(19, 33, 45, 0.08);
-  padding: 0.12em 0.36em;
-  font-size: 0.92em;
-  font-family: "JetBrains Mono", "SFMono-Regular", monospace;
-  word-break: break-all;
-}
-
-.markdown-body pre {
+.session-event-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 60vh;
   overflow: auto;
 }
 
-.markdown-body blockquote {
-  border-left: 3px solid rgba(31, 122, 106, 0.35);
-  margin-left: 0;
-  padding-left: 14px;
-  color: var(--muted);
-}
-
-.trace-item {
-  display: grid;
-  grid-template-columns: 90px minmax(0, 1fr);
-  gap: 12px;
-  align-items: start;
-}
-
-.trace-time {
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 700;
-  padding-top: 12px;
-}
-
-.trace-card {
-  border-left: 3px solid var(--line);
-  border-radius: 14px;
-  background: var(--card-strong);
-  box-shadow: var(--shadow-soft);
-  padding: 12px 14px;
-  min-width: 0;
+.session-event {
+  border-left: 3px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--card);
+  padding: 10px 14px;
   overflow-wrap: anywhere;
+}
+
+.session-event-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font: 600 10px/1 var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+.session-event-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--surface);
+  font-size: 10px;
+}
+.session-event-label { flex: 1; }
+.session-event-time { font-variant-numeric: tabular-nums; }
+
+.session-event-body {
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--ink);
+  white-space: pre-wrap;
+}
+
+.session-tool-call { display: flex; flex-direction: column; gap: 6px; }
+.session-tool-name {
+  display: inline-block;
+  align-self: flex-start;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font: 700 10.5px/1 var(--font-mono);
+}
+.session-tool-input, .session-tool-output {
+  margin: 0;
+  border-radius: var(--radius-sm);
+  background: #0f1924;
+  color: #e3edf2;
+  padding: 10px 12px;
+  font: 11.5px/1.5 var(--font-mono);
+  overflow: auto;
+  white-space: pre-wrap;
   word-break: break-word;
 }
 
-.trace-item.status-success .trace-card {
-  border-left-color: var(--accent);
-}
+.event-system     { border-left-color: var(--muted); }
+.event-assistant  { border-left-color: var(--accent); background: rgba(31, 111, 96, 0.04); }
+.event-user       { border-left-color: var(--info); }
+.event-tool-use   { border-left-color: var(--warning); }
+.event-tool-result{ border-left-color: var(--ink-soft); }
+.event-approval   { border-left-color: var(--accent); background: var(--accent-soft); }
+.event-feedback   { border-left-color: var(--warning); background: var(--warning-soft); }
 
-.trace-item.status-warning .trace-card {
-  border-left-color: var(--warning);
-}
+/* =====================================================================
+   File tree (legacy, used in some pages)
+   ===================================================================== */
 
-.trace-item.status-neutral .trace-card {
-  border-left-color: #8a95a1;
+.tree-node { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.tree-label {
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: none;
+  text-align: left;
+  padding: 6px 10px;
+  color: var(--ink);
+  font: 12.5px/1.4 var(--font-mono);
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  word-break: break-all;
 }
-
-.trace-title {
-  font-weight: 700;
+.tree-label:hover, .tree-label.is-active {
+  color: var(--accent);
+  border-color: rgba(31, 111, 96, 0.22);
+  background: rgba(31, 111, 96, 0.05);
 }
-
-.paper-frame-container {
-  min-height: 72vh;
-  border: 1px solid rgba(216, 224, 231, 0.9);
-  border-radius: 18px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(246, 242, 234, 0.92));
-  overflow: hidden;
-}
-
-.paper-frame {
-  width: 100%;
-  min-height: 72vh;
-  border: none;
-}
-
-.inspector-block {
+.tree-children {
+  margin-left: 12px;
+  padding-left: 10px;
+  border-left: 1px dotted var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
   min-width: 0;
 }
 
-.inspector-block h3 {
-  margin-bottom: 10px;
+/* =====================================================================
+   Toasts
+   ===================================================================== */
+
+.toast-stack {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;
 }
-
-@media (max-width: 1280px) {
-  .overview-grid,
-  .review-grid,
-  .files-grid,
-  .paper-grid,
-  .history-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .hub-create .project-form-inline {
-    grid-template-columns: 1fr;
-  }
-
-  .workspace-header-body,
-  .topbar {
-    flex-direction: column;
-  }
+.toast {
+  min-width: 240px;
+  max-width: 420px;
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  background: var(--card);
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: var(--shadow);
+  border-left: 3px solid var(--accent);
+  transform: translateX(24px);
+  opacity: 0;
+  transition: transform 220ms ease, opacity 220ms ease;
+  pointer-events: auto;
+  overflow-wrap: anywhere;
 }
+.toast.toast-visible { transform: translateX(0); opacity: 1; }
+.toast.toast-success { border-left-color: var(--accent); }
+.toast.toast-warn    { border-left-color: var(--warning); background: var(--warning-soft); color: var(--warning); }
+.toast.toast-error   { border-left-color: var(--danger);  background: var(--danger-soft); color: var(--danger); }
+.toast.toast-info    { border-left-color: var(--info); }
 
-@media (max-width: 720px) {
-  body {
-    padding: 14px;
-  }
+/* =====================================================================
+   Notebook view — refined 3-column
+   ===================================================================== */
 
-  .panel-header,
-  .panel-body,
-  .workspace-header {
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-
-  .summary-list,
-  .plan-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .projects-grid,
-  .runs-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* ======================================================================
-   Notebook view — NotebookLM-style 3-column layout.
-   ====================================================================== */
-
-#page-notebook {
-  padding: 0;
-}
+#page-notebook { padding: 0; gap: 0; }
 
 .notebook-layout {
   display: grid;
-  grid-template-columns: 280px 1fr 360px;
+  grid-template-columns: 280px minmax(0, 1fr) 360px;
   gap: 0;
-  height: calc(100vh - 220px);
-  min-height: 520px;
-  background: var(--color-card, #fbfcfd);
-  border: 1px solid var(--color-divider, #d8e0e7);
-  border-radius: 12px;
+  height: calc(100vh - 260px);
+  min-height: 540px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
   overflow: hidden;
+  box-shadow: var(--shadow-soft);
 }
 
-.notebook-sources,
-.notebook-center,
-.notebook-viewer {
+.notebook-sources, .notebook-center, .notebook-viewer {
   display: flex;
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-  background: var(--color-card, #fbfcfd);
 }
-
-.notebook-sources {
-  border-right: 1px solid var(--color-divider, #d8e0e7);
-  background: var(--color-surface, #eef3f6);
-}
-
-.notebook-viewer {
-  border-left: 1px solid var(--color-divider, #d8e0e7);
-  background: #f8fafc;
-}
+.notebook-sources { background: var(--paper); border-right: 1px solid var(--line); }
+.notebook-viewer  { background: var(--paper); border-left: 1px solid var(--line); }
+.notebook-center  { background: var(--card); }
 
 .notebook-col-header {
-  padding: 14px 16px 10px;
-  border-bottom: 1px solid var(--color-divider, #d8e0e7);
+  padding: 14px 18px 12px;
+  border-bottom: 1px solid var(--line);
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 10px;
-  background: rgba(255, 255, 255, 0.6);
 }
-
-.notebook-col-header h3 {
-  margin: 2px 0 0;
-  font-size: 15px;
+.notebook-col-title {
+  margin: 4px 0 0;
+  font-family: var(--font-serif);
+  font-size: 16px;
   font-weight: 600;
-  color: var(--color-ink, #18222d);
+  letter-spacing: -0.005em;
+  color: var(--ink);
 }
+.notebook-col-header .kicker { margin: 0; }
 
-.notebook-col-header .eyebrow {
-  margin: 0;
-}
-
+/* Sources column */
 .notebook-sources-body {
   flex: 1 1 auto;
   overflow-y: auto;
-  padding: 12px 12px 40px;
+  padding: 14px 14px 32px;
 }
-
 .notebook-source-section {
-  margin-bottom: 14px;
-  background: #fff;
-  border: 1px solid var(--color-divider, #d8e0e7);
-  border-radius: 8px;
+  margin-bottom: 12px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   padding: 10px 12px 12px;
 }
-
 .notebook-source-section summary {
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font: 600 10.5px/1 var(--font-mono);
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--color-muted, #5b6875);
+  color: var(--muted);
   cursor: pointer;
+  padding: 4px 0;
 }
-
-.notebook-source-body {
-  margin-top: 10px;
-  font-size: 13px;
-  color: var(--color-ink, #18222d);
-}
-
-.notebook-source-title {
-  margin: 0 0 4px;
-  font-weight: 600;
-}
-
-.notebook-source-thesis {
-  margin: 0;
-  color: var(--color-muted, #5b6875);
-  line-height: 1.5;
-}
-
+.notebook-source-body { margin-top: 10px; font-size: 13px; color: var(--ink); }
+.notebook-source-title { margin: 0 0 4px; font-weight: 600; font-family: var(--font-serif); font-size: 14px; }
+.notebook-source-thesis { margin: 0; color: var(--ink-soft); line-height: 1.5; font-size: 12.5px; }
 .notebook-source-dl {
   display: grid;
   grid-template-columns: 80px 1fr;
   row-gap: 4px;
   column-gap: 8px;
   margin: 0;
-  font-size: 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
 }
-
-.notebook-source-dl > div {
-  display: contents;
-}
-
-.notebook-source-dl dt {
-  color: var(--color-muted, #5b6875);
-}
-
-.notebook-source-dl dd {
-  margin: 0;
-  word-break: break-all;
-}
+.notebook-source-dl > div { display: contents; }
+.notebook-source-dl dt { color: var(--muted); }
+.notebook-source-dl dd { margin: 0; word-break: break-all; color: var(--ink); }
 
 .notebook-source-list {
   list-style: none;
@@ -1880,88 +1873,51 @@ textarea {
 
 .notebook-stage-row {
   display: grid;
-  grid-template-columns: 10px 1fr auto;
+  grid-template-columns: 8px 1fr auto;
   align-items: center;
   gap: 8px;
   padding: 6px 8px;
   border-radius: 6px;
   cursor: pointer;
-  font-size: 13px;
+  font-size: 12.5px;
   line-height: 1.3;
+  color: var(--ink);
 }
-
-.notebook-stage-row:hover {
-  background: rgba(31, 122, 106, 0.08);
-}
-
-.notebook-status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #cbd5e1;
-}
-
+.notebook-stage-row:hover { background: rgba(31, 111, 96, 0.07); }
+.notebook-status-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--line-strong); }
 .notebook-status-approved .notebook-status-dot,
-.notebook-status-completed .notebook-status-dot {
-  background: #1f7a6a;
-}
-
+.notebook-status-completed .notebook-status-dot { background: var(--accent); }
 .notebook-status-running .notebook-status-dot,
-.notebook-status-human_review .notebook-status-dot {
-  background: #b9822e;
-}
-
-.notebook-status-failed .notebook-status-dot {
-  background: #c65a46;
-}
-
+.notebook-status-human_review .notebook-status-dot { background: var(--warning); }
+.notebook-status-failed .notebook-status-dot { background: var(--danger); }
 .notebook-stage-status {
-  font-size: 11px;
-  color: var(--color-muted, #5b6875);
+  font: 600 9.5px/1 var(--font-mono);
+  color: var(--muted);
   text-transform: uppercase;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.06em;
 }
+.notebook-stage-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-.notebook-stage-label {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.notebook-tree-node {
-  font-size: 12px;
-}
-
+.notebook-tree-node { font-family: var(--font-mono); font-size: 11.5px; }
 .notebook-tree-node details > summary {
   cursor: pointer;
-  padding: 3px 2px;
+  padding: 3px 4px;
   border-radius: 4px;
-  color: var(--color-ink, #18222d);
-  font-weight: 500;
+  color: var(--ink);
 }
-
-.notebook-tree-node details > summary:hover {
-  background: rgba(31, 122, 106, 0.08);
-}
-
+.notebook-tree-node details > summary:hover { background: rgba(31, 111, 96, 0.07); }
 .notebook-tree-children {
-  padding-left: 14px;
-  border-left: 1px dotted var(--color-divider, #d8e0e7);
+  padding-left: 12px;
+  border-left: 1px dotted var(--line);
   margin-left: 4px;
 }
-
 .notebook-tree-file {
   cursor: pointer;
   padding: 3px 6px;
   border-radius: 4px;
-  color: var(--color-muted, #5b6875);
+  color: var(--muted);
 }
-
-.notebook-tree-file:hover {
-  background: rgba(31, 122, 106, 0.08);
-  color: var(--color-ink, #18222d);
-}
+.notebook-tree-file:hover { background: rgba(31, 111, 96, 0.07); color: var(--ink); }
 
 .notebook-paper-link {
   display: flex;
@@ -1972,126 +1928,73 @@ textarea {
   cursor: pointer;
   font-size: 12px;
 }
+.notebook-paper-link:hover { background: rgba(31, 111, 96, 0.07); }
+.notebook-paper-link .meta { font-size: 10px; max-width: 60%; }
 
-.notebook-paper-link:hover {
-  background: rgba(31, 122, 106, 0.08);
-}
-
-.notebook-paper-link .meta {
-  color: var(--color-muted, #5b6875);
-  font-size: 10px;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-  max-width: 60%;
-}
-
-/* ------------------------- Center (CC chat) ------------------------- */
-
-.notebook-center-header {
-  justify-content: space-between;
-  align-items: center;
-}
-
-.notebook-center-actions {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.notebook-center-actions .status-chip {
-  font-size: 11px;
-  padding: 3px 8px;
-  border-radius: 10px;
-}
-
-.status-chip.status-running {
-  background: #fde68a;
-  color: #92400e;
-}
-
-.status-chip.status-error {
-  background: #fecaca;
-  color: #991b1b;
-}
+/* Center column - chat */
+.notebook-center-header { justify-content: space-between; align-items: center; }
+.notebook-center-actions { display: flex; align-items: center; gap: 10px; }
+.notebook-center-actions .status-chip { font-size: 10px; padding: 3px 8px; }
 
 .notebook-events {
   flex: 1 1 auto;
   overflow-y: auto;
   list-style: none;
-  padding: 18px 22px 22px;
+  padding: 22px 28px 28px;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 14px;
 }
-
-.notebook-event {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
+.notebook-event { display: flex; flex-direction: column; gap: 4px; }
 .notebook-bubble {
-  padding: 10px 14px;
-  border-radius: 10px;
-  max-width: 80%;
-  line-height: 1.5;
+  padding: 11px 16px;
+  border-radius: 14px 14px 4px 14px;
+  max-width: 78%;
+  line-height: 1.55;
   white-space: pre-wrap;
   word-wrap: break-word;
+  font-size: 13.5px;
 }
-
 .notebook-bubble-user {
   align-self: flex-end;
-  background: #1f7a6a;
-  color: white;
+  background: var(--accent);
+  color: #fff;
 }
-
-.notebook-event-user {
-  align-items: flex-end;
-}
-
-.notebook-event-assistant {
-  align-items: flex-start;
-}
-
+.notebook-event-user { align-items: flex-end; }
+.notebook-event-assistant { align-items: flex-start; }
 .notebook-assistant-text {
-  background: #fff;
-  border: 1px solid var(--color-divider, #d8e0e7);
-  border-radius: 10px;
-  padding: 12px 16px;
-  line-height: 1.55;
-  font-size: 14px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 14px 14px 14px 4px;
+  padding: 14px 18px;
+  line-height: 1.6;
+  font-size: 13.5px;
+  font-family: var(--font-serif);
+  color: var(--ink);
   max-width: 100%;
 }
-
-.notebook-assistant-text h1,
-.notebook-assistant-text h2,
-.notebook-assistant-text h3,
-.notebook-assistant-text h4 {
+.notebook-assistant-text h1, .notebook-assistant-text h2,
+.notebook-assistant-text h3, .notebook-assistant-text h4 {
   margin: 0.8em 0 0.4em;
+  font-family: var(--font-sans);
+  font-weight: 600;
 }
-
-.notebook-assistant-text p {
-  margin: 0.4em 0;
-}
-
+.notebook-assistant-text p { margin: 0.4em 0; }
 .notebook-assistant-text code {
-  background: rgba(15, 23, 42, 0.08);
+  background: rgba(20, 30, 40, 0.07);
   padding: 1px 4px;
   border-radius: 3px;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 12.5px;
+  font-family: var(--font-mono);
+  font-size: 12px;
 }
-
 .notebook-assistant-text .notebook-code,
 .notebook-viewer-body .notebook-code {
-  background: #0f172a;
-  color: #e2e8f0;
+  background: #0f1924;
+  color: #e3edf2;
   padding: 10px 12px;
-  border-radius: 8px;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 12px;
+  border-radius: var(--radius-sm);
+  font: 11.5px/1.55 var(--font-mono);
   overflow-x: auto;
   white-space: pre;
 }
@@ -2099,236 +2002,211 @@ textarea {
 .notebook-tool-chip {
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  background: #f1f5f9;
-  border: 1px solid var(--color-divider, #d8e0e7);
-  border-radius: 8px;
-  padding: 6px 10px;
-  font-size: 12px;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  color: var(--color-ink, #18222d);
+  gap: 3px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 7px 11px;
+  font: 11.5px/1.4 var(--font-mono);
+  color: var(--ink);
 }
-
-.notebook-tool-head {
-  display: flex;
-  gap: 8px;
-  align-items: baseline;
-}
-
-.notebook-tool-name {
-  font-weight: 600;
-  color: #1f7a6a;
-}
-
-.notebook-tool-target {
-  color: var(--color-muted, #5b6875);
-  word-break: break-all;
-}
-
-.notebook-tool-clickable {
-  cursor: pointer;
-  transition: background-color 120ms;
-}
-
-.notebook-tool-clickable:hover {
-  background: #dbeafe;
-}
+.notebook-tool-head { display: flex; gap: 8px; align-items: baseline; }
+.notebook-tool-name { font-weight: 600; color: var(--accent); }
+.notebook-tool-target { color: var(--muted); word-break: break-all; }
+.notebook-tool-clickable { cursor: pointer; transition: background 140ms ease, border-color 140ms ease; }
+.notebook-tool-clickable:hover { background: var(--accent-soft); border-color: var(--accent); }
 
 .notebook-thinking {
-  background: #fef3c7;
-  border: 1px dashed #d4a044;
-  border-radius: 8px;
-  padding: 6px 10px;
+  background: var(--warning-soft);
+  border: 1px dashed var(--warning);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
   font-size: 12px;
-  color: #7c4a03;
+  color: #5a3712;
 }
-
 .notebook-thinking pre {
   margin: 6px 0 0;
   white-space: pre-wrap;
-  font-size: 12px;
+  font: 11px/1.5 var(--font-mono);
   max-height: 240px;
   overflow-y: auto;
 }
 
 .notebook-event-tool-result details {
-  background: #f8fafc;
-  border: 1px dashed var(--color-divider, #d8e0e7);
-  border-radius: 8px;
-  padding: 6px 10px;
+  background: var(--paper);
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  padding: 7px 11px;
   font-size: 12px;
 }
-
 .notebook-event-tool-result pre {
   white-space: pre-wrap;
   margin: 6px 0 0;
   max-height: 280px;
   overflow-y: auto;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  color: var(--color-muted, #5b6875);
+  font: 11.5px/1.5 var(--font-mono);
+  color: var(--muted);
 }
 
-.notebook-event-init,
-.notebook-event-result {
-  align-self: center;
+.notebook-event-init, .notebook-event-result { align-self: center; }
+.notebook-meta-line, .notebook-event-init {
+  font: 10.5px/1.5 var(--font-mono);
+  color: var(--muted);
+  letter-spacing: 0.04em;
 }
-
-.notebook-meta-line,
-.notebook-event-init {
-  font-size: 11px;
-  color: var(--color-muted, #5b6875);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-}
-
 .notebook-event-error {
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  color: #991b1b;
-  padding: 8px 12px;
-  border-radius: 8px;
-  font-size: 13px;
+  background: var(--danger-soft);
+  border: 1px solid rgba(176, 74, 54, 0.3);
+  color: var(--danger);
+  padding: 9px 14px;
+  border-radius: var(--radius-sm);
+  font-size: 12.5px;
   align-self: stretch;
 }
 
-.notebook-input-row {
-  border-top: 1px solid var(--color-divider, #d8e0e7);
-  padding: 12px 18px 14px;
-  background: #fff;
+.notebook-composer {
+  border-top: 1px solid var(--line);
+  padding: 14px 22px 18px;
+  background: var(--card);
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
-
-.notebook-input-row textarea {
+.notebook-composer textarea {
   width: 100%;
-  min-height: 60px;
+  min-height: 64px;
   resize: vertical;
-  padding: 10px 12px;
-  border: 1px solid var(--color-divider, #d8e0e7);
-  border-radius: 8px;
-  font-family: inherit;
-  font-size: 14px;
-  color: var(--color-ink, #18222d);
-  background: #fff;
+  font-size: 13.5px;
+  background: var(--paper);
 }
-
-.notebook-input-row textarea:focus {
-  outline: 2px solid rgba(31, 122, 106, 0.35);
-  outline-offset: 0;
-  border-color: #1f7a6a;
+.notebook-composer textarea:focus {
+  background: var(--card);
 }
-
-.notebook-input-actions {
+.notebook-composer-actions {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 10px;
 }
-
-.notebook-input-hint {
-  font-size: 11px;
-  color: var(--color-muted, #5b6875);
+.notebook-composer-hint {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
 }
 
-/* ------------------------- Viewer ------------------------- */
-
-.notebook-viewer-header h3 {
-  word-break: break-all;
-}
-
+/* Viewer */
+.notebook-viewer-header h3 { word-break: break-all; }
 .notebook-viewer-toolbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 10px;
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--color-divider, #d8e0e7);
-  background: rgba(255, 255, 255, 0.7);
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--card);
 }
-
 .notebook-path-breadcrumb {
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 11px;
-  color: var(--color-muted, #5b6875);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--muted);
   word-break: break-all;
-}
-
-.pill-disabled {
-  opacity: 0.55;
 }
 
 .notebook-viewer-body {
   flex: 1 1 auto;
   overflow-y: auto;
-  padding: 16px 18px 26px;
-  background: #fff;
+  padding: 18px 22px 28px;
+  background: var(--card);
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--ink);
 }
-
 .notebook-viewer-body.empty-state {
   display: flex;
   justify-content: center;
   align-items: center;
-  color: var(--color-muted, #5b6875);
-  font-size: 13px;
+  color: var(--muted);
+  font-size: 12.5px;
   text-align: center;
+  font-family: var(--font-sans);
+  font-style: italic;
 }
-
-.notebook-viewer-loading {
-  color: var(--color-muted, #5b6875);
-  font-size: 13px;
-}
-
-.notebook-pdf-frame {
-  width: 100%;
-  height: 100%;
-  min-height: 420px;
-  border: none;
-}
-
-.notebook-image {
-  max-width: 100%;
-  display: block;
-  margin: 0 auto;
-}
-
-.notebook-viewer-body h1,
-.notebook-viewer-body h2,
-.notebook-viewer-body h3,
-.notebook-viewer-body h4 {
+.notebook-viewer-loading { color: var(--muted); font-size: 12.5px; }
+.notebook-pdf-frame { width: 100%; height: 100%; min-height: 420px; border: none; }
+.notebook-image { max-width: 100%; display: block; margin: 0 auto; }
+.notebook-viewer-body h1, .notebook-viewer-body h2,
+.notebook-viewer-body h3, .notebook-viewer-body h4 {
   margin: 0.9em 0 0.4em;
+  font-family: var(--font-sans);
+  font-weight: 600;
 }
-
-.notebook-viewer-body p {
-  line-height: 1.6;
-  margin: 0.4em 0;
-}
-
+.notebook-viewer-body p { line-height: 1.65; margin: 0.4em 0; }
 .notebook-viewer-body code {
-  background: rgba(15, 23, 42, 0.08);
+  background: rgba(20, 30, 40, 0.07);
   padding: 1px 4px;
   border-radius: 3px;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 12.5px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.paper-frame { width: 100%; min-height: 72vh; border: none; }
+
+/* =====================================================================
+   Banners
+   ===================================================================== */
+
+.banner {
+  border-radius: var(--radius-sm);
+  padding: 14px 16px;
+  background: var(--accent-soft);
+  border: 1px solid rgba(31, 111, 96, 0.25);
+  overflow-wrap: anywhere;
+}
+.banner.subtle { background: var(--paper); border: 1px dashed var(--line); color: var(--muted); }
+
+/* =====================================================================
+   Responsive
+   ===================================================================== */
+
+@media (max-width: 1280px) {
+  .overview-grid,
+  .review-grid,
+  .versions-grid {
+    grid-template-columns: 1fr;
+  }
+  .hub-poster {
+    grid-template-columns: 1fr;
+    gap: 32px;
+    padding: 24px 8px 0;
+  }
+  .run-summary-body {
+    grid-template-columns: 1fr;
+  }
+  .summary-divider { display: none; }
+  .workspace-header-row { flex-direction: column; align-items: flex-start; }
 }
 
 @media (max-width: 1100px) {
-  .notebook-layout {
-    grid-template-columns: 240px 1fr 320px;
-  }
+  .notebook-layout { grid-template-columns: 240px minmax(0, 1fr) 320px; }
 }
 
 @media (max-width: 900px) {
+  body { padding: 18px 18px 40px; }
+  .topbar { flex-direction: column; align-items: flex-start; }
+  .display-headline { font-size: 38px; }
   .notebook-layout {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto auto;
     height: auto;
   }
-  .notebook-sources,
-  .notebook-viewer {
+  .notebook-sources, .notebook-viewer {
     border: none;
-    border-bottom: 1px solid var(--color-divider, #d8e0e7);
+    border-bottom: 1px solid var(--line);
   }
-  .notebook-events {
-    max-height: 50vh;
-  }
+  .notebook-events { max-height: 50vh; }
+  .summary-list, .plan-grid { grid-template-columns: 1fr; }
+  .projects-grid { grid-template-columns: 1fr; }
+  .stage-strip { grid-template-columns: repeat(auto-fit, minmax(64px, 1fr)); }
 }


### PR DESCRIPTION
## Summary
Refresh the AutoR Studio frontend into an editorial research-console aesthetic — calmer, more typographic, less SaaS-card-grid. **Frontend-only**: no backend, API contract, or business logic touched.

## Scope of change
- `src/frontend/static/index.html` — restructured (Hub poster, breadcrumb workspace header, underline tab nav, Overview hero reorg, Review hero-only first screen, Versions timeline, Notebook 3-col rebalance, removed `(planned)` placeholder pills)
- `src/frontend/static/styles.css` — rewritten (kept all design tokens, refined type scale, softer chrome, page-fade motion, hover-lift cards, vertical timeline for versions)
- `src/frontend/static/app.js` — **5 lines** added in `setConnection()` only, to set a `data-status` attribute on the connection pill so CSS can color it. No fetch / state / event behavior changed.

## What was preserved
- All API routes, request/response shapes, SSE event format
- Every JS-injected class name and DOM ID (`stage-strip-pill`, `previous-stage-item`, `live-dot is-*`, `notebook-event-*`, `trace-card`, etc.)
- All dynamic-content CSS classes (session events, activity feed, project cards, version cards, notebook tool chips, markdown body, toasts…)
- All design tokens (cream/teal palette, IBM Plex Sans + Source Serif 4 + JetBrains Mono trio)

## Visual changes
| Surface | Before | After |
|---|---|---|
| Topbar | Big H1 + subtitle | Compact brand mark + tagline |
| Hub | Generic form on top of empty grid | Editorial poster (serif headline w/ italic accent + lede) + double-bordered create card |
| Workspace header | Stacked title + status | Breadcrumb (`Project › Run`) + status pill right |
| Tab nav | Pill buttons | Underline tabs (editorial publication style) |
| Overview | 6 stacked panels | Hero panel (gradient strip + stage strip + CTAs) + 2-col grid + run-summary footer |
| Review | Hero + advanced form mixed | Hero-only first screen, advanced iteration deeper in `<details>` |
| Versions | 3-col cards | Left vertical timeline rail with dots that color on hover/active |
| Notebook | 3 equal cols | Rails de-emphasized, center conversation enlarged, viewer placeholder pills removed |
| Project card | Flat card | Left teal accent bar, dashed footer divider, progress ring intact |
| Markdown | Mixed | Source Serif 4 body + sans headings + teal blockquote rule |

## Motion
- Page tabs fade + slide on switch
- Stage-strip running/review pills pulse
- Cards lift + accent on hover
- Live dot keeps existing pulse animation

## Test plan
- [ ] Open `http://127.0.0.1:8765/studio` (or wherever studio runs)
- [ ] Hub: create a project; project card renders correctly
- [ ] Click into a project → workspace loads, breadcrumb shows project › run
- [ ] Switch through all 4 tabs (Overview / Human Review / Versions / Notebook); fade-in smooth, underline animates
- [ ] Overview: stage strip clickable, Approve / Send feedback buttons enabled when run is human_review, live ticker streams
- [ ] Review: TLDR + files + actions visible, feedback textarea works, Advanced details expands
- [ ] Versions: timeline rail dots highlight on hover/select, checkpoint detail + execution timeline render
- [ ] Notebook: 3 cols load sources / chat / viewer; composer Enter-to-send + Shift+Enter newline still works; reset session button still works
- [ ] Connection pill changes color on connect/error
- [ ] Backend tests still pass (no Python changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)