### PR TITLE
Add reference documentation set and open-source project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,11 @@ AGENTS.local/
 .codex
 .autor/
 configs/diagram_config.yaml
-docs/
-!docs/
+# docs/ holds published documentation plus local scratch notes. Ignore the
+# directory contents by default, then allow every markdown page back in --
+# without the `!docs/*.md` line a newly added doc is silently untracked.
 docs/*
-!docs/tutorial_zh.md
-!docs/tutorial_en.md
+!docs/*.md
 !docs/ui-design/
 !docs/ui-design/**
 docs/ui-design/.DS_Store

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,145 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic
+status, nationality, personal appearance, race, caste, color, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Research-specific expectations
+
+AutoR is a research tool, and a few things follow from that:
+
+- **Be honest about what a run produced.** Do not present AI-generated
+  results, figures, or claims as verified when they have not been verified.
+  The whole point of the artifact trail is that claims can be checked.
+- **Disclose AI involvement** when sharing outputs, in line with the norms of
+  the venue or community you are sharing them with.
+- **Do not use AutoR to fabricate results.** Producing plausible-looking
+  research artifacts that are not backed by real experiments is the failure
+  mode this project exists to prevent.
+- **Critique work, not people.** Pointing out that a run's evidence does not
+  support its claim is welcome and useful. Attacking the person who shared it
+  is not.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+Examples include using an official email address, posting via an official
+social media account, or acting as an appointed representative at an online or
+offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers by opening a
+[GitHub issue](https://github.com/tangxiangru/AutoR/issues) for public matters,
+or by contacting the maintainers privately for anything sensitive.
+
+All complaints will be reviewed and investigated promptly and fairly. All
+community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of
+Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to AutoR
+
+Thanks for considering a contribution. AutoR is a small, deliberately
+constrained codebase: stdlib-only, file-based, one loop, no framework. Changes
+that keep it that way are the easiest to land.
+
+- **Using AutoR?** Start with the [English Guide](docs/tutorial_en.md) or
+  [中文教程](docs/tutorial_zh.md).
+- **Hacking on AutoR?** [docs/development.md](docs/development.md) has setup,
+  tests, conventions, and extension recipes.
+
+---
+
+## Ways to help
+
+| | |
+| --- | --- |
+| **Report a bug** | Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml). Include the command, the relevant `logs.txt` lines, and the stage's `run_manifest.json` entry. |
+| **Request a feature** | Use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml). Say what research workflow it unblocks — AutoR's roadmap is driven by real research chores, not by framework completeness. |
+| **Improve the docs** | Use the [docs issue template](.github/ISSUE_TEMPLATE/docs_issue.yml), or send the fix directly. Documentation fixes need no prior discussion. |
+| **Ask a question** | Use the [question template](.github/ISSUE_TEMPLATE/question.yml). |
+| **Share a run** | Real runs — what worked, what the model got wrong, where you had to intervene — are among the most useful things you can contribute. |
+
+---
+
+## Development setup
+
+```bash
+git clone https://github.com/tangxiangru/AutoR.git
+cd AutoR
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+That is all of it. Python 3.10+, no virtualenv step, no `pip install`, no
+build. **AutoR has no third-party Python dependencies** and we would like to
+keep it that way — a new dependency needs a reason that outweighs "this repo
+runs anywhere Python does".
+
+You do not need a backend CLI installed. Tests run against fakes, and
+`--fake-operator` exercises the whole workflow without one.
+
+---
+
+## Before you open a pull request
+
+```bash
+python -m py_compile main.py studio.py src/*.py src/*/*.py tests/*.py
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+Both must pass. CI runs the same two steps on Python 3.12 (with slightly
+narrower compile globs), so a green local run is a good predictor.
+
+### Add a test
+
+Every behaviour change needs one. The suite is stdlib `unittest`, it runs in
+about ten seconds, and it works on temp directories — there is no reason not
+to.
+
+- New validation rule → `tests/test_utils_contracts.py`
+- New artifact schema → the test module for that manifest
+- Workflow behaviour → `tests/test_manager_smoke.py` or
+  `tests/test_manager_workflow.py`
+- Studio endpoint → `tests/test_studio_http.py`
+
+A test that would pass before your change is not a test of your change.
+
+### Match the surrounding code
+
+See [docs/development.md](docs/development.md#code-conventions) for the full
+list. The load-bearing ones:
+
+- Frozen dataclasses with explicit `to_dict`/`from_dict` for anything written
+  to disk.
+- Validators return `list[str]` — they never raise and never print.
+- Paths come from `RunPaths`, never from manual joins.
+- Terminal output goes through `TerminalUI`.
+- `from __future__ import annotations` and modern type annotations.
+
+### Update the docs
+
+If you change a flag, a schema, a validation rule, or an endpoint, update the
+matching page under [docs/](docs/). A rule that is enforced but undocumented
+reads as a bug to the next person who hits it.
+
+---
+
+## Pull requests
+
+**Keep them focused.** One change per PR. A refactor bundled with a feature is
+two PRs.
+
+**Describe the behaviour change**, not just the diff:
+
+- What was wrong or missing.
+- What the change does.
+- How you verified it — the test you added, or the run you did.
+- Anything you deliberately left out.
+
+**Do not add a changelog file.** Release notes are derived from PR
+descriptions, so put the detail there instead.
+
+**Draft PRs are welcome** for work in progress or for design feedback before
+you invest in tests.
+
+### What a reviewer will look for
+
+- Does it hold the invariants? Approved memory as the only cross-stage
+  channel; the filesystem as the only state; validation that is structural
+  rather than semantic; nothing advancing without a human by default.
+- Does the failure path degrade rather than crash? A corrupt artifact should
+  produce a problem string, not kill a six-hour run.
+- Is the new rule tested by something that would have failed before?
+- Does it make AutoR more like a research workflow, or more like a framework?
+  The first is the goal.
+
+---
+
+## Design principles
+
+These are the reasons behind most review feedback. Full context in
+[docs/architecture.md](docs/architecture.md).
+
+**Human approval is the default, not a mode.** `--full-auto` exists for
+unattended sweeps. It must never become the recommended path, and changes to
+the automated reviewer should make it stricter rather than more permissive.
+
+**Artifacts over prose.** A stage is judged by files that exist and parse. If
+a change lets a stage pass on markdown alone, it is going the wrong way.
+
+**The filesystem is the database.** No runtime services, no schema
+migrations, no global state. A run directory is complete on its own.
+
+**Structural validation only.** AutoR checks what a machine can be trusted to
+check. It never claims the science is right, and it should not start
+pretending to.
+
+**Prompts before code.** Much of AutoR's behaviour lives in
+`src/prompts/*.md`. If a prompt edit achieves the goal, prefer it.
+
+### Out of scope
+
+Generic multi-agent orchestration · database-backed runtime state · concurrent
+stage execution · heavyweight platform abstractions · dashboard-first
+productization.
+
+These are not oversights. Each one has been considered and declined; a PR that
+adds one will be closed with a pointer here.
+
+---
+
+## Community
+
+Be respectful and factual. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+For security issues, do **not** open a public issue — follow
+[SECURITY.md](SECURITY.md).
+
+Community channels (Discord, WeChat, WhatsApp) are linked from the
+[README](README.md#-community).

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
   <img src="https://img.shields.io/badge/Human-Approval%20Required-orange" alt="Human approval required" />
   <img src="https://img.shields.io/badge/Execution-Agent%20Harness-purple" alt="Agent harness" />
   <img src="https://img.shields.io/badge/Artifacts-Reproducible%20Research%20Runs-red" alt="Reproducible research runs" />
-  <a href="https://github.com/HavenIntelligence/AutoR">
-    <img src="https://img.shields.io/github/stars/HavenIntelligence/AutoR?style=social" alt="GitHub stars" />
+  <a href="https://github.com/tangxiangru/AutoR">
+    <img src="https://img.shields.io/github/stars/tangxiangru/AutoR?style=social" alt="GitHub stars" />
   </a>
 </p>
 
@@ -35,6 +35,8 @@
   ·
   <a href="#-architecture">Architecture</a>
   ·
+  <a href="#-documentation">Documentation</a>
+  ·
   <a href="#-roadmap">Roadmap</a>
 </p>
 
@@ -43,6 +45,8 @@
   <a href="docs/tutorial_en.md">English Guide</a>
   ·
   <a href="docs/tutorial_zh.md">中文教程</a>
+  ·
+  <a href="docs/">Full Documentation</a>
 </p>
 
 <p align="center">
@@ -287,6 +291,14 @@ AI handles execution load; humans steer the research when direction actually mat
 | Resume the latest run | `python main.py --resume-run latest` |
 | Redo a stage inside the same run | `python main.py --resume-run 20260329_210252 --redo-stage 03` |
 | Roll back to a stage inside the same run | `python main.py --resume-run 20260329_210252 --rollback-stage 03` |
+| Re-enter an existing project instead of starting over | `python main.py --project-root ~/code/my-project --goal "..."` |
+| Seed the run from your own prior papers | `python main.py --paper-corpus ~/papers --goal "..."` |
+| Store runs on another disk | `python main.py --runs-dir /mnt/big-disk/runs --goal "..."` |
+| Raise the per-attempt ceiling for long training runs | `python main.py --stage-timeout 43200 --goal "..."` |
+| Skip the intake stage | `python main.py --skip-intake --goal "..."` |
+| Add a generated method diagram to the paper | `python main.py --research-diagram --goal "..."` |
+
+Every flag, its default, and what is preserved on resume: **[docs/cli-reference.md](docs/cli-reference.md)**.
 
 If `--venue` is omitted, AutoR defaults to `neurips_2025`.
 
@@ -326,7 +338,11 @@ What you can do in the Studio:
 - **Paper preview** — the Paper tab renders the compiled PDF, the LaTeX sources, and the build log
 - **Versions page** — the full checkpoint/attempt timeline for every stage
 
-The Studio requires the **Claude CLI** (`claude` on `PATH`) since every run is a real Claude-driven pipeline. If `claude` isn't installed, the server fails fast at startup with a clear error.
+The Studio requires the **Claude CLI** (`claude` on `PATH`) since every run is a real Claude-driven pipeline. The check happens when you start a run, not at server startup: without `claude` the server still comes up and you can browse existing runs, read stage documents, and view papers, but starting a run fails with a clear error.
+
+> The Studio API has **no authentication**. It binds to `127.0.0.1` by default; anything that can reach it can start runs, approve stages, and read every file under the runs directory. For remote access prefer an SSH tunnel over `--host 0.0.0.0`. See [SECURITY.md](SECURITY.md).
+
+Full page-by-page walkthrough and the complete HTTP API: **[docs/studio.md](docs/studio.md)**.
 
 ## ⚙️ How It Works
 
@@ -441,11 +457,16 @@ AutoR does not consider a run successful just because it generated a plausible m
 
 | Stage | Required non-toy output |
 | --- | --- |
+| Stage 01 | A cross-referenced evidence ledger: `sources.json` and `claims.json`, where every cited `source_id` resolves |
 | Stage 03+ | Machine-readable data under `workspace/data/` |
-| Stage 05+ | Machine-readable results under `workspace/results/` |
+| Stage 05+ | Machine-readable results under `workspace/results/`, plus a valid `experiment_manifest.json` |
 | Stage 06+ | Real figure files under `workspace/figures/` |
-| Stage 07+ | Manuscript sources plus a compiled PDF |
+| Stage 07+ | `main.tex` matching the venue, `sections/*.tex`, a bibliography, a compiled PDF, `build_log.txt`, `citation_verification.json`, `self_review.json`, `layout_review.json` |
 | Stage 08+ | Review and readiness assets under `workspace/reviews/` |
+
+Requirements are cumulative, and the stage that *produces* a class of artifact must produce it **during that stage's execution** — a re-run is not credited with the previous attempt's files.
+
+The complete gate, including every JSON schema that is parsed rather than merely counted, is in **[docs/stage-contract.md](docs/stage-contract.md)**.
 
 Required stage summary shape:
 
@@ -457,6 +478,7 @@ Required stage summary shape:
 ## What I Did
 ## Key Results
 ## Files Produced
+## Decision Ledger
 ## Suggestions for Refinement
 ## Your Options
 ```
@@ -606,7 +628,14 @@ File boundaries:
 - [src/artifact_index.py](src/artifact_index.py): Run-wide artifact indexing over data, results, and figures.
 - [src/experiment_manifest.py](src/experiment_manifest.py): Standardized experiment bundle summary used by later stages.
 - [src/utils.py](src/utils.py): Stage metadata, prompt assembly, run paths, markdown validation, artifact validation, and handoff helpers.
+- [src/evidence_ledger.py](src/evidence_ledger.py): Stage 01 literature evidence and Stage 07 citation verification.
+- [src/hypothesis_manifest.py](src/hypothesis_manifest.py): Stage 02 typed propositions, hypotheses, and paper claims.
+- [src/bootstrap.py](src/bootstrap.py) and [src/project_bootstrap.py](src/project_bootstrap.py): `--paper-corpus` and `--project-root` scanning.
+- [src/approval_agent.py](src/approval_agent.py): The strict reviewer agent used by `--full-auto`.
+- [src/backend/](src/backend) and [src/frontend/](src/frontend): AutoR Studio service, HTTP layer, and the browser UI.
 - [src/prompts/](src/prompts): Per-stage prompt templates.
+
+The full module map, the stage attempt loop, how prompts are assembled, and the extension points are in **[docs/architecture.md](docs/architecture.md)**.
 
 ## 🗂️ Run State
 
@@ -662,6 +691,7 @@ Required stage markdown shape:
 ## What I Did
 ## Key Results
 ## Files Produced
+## Decision Ledger
 ## Suggestions for Refinement
 ## Your Options
 ```
@@ -713,6 +743,42 @@ A run with only markdown notes does not pass validation.
 - heavyweight platform abstractions
 - dashboard-first productization
 
+## 📚 Documentation
+
+The [docs/](docs/) directory is the reference documentation. This README is the overview; everything below is the detail behind it.
+
+**Guides**
+
+| | |
+| --- | --- |
+| [English Guide](docs/tutorial_en.md) · [中文教程](docs/tutorial_zh.md) | Install, run your first project end to end, review each stage, and write feedback that actually improves output. |
+
+**Reference**
+
+| | |
+| --- | --- |
+| [CLI Reference](docs/cli-reference.md) | Every flag on `main.py` and `studio.py`, defaults, what is preserved on resume, exit codes. |
+| [Configuration](docs/configuration.md) | `run_config.json`, the venue registry, diagram setup, environment variables, hard-coded limits. |
+| [Run Artifacts](docs/run-artifacts.md) | The run directory, file by file, and the schema of every machine-readable artifact. |
+| [Stage Contract](docs/stage-contract.md) | Exactly what a stage must produce to be accepted, as the code enforces it. |
+| [Studio Guide & API](docs/studio.md) | The browser workspace and its complete HTTP API. |
+
+**Internals**
+
+| | |
+| --- | --- |
+| [Architecture](docs/architecture.md) | Layers, module map, the stage attempt loop, prompt assembly, recovery, extension points. |
+| [Development](docs/development.md) | Dev setup, tests, CI, conventions, and recipes for adding a stage, venue, or backend. |
+| [Troubleshooting](docs/troubleshooting.md) | Symptom-to-fix for the errors AutoR actually raises. |
+
+**Project**
+
+| | |
+| --- | --- |
+| [Contributing](CONTRIBUTING.md) | How to propose and land a change, and what a reviewer looks for. |
+| [Security](SECURITY.md) | The security model, the sandbox trade-offs, and how to report a vulnerability. |
+| [Code of Conduct](CODE_OF_CONDUCT.md) | Community expectations. |
+
 ## 🛣️ Roadmap
 
 The most valuable next steps are the ones that make AutoR more like a real research workflow, not more like a demo framework.
@@ -744,6 +810,18 @@ Implemented milestone:
 - README and open-source assets. Keep refining the README and add `assets/` images such as workflow diagrams, UI screenshots, and artifact examples. This is important for open-source clarity, onboarding, and project presentation.
 
 </details>
+
+## 🤝 Contributing
+
+Bug reports, feature requests, documentation fixes, and shared runs are all welcome. Setup is one clone and one command — AutoR has no third-party Python dependencies and no build step:
+
+```bash
+git clone https://github.com/tangxiangru/AutoR.git
+cd AutoR
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request, and [docs/development.md](docs/development.md) before changing code. Security issues go through [SECURITY.md](SECURITY.md), not a public issue.
 
 ## 🌍 Community
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,163 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for a security vulnerability.
+
+Report it privately through
+[GitHub Security Advisories](https://github.com/tangxiangru/AutoR/security/advisories/new),
+which lets us discuss and fix the issue before it is disclosed.
+
+Please include:
+
+- What the issue is and where in the code it lives.
+- How to reproduce it, ideally as a minimal case.
+- What an attacker could achieve.
+- Any suggested fix.
+
+We will acknowledge the report, work with you on a fix, and credit you in the
+advisory unless you prefer otherwise.
+
+## Supported versions
+
+AutoR is developed on `main`. Security fixes land there. There are no
+long-term support branches.
+
+---
+
+## The security model, and why it matters
+
+Read this before running AutoR on anything you care about. **AutoR is a
+harness that runs a coding agent with permission prompts disabled, on your
+machine, with your credentials.** That is the design — it is what makes an
+unattended multi-hour research run possible — and it has consequences you
+should choose deliberately rather than discover.
+
+### What AutoR grants the agent
+
+Every stage runs the backend CLI with its approval gate off:
+
+```bash
+claude --permission-mode bypassPermissions --dangerously-skip-permissions ...
+codex exec --sandbox workspace-write ...
+```
+
+In practice the agent can read and write files, run arbitrary shell commands,
+install packages, and reach the network — under **your** user account, with
+whatever credentials that account has.
+
+AutoR does not sandbox this. It never asks the agent's permission system to
+confirm an action, because a run that stops every few minutes for a
+confirmation is not a run you can leave overnight.
+
+**Treat an AutoR run the way you would treat running a script you have not
+read.**
+
+### The threat that matters most: the goal is an instruction
+
+Your research goal, your `--resources`, your `--paper-corpus`, and the web
+pages the agent reads during a literature survey all become part of a prompt
+that drives a shell-capable agent. A malicious PDF or web page can attempt
+prompt injection, and the agent has no sandbox to fall back on.
+
+- Only ingest resources you trust.
+- Be wary of goals that direct the agent to fetch and act on arbitrary
+  external content.
+- Read `logs_raw.jsonl` if a run does something surprising — every tool call
+  is recorded there.
+
+### Codex sandbox modes
+
+For `--operator codex`, AutoR exposes the Codex CLI's sandbox:
+
+| Mode | Grants |
+| --- | --- |
+| `read-only` | Read the workspace, no writes. |
+| `workspace-write` | **Default.** Read and write inside the run workspace. |
+| `danger-full-access` | **No sandbox.** Arbitrary local commands, SSH, remote hosts, external GPUs. |
+
+Use `danger-full-access` only when a specific verified experiment needs remote
+execution, and only for a goal and resource set you trust completely. It is
+opt-in for a reason, and it is recorded in `run_config.json` so a resumed run
+does not silently inherit it by accident — check that field before resuming
+someone else's run.
+
+The Claude backend has no equivalent tiering: it runs with permissions
+bypassed. If you need containment there, run AutoR inside a container or VM.
+
+### Recommended containment
+
+For untrusted goals or untrusted input materials:
+
+- Run inside a container or a dedicated VM.
+- Use a user account with no access to credentials, SSH keys, or cloud
+  configuration you would not hand to a stranger.
+- Point `--runs-dir` at an isolated volume.
+- Do not run AutoR in a directory that also contains secrets — the agent can
+  read the filesystem.
+
+---
+
+## Studio
+
+`python studio.py` starts an HTTP server with **no authentication and no
+authorization**. Any client that can reach it can:
+
+- list, read, and traverse every run directory
+- read arbitrary files under a run root
+- start new Claude-backed agent runs
+- approve stages, which advances a run past its human gate
+
+It binds to `127.0.0.1` by default, which is the right default. **Do not use
+`--host 0.0.0.0` on an untrusted network.** For remote access use an SSH
+tunnel:
+
+```bash
+ssh -L 8000:127.0.0.1:8000 you@host
+# then browse http://127.0.0.1:8000/studio/ locally
+```
+
+Path traversal is guarded — static asset and run-file handlers reject paths
+that escape their root — but that is a single control, not a substitute for
+network isolation.
+
+---
+
+## Secrets
+
+**AutoR stores no credentials.** Backend authentication belongs to the
+`claude` or `codex` CLI and is configured there.
+
+The one key AutoR reads directly is the optional Gemini key for
+`--research-diagram`, from `GOOGLE_API_KEY`, `GEMINI_API_KEY`, or
+`configs/diagram_config.yaml` — which is gitignored and should stay that way.
+
+### Before sharing a run directory
+
+Run directories are designed to be shareable, and are therefore easy to share
+carelessly. Before you publish one, check:
+
+| Path | May contain |
+| --- | --- |
+| `user_input.txt`, `memory.md` | your unpublished research direction |
+| `prompt_cache/` | every prompt, including ingested resource content |
+| `logs_raw.jsonl` | every command run, every file path touched, command output |
+| `workspace/` | your data, and anything the agent copied into it |
+| `intake_context.json` | absolute paths to your local files |
+
+`runs/` is gitignored so a run cannot be committed by accident. That protects
+the repository, not a tarball you email to a collaborator.
+
+---
+
+## What is out of scope
+
+- **Agent behaviour.** AutoR cannot prevent a model from writing bad or
+  harmful code. Structural validation checks that files exist and parse, not
+  what they do. Review generated code before running it anywhere that matters.
+- **Backend CLI vulnerabilities.** Report those to Anthropic or OpenAI
+  respectively.
+- **The absence of a sandbox.** That is a documented design decision, not a
+  vulnerability. A concrete escape from a control AutoR *does* claim — the
+  Codex sandbox mode, the Studio path-traversal guards, the gitignore of
+  secrets — is in scope, and we want to hear about it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,87 @@
+# AutoR Documentation
+
+This directory is the reference documentation for AutoR. The
+[root README](../README.md) is the project pitch; everything here is the
+detail behind it.
+
+## Start here
+
+| If you want to… | Read |
+| --- | --- |
+| Install AutoR and run your first project end to end | [English Guide](tutorial_en.md) · [中文教程](tutorial_zh.md) |
+| Look up a command-line flag | [CLI Reference](cli-reference.md) |
+| Understand what a run leaves on disk | [Run Artifacts](run-artifacts.md) |
+| Know exactly what a stage must produce to be accepted | [Stage Contract](stage-contract.md) |
+| Configure venues, backends, sandboxes, or API keys | [Configuration](configuration.md) |
+| Use or script the browser UI | [Studio Guide & HTTP API](studio.md) |
+| Understand how the code is organized | [Architecture](architecture.md) |
+| Hack on AutoR, run the tests, add a stage or a venue | [Development](development.md) |
+| Fix an error you just hit | [Troubleshooting](troubleshooting.md) |
+
+## The whole documentation set
+
+### User guides
+
+- **[tutorial_en.md](tutorial_en.md)** — the full end-to-end user guide.
+  Installation, first run, how to review each stage, how to write feedback
+  that actually improves output, and the fastest path to a strong final PDF.
+- **[tutorial_zh.md](tutorial_zh.md)** — the same guide in Chinese.
+
+### Reference
+
+- **[cli-reference.md](cli-reference.md)** — every flag on `main.py` and
+  `studio.py`, what each one defaults to, what is persisted on resume, and
+  which flags are mutually exclusive.
+- **[configuration.md](configuration.md)** — `run_config.json`, the venue
+  registry, the optional Gemini diagram config, environment variables, and
+  which settings survive a resume.
+- **[run-artifacts.md](run-artifacts.md)** — the run directory layout and the
+  JSON schema of every machine-readable file AutoR writes or validates.
+- **[stage-contract.md](stage-contract.md)** — the stage summary markdown
+  contract and the per-stage artifact gate, as enforced by
+  `validate_stage_markdown` and `validate_stage_artifacts`.
+- **[studio.md](studio.md)** — running the local browser workspace, what each
+  page does, and the complete HTTP API surface.
+
+### Internals
+
+- **[architecture.md](architecture.md)** — layers, module map, the stage
+  attempt loop, how prompts are assembled, how recovery works, and the
+  extension points.
+- **[development.md](development.md)** — dev environment, tests, CI, coding
+  conventions, and step-by-step recipes for adding a stage, a venue, or an
+  execution backend.
+- **[troubleshooting.md](troubleshooting.md)** — symptom-to-fix table for the
+  errors AutoR actually raises.
+
+### Design notes
+
+- **[ui-design/](ui-design/)** — the Studio design record: information
+  architecture, screen specs, system architecture, development plan, and
+  reference screenshots. These are design documents, not user documentation.
+
+### Project notices
+
+- **[star-activity-notice.md](star-activity-notice.md)** — maintainer
+  statement on unusual star activity on the repository.
+
+## Project-level documents
+
+Outside this directory:
+
+- [../README.md](../README.md) — overview, showcase, quick start.
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — how to propose and land changes.
+- [../SECURITY.md](../SECURITY.md) — the security model, the sandbox
+  trade-offs, and how to report a vulnerability.
+- [../CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) — community expectations.
+
+## Documentation conventions
+
+- Paths written as `workspace/results/` are relative to a single run root,
+  `runs/<run_id>/`.
+- Paths written as `src/utils.py` are relative to the repository root.
+- Stage identifiers are written in their canonical slug form
+  (`03_study_design`). Every CLI flag that takes a stage also accepts `3` and
+  `03`.
+- Anything described as *validated* is checked in code, and the source of that
+  check is named so you can read it yourself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,302 @@
+# Architecture
+
+AutoR is a **research control loop layered over a coding-agent execution
+loop**. The agent CLI does the work; AutoR decides what work happens, checks
+what came back, and stops for a human at every stage boundary.
+
+This page describes how that is put together. For what a run *produces*, see
+[Run Artifacts](run-artifacts.md); for what a stage must satisfy, see the
+[Stage Contract](stage-contract.md).
+
+---
+
+## Design commitments
+
+Four constraints shape almost every decision in the codebase.
+
+**The filesystem is the database.** A run is a directory. There is no
+persistent process, no schema migration, no server that must be up. Run state
+survives a crash because it was never anywhere else.
+
+**Approved memory is the only cross-stage channel.** Stage 05 cannot see Stage
+03's conversation — only the approved entries in `memory.md`. This is what
+makes human approval load-bearing rather than ceremonial: refuse a stage and
+its content genuinely does not propagate.
+
+**Validation is structural, not semantic.** AutoR checks that files exist, are
+parseable, are fresh, and cross-reference correctly. It never judges whether
+the science is right. Every check is one a machine can be trusted with; the
+rest is left explicitly to you.
+
+**One conversation per stage.** Refinement continues the same backend session
+rather than restarting it, so iterating on a stage does not discard everything
+the agent learned in it.
+
+---
+
+## Layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Interfaces      main.py (terminal)    studio.py (browser)  │
+├─────────────────────────────────────────────────────────────┤
+│  Control loop    ResearchManager                            │
+│                  stage sequencing · approval · repair ·     │
+│                  resume · redo · rollback                   │
+├─────────────────────────────────────────────────────────────┤
+│  Contract        utils.py · manifest.py · artifact_index.py │
+│                  experiment_manifest.py · evidence_ledger.py│
+│                  hypothesis_manifest.py · writing_manifest.py│
+├─────────────────────────────────────────────────────────────┤
+│  Execution       OperatorProtocol                           │
+│                  ClaudeOperator · CodexOperator             │
+├─────────────────────────────────────────────────────────────┤
+│  Backend CLI     claude          codex                      │
+└─────────────────────────────────────────────────────────────┘
+                              ↕
+                   runs/<run_id>/  (the only state)
+```
+
+Each layer talks only to the one below it. The control loop never shells out
+to a CLI directly; the operators never decide what stage runs next.
+
+---
+
+## Module map
+
+### Entry points
+
+| Module | Responsibility |
+| --- | --- |
+| [`main.py`](../main.py) | CLI parsing, backend and reviewer construction, new-run vs resume dispatch. Contains no workflow logic. |
+| [`studio.py`](../studio.py) | Three-line shim over `src/backend/studio_http.main`. |
+
+### Control loop
+
+| Module | Responsibility |
+| --- | --- |
+| [`src/manager.py`](../src/manager.py) | `ResearchManager` — the whole workflow. Intake, bootstrap, the stage loop, prompt assembly, validation dispatch, the approval menu, repair and normalization, retry exhaustion handling, skip/back control commands, resume, redo, rollback. |
+| [`src/terminal_ui.py`](../src/terminal_ui.py) | All terminal rendering: banners, stage panels, backend event streams, display-width-aware markdown wrapping, keyboard-selectable menus. The manager never writes to stdout directly. |
+| [`src/approval_agent.py`](../src/approval_agent.py) | `AutomatedReviewer` — the strict reviewer agent that stands in for the human gate under `--full-auto`. Returns a `ReviewDecision`. |
+
+### Execution
+
+| Module | Responsibility |
+| --- | --- |
+| [`src/operator_protocol.py`](../src/operator_protocol.py) | `OperatorProtocol` — the interface the manager depends on. Implement this to add a backend. |
+| [`src/operator.py`](../src/operator.py) | `ClaudeOperator` — session management, prompt-file invocation, live `stream-json` parsing, resume-failure detection and fallback, the repair pass, per-attempt state records. Also the shared base for other CLI backends. |
+| [`src/operator_codex.py`](../src/operator_codex.py) | `CodexOperator` — subclass of `ClaudeOperator` overriding invocation. Runs `codex exec --json`, applies the sandbox mode, and works through a stable temp-directory symlink to the run root. |
+
+### Contract and state
+
+| Module | Responsibility |
+| --- | --- |
+| [`src/utils.py`](../src/utils.py) | The contract layer. `StageSpec`/`STAGES`, `RunPaths`/`build_run_paths`, prompt assembly, `validate_stage_markdown`, `validate_stage_artifacts`, memory rendering, handoff read/write, venue resolution, `run_config.json` I/O. Everything shared lives here. |
+| [`src/manifest.py`](../src/manifest.py) | `run_manifest.json`: stage lifecycle, status transitions, rollback and stale marking, memory rebuild from approved entries. |
+| [`src/artifact_index.py`](../src/artifact_index.py) | Scans `data/`, `results/`, `figures/`; infers or reads declared schemas; writes `artifact_index.json`. |
+| [`src/experiment_manifest.py`](../src/experiment_manifest.py) | Builds and validates `results/experiment_manifest.json` as a view over the artifact index. |
+| [`src/evidence_ledger.py`](../src/evidence_ledger.py) | Validates the Stage 01 `sources.json`/`claims.json` pair and the Stage 07 `citation_verification.json`. |
+| [`src/hypothesis_manifest.py`](../src/hypothesis_manifest.py) | Parses Stage 02's typed `T*`/`H*`/`C*` identifiers into `hypothesis_manifest.json`. |
+| [`src/writing_manifest.py`](../src/writing_manifest.py) | Stage 07 support: writing manifest, figure/result scanning, layout review generation and validation. |
+
+### Inputs
+
+| Module | Responsibility |
+| --- | --- |
+| [`src/intake.py`](../src/intake.py) | Stage 00: clarification-question parsing, resource classification and ingestion, `intake_context.json`. |
+| [`src/bootstrap.py`](../src/bootstrap.py) | `--paper-corpus`: scans your prior papers (PDF/LaTeX/BibTeX) into a researcher profile, citation neighborhood, and style profile. |
+| [`src/project_bootstrap.py`](../src/project_bootstrap.py) | `--project-root`: scans an existing repository, assesses per-stage completion, recommends a re-entry stage. |
+
+### Output
+
+| Module | Responsibility |
+| --- | --- |
+| [`src/platform/foundry.py`](../src/platform/foundry.py) | Post-approval packaging: paper package and release package. |
+| [`src/diagram_gen.py`](../src/diagram_gen.py) | Optional Gemini method-diagram generation and LaTeX injection. The only module with a third-party dependency. |
+| [`src/prompts/`](../src/prompts) | One markdown template per stage, plus intake and bootstrap templates. Editing these changes agent behaviour with no code change. |
+
+### Studio
+
+| Module | Responsibility |
+| --- | --- |
+| [`src/backend/studio_http.py`](../src/backend/studio_http.py) | `ThreadingHTTPServer` request router, static asset serving, SSE for the Notebook. Stdlib `http.server` only. |
+| [`src/backend/studio_service.py`](../src/backend/studio_service.py) | The service layer: project index, run summaries, stage documents, file tree, paper preview, version history, iteration planning. |
+| [`src/backend/studio_runner.py`](../src/backend/studio_runner.py) | Drives real `ResearchManager` runs in a background thread under the Studio's approval gate. |
+| [`src/backend/sessions.py`](../src/backend/sessions.py) | Per-stage trace events for the live view; parses `logs_raw.jsonl` into renderable events. |
+| [`src/backend/notebook.py`](../src/backend/notebook.py) | The Notebook view's Claude conversation over a run. |
+| [`src/frontend/static/`](../src/frontend/static) | The single-page UI: `index.html`, `app.js`, `notebook.js`, `styles.css`. No build step, no framework. |
+
+`src/studio_http.py` and `src/studio_service.py` are backwards-compatible
+shims that re-export from `src/backend/`. New code should import from
+`src.backend.*`.
+
+---
+
+## The stage attempt loop
+
+This is the core of the system. Everything else supports it.
+
+```mermaid
+flowchart TD
+    A[Assemble prompt] --> B[Write to prompt_cache/]
+    B --> C[Start or resume the stage session]
+    C --> D[Backend writes stages/&lt;slug&gt;.tmp.md]
+    D --> E{Draft present?}
+    E -- No --> F[Repair pass: rewrite the summary only]
+    F --> G{Present now?}
+    G -- No --> H[Local fallback normalization]
+    G -- Yes --> I
+    H --> I[Validate markdown + artifacts]
+    E -- Yes --> I
+    I --> J{Valid?}
+    J -- No, attempts left --> A
+    J -- No, attempts exhausted --> K[Escalate: skip / roll back / abort]
+    J -- Yes --> L[Show draft for review]
+    L --> M{Decision}
+    M -- 1/2/3 --> N[Continue session with a suggestion] --> A
+    M -- 4 --> O[Continue session with your feedback] --> A
+    M -- 5 --> P[Promote to stages/&lt;slug&gt;.md]
+    P --> Q[Append to memory.md · write handoff/ · update manifest]
+    Q --> R[Next stage]
+    M -- 6 --> S[Abort]
+```
+
+### Prompt assembly
+
+`ResearchManager._build_stage_prompt` composes, in order:
+
+1. The stage template from `src/prompts/<slug>.md`.
+2. The stage summary contract and execution-discipline constraints.
+3. `user_input.txt` — the original goal.
+4. `memory.md` — approved stage summaries.
+5. `intake_context.json`, when present.
+6. Venue configuration for the run.
+7. The structured artifact index, regenerated at prompt time.
+8. The experiment bundle manifest, for Stage 05 and later.
+9. Up to four prior handoff summaries, with the Decision Ledger stripped.
+10. Refinement feedback, on a refinement attempt.
+11. The current draft and workspace context, on a continuation attempt.
+12. Previous validation errors, when re-running after a failure.
+
+The result is written to `prompt_cache/<slug>_attempt_NN.prompt.md` and passed
+to the CLI **by reference** (`-p @<path>`). Two consequences worth knowing:
+the prompt cache is load-bearing during a run rather than a log, and every
+prompt that ever ran is auditable afterwards.
+
+### Backend invocation
+
+**Claude**, first attempt for a stage:
+
+```bash
+claude --model <model> \
+  --permission-mode bypassPermissions \
+  --dangerously-skip-permissions \
+  --session-id <stage_session_id> \
+  -p @runs/<run_id>/prompt_cache/<stage>_attempt_01.prompt.md \
+  --output-format stream-json --verbose
+```
+
+Continuation within the same stage swaps `--session-id` for `--resume`.
+
+**Codex:**
+
+```bash
+codex -C <workspace-symlink> exec --json \
+  --sandbox <workspace-write|read-only|danger-full-access> \
+  --skip-git-repo-check [-m <model>] [resume <session_id>] -
+```
+
+Codex reads the prompt from stdin and runs through a stable symlink under the
+system temp directory, so its working directory stays constant across
+attempts.
+
+Both backends run with permission prompts disabled — that is what makes an
+unattended research run possible, and it is the main reason to care about what
+goes into a goal. See [SECURITY.md](../SECURITY.md).
+
+### Three levels of recovery
+
+Failures are handled at escalating cost, and only the cheapest one that works
+is used:
+
+1. **Repair pass** — the draft is missing or malformed. A narrowly scoped
+   prompt asks the backend to rewrite *only* the stage summary file, with web
+   access forbidden and no instruction to continue the research. Written to
+   `<slug>_attempt_NN_repair.prompt.md`.
+2. **Local normalization** — repair also failed. AutoR synthesizes a
+   contract-shaped draft locally from whatever the attempt produced, with no
+   backend call at all.
+3. **Re-run** — the draft is present but validation failed. The next attempt
+   receives the validation errors and tries again.
+
+A separate mechanism handles a **resume failure**: if the backend reports that
+a session ID no longer exists, the operator detects it from the error text and
+falls back to a fresh session rather than failing the stage.
+
+After `MAX_STAGE_ATTEMPTS` (5), AutoR stops and offers you skip, roll back, or
+abort. It never silently gives up and it never silently continues.
+
+---
+
+## Rollback and staleness
+
+`--redo-stage` and `--rollback-stage` differ in blast radius:
+
+**Redo** re-runs one stage. Downstream stages are untouched. Use it when the
+output was weak but the direction was right.
+
+**Rollback** returns to a stage and marks every downstream stage `stale` in
+`run_manifest.json`, recording `invalidated_reason` and `invalidated_by_stage`
+on each. `memory.md` is rebuilt from the approved entries that survive. Use it
+when a later stage proved an earlier decision wrong — which is the normal
+shape of real research, not an exception.
+
+Staleness is recorded rather than enforced: a stale stage is visibly marked,
+and re-running it clears the mark.
+
+---
+
+## Two interfaces, one model
+
+The Studio is not a second system. It drives the same `ResearchManager` over
+the same run directories, writing the same files.
+
+| | Terminal | Studio |
+| --- | --- | --- |
+| Backends | Claude, Codex | Claude only |
+| Approval | six-option menu | Approve button / feedback box |
+| Live output | streamed to the terminal | session trace from `logs_raw.jsonl` |
+| Restart safety | resume by `run_id` | lazy-resume on the next approve/feedback |
+| Extra state | none | `.autor/projects.json`, `<run>/sessions/`, `<run>/notebook/` |
+
+You can start a run in the terminal and inspect it in the Studio, or the
+reverse. The run directory is the contract between them.
+
+---
+
+## Extension points
+
+Ordered by how much of the system you have to understand first.
+
+| To change… | Edit | Code change needed |
+| --- | --- | --- |
+| What a stage asks the agent to do | `src/prompts/<slug>.md` | none |
+| The set of target venues | `templates/registry.yaml` | none |
+| What a stage must produce | `validate_stage_artifacts` in `src/utils.py` | small |
+| The summary contract | `REQUIRED_STAGE_HEADINGS` + `validate_stage_markdown` | small |
+| The stage list | `STAGES` in `src/utils.py`, plus a new prompt template | moderate |
+| The execution backend | implement `OperatorProtocol`, or subclass `ClaudeOperator` | moderate |
+| The approval policy | `AutomatedReviewer` in `src/approval_agent.py` | moderate |
+
+Step-by-step recipes are in [Development](development.md#extending-autor).
+
+---
+
+## What AutoR deliberately is not
+
+- **Not a multi-agent framework.** One agent executes; one loop supervises.
+- **Not concurrent.** Stages run in order, one at a time. Ordering is the
+  point.
+- **Not database-backed.** Files, and nothing else.
+- **Not a dashboard product.** The Studio is a view over run directories.
+- **Not autonomous.** The default is that nothing advances without a human.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,207 @@
+# CLI Reference
+
+Complete reference for AutoR's two entry points:
+
+- `python main.py` — the terminal research workflow ([source](../main.py))
+- `python studio.py` — the local browser workspace
+  ([source](../src/backend/studio_http.py))
+
+For a task-oriented introduction, read the [English Guide](tutorial_en.md)
+instead. This page is the exhaustive list.
+
+---
+
+## `main.py`
+
+```
+python main.py [--goal GOAL] [--runs-dir DIR] [--fake-operator]
+               [--model MODEL] [--operator {claude,codex}]
+               [--codex-sandbox {read-only,workspace-write,danger-full-access}]
+               [--approval-mode {manual,agent}] [--full-auto]
+               [--review-operator {claude,codex}] [--review-model MODEL]
+               [--venue VENUE] [--resume-run RUN_ID] [--redo-stage STAGE]
+               [--rollback-stage STAGE] [--resources PATH [PATH ...]]
+               [--skip-intake] [--research-diagram]
+               [--project-root PATH] [--paper-corpus PATH]
+               [--stage-timeout SECONDS]
+```
+
+### Goal and run location
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--goal GOAL` | prompted interactively | The research goal. If omitted, AutoR reads a multi-line goal from stdin and stops at the first empty line. An empty goal is an error. |
+| `--runs-dir DIR` | `runs` | Where run directories are created. Resolved **relative to the repository root**, not the current working directory. Point this at a large disk for heavy experiments. |
+
+### Execution backend
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--operator {claude,codex}` | `claude` | Which coding-agent CLI executes each stage. On resume, the existing run's backend is preserved unless you pass this flag. |
+| `--model MODEL` | `sonnet` for Claude, `default` for Codex | Model alias or full model name for the execution backend. On resume, the run's recorded model is reused unless you pass this flag or switch backends. |
+| `--codex-sandbox MODE` | `workspace-write` | Codex CLI sandbox mode. Only meaningful for `--operator codex`. See [the sandbox modes](#codex-sandbox-modes) below. Persisted in `run_config.json` and preserved on resume. |
+| `--fake-operator` | off | Replace the real backend with a deterministic stub that fabricates a valid stage summary. Use this for smoke tests and for exercising the workflow without spending tokens. It does **not** produce real research artifacts. |
+| `--stage-timeout SECONDS` | `14400` (4 hours) | Wall-clock ceiling for a single stage attempt. Raise it for long training runs; a stage that exceeds it is treated as a failed attempt. |
+
+#### Codex sandbox modes
+
+Defined in [`CODEX_SANDBOX_CHOICES`](../src/utils.py).
+
+| Mode | Effect |
+| --- | --- |
+| `read-only` | Codex may read the workspace but not write. Rarely useful for a research run, which must produce artifacts. |
+| `workspace-write` | **Default.** Codex may read and write inside the run workspace. This is the right setting for almost everything. |
+| `danger-full-access` | No sandbox. Codex may execute arbitrary local commands, SSH to remote hosts, and reach external GPUs. Choose this only when a verified remote experiment genuinely needs it, and only for a goal you trust. See [SECURITY.md](../SECURITY.md). |
+
+### Approval control
+
+By default a human approves every stage boundary. `--full-auto` swaps that
+gate for a strict reviewer agent; it does **not** change the stage pipeline.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--approval-mode {manual,agent}` | `manual` | Who approves a stage. `manual` shows the six-option review menu. `agent` delegates to an automated reviewer. Preserved on resume. |
+| `--full-auto` | off | Shortcut for `--approval-mode agent`. |
+| `--review-operator {claude,codex}` | same as `--operator` | Backend used by the automated reviewer. Using a different backend than the executor gives the review some independence. |
+| `--review-model MODEL` | backend default | Model for the reviewer. A stronger reviewer model than the executor model is a reasonable configuration. |
+
+Manual review is still the recommended mode for research you intend to
+publish. `agent` mode exists for unattended sweeps, overnight runs, and
+automated dry runs.
+
+### Writing venue
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--venue VENUE` | `neurips_2025` | Target venue profile for Stage 07 writing. Accepts a registry key (`iclr_2026`), a display name (`ICLR 2026`), or a style package name (`iclr2026_conference`); matching ignores case, spaces, and punctuation. An unknown venue raises `Unknown venue: <value>`. Preserved on resume. |
+
+The full list of venue keys and their metadata is in
+[Configuration → Venue registry](configuration.md#venue-registry).
+
+### Resuming, redoing, rolling back
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--resume-run RUN_ID` | — | Continue an existing run under `--runs-dir`. Pass `latest` to resume the most recent run directory (lexicographic order over the timestamped directory names). |
+| `--redo-stage STAGE` | — | With `--resume-run`: re-run this stage in place, keeping everything downstream untouched. Use it when the stage output was weak but the direction is right. |
+| `--rollback-stage STAGE` | — | With `--resume-run`: return to this stage and mark every downstream stage stale before continuing. Use it when a later stage proved an earlier decision wrong. |
+
+`--redo-stage` and `--rollback-stage` are mutually exclusive; passing both
+raises `--redo-stage and --rollback-stage are mutually exclusive.` Both accept
+`03`, `3`, or `03_study_design`; an unrecognized value raises
+`Unknown stage identifier: <value>`.
+
+Neither flag does anything without `--resume-run`.
+
+### Inputs and priming
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--resources PATH [PATH ...]` | — | Files or directories to ingest into the run before Stage 01: PDFs, code repositories, datasets, `.bib` files, notes. Each path is classified by type and copied into the matching workspace directory. Starting with resources is the single highest-leverage thing you can do for output quality. |
+| `--skip-intake` | off | Skip Stage 00. **Also implied automatically when stdin is not a TTY**, which is why piped and CI invocations never block on the intake prompt. |
+| `--project-root PATH` | — | Scan an existing project repository, infer how far it has already progressed, and recommend a re-entry stage. Use this instead of starting from zero on work you already have. |
+| `--paper-corpus PATH` | — | Scan a directory of your own prior papers (PDF, LaTeX, BibTeX, notes) to build a researcher profile — topics, citation neighborhood, and writing style — that seeds downstream stages. |
+
+### Optional enhancements
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--research-diagram` | off | After Stage 07, generate a method illustration with the Gemini API and inject it into the LaTeX paper. Requires `pip install google-genai pyyaml` and a Gemini API key. If the SDK or key is missing, the diagram step prints a failure line and the run continues unaffected. See [Configuration → Diagram generation](configuration.md#diagram-generation-optional). |
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The workflow completed and the final stage was approved. |
+| `1` | The workflow returned failure — aborted at a review menu, exhausted its attempts, or raised an exception (the message is printed to stderr as `Error: <detail>`). |
+| `130` | Interrupted with Ctrl-C. Run state on disk stays valid; resume with `--resume-run latest`. |
+
+### Interactive controls
+
+Inside a run, the review menu takes `1`–`6` (see
+[Stage Contract → Your Options](stage-contract.md#your-options)). Two extra
+control commands are accepted where the UI offers a recovery prompt:
+
+| Command | Effect |
+| --- | --- |
+| `/skip` | Skip the current stage and continue to the next one. |
+| `/back <stage>` | Roll back to an earlier stage and mark downstream stages stale, e.g. `/back 01` or `/back 03_study_design`. |
+
+Anything else is rejected with
+`Unknown control command. Supported commands are '/skip' and '/back <stage>'.`
+
+A stage gets at most `MAX_STAGE_ATTEMPTS` (5, in [`src/utils.py`](../src/utils.py))
+attempts before AutoR stops and escalates to you.
+
+### Examples
+
+```bash
+# First run, fully interactive
+python main.py
+
+# Explicit goal, primed with your own materials, targeting ICLR
+python main.py \
+  --goal "Does parameter-matched MoE-LoRA beat dense LoRA on instruction tuning?" \
+  --resources ~/papers/moe_survey.pdf ~/refs.bib ~/data/alpaca_subset.jsonl \
+  --venue iclr_2026
+
+# Smoke test the whole pipeline with no backend and no tokens
+python main.py --fake-operator --goal "Smoke test" --skip-intake
+
+# Unattended overnight run with an independent reviewer
+python main.py --full-auto \
+  --operator codex --model default \
+  --review-operator claude --review-model opus \
+  --goal "..."
+
+# A remote-GPU experiment that genuinely needs SSH
+python main.py --operator codex --codex-sandbox danger-full-access --goal "..."
+
+# Rework only the analysis stage of an existing run
+python main.py --resume-run 20260329_210252 --redo-stage 06
+
+# The study design was wrong; go back and invalidate everything after it
+python main.py --resume-run 20260329_210252 --rollback-stage 03
+
+# Continue where you left off, keeping every recorded setting
+python main.py --resume-run latest
+
+# Re-enter an existing project instead of starting over
+python main.py --project-root ~/code/my-existing-project --goal "..."
+
+# Long training runs: raise the per-attempt ceiling to 12 hours
+python main.py --stage-timeout 43200 --goal "..."
+```
+
+---
+
+## `studio.py`
+
+Starts the local browser workspace over the same run directories.
+
+```
+python studio.py [--host HOST] [--port PORT] [--repo-root PATH]
+                 [--runs-dir PATH] [--metadata-root PATH]
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--host HOST` | `127.0.0.1` | Bind address. The server has no authentication; see the warning below before changing this. |
+| `--port PORT` | `8000` | Bind port. |
+| `--repo-root PATH` | `.` | Repository root. Used to locate `src/prompts/`, and to derive the defaults for the two paths below. |
+| `--runs-dir PATH` | `<repo-root>/runs` | Run directory the Studio reads and writes. |
+| `--metadata-root PATH` | `<repo-root>/.autor` | Where the Studio project index (`projects.json`) lives. Projects are Studio-only metadata; runs remain plain directories. |
+
+```bash
+python studio.py                                 # http://127.0.0.1:8000/studio/
+python studio.py --port 8765
+python studio.py --runs-dir /mnt/big-disk/runs
+```
+
+> **Binding beyond localhost.** `--host 0.0.0.0` exposes an unauthenticated
+> API that can start agent runs and read every file under the runs directory.
+> Only do this on a trusted network, and prefer an SSH tunnel
+> (`ssh -L 8000:127.0.0.1:8000 host`) for remote access.
+
+Studio pages, behaviour, and the full HTTP API are documented in
+[studio.md](studio.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,223 @@
+# Configuration
+
+AutoR has deliberately little configuration. There is no global config file,
+no environment-based profile system, and no database. What a run needs is
+recorded inside that run.
+
+Three things are configurable:
+
+1. **Per-run settings** — `runs/<run_id>/run_config.json`, set from CLI flags
+   and preserved across resume.
+2. **Venue profiles** — `templates/registry.yaml`, shared across runs.
+3. **Optional diagram generation** — `configs/diagram_config.yaml` or
+   environment variables.
+
+---
+
+## Requirements
+
+| Requirement | Needed for |
+| --- | --- |
+| Python 3.10+ | everything |
+| `claude` on `PATH` ([Claude Code](https://docs.claude.com/en/docs/claude-code)) | real runs with `--operator claude`, and all Studio runs |
+| `codex` on `PATH` ([Codex CLI](https://developers.openai.com/codex/cli)) | real runs with `--operator codex` |
+| A LaTeX toolchain (`pdflatex`/`latexmk`) | Stage 07 compiling a PDF |
+| `pip install google-genai pyyaml` | `--research-diagram` only |
+
+**AutoR itself has no third-party Python dependencies.** Everything but the
+optional diagram feature runs on the standard library, which is why there is
+no `requirements.txt` — there is nothing to put in it. `pip install` is
+never a step in setting AutoR up.
+
+Neither CLI backend is needed for `--fake-operator` runs or for the test
+suite.
+
+---
+
+## `run_config.json`
+
+Written to each run root. Full field reference in
+[Run Artifacts](run-artifacts.md#run_configjson).
+
+### What is preserved on resume
+
+When you resume, AutoR reuses the recorded settings unless you override them.
+The precedence rules differ slightly per field:
+
+| Field | On resume, without a flag | Notes |
+| --- | --- | --- |
+| `operator` | recorded value | |
+| `model` | recorded value | If you switch backends with `--operator` and give no `--model`, the *new* backend's default is used, not the old model name. A recorded `"unknown"` also falls back to the default. |
+| `codex_sandbox` | recorded value | |
+| `venue` | recorded value | |
+| `approval_mode` | recorded value | `--full-auto` always forces `agent`. |
+| `review_operator` | recorded value, else `operator` | |
+| `review_model` | recorded value | If you pass `--review-operator` without `--review-model`, the new reviewer backend's default is used. |
+| `created_at` | preserved | Never rewritten. |
+
+The one thing that is *not* configurable per run is the runs directory itself:
+`--runs-dir` is where AutoR looks for the run, so it must match the directory
+the run lives in.
+
+### Model defaults
+
+| Backend | Default model |
+| --- | --- |
+| `claude` | `sonnet` |
+| `codex` | `default` |
+
+`--model` takes an alias (`sonnet`, `opus`) or a full model name; AutoR passes
+the value straight through to the backend CLI, so whatever that CLI accepts
+works here.
+
+---
+
+## Venue registry
+
+`templates/registry.yaml` holds venue metadata for Stage 07. AutoR stores
+metadata only — it does **not** vendor official style packages, so the writing
+stage fetches or reproduces the style itself.
+
+### Available venues
+
+| Key | Display name | Type | Style package | Bib style | Citation style | Page limit | Refs count toward limit |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `neurips_2025` | NeurIPS 2025 | conference | `neurips_2025` | `plainnat` | `natbib` | 9 | no |
+| `neurips_2026` | NeurIPS 2026 | conference | `neurips_2026` | `plainnat` | `natbib` | 9 | no |
+| `iclr_2026` | ICLR 2026 | conference | `iclr2026_conference` | `iclr2026_conference` | `natbib` | 9 | no |
+| `icml_2026` | ICML 2026 | conference | `icml2026` | `icml2026` | `natbib` | 8 | no |
+| `cvpr_2026` | CVPR 2026 | conference | `cvpr` | `ieee_fullname` | `natbib` | 8 | no |
+| `acl_2026` | ACL 2026 | conference | `acl` | `acl_natbib` | `natbib` | 8 | no |
+| `aaai_2026` | AAAI 2026 | conference | `aaai2026` | `aaai2026` | `natbib` | 7 | yes |
+| `ieee_conference` | IEEE Conference | conference | `IEEEtran` | `IEEEtran` | `cite` | 6 | yes |
+| `ieee_journal` | IEEE Transactions / Letters | journal | `IEEEtran` | `IEEEtran` | `cite` | 14 | yes |
+| `nature` | Nature | journal | — | `inline_or_manual` | `numeric` | 8 | yes |
+| `nature_communications` | Nature Communications | journal | — | `inline_or_manual` | `numeric` | flexible | yes |
+| `jmlr` | Journal of Machine Learning Research | journal | `jmlr2e` | `plain` | `numeric` | flexible | yes |
+
+Default: `neurips_2025`.
+
+### How `--venue` is matched
+
+`resolve_venue_key` accepts any of:
+
+- the registry key — `iclr_2026`
+- the display name — `"ICLR 2026"`
+- the style package name — `iclr2026_conference`
+
+Matching ignores case, spaces, and punctuation, so `ICLR-2026` and `iclr 2026`
+both resolve. An unmatched value raises `Unknown venue: <value>`.
+
+Set the venue at the start of a run. It shapes Stage 07's structure, page
+budget, and citation style, and switching late means rewriting the manuscript.
+
+### Adding a venue
+
+Append a block to `templates/registry.yaml`:
+
+```yaml
+my_venue_2027:
+  display_name: "My Venue 2027"
+  venue_type: "conference"        # conference | journal
+  official_url: "https://..."
+  style_package: "myvenue2027"    # matched against main.tex; "" for none
+  bib_style: "plainnat"
+  citation_style: "natbib"
+  page_limit: 8                   # integer, or "flexible"
+  refs_in_limit: false
+```
+
+No code change is needed — the registry is read at runtime. Note that the
+parser is a small purpose-built one in `_load_template_registry`
+([`src/utils.py`](../src/utils.py)), not a full YAML parser: keep entries to
+flat `key: value` pairs under a top-level venue key, as the existing ones are.
+
+`style_package` is what the [Stage 07 artifact gate](stage-contract.md#venue-matching)
+looks for in `main.tex`. A run can always override the detection with a
+`% AutoR venue: my_venue_2027` comment.
+
+---
+
+## Diagram generation (optional)
+
+`--research-diagram` generates a method illustration with the Gemini API after
+Stage 07 and injects it into the LaTeX paper. It is an enhancement: if it is
+not configured, the step prints a failure line and the run continues.
+
+### Setup
+
+```bash
+pip install google-genai pyyaml
+export GOOGLE_API_KEY="..."      # or GEMINI_API_KEY
+```
+
+Or, instead of the environment variable:
+
+```bash
+cp configs/diagram_config.template.yaml configs/diagram_config.yaml
+# then fill in api_keys.google_api_key
+```
+
+`configs/diagram_config.yaml` is gitignored.
+
+```yaml
+api_keys:
+  google_api_key: ""        # or gemini_api_key
+
+defaults:
+  model_name: "gemini-2.5-flash"
+  max_critic_rounds: 2
+```
+
+Key resolution order: `GOOGLE_API_KEY`, then `GEMINI_API_KEY`, then
+`api_keys.google_api_key`, then `api_keys.gemini_api_key` from the config file.
+With none of them set, the step raises
+`Gemini API key not found. Set GOOGLE_API_KEY or GEMINI_API_KEY ...`.
+
+If `google-genai` is not installed you will see
+`Diagram generation failed: No module named 'google'` — the rest of the run is
+unaffected.
+
+---
+
+## Environment variables
+
+AutoR reads very few environment variables of its own.
+
+| Variable | Read by | Effect |
+| --- | --- | --- |
+| `GOOGLE_API_KEY` | `src/diagram_gen.py` | Gemini key for `--research-diagram`. |
+| `GEMINI_API_KEY` | `src/diagram_gen.py` | Same, checked second. |
+| `TERM` | `src/terminal_ui.py` | `TERM=dumb` disables colored output. Useful for CI logs and for piping to a file. |
+
+Everything else — API keys, authentication, model access — belongs to the
+`claude` or `codex` CLI, and is configured there, not in AutoR.
+
+---
+
+## Filesystem locations
+
+| Path | Default | Override |
+| --- | --- | --- |
+| Runs | `<repo>/runs/` | `--runs-dir` (resolved relative to the repository root) |
+| Studio project index | `<repo>/.autor/projects.json` | `python studio.py --metadata-root` |
+| Prompt templates | `<repo>/src/prompts/` | — (derived from `--repo-root` in the Studio) |
+| Venue registry | `<repo>/templates/registry.yaml` | — |
+| Diagram config | `<repo>/configs/diagram_config.yaml` | — |
+
+`runs/`, `.autor/`, and `configs/diagram_config.yaml` are all gitignored.
+
+---
+
+## Hard-coded limits
+
+These are constants in [`src/utils.py`](../src/utils.py) rather than settings.
+Change them in source if you must, and expect the tests to have an opinion.
+
+| Constant | Value | Meaning |
+| --- | --- | --- |
+| `MAX_STAGE_ATTEMPTS` | 5 | Attempts before a stage escalates to you. |
+| `DEFAULT_VENUE` | `neurips_2025` | Venue when `--venue` is omitted. |
+| `DEFAULT_CODEX_SANDBOX` | `workspace-write` | Codex sandbox when unspecified. |
+| stage timeout | 14400 s | Per-attempt ceiling — this one *is* a flag, `--stage-timeout`. |
+| handoff window | 4 stages | How many prior handoff summaries enter a prompt. |

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,242 @@
+# Development
+
+How to work on AutoR itself. If you want to *use* AutoR, read the
+[English Guide](tutorial_en.md) instead.
+
+---
+
+## Setup
+
+```bash
+git clone https://github.com/tangxiangru/AutoR.git
+cd AutoR
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+That is the whole setup. There is no virtualenv step, no `pip install`, and no
+build.
+
+**AutoR has no third-party Python dependencies.** Everything except optional
+diagram generation runs on the standard library. Python 3.10+ is the only hard
+requirement; CI runs 3.12.
+
+Neither backend CLI is needed for development — the test suite runs against
+fakes and temp directories, and `--fake-operator` exercises the full workflow
+without a backend.
+
+Optional, for `--research-diagram` work only:
+
+```bash
+pip install google-genai pyyaml
+```
+
+---
+
+## Tests
+
+```bash
+# Everything (~10s, 234 tests)
+python -m unittest discover -s tests -p "test_*.py"
+
+# Verbose
+python -m unittest discover -s tests -p "test_*.py" -v
+
+# One module
+python -m unittest tests.test_manager_smoke
+
+# One test
+python -m unittest tests.test_manager_smoke.ManagerSmokeTest.test_full_run
+```
+
+Tests are stdlib `unittest`. They create temporary run directories, drive the
+manager with a fake operator, and assert on files. They do not call any
+network service, and they do not need a backend CLI installed.
+
+### Coverage map
+
+| Area | Tests |
+| --- | --- |
+| Workflow end to end | `test_manager_smoke.py`, `test_manager_workflow.py`, `test_cli_smoke.py` |
+| Operator sessions, resume fallback, repair | `test_operator_recovery.py`, `test_bounded_recovery.py`, `test_operator_codex.py` |
+| Stage contract and validation | `test_utils_contracts.py`, `test_decision_ledger.py`, `test_revision_delta.py` |
+| Run state, rollback, handoff | `test_run_manifest.py`, `test_stage_rollback.py`, `test_stage_handoff.py` |
+| Manifests and ledgers | `test_artifact_index.py`, `test_experiment_manifest.py`, `test_hypothesis_manifest.py`, `test_evidence_ledger.py` |
+| Writing and packaging | `test_writing_pipeline.py`, `test_foundry_paper_package.py`, `test_release_package.py` |
+| Intake and bootstrap | `test_intake.py`, `test_bootstrap.py`, `test_project_bootstrap.py` |
+| Studio | `test_studio_service.py`, `test_studio_http.py` |
+| Terminal UI | `test_terminal_ui.py` |
+| Diagram generation | `test_diagram_gen.py` |
+
+### Before you push
+
+```bash
+python -m py_compile main.py studio.py src/*.py src/*/*.py tests/*.py
+python -m unittest discover -s tests -p "test_*.py"
+```
+
+The compile step catches syntax errors in modules no test happens to import.
+Note that it covers more than CI does — see below.
+
+---
+
+## CI
+
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml), on pull requests,
+pushes to `main`, and manual dispatch:
+
+1. Ubuntu latest, Python 3.12, 15-minute timeout.
+2. `python -m py_compile main.py src/*.py tests/*.py`
+3. `python -m unittest discover -s tests -p "test_*.py" -v`
+
+The compile step's globs are one level deep, so `src/backend/`,
+`src/platform/`, and `studio.py` are compiled only insofar as a test imports
+them. Run the wider compile locally.
+
+CI installs nothing. Adding a third-party dependency would change that, which
+is a good reason to avoid one.
+
+---
+
+## Code conventions
+
+Match the file you are editing. The house style, as it stands:
+
+- **`from __future__ import annotations`** at the top of every module, with
+  modern annotations (`str | None`, `list[str]`) throughout.
+- **Frozen dataclasses** for anything serialized, with explicit `to_dict` and
+  `from_dict`. Do not rely on `asdict`; the round trip is written out so the
+  on-disk shape is visible in one place.
+- **Defensive `from_dict`.** Coerce, default, and skip malformed entries
+  rather than raising. A corrupt artifact should degrade a view, not kill a
+  six-hour run.
+- **Validators return `list[str]`**, never raise, never print. An empty list
+  means valid; each string is one human-readable problem. The caller decides
+  what to do.
+- **Paths come from `RunPaths`.** Never join run paths by hand — add a field
+  to `RunPaths` and `build_run_paths` instead.
+- **Rendering goes through `TerminalUI`.** The manager does not print.
+- **Local imports for cycles.** `src/utils.py` imports validators inside
+  functions to avoid import cycles; keep that pattern rather than
+  restructuring around it.
+- **Comments explain *why*.** The existing comments mostly record a decision
+  or a trap — for example why `claims.json` accepts both `statement` and
+  `claim`. Match that density; do not narrate the code.
+
+---
+
+## Extending AutoR
+
+### Change what a stage asks for
+
+Edit `src/prompts/<slug>.md`. No code change, no test change. This is the
+right lever for most behaviour changes, and it is worth trying before
+reaching for anything below.
+
+### Add a venue
+
+Append a block to `templates/registry.yaml`. See
+[Configuration → Adding a venue](configuration.md#adding-a-venue). No code
+change.
+
+### Add or change an artifact requirement
+
+Edit `validate_stage_artifacts` in [`src/utils.py`](../src/utils.py).
+
+1. Add the check under the right `if stage.number >= N:` block.
+2. Append to `problems` with a message that names the stage and the fix.
+3. If the stage *produces* the artifact, add a freshness check against
+   `stage_execution_started_at`, or a re-run will be credited with the
+   previous attempt's files.
+4. Add a test in `tests/test_utils_contracts.py`.
+
+Requirements are cumulative — a check under `>= 5` also applies at Stage 8.
+
+### Add a validated JSON artifact
+
+1. Write a `validate_*(path) -> list[str]` function in the module that owns
+   that artifact class.
+2. Call it from `validate_stage_artifacts`, prefixing each problem with
+   `stage.stage_title`.
+3. Import it *inside* the function, not at module level.
+4. Document the schema in [Run Artifacts](run-artifacts.md).
+
+### Add a stage
+
+1. Add a `StageSpec` to `STAGES` in `src/utils.py`.
+2. Create `src/prompts/<NN>_<slug>.md`.
+3. Extend `validate_stage_artifacts` if the stage owns an artifact class.
+4. Check anything that hard-codes stage numbers — the artifact gate, the
+   Stage 02 hypothesis rules, `writing_manifest`, Studio stage display names.
+
+Stage numbers appear in enough places that this is the most invasive change on
+this list. Grep for `stage.number` before you start.
+
+### Add an execution backend
+
+Implement [`OperatorProtocol`](../src/operator_protocol.py), or subclass
+`ClaudeOperator` and override `_prepare_invocation` — that is all
+`CodexOperator` does, in about 100 lines.
+
+You will need to handle:
+
+- **Session lifecycle** — start vs resume, and persisting the session ID.
+- **Streaming** — parse the backend's event stream into `TerminalUI` calls.
+- **Resume failure** — extend `_looks_like_resume_failure` with the error text
+  your backend produces when a session is gone, so AutoR falls back to a fresh
+  session rather than failing the stage.
+- **Prompt delivery** — file reference, stdin, or argument.
+
+Then register it in `create_operator` in [`main.py`](../main.py) and add the
+name to the `--operator` choices.
+
+### Change the approval policy
+
+`AutomatedReviewer` in [`src/approval_agent.py`](../src/approval_agent.py)
+returns a `ReviewDecision`. It is the only thing standing between a
+`--full-auto` run and unattended advancement, so changes here should make it
+stricter, not more permissive.
+
+---
+
+## Repository layout
+
+```
+main.py                     terminal entry point
+studio.py                   Studio entry point (shim)
+src/
+  manager.py                the control loop
+  operator*.py              backend adapters + protocol
+  utils.py                  contract layer: stages, paths, prompts, validation
+  manifest.py               run_manifest.json
+  artifact_index.py         artifact scanning and schema inference
+  experiment_manifest.py    results/experiment_manifest.json
+  evidence_ledger.py        literature + citation validation
+  hypothesis_manifest.py    Stage 02 typed claims
+  writing_manifest.py       Stage 07 support and layout review
+  intake.py                 Stage 00 and resource ingestion
+  bootstrap.py              --paper-corpus
+  project_bootstrap.py      --project-root
+  approval_agent.py         --full-auto reviewer
+  terminal_ui.py            all terminal rendering
+  diagram_gen.py            optional Gemini diagrams
+  platform/foundry.py       paper and release packaging
+  prompts/                  per-stage templates
+  backend/                  Studio service, HTTP, runner, sessions, notebook
+  frontend/static/          the Studio SPA (no build step)
+templates/registry.yaml     venue registry
+configs/                    optional diagram config template
+tests/                      unittest suite
+docs/                       this documentation
+.claude/skills/guides/      writing, citation, and venue reference material
+```
+
+`.claude/skills/guides/` holds long-form reference material — writing
+principles, citation discipline, venue checklists — available to agents
+working in this repository. It is guidance, not code.
+
+---
+
+## Contributing
+
+Read [CONTRIBUTING.md](../CONTRIBUTING.md) for the pull-request process,
+commit conventions, and what a reviewer will look for.

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -1,0 +1,502 @@
+# Run Artifacts
+
+Everything a run produces lives inside one directory, `runs/<run_id>/`, where
+`run_id` is a `YYYYMMDD_HHMMSS` timestamp. Nothing is stored in a database,
+nothing is stored globally, and a run directory can be copied, archived, or
+handed to someone else and remain complete.
+
+This page documents every file in that directory and the schema of every
+machine-readable one.
+
+---
+
+## Directory layout
+
+```text
+runs/<run_id>/
+├── user_input.txt              # the original research goal, verbatim
+├── memory.md                   # approved cross-stage memory (the only shared context)
+├── run_config.json             # backend, model, venue, approval mode, sandbox
+├── run_manifest.json           # stage lifecycle state — the machine-readable source of truth
+├── artifact_index.json         # index over workspace/{data,results,figures}
+├── intake_context.json         # Stage 00 Q&A, ingested resources, refined goal
+├── logs.txt                    # human-readable workflow log
+├── logs_raw.jsonl              # raw backend stream-json events
+├── prompt_cache/               # the exact prompt sent for every attempt
+├── operator_state/             # per-stage session IDs, attempt state, start markers
+├── handoff/                    # compressed per-stage handoff summaries
+├── stages/                     # stage summaries: <slug>.tmp.md draft, <slug>.md approved
+├── notebook/                   # Studio Notebook session and transcript (Studio runs only)
+├── sessions/                   # Studio trace events per stage (Studio runs only)
+└── workspace/                  # the research payload
+    ├── literature/             # reading notes, survey tables, sources.json, claims.json
+    ├── code/                   # runnable code, scripts, configs
+    ├── data/                   # machine-readable datasets and manifests
+    ├── results/                # metrics, predictions, ablations, experiment_manifest.json
+    ├── writing/                # LaTeX sources, sections/, bibliography, tables
+    ├── figures/                # plots and paper figures
+    ├── artifacts/              # compiled PDFs, build_log.txt, review JSON, deliverables
+    ├── notes/                  # supporting notes, hypothesis_manifest.json
+    ├── reviews/                # readiness, critique, dissemination material
+    ├── bootstrap/              # --paper-corpus / --project-root scan output
+    └── profile/                # derived researcher profile
+```
+
+The directory shape is created by `ensure_run_layout` and the paths are
+defined once, in `build_run_paths` ([`src/utils.py`](../src/utils.py)). If you
+need a path in code, take it from `RunPaths` rather than joining strings.
+
+---
+
+## Top-level files
+
+### `user_input.txt`
+
+The research goal exactly as given, before any intake refinement. Required for
+resume; a run without it cannot be resumed.
+
+### `memory.md`
+
+The **only** context shared across stages. A stage does not see another
+stage's conversation — it sees this file.
+
+Each approved stage contributes one entry containing its `Objective`,
+`What I Did`, `Key Results`, and `Files Produced` sections. Nothing enters
+`memory.md` before you approve it, which is what makes "approval" mean
+something: an unapproved stage cannot influence the rest of the run.
+
+Required for resume. Rebuilt from `run_manifest.json` after a rollback.
+
+### `run_config.json`
+
+The settings the run was started with, so a resume reproduces them.
+
+```json
+{
+  "model": "sonnet",
+  "operator": "claude",
+  "venue": "neurips_2025",
+  "approval_mode": "manual",
+  "review_operator": "claude",
+  "review_model": "sonnet",
+  "codex_sandbox": "workspace-write",
+  "created_at": "2026-03-30T10:12:22"
+}
+```
+
+| Field | Values |
+| --- | --- |
+| `model` | Model alias or full name for the execution backend. `"unknown"` if never recorded. |
+| `operator` | `claude` or `codex`. |
+| `venue` | A key from the [venue registry](configuration.md#venue-registry). |
+| `approval_mode` | `manual` or `agent`. |
+| `review_operator` | `claude` or `codex`; defaults to `operator`. |
+| `review_model` | Reviewer model; defaults to `sonnet` (Claude) or `default` (Codex). |
+| `codex_sandbox` | `read-only`, `workspace-write`, or `danger-full-access`. |
+| `created_at` | ISO-8601 to the second. Preserved across rewrites. |
+
+A missing or corrupt file falls back to defaults rather than failing the run.
+See [Configuration](configuration.md#run_configjson) for which CLI flags
+override which fields on resume.
+
+### `run_manifest.json`
+
+The machine-readable lifecycle state of the run — what the Studio reads, and
+what rollback rewrites. Written by [`src/manifest.py`](../src/manifest.py).
+
+```json
+{
+  "run_id": "20260330_101222",
+  "created_at": "2026-03-30T10:12:22",
+  "updated_at": "2026-03-30T18:40:07",
+  "run_status": "human_review",
+  "last_event": "stage.human_review",
+  "current_stage_slug": "05_experimentation",
+  "last_error": null,
+  "completed_at": null,
+  "stages": [
+    {
+      "number": 1,
+      "slug": "01_literature_survey",
+      "title": "Stage 01: Literature Survey",
+      "status": "approved",
+      "approved": true,
+      "dirty": false,
+      "stale": false,
+      "attempt_count": 2,
+      "session_id": "a1b2c3d4-...",
+      "final_stage_path": "stages/01_literature_survey.md",
+      "draft_stage_path": "stages/01_literature_survey.tmp.md",
+      "artifact_paths": ["workspace/literature/sources.json"],
+      "last_error": null,
+      "invalidated_reason": null,
+      "invalidated_by_stage": null,
+      "updated_at": "2026-03-30T11:02:15",
+      "approved_at": "2026-03-30T11:02:15"
+    }
+  ]
+}
+```
+
+**`run_status`** — one of `pending`, `running`, `human_review`, `completed`,
+`failed`, `cancelled`.
+
+**Stage `status`** — one of `not_started`, `pending`, `running`,
+`human_review`, `approved`, `completed`, `failed`, `cancelled`.
+
+**Stage flags:**
+
+| Flag | Meaning |
+| --- | --- |
+| `approved` | You (or the reviewer agent) accepted this stage. |
+| `dirty` | The stage has an unpromoted draft. |
+| `stale` | An earlier stage was rolled back, so this stage's conclusions may no longer hold. `invalidated_reason` and `invalidated_by_stage` say why. |
+
+`session_id` is the backend conversation for that stage, which is what makes
+refinement continue a conversation instead of restarting one.
+
+### `artifact_index.json`
+
+An index over `workspace/data/`, `workspace/results/`, and
+`workspace/figures/`, regenerated whenever artifacts change and fed into later
+stages' prompts so a stage can find data without guessing filenames. Written
+by [`src/artifact_index.py`](../src/artifact_index.py).
+
+```json
+{
+  "generated_at": "2026-03-30T18:31:44",
+  "artifact_count": 12,
+  "counts_by_category": { "data": 3, "results": 6, "figures": 3 },
+  "artifacts": [
+    {
+      "category": "results",
+      "rel_path": "results/actor_main.json",
+      "filename": "actor_main.json",
+      "suffix": ".json",
+      "size_bytes": 4211,
+      "updated_at": "2026-03-30T18:22:03",
+      "schema": {
+        "source": "inferred",
+        "kind": "object",
+        "keys": ["accuracy", "seed", "std"]
+      }
+    }
+  ]
+}
+```
+
+`experiment_manifest.json` and any `*.schema.json` sidecar are excluded from
+the index — the manifest is a view of the index, not an entry in it.
+
+#### Schema metadata
+
+Each artifact carries a `schema` block, from one of two sources:
+
+**Declared** — write a sidecar next to the file, named
+`<filename>.schema.json`, and it is used verbatim:
+
+```json
+{
+  "source": "declared",
+  "sidecar_path": "results/actor_main.json.schema.json",
+  "definition": { "...": "your schema" }
+}
+```
+
+Declaring a schema is the cheapest way to make a result file legible to later
+stages. Invalid JSON in a sidecar is recorded as `"error": "invalid_json"`
+rather than crashing the index.
+
+**Inferred** — otherwise AutoR reads the file and infers a shape:
+
+| Suffix | Inferred `kind` |
+| --- | --- |
+| `.json` | `object` with up to 20 sorted `keys`, or `array` with `item_count` and `item_keys` |
+| `.jsonl` | `jsonl` with `row_count` and the union of keys across rows |
+| `.csv`, `.tsv` | column names |
+| `.yaml`, `.yml` | `yaml_document` |
+| `.parquet` | `parquet_table` |
+| `.npz` / `.npy` | `numpy_archive` / `numpy_array` |
+| figures | `figure`, plus `format` |
+| anything else | `file` |
+
+### `intake_context.json`
+
+Stage 00 output: the original goal, the refined goal, the clarification Q&A
+transcript, the ingested resources, and free-form notes.
+
+```json
+{
+  "goal": "refined goal after clarification",
+  "original_goal": "what the user first typed",
+  "resources": [
+    {
+      "source_path": "/home/me/papers/moe.pdf",
+      "resource_type": "pdf",
+      "dest_dir": "literature",
+      "dest_relative": "literature/moe.pdf",
+      "description": ""
+    }
+  ],
+  "qa_transcript": [
+    { "question": "Which base model?", "answer": "Llama-3-8B" }
+  ],
+  "notes": ""
+}
+```
+
+`resource_type` is one of `pdf`, `bib`, `code`, `dataset`, `notes`, `other`;
+`dest_dir` is the workspace subdirectory the resource was copied into.
+
+### `logs.txt` and `logs_raw.jsonl`
+
+`logs.txt` is the human-readable workflow log: stage starts, attempts,
+validation failures, approvals, rollbacks, aborts. Read this first when
+something went wrong.
+
+`logs_raw.jsonl` is one JSON object per line, the raw `stream-json` event
+stream from the backend — every tool call the agent made, in order. This is
+the ground truth for "what did it actually do", and it is what the Studio
+session trace renders.
+
+---
+
+## Directories
+
+### `stages/`
+
+- `<slug>.tmp.md` — the current draft, rewritten on each attempt.
+- `<slug>.md` — the approved summary. Only appears after you approve.
+
+The required shape of both is the [stage contract](stage-contract.md).
+
+### `prompt_cache/`
+
+The exact prompt text sent to the backend, one file per attempt:
+
+| Filename | Written by |
+| --- | --- |
+| `<slug>_attempt_NN.prompt.md` | a normal stage attempt |
+| `<slug>_attempt_NN_repair.prompt.md` | a repair pass after a malformed summary |
+| `<slug>_review_attempt_NN.prompt.md` | the automated reviewer in `--full-auto` |
+
+Nothing is elided: if you want to know why a stage did what it did, the prompt
+that caused it is on disk. Prompts are passed to the backend by reference
+(`-p @<path>`), so these files are load-bearing during a run, not just a log.
+
+### `operator_state/`
+
+| File | Contents |
+| --- | --- |
+| `<slug>.session_id.txt` | the backend session ID for that stage |
+| `<slug>.session.json` | session bookkeeping |
+| `<slug>.attempt_NN.json` | per-attempt state: command line, mode (`start`/`resume`), prompt path, timestamps |
+| `<slug>.started_at.txt` | the freshness cutoff used by the [artifact gate](stage-contract.md#freshness-checks) |
+
+`<slug>.attempt_NN.json` records the literal argv used, which makes a failed
+attempt reproducible by hand.
+
+### `handoff/`
+
+One `<slug>.md` per completed stage: a compressed view carrying only
+`Objective`, `Key Results`, `Files Produced`, and the `Decision Ledger`.
+
+At most the four most recent handoffs before the current stage are injected
+into a prompt, and the `Decision Ledger` section is stripped from that
+injection — the ledger is kept on disk for audit, not spent on context. This
+is what keeps long runs from growing their prompts without bound.
+
+### `workspace/`
+
+| Directory | Holds | Gated at |
+| --- | --- | --- |
+| `literature/` | reading notes, survey tables, `sources.json`, `claims.json` | Stage 01 |
+| `code/` | runnable scripts, configs, method implementations | — |
+| `data/` | machine-readable datasets, manifests, splits, loaders | Stage 03+ |
+| `results/` | metrics, predictions, ablations, `experiment_manifest.json` | Stage 05+ |
+| `figures/` | plots, diagrams, paper figures | Stage 06+ |
+| `writing/` | `main.tex`, `sections/*.tex`, `.bib`, tables | Stage 07+ |
+| `artifacts/` | compiled PDF, `build_log.txt`, review JSON, packaged deliverables | Stage 07+ |
+| `reviews/` | readiness checklists, threats to validity, critique notes | Stage 08+ |
+| `notes/` | supporting notes, `hypothesis_manifest.json` | — |
+| `bootstrap/` | `--paper-corpus` / `--project-root` scan output | — |
+| `profile/` | derived researcher profile and style notes | — |
+
+---
+
+## Validated JSON files
+
+These are the files AutoR parses and rejects rather than merely counting. Each
+schema below is what the validator actually requires.
+
+### `workspace/literature/sources.json`
+
+```json
+{
+  "sources": [
+    { "source_id": "S1", "title": "Attention Is All You Need", "path": "literature/vaswani2017.pdf" }
+  ]
+}
+```
+
+Required per entry: a unique non-empty `source_id`, a non-empty `title`. A
+bare top-level array is also accepted.
+
+### `workspace/literature/claims.json`
+
+```json
+{
+  "claims": [
+    {
+      "claim_id": "CL1",
+      "statement": "Attention sinks emerge within the first 2k training steps.",
+      "source_ids": ["S1", "S4"]
+    }
+  ]
+}
+```
+
+Required per entry: a non-empty `claim_id`; claim text under `statement` **or**
+`claim`; at least one `source_ids` entry, and **every referenced ID must exist
+in `sources.json`**.
+
+Validated by `validate_literature_evidence` in
+[`src/evidence_ledger.py`](../src/evidence_ledger.py).
+
+### `workspace/results/experiment_manifest.json`
+
+Generated by AutoR from the artifact index — you do not normally hand-write
+it, but Stage 05+ fails if it is missing or malformed.
+
+```json
+{
+  "generated_at": "2026-03-30T18:31:44",
+  "ready_for_analysis": true,
+  "result_artifacts": [
+    { "rel_path": "results/actor_main.json", "schema": { "source": "inferred", "...": "..." } }
+  ],
+  "code_artifacts": ["code/train.py", "code/eval.py"],
+  "note_artifacts": ["notes/setup.md"],
+  "summary": {
+    "result_artifact_count": 6,
+    "code_artifact_count": 2,
+    "note_artifact_count": 1
+  }
+}
+```
+
+Required: non-empty `generated_at`; boolean `ready_for_analysis`; all three
+`summary.*_count` keys; and every `result_artifacts` entry must have a
+non-empty `rel_path` and a `schema` object. Non-integer values you add under
+`summary` are preserved across regeneration rather than dropped.
+
+Validated by `validate_experiment_manifest` in
+[`src/experiment_manifest.py`](../src/experiment_manifest.py).
+
+### `workspace/notes/hypothesis_manifest.json`
+
+Parsed out of the Stage 02 summary's typed subsections.
+
+```json
+{
+  "generated_at": "2026-03-30T12:40:11",
+  "theoretical_propositions": [
+    {
+      "id": "T1",
+      "type": "theoretical_proposition",
+      "statement": "...",
+      "derived_from": "",
+      "depends_on": "",
+      "verification_needed": "",
+      "status": ""
+    }
+  ],
+  "empirical_hypotheses": [],
+  "paper_claims": []
+}
+```
+
+Written by [`src/hypothesis_manifest.py`](../src/hypothesis_manifest.py).
+
+### `workspace/artifacts/citation_verification.json`
+
+```json
+{
+  "overall_status": "verified",
+  "total_citations": 41,
+  "claim_coverage": [
+    {
+      "claim": "AGSNv2 improves Actor accuracy over the dense baseline.",
+      "citation_keys": ["vaswani2017"],
+      "source_ids": ["S1"]
+    }
+  ]
+}
+```
+
+Required: non-empty `overall_status`; non-negative integer `total_citations`;
+non-empty `claim_coverage` list, where each entry has a non-empty `claim` and
+at least one of `citation_keys` or `source_ids`.
+
+Validated by `validate_citation_verification` in
+[`src/evidence_ledger.py`](../src/evidence_ledger.py).
+
+### `workspace/artifacts/layout_review.json`
+
+```json
+{
+  "overall_status": "pass",
+  "pdf_available": true,
+  "build_log_checked": true,
+  "issue_counts": { "overfull_hbox": 3, "missing_figure": 0 },
+  "issues": [],
+  "priority_fixes": ["Trim Section 4 to fit the 9-page limit."]
+}
+```
+
+Required: non-empty string `overall_status`; booleans `pdf_available` and
+`build_log_checked`; object `issue_counts`; list `issues`; and
+`priority_fixes` as a list of non-empty strings.
+
+Validated by `validate_layout_review` in
+[`src/writing_manifest.py`](../src/writing_manifest.py).
+
+### `workspace/artifacts/self_review.json`
+
+Required to exist at Stage 07+. Its contents are not schema-validated, so its
+shape is up to the writing stage.
+
+### `workspace/artifacts/build_log.txt`
+
+The LaTeX build output. Required at Stage 07+, and required to be *fresh* —
+written during the Stage 07 execution that is asking for approval.
+
+---
+
+## Studio-only state
+
+Present only for runs driven through [AutoR Studio](studio.md):
+
+| Path | Contents |
+| --- | --- |
+| `<run>/sessions/<slug>.jsonl` | per-stage trace events rendered in the Studio live view |
+| `<run>/notebook/session.json` | the Notebook conversation's session ID |
+| `<run>/notebook/transcript.jsonl` | the Notebook conversation transcript |
+| `<repo>/.autor/projects.json` | the Studio project index (**outside** the run directory) |
+
+`.autor/projects.json` is the one piece of state that is not per-run. Deleting
+it loses the Studio's project groupings; the runs themselves are unaffected.
+
+---
+
+## Practical notes
+
+- **A run directory is self-contained.** Copy or archive `runs/<run_id>/` and
+  you have the whole record.
+- **`runs/` is gitignored.** Runs are outputs, not source. Archive them
+  yourself if you need them.
+- **`--runs-dir` is resolved relative to the repository root.** Point it at a
+  large disk before a heavy experiment; a real run with datasets and
+  checkpoints gets big.
+- **Read `logs.txt`, then `logs_raw.jsonl`, then `prompt_cache/`.** That is
+  the fastest path from "the output is wrong" to "here is why".

--- a/docs/stage-contract.md
+++ b/docs/stage-contract.md
@@ -1,0 +1,208 @@
+# Stage Contract
+
+A stage is only accepted when it satisfies two independent checks:
+
+1. **The markdown contract** — the stage summary has the required shape.
+   Enforced by `validate_stage_markdown` in [`src/utils.py`](../src/utils.py).
+2. **The artifact gate** — real files exist in the right places, and for the
+   stages that produce them, they were written *during this stage's execution*.
+   Enforced by `validate_stage_artifacts` in [`src/utils.py`](../src/utils.py).
+
+A stage that passes both is shown to you for approval. A stage that fails
+either one is repaired, normalized locally, or re-run — up to
+`MAX_STAGE_ATTEMPTS` (5) attempts, after which AutoR stops and escalates.
+
+Neither check is a substitute for reading the output. They are a floor, not a
+quality bar: they stop markdown-only theater, they do not certify science.
+
+---
+
+## 1. The markdown contract
+
+Every stage writes `runs/<run_id>/stages/<slug>.tmp.md` as a draft, and
+`runs/<run_id>/stages/<slug>.md` once approved.
+
+### Required shape
+
+```md
+# Stage 03: Study Design
+
+## Objective
+## Previously Approved Stage Summaries
+## What I Did
+## Key Results
+## Files Produced
+## Decision Ledger
+## Suggestions for Refinement
+## Your Options
+```
+
+All eight headings are required, in the list defined by
+`REQUIRED_STAGE_HEADINGS`. A missing heading is reported as
+`Missing required section: <name>`.
+
+### Title
+
+The first non-empty line must be exactly `# Stage NN: <Display Name>` for that
+stage — for example `# Stage 03: Study Design`. Anything else fails with
+`Stage markdown title must be exactly '...'`.
+
+### No placeholders
+
+No section may contain unfinished-work markers. The rejected patterns
+(`PLACEHOLDER_PATTERNS`) are, case-insensitively:
+
+`[in progress…]` · `[pending…]` · `[todo…]` · `[to be determined…]` ·
+`[placeholder…]` · `[to be populated…]`
+
+This is checked per section and again on each refinement suggestion.
+
+### Files Produced
+
+Must list at least one concrete file path. When the run paths are available,
+**every listed path is checked for existence** — a summary that claims files it
+did not write fails with
+`Section 'Files Produced' references missing file(s): ...`.
+
+This is the check that most often catches a stage describing work it did not
+actually do.
+
+### Decision Ledger
+
+Must mention all four of:
+
+- `Open Questions`
+- `Locked Decisions`
+- `Assumptions`
+- `Rejected Alternatives`
+
+The ledger is the run's record of *why* the research went the way it did. It
+is what makes an approved run auditable months later.
+
+### Suggestions for Refinement
+
+Exactly three numbered suggestions, numbered `1.`, `2.`, `3.`, in order, with
+no extras. These become options 1–3 on the review menu.
+
+### Your Options
+
+Exactly six numbered options, in order, with these exact texts
+(`FIXED_STAGE_OPTIONS`):
+
+```
+1. Use suggestion 1
+2. Use suggestion 2
+3. Use suggestion 3
+4. Refine with your own feedback
+5. Approve and continue
+6. Abort
+```
+
+| Choice | What happens |
+| --- | --- |
+| `1` / `2` / `3` | Continue the same stage conversation, applying that refinement suggestion. |
+| `4` | Continue the same stage conversation with feedback you type. |
+| `5` | Approve. The summary is promoted to `stages/<slug>.md`, appended to `memory.md`, and the run advances. |
+| `6` | Abort the run. Everything on disk stays valid and resumable. |
+
+### Stage 02 additional contract
+
+`02_hypothesis_generation` must carry typed subsections inside `Key Results`
+(`TYPED_HYPOTHESIS_HEADINGS`):
+
+| Subsection | Required identifier format |
+| --- | --- |
+| `Theoretical Propositions` | at least one `**T1**:` |
+| `Empirical Hypotheses` | at least one `**H1**:` |
+| `Paper Claims (Provisional)` | at least one `**C1**:` |
+
+These identifiers are parsed into
+[`workspace/notes/hypothesis_manifest.json`](run-artifacts.md#workspacenoteshypothesis_manifestjson)
+so later stages can refer to a specific hypothesis rather than to prose.
+
+---
+
+## 2. The artifact gate
+
+Artifact requirements are **cumulative**: a Stage 07 run must still satisfy
+everything Stage 03, 05, and 06 required.
+
+| From stage | Requirement |
+| --- | --- |
+| **01** | `workspace/literature/sources.json` and `workspace/literature/claims.json` exist and cross-reference correctly (see [the evidence ledger](#the-evidence-ledger)). |
+| **03+** | At least one machine-readable file under `workspace/data/` with a suffix in `.json .jsonl .csv .tsv .parquet .yaml .yml`. |
+| **05+** | At least one result file under `workspace/results/` with a suffix in `.json .jsonl .csv .tsv .parquet .npz .npy`. |
+| **05+** | `workspace/results/experiment_manifest.json` exists and is structurally valid. |
+| **06+** | At least one figure under `workspace/figures/` with a suffix in `.png .pdf .svg .jpg .jpeg`. |
+| **07+** | `workspace/writing/main.tex` exists **and** matches the selected venue (see [venue matching](#venue-matching)). |
+| **07+** | A `.bib` file under `workspace/writing/`, or an inline bibliography. |
+| **07+** | At least one `.tex` file under `workspace/writing/sections/`. |
+| **07+** | A compiled PDF under `workspace/writing/` or `workspace/artifacts/`. |
+| **07+** | `workspace/artifacts/build_log.txt`. |
+| **07+** | `workspace/artifacts/citation_verification.json`, structurally valid. |
+| **07+** | `workspace/artifacts/self_review.json`. |
+| **07+** | `workspace/artifacts/layout_review.json`, structurally valid. |
+| **08+** | At least one file under `workspace/reviews/`. |
+
+The schemas of the validated JSON files are in
+[Run Artifacts](run-artifacts.md).
+
+### Freshness checks
+
+Existence alone is not enough for the stage that is supposed to *produce* a
+class of artifact. AutoR records a timestamp when a stage starts executing
+(`operator_state/<slug>.started_at.txt`) and requires the artifacts that stage
+owns to be at least that new.
+
+| Stage | Must be newly written during this stage |
+| --- | --- |
+| `03_study_design` | at least one file under `workspace/data/` |
+| `06_analysis` | at least one file under `workspace/figures/` |
+| `07_writing` | `main.tex`, `build_log.txt`, `citation_verification.json`, `self_review.json`, `layout_review.json`, a PDF, and at least one `sections/*.tex` |
+| `08_dissemination` | at least one file under `workspace/reviews/` |
+
+This is what stops a re-run from being credited with the previous attempt's
+files. Stages that only *consume* an artifact class (for example Stage 05
+reading `workspace/data/`) check existence but not freshness.
+
+### The evidence ledger
+
+Stage 01 must leave a citable trail rather than a paper list.
+
+`workspace/literature/sources.json` — every entry needs a unique non-empty
+`source_id` and a non-empty `title`. Duplicate IDs are rejected.
+
+`workspace/literature/claims.json` — every entry needs a non-empty `claim_id`,
+claim text under either `statement` or `claim`, and at least one entry in
+`source_ids`. **Every referenced `source_id` must exist in `sources.json`**;
+dangling references are reported by name.
+
+That last rule is the point of the ledger: a claim that cites nothing real
+cannot pass Stage 01.
+
+### Venue matching
+
+Stage 07's `main.tex` must look like a manuscript for the venue the run was
+started with. AutoR checks for the venue's style package, and accepts an
+explicit override comment near the top of the file:
+
+```tex
+% AutoR venue: iclr_2026
+```
+
+The failure message names the expected venue key, so a mismatch is
+self-explanatory.
+
+---
+
+## What the gate deliberately does not check
+
+- Whether the science is correct.
+- Whether the experiment is more than a smoke test.
+- Whether the numbers in the summary match the numbers in the result files.
+- Whether a figure is meaningful or merely present.
+- Whether a citation supports the claim it is attached to.
+
+Those are yours. The
+[review checklists in the user guide](tutorial_en.md#10-how-to-review-each-stage)
+are the practical counterpart to this page.

--- a/docs/studio.md
+++ b/docs/studio.md
@@ -1,0 +1,294 @@
+# AutoR Studio
+
+Studio is a local browser workspace over the same run-based workflow as the
+terminal. Same run directories, same stage contract, same artifacts — a
+different way to watch and approve them.
+
+It is not a hosted product. It is a stdlib `http.server` bound to localhost by
+default, reading and writing the run directories already on your disk.
+
+---
+
+## Running it
+
+```bash
+python studio.py
+# → http://127.0.0.1:8000/studio/
+```
+
+| Flag | Default | Purpose |
+| --- | --- | --- |
+| `--host` | `127.0.0.1` | Bind address |
+| `--port` | `8000` | Bind port |
+| `--repo-root` | `.` | Repository root; also the base for the two paths below |
+| `--runs-dir` | `<repo-root>/runs` | Run directory to read and write |
+| `--metadata-root` | `<repo-root>/.autor` | Where the project index lives |
+
+```bash
+python studio.py --port 8765
+python studio.py --runs-dir /mnt/big-disk/runs
+```
+
+### Requirements
+
+Studio runs are **Claude-backed only** — there is no Codex path through the
+browser UI. The `claude` CLI must be on `PATH`.
+
+The check happens when you **start a run**, not at server startup: the server
+comes up fine without `claude` installed, and you can browse existing runs,
+read stage documents, and view papers. Starting a run without it fails with
+`Claude CLI not available on PATH.`
+
+### Exposing it beyond localhost
+
+> **The API has no authentication.** It can start agent runs and read any file
+> under the runs directory. `--host 0.0.0.0` publishes all of that to your
+> network.
+>
+> For remote access, prefer an SSH tunnel:
+> `ssh -L 8000:127.0.0.1:8000 you@host`, then browse to
+> `http://127.0.0.1:8000/studio/` locally.
+
+---
+
+## What you can do
+
+### Projects hub
+
+Create a project with a title and a thesis, and a real Claude-backed run
+starts immediately. A **project** is Studio-only metadata that groups runs
+together — it lives in `.autor/projects.json`, never inside a run. Deleting it
+loses the grouping; the runs are untouched.
+
+### Overview
+
+The live view of a run: the stage strip with the current stage pulsing, and a
+session trace streaming the agent's real tool calls as they are parsed out of
+`logs_raw.jsonl`.
+
+### Review
+
+The human gate. A "You are reviewing" card with a TL;DR pulled from the stage
+markdown, a **Files Produced** pill list, and
+`✅ Approve → Advance to <next stage>`.
+
+### Feedback and re-run
+
+Feedback is woven into the **first attempt's prompt** of the next run rather
+than spent on an intermediate call. It works on stages in `human_review` and
+on `failed` stages, which is what makes a failed stage recoverable from the
+browser.
+
+### Paper
+
+The compiled PDF, the LaTeX sources, and the build log, side by side.
+
+### Versions
+
+The full checkpoint and attempt timeline for every stage, reconstructed from
+the run manifest and the stage files.
+
+### Notebook
+
+A Claude conversation scoped to one run, with the run's thesis, status, and
+stage list as context. Transcript and session ID persist under
+`<run>/notebook/`, so the conversation survives a restart.
+
+### Resume across restarts
+
+Stop the server, come back later, click Approve or Feedback: the Studio
+lazy-resumes the on-disk run without re-running stages that already have a
+draft. There is no in-memory state to lose, because there is no in-memory
+state.
+
+---
+
+## HTTP API
+
+Everything below is served by
+[`src/backend/studio_http.py`](../src/backend/studio_http.py). Responses are
+JSON unless noted. Errors are `{"error": "<detail>"}` with the status codes in
+[the table at the end](#error-responses).
+
+Path parameters: `{run_id}` is a run directory name, `{project_id}` a Studio
+project ID, `{slug}` a stage slug such as `03_study_design`.
+
+### Health and static assets
+
+| Method | Path | Returns |
+| --- | --- | --- |
+| `GET` | `/healthz` | `{"status": "ok"}` |
+| `GET` | `/`, `/studio`, `/studio/` | the single-page app |
+| `GET` | `/studio/<asset>` | static assets from `src/frontend/static/` |
+| `GET` | `/studio/ext/<asset>` | modules from `src/frontend/` |
+
+Both static handlers reject paths that escape their root with `400`.
+
+### Projects
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/projects` | All project records. |
+| `GET` | `/api/projects/overview` | All projects with their run summaries resolved. |
+| `GET` | `/api/projects/{project_id}` | One project summary. |
+| `POST` | `/api/projects` | Create a project. `201`. |
+| `POST` | `/api/projects/{project_id}/runs` | Attach an existing run to a project. |
+| `POST` | `/api/projects/{project_id}/runs/start` | Start a new Claude-backed run. `201`. |
+
+`POST /api/projects`
+
+```json
+{ "title": "MoE-LoRA study", "thesis": "...", "default_mode": null, "tags": ["nlp"] }
+```
+
+`participation_model` is always `human_in_loop`.
+
+`POST /api/projects/{project_id}/runs`
+
+```json
+{ "run_id": "20260330_101222", "make_active": true }
+```
+
+`POST /api/projects/{project_id}/runs/start`
+
+```json
+{ "goal": "optional; defaults to the project thesis" }
+```
+
+→ `{"run_id": "...", "project_id": "..."}`. Requires `claude` on `PATH`.
+
+### Runs
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/runs` | `{"run_ids": [...]}` |
+| `GET` | `/api/runs/{run_id}` | Run summary: status, current stage, per-stage entries. |
+| `GET` | `/api/runs/{run_id}/history` | Version records and trace events. |
+| `GET` | `/api/runs/{run_id}/artifacts` | The run's `artifact_index.json`, or `{}`. |
+| `GET` | `/api/runs/{run_id}/sessions` | Session summary across stages. |
+
+### Stages
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/runs/{run_id}/stages/{slug}` | `{"run_id", "stage_slug", "markdown"}` |
+| `GET` | `/api/runs/{run_id}/stages/{slug}/session` | Trace events for that stage. |
+| `POST` | `/api/runs/{run_id}/stages/{slug}/approve` | Approve and advance. |
+| `POST` | `/api/runs/{run_id}/stages/{slug}/feedback` | Re-run with feedback. |
+
+`POST .../feedback`
+
+```json
+{ "feedback": "The baselines are missing. Add dense LoRA at matched parameter count." }
+```
+
+→ `{"run_id", "stage_slug", "action": "feedback_submitted"}`
+
+### Paper
+
+| Method | Path | Returns |
+| --- | --- | --- |
+| `GET` | `/api/runs/{run_id}/paper` | Preview: `tex_relative_path`, `tex_content`, `section_paths`, `pdf_relative_path`, `pdf_available`, `build_log_relative_path`, `build_log_content`. |
+| `GET` | `/api/runs/{run_id}/paper/pdf` | The compiled PDF as `application/pdf`. |
+
+### Files
+
+| Method | Path | Query | Description |
+| --- | --- | --- | --- |
+| `GET` | `/api/runs/{run_id}/files/tree` | `root` (default `workspace`), `depth` | File tree under the run. |
+| `GET` | `/api/runs/{run_id}/files/content` | `path` | Contents of one file, relative to the run root. |
+
+### Iteration planning
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/api/runs/{run_id}/iterations/plan` | Compute — but do not execute — the effect of an iteration. |
+
+```json
+{
+  "base_stage_slug": "05_experimentation",
+  "scope_type": "stage",
+  "scope_value": "",
+  "mode": "continue",
+  "freeze_upstream": true,
+  "invalidate_downstream": true,
+  "user_feedback": ""
+}
+```
+
+`scope_type` ∈ `stage` · `file` · `subtree` · `manuscript`
+`mode` ∈ `continue` · `redo` · `branch`
+
+The response reports `preserved_stages`, `affected_stages`, `stale_stages`,
+`branch_run_id`, `reuses_current_run`, a human-readable `summary`, an
+`operator_brief`, and `reviewer_actions`. This is a dry run: nothing on disk
+changes.
+
+### Notebook
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/notebook/transcript?run_id=...` | `{"run_id", "events", "session_id"}` |
+| `POST` | `/api/notebook/stream` | Stream a reply as Server-Sent Events. |
+| `POST` | `/api/notebook/reset` | Clear the notebook session and transcript. |
+
+`POST /api/notebook/stream` takes `{"run_id": "...", "message": "..."}` and
+responds with `text/event-stream`. Each event is a `data:` line containing a
+JSON object; the stream ends with `{"type": "done"}`. A missing `claude` CLI
+arrives as `{"type": "error", "detail": "..."}` followed by `done`, rather than
+as an HTTP error — the stream has already started by then.
+
+Both `run_id` and `message` are required; either missing gives `400`.
+
+### Error responses
+
+| Status | Raised for |
+| --- | --- |
+| `400` | Bad request — bad parameters, or a static path escaping its root. |
+| `404` | Unknown route, unknown run or project, or a missing file. |
+| `409` | Conflicting state — e.g. approving a stage that is not awaiting review. |
+| `500` | Unhandled error; the detail is included. |
+
+---
+
+## Scripting the API
+
+The API is plain HTTP with no auth, which makes it convenient to script
+locally.
+
+```bash
+# What runs exist?
+curl -s localhost:8000/api/runs | python -m json.tool
+
+# Where is the newest run?
+curl -s localhost:8000/api/runs/20260330_101222 | python -m json.tool
+
+# Read a stage summary
+curl -s localhost:8000/api/runs/20260330_101222/stages/05_experimentation \
+  | python -c 'import json,sys; print(json.load(sys.stdin)["markdown"])'
+
+# Approve it
+curl -s -X POST \
+  localhost:8000/api/runs/20260330_101222/stages/05_experimentation/approve
+
+# Send feedback instead
+curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"feedback":"Add the dense LoRA baseline at matched parameter count."}' \
+  localhost:8000/api/runs/20260330_101222/stages/05_experimentation/feedback
+
+# Fetch the compiled PDF
+curl -s -o paper.pdf localhost:8000/api/runs/20260330_101222/paper/pdf
+```
+
+Scripting `approve` is scripting away the human gate. That is a legitimate
+thing to do for a dry run or a sweep; it is not the mode to use for research
+you intend to publish.
+
+---
+
+## Design documents
+
+The Studio's design record lives in [ui-design/](ui-design/): information
+architecture, screen specs, system architecture, development plan, and
+reference screenshots. Those are design documents and may describe intent
+ahead of what is implemented; this page describes what is implemented.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,269 @@
+# Troubleshooting
+
+Symptom-to-fix for the errors AutoR actually produces. If your problem is
+"the output is not good enough" rather than "something broke", the
+[user guide](tutorial_en.md#9-the-most-important-usage-principle-first-pass-output-is-often-toy-level)
+is the right page.
+
+---
+
+## Where to look first
+
+In this order:
+
+1. **`runs/<run_id>/logs.txt`** — the workflow log. Stage starts, attempts,
+   validation failures, approvals, aborts. Nine times out of ten the answer is
+   here.
+2. **`runs/<run_id>/run_manifest.json`** — where the run actually is. Stage
+   statuses, attempt counts, `last_error`, stale flags.
+3. **`runs/<run_id>/logs_raw.jsonl`** — every tool call the agent made. This is
+   the ground truth for "what did it actually do".
+4. **`runs/<run_id>/prompt_cache/<slug>_attempt_NN.prompt.md`** — exactly what
+   the agent was asked. If behaviour is baffling, read the prompt.
+5. **`runs/<run_id>/operator_state/<slug>.attempt_NN.json`** — the literal
+   command line used, so you can rerun the backend by hand.
+
+---
+
+## Startup and configuration
+
+### `claude CLI not found: claude` / `codex CLI not found: codex`
+
+The backend is not on `PATH`. Install it
+([Claude Code](https://docs.claude.com/en/docs/claude-code) ·
+[Codex CLI](https://developers.openai.com/codex/cli)), or run with
+`--fake-operator` to exercise the workflow without a backend.
+
+Check with `which claude` in the same shell you run AutoR from — a CLI
+installed under a version manager may not be on `PATH` for non-login shells.
+
+### `Unknown venue: <value>`
+
+Not a registry key, display name, or style package. See the
+[venue table](configuration.md#venue-registry). Matching ignores case and
+punctuation, so the value is genuinely absent rather than misspelled in
+formatting.
+
+### `Unknown stage identifier: <value>`
+
+`--redo-stage` / `--rollback-stage` accept `03`, `3`, or `03_study_design`.
+Anything else — including `stage03` and `3_study_design` — is rejected.
+
+### `--redo-stage and --rollback-stage are mutually exclusive.`
+
+Pick one. Redo re-runs a single stage; rollback returns to a stage and marks
+everything after it stale. See
+[Architecture → Rollback and staleness](architecture.md#rollback-and-staleness).
+
+### `Research goal cannot be empty.`
+
+The interactive goal prompt got nothing. Type the goal, then press Enter on an
+empty line to finish. Or pass `--goal "..."`.
+
+### `No runs found in <dir>`
+
+`--resume-run latest` with an empty runs directory. Check `--runs-dir` — it is
+resolved **relative to the repository root**, not your current directory, so
+running from a subdirectory does not change where AutoR looks.
+
+### `Run not found: <path>`
+
+The `run_id` does not exist under `--runs-dir`. List them with
+`ls runs/`. A `run_id` is a `YYYYMMDD_HHMMSS` timestamp.
+
+### `Missing user_input.txt in run: <path>` / `Missing memory.md in run: <path>`
+
+Both are required to resume. If they were deleted, the run cannot be resumed —
+the goal and the approved memory are the two things AutoR cannot reconstruct.
+The workspace artifacts are still there and still usable.
+
+### `Project root not found` / `Paper corpus path not found`
+
+The `--project-root` or `--paper-corpus` path does not exist. Both are
+expanded (`~`) and resolved, so a relative path is interpreted from your
+current directory.
+
+---
+
+## During a run
+
+### A stage keeps failing validation
+
+Read the validation errors — they name the exact requirement. The
+[Stage Contract](stage-contract.md) explains each one. The usual causes:
+
+| Error | Cause |
+| --- | --- |
+| `Section 'Files Produced' references missing file(s)` | The summary claimed files that were not written. Usually the agent described intended work rather than completed work. |
+| `Missing required section: Decision Ledger` | An older prompt or a truncated response. The repair pass normally fixes this. |
+| `... requires machine-readable data artifacts under workspace/data` | Only markdown notes were produced. Push the stage to write real `.json`/`.csv` files. |
+| `... requires <artifact> produced or updated during the current stage execution` | The artifact exists but is stale — left over from a previous attempt. The stage must genuinely regenerate it. |
+| `claims.json entry N references unknown source_ids` | A claim cites a source that is not in `sources.json`. |
+| `... requires a supported conference or journal manuscript` | `main.tex` does not match the run's venue. Add `% AutoR venue: <key>` near the top, or use the venue's style package. |
+
+### `Stage X failed after 5 attempts. Escalating to user.`
+
+`MAX_STAGE_ATTEMPTS` is exhausted. You are offered skip, roll back, or abort.
+
+Repeated failure at the same stage usually means the goal is too broad for the
+stage to complete, or a dependency is missing (no dataset, no GPU, no LaTeX).
+Read the last attempt's prompt and the raw log before choosing. Rolling back
+to an earlier stage and narrowing the scope is often more effective than
+retrying.
+
+### The run appears to hang
+
+Most likely it is working. A real Stage 05 can run for hours; the per-attempt
+ceiling is `--stage-timeout`, default 4 hours.
+
+To check: watch `logs_raw.jsonl` grow (`tail -f`), or look at the
+`operator_state/<slug>.attempt_NN.json` timestamps.
+
+If it is genuinely stuck, Ctrl-C exits with code 130 leaving the run
+resumable, and `--resume-run latest` picks it back up.
+
+### A long training run keeps timing out
+
+Raise the ceiling: `--stage-timeout 43200` for 12 hours.
+
+### `Failed to capture <backend> output stream.`
+
+The backend process produced no readable stream. Usually a crashed or
+misconfigured CLI. Verify the backend works standalone:
+
+```bash
+claude --version
+claude -p "say hi"
+```
+
+### Resume produced a fresh session instead of continuing
+
+Expected behaviour, not a bug. If the backend reports that a session ID no
+longer exists, AutoR detects it and starts a fresh session rather than failing
+the stage. Backend session stores expire; the run continues with the approved
+memory intact.
+
+### Terminal rendering is broken or full of escape codes
+
+`TERM=dumb python main.py ...` disables color. Useful when piping to a file or
+running under a CI log collector.
+
+Wide characters and long lines are handled, but a terminal narrower than
+~40 columns will wrap awkwardly.
+
+### The intake prompt never appears
+
+Stage 00 is skipped automatically when stdin is not a TTY. Piped input, `nohup`,
+and most CI runners all trigger this. Pass `--goal` explicitly for those, and
+know that intake will not run.
+
+---
+
+## Stage 07 writing
+
+### The PDF never compiles
+
+Stage 07 needs a working LaTeX toolchain. Check:
+
+```bash
+which pdflatex latexmk
+```
+
+Read `workspace/artifacts/build_log.txt` for the actual LaTeX error. A missing
+style package is the most common cause — AutoR stores venue *metadata* and
+does not vendor official style files, so the stage has to obtain them.
+
+### `... requires build_log.txt under workspace/artifacts`
+
+The build never ran, or ran somewhere else. The build log is required
+evidence that compilation was attempted, and at Stage 07 it must be fresh.
+
+### `citation_verification.json` / `layout_review.json` validation fails
+
+The file exists but does not match the schema. The exact missing field is in
+the error. Schemas are in
+[Run Artifacts → Validated JSON files](run-artifacts.md#validated-json-files).
+
+---
+
+## Diagram generation
+
+### `Diagram generation failed: No module named 'google'`
+
+`pip install google-genai pyyaml`. The SDK is not a default dependency. The
+run continues without the diagram either way.
+
+### `Gemini API key not found. Set GOOGLE_API_KEY or GEMINI_API_KEY ...`
+
+Export one of those, or fill in `configs/diagram_config.yaml` (copy from
+`configs/diagram_config.template.yaml`). See
+[Configuration → Diagram generation](configuration.md#diagram-generation-optional).
+
+---
+
+## Studio
+
+### `Claude CLI not available on PATH.` when starting a run
+
+Studio runs are Claude-backed only. Install the Claude CLI. The server starts
+without it — you can browse existing runs, read stage documents, and view
+papers — but starting a run needs it.
+
+### `Unknown route: <path>`
+
+The path is not in the API. The full surface is in
+[the Studio API reference](studio.md#http-api).
+
+### `Address already in use`
+
+Another process holds the port. Use `--port 8765`, or find the holder with
+`lsof -i :8000`.
+
+### The Studio shows no runs
+
+Check `--runs-dir`. It defaults to `<repo-root>/runs`, and the Studio only
+sees runs under whichever directory it was given.
+
+### A `409 Conflict` on approve
+
+The stage is not awaiting review — it may already be approved, or still
+running. Refresh the run summary
+(`GET /api/runs/{run_id}`) to see its actual status.
+
+### Notebook replies with an error event instead of text
+
+The stream had already started when the failure occurred, so errors arrive as
+`{"type": "error", "detail": "..."}` inside the SSE stream rather than as an
+HTTP status. A missing `claude` CLI is the usual detail.
+
+---
+
+## Recovering a run
+
+| Situation | Do this |
+| --- | --- |
+| Stage output was weak, direction is right | `--resume-run <id> --redo-stage <n>` |
+| A later stage proved an earlier decision wrong | `--resume-run <id> --rollback-stage <n>` |
+| Process died or was interrupted | `--resume-run latest` |
+| A stage is unfixable and you want to move past it | `/skip` at the recovery prompt |
+| You want to jump back mid-run | `/back <stage>` at the recovery prompt |
+| The run is beyond saving | Start fresh with a narrower goal. The old run stays on disk. |
+
+Rolling back rebuilds `memory.md` from the surviving approved stages and marks
+downstream stages stale. Nothing is deleted, so a rollback is recoverable by
+re-running forward.
+
+---
+
+## Still stuck
+
+Open an issue with:
+
+- The command you ran.
+- The relevant lines from `logs.txt`.
+- The stage's entry from `run_manifest.json`.
+- Your Python version and OS, and which backend CLI you used.
+
+Redact anything sensitive — prompts and logs may contain your research goal,
+file paths, and data. See [CONTRIBUTING.md](../CONTRIBUTING.md) for the issue
+templates.


### PR DESCRIPTION
## What this adds

The repo had a strong README and two long user tutorials, but no **reference layer** — no way to look up a flag, an artifact schema, a validation rule, or an HTTP endpoint without reading the source. This adds that layer, plus the project files an open-source repo is expected to carry.

### New reference docs

| File | Covers |
| --- | --- |
| `docs/README.md` | Documentation index — what to read for which question |
| `docs/cli-reference.md` | Every `main.py` / `studio.py` flag, defaults, what is preserved on resume, exit codes, the `/skip` and `/back` control commands |
| `docs/configuration.md` | `run_config.json`, the full 12-venue registry table, diagram setup, env vars, hard-coded limits |
| `docs/run-artifacts.md` | The run directory file by file, and the schema of every machine-readable artifact AutoR writes or parses |
| `docs/stage-contract.md` | The markdown contract and the artifact gate exactly as `validate_stage_markdown` / `validate_stage_artifacts` enforce them, including the freshness checks |
| `docs/studio.md` | Studio walkthrough and the complete HTTP API surface |
| `docs/architecture.md` | Layers, module map, the stage attempt loop, prompt assembly, the three recovery levels, extension points |
| `docs/development.md` | Setup, tests, CI, code conventions, recipes for adding a stage / venue / backend |
| `docs/troubleshooting.md` | Symptom-to-fix for the errors AutoR actually raises |

### New project files

`CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`.

`SECURITY.md` documents what was previously only implicit: AutoR runs a coding agent with permission prompts bypassed, the Studio API is unauthenticated, and prompt injection through ingested resources is the threat that matters most. Those are design decisions, and they should be chosen rather than discovered.

## README corrections

Each one was verified against the code, not inferred:

- **Both stage-summary snippets were missing `## Decision Ledger`**, which `REQUIRED_STAGE_HEADINGS` has enforced all along. Following the README produced a summary that fails validation.
- **The Studio does not fail fast at startup when `claude` is absent.** The check is deferred to `start_run()` — `studio_service.py` says so in a comment. The old wording sends people looking for a startup error that never prints.
- **The Validation Bar listed five requirements out of a much larger set**, omitting the Stage 01 evidence ledger, the Stage 07 build/review artifacts, and the freshness rule entirely.
- **Seven CLI flags were undocumented**: `--project-root`, `--paper-corpus`, `--runs-dir`, `--stage-timeout`, `--skip-intake`, `--research-diagram`, `--approval-mode`.
- Star badge pointed at a pre-rename org path.

## .gitignore fix

`docs/*` plus a per-file allowlist meant **every new documentation page was silently untracked**. `docs/star-activity-notice.md` is in the tree only because it was force-added. Replaced the allowlist with `!docs/*.md`, so documentation is tracked by default and scratch non-markdown content is still ignored.

## Verification

- `python -m unittest discover -s tests -p "test_*.py"` — 234 passed
- `python -m py_compile main.py studio.py src/*.py src/*/*.py tests/*.py` — clean
- Every relative link and cross-file anchor in the new docs resolves (checked programmatically)
- No source files touched — documentation, README, and `.gitignore` only

## Note for a follow-up

CI's compile step globs one level deep (`src/*.py`), so `src/backend/`, `src/platform/`, and `studio.py` are only compiled insofar as a test imports them. `docs/development.md` documents the wider local command; widening CI itself is left as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)