### PR TITLE
Add proprietary license, copyright Xiangru Tang

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,29 @@ that keep it that way are the easiest to land.
 
 ---
 
+## Read this before you start
+
+**AutoR is proprietary software, not an open source project.** Read
+[LICENSE](LICENSE) first. Two consequences matter before you write any code:
+
+1. **Running AutoR requires written permission.** Publication of this
+   repository grants no right to use, run, modify, or fork it. That includes
+   running it locally to develop against, so obtain permission before you begin
+   — see Section 5 of the LICENSE.
+2. **Contributions are assigned to the copyright holder.** By opening a pull
+   request you grant Xiangru Tang a perpetual, irrevocable, worldwide right to
+   use, modify, distribute, and **relicense** your contribution under any
+   terms, including proprietary terms, with no compensation or attribution
+   owed to you. That is Section 6 of the LICENSE, and it is not negotiable per
+   contribution. If you are not comfortable with it, or if your employer's
+   IP agreement forbids it, do not submit code — a well-written issue is still
+   genuinely valuable.
+
+Contributions are welcome under those terms. They are not a route to obtaining
+a license to the Software.
+
+---
+
 ## Ways to help
 
 | | |
@@ -146,6 +169,18 @@ productization.
 
 These are not oversights. Each one has been considered and declined; a PR that
 adds one will be closed with a pointer here.
+
+---
+
+## Licensing
+
+Every contribution is submitted under Section 6 of [LICENSE](LICENSE), which
+assigns the copyright holder a relicensable right over it. There is no separate
+CLA to sign; opening a pull request is the act of agreement.
+
+Do not add SPDX headers, license blocks, or copyright notices to individual
+files. The repository carries a single license, held by a single copyright
+holder, and per-file notices only create room for that to drift.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,135 @@
+AutoR Proprietary License 1.0
+SPDX-License-Identifier: LicenseRef-AutoR-Proprietary-1.0
+
+Copyright (c) 2026 Xiangru Tang. All rights reserved.
+
+PREAMBLE
+
+AutoR is proprietary software. It is published in a public repository so that
+its design and behaviour can be examined, cited, and discussed. Publication is
+not a license. No right to use, copy, modify, or distribute this software is
+granted by its availability, by the acceptance of a contribution, or by any
+statement outside this document.
+
+This license is not an open source license. It is not compatible with any
+OSI-approved license, and it grants none of the freedoms such licenses confer.
+
+1. DEFINITIONS
+
+   "Software" means the contents of this repository, including source code,
+   prompt templates, configuration, documentation, assets, and any output of
+   the Software that reproduces a substantial portion of it.
+
+   "Licensor" means Xiangru Tang, the sole copyright holder.
+
+   "You" means any individual or legal entity that accesses the Software.
+
+2. RESERVATION OF RIGHTS
+
+   All rights in the Software are reserved to the Licensor. No license,
+   whether express, implied, by estoppel, by exhaustion, or otherwise, is
+   granted to You under this document.
+
+   Without prior written permission from the Licensor, You may not:
+
+   (a) use the Software, in whole or in part, for any purpose, whether
+       commercial, academic, personal, governmental, or otherwise;
+   (b) run, execute, deploy, or host the Software, or offer it to third
+       parties as a product or service;
+   (c) copy, reproduce, or store the Software beyond the transient copies
+       your browser or Git client makes while viewing the repository;
+   (d) modify the Software or create derivative works from it;
+   (e) fork, redistribute, sublicense, sell, lease, or otherwise transfer the
+       Software or any derivative work;
+   (f) use the Software, or any part of it, to train, fine-tune, evaluate, or
+       otherwise develop any machine learning model;
+   (g) remove, obscure, or alter this license, any copyright notice, or any
+       attribution contained in the Software.
+
+3. PERMITTED ACCESS
+
+   You may view the Software in this repository, and You may make the
+   automatic local copies that GitHub's own Terms of Service require in order
+   to view or clone a public repository. That permission extends no further:
+   it does not authorise execution, modification, redistribution, or any use
+   described in Section 2.
+
+   You may quote short excerpts of the Software for the purposes of academic
+   citation, commentary, review, teaching, or news reporting, with attribution
+   to the Licensor, to the extent such quotation is permitted by applicable
+   copyright law independently of this license.
+
+4. NO PATENT OR TRADEMARK LICENSE
+
+   No patent rights are granted under this license, expressly or by
+   implication. "AutoR" and any associated names, logos, and marks are the
+   property of the Licensor, and no trademark license is granted.
+
+5. REQUESTING PERMISSION
+
+   Any use beyond Section 3 requires prior written permission from the
+   Licensor. Requests may be made by opening an issue in this repository or by
+   contacting the Licensor directly. Permission, if granted, applies only to
+   the specific use, party, and period stated in writing, and confers no
+   rights beyond those terms.
+
+6. CONTRIBUTIONS
+
+   By submitting a contribution to this repository — including a pull request,
+   patch, issue containing code, or any other submission — You grant the
+   Licensor a perpetual, worldwide, irrevocable, royalty-free, transferable
+   right to use, reproduce, modify, distribute, sublicense, and relicense that
+   contribution under any terms, including proprietary terms, without further
+   notice, compensation, or attribution to You.
+
+   You represent that You have the right to grant that permission, and that
+   the contribution is Your original work or that You are otherwise entitled
+   to submit it.
+
+   Submitting a contribution does not grant You any license to the Software.
+
+7. TERMINATION
+
+   Any permission granted under Section 3 or Section 5 terminates
+   automatically, without notice and without a cure period, upon any breach of
+   this license. The Licensor may revoke any permission granted under Section
+   5 at any time, at the Licensor's sole discretion. Upon termination You must
+   cease all use of the Software and destroy all copies in Your possession.
+
+   Sections 4, 6, 8, 9, and 10 survive termination.
+
+8. NO WARRANTY
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NONINFRINGEMENT.
+
+   The Software orchestrates autonomous coding agents that execute commands
+   with their permission prompts disabled, and it produces research artifacts
+   that are not verified for correctness. The Licensor makes no representation
+   that any output is accurate, reproducible, safe to execute, or suitable for
+   publication.
+
+9. LIMITATION OF LIABILITY
+
+   IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING
+   FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OR OTHER
+   DEALINGS IN THE SOFTWARE, INCLUDING WITHOUT LIMITATION ANY LOSS OF DATA,
+   LOSS OF COMPUTE RESOURCES, DAMAGE CAUSED BY COMMANDS EXECUTED BY AN AGENT,
+   OR ANY CONSEQUENCE OF RELYING ON GENERATED RESEARCH OUTPUT.
+
+10. GOVERNING LAW
+
+    This license is governed by the laws of the State of Connecticut, United
+    States of America, without regard to its conflict of law provisions. The
+    state and federal courts located in Connecticut shall have exclusive
+    jurisdiction over any dispute arising under this license.
+
+11. ENTIRE AGREEMENT
+
+    This document is the entire agreement between You and the Licensor
+    concerning the Software, and supersedes any prior or contemporaneous
+    understanding. If any provision is held unenforceable, the remaining
+    provisions remain in full force, and the unenforceable provision shall be
+    reformed only to the minimum extent necessary to make it enforceable.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,22 @@
+AutoR
+Copyright (c) 2026 Xiangru Tang. All rights reserved.
+
+This software is proprietary. See LICENSE for the full terms.
+
+Publication of this repository is not a license. No right to use, run, copy,
+modify, fork, or redistribute AutoR is granted by its availability. Any use
+beyond viewing the repository and quoting short excerpts for citation or
+commentary requires prior written permission from the copyright holder.
+
+Contributions submitted to this repository are licensed to the copyright
+holder under Section 6 of LICENSE, which grants the copyright holder the right
+to relicense them under any terms.
+
+AutoR invokes third-party command-line tools and services that are not part of
+this software and are governed by their own terms:
+
+  - Claude Code (Anthropic)
+  - Codex CLI (OpenAI)
+  - Gemini API (Google), used optionally for research diagrams and web search
+
+No affiliation with or endorsement by those vendors is claimed.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
   <img src="https://img.shields.io/badge/Human-Approval%20Required-orange" alt="Human approval required" />
   <img src="https://img.shields.io/badge/Execution-Agent%20Harness-purple" alt="Agent harness" />
   <img src="https://img.shields.io/badge/Artifacts-Reproducible%20Research%20Runs-red" alt="Reproducible research runs" />
+  <a href="LICENSE">
+    <img src="https://img.shields.io/badge/License-Proprietary-lightgrey" alt="Proprietary license" />
+  </a>
   <a href="https://github.com/tangxiangru/AutoR">
     <img src="https://img.shields.io/github/stars/tangxiangru/AutoR?style=social" alt="GitHub stars" />
   </a>
@@ -38,6 +41,8 @@
   <a href="#-documentation">Documentation</a>
   ·
   <a href="#-roadmap">Roadmap</a>
+  ·
+  <a href="#-license">License</a>
 </p>
 
 <p align="center">
@@ -822,7 +827,7 @@ Implemented milestone:
 - Writing pipeline hardening. Turn Stage 07 into a reliable manuscript production pipeline with stable conference and journal-style writing structures, bibliography handling, table and figure inclusion, and reproducible PDF compilation. The goal is a submission-grade research package, not just writing notes.
 - Review and dissemination package. Expand Stage 08 so it produces readiness checklists, threats-to-validity notes, artifact manifests, release notes, and external-facing research bundles. The final stage should feel like packaging a verifiable research release, not just wrapping up text.
 - Frontend run dashboard. Build a lightweight UI that can browse runs, stage status, summaries, logs, artifacts, and validation failures. It should read from the run directory and manifest rather than introducing a database first.
-- README and open-source assets. Keep refining the README and add `assets/` images such as workflow diagrams, UI screenshots, and artifact examples. This is important for open-source clarity, onboarding, and project presentation.
+- README and presentation assets. Keep refining the README and add `assets/` images such as workflow diagrams, UI screenshots, and artifact examples. This is important for clarity, onboarding, and project presentation.
 
 </details>
 
@@ -837,3 +842,23 @@ python -m unittest discover -s tests -p "test_*.py"
 ```
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request, and [docs/development.md](docs/development.md) before changing code. Security issues go through [SECURITY.md](SECURITY.md), not a public issue.
+
+
+Note that contributions are assigned to the copyright holder under Section 6 of the [LICENSE](LICENSE), and that running AutoR requires written permission — see below.
+
+## 📜 License
+
+**AutoR is proprietary software. It is not open source.**
+
+Copyright © 2026 **Xiangru Tang**. All rights reserved. See [LICENSE](LICENSE) for the full terms and [NOTICE](NOTICE) for the summary.
+
+This repository is public so that AutoR's design and behaviour can be examined, cited, and discussed. **Publication is not a license.** No right to use, run, copy, modify, fork, or redistribute the Software is granted by its availability here.
+
+| | |
+| --- | --- |
+| **Permitted** | Viewing this repository. Quoting short excerpts for academic citation, commentary, review, teaching, or news reporting, with attribution. |
+| **Requires written permission** | Any use at all — running AutoR, deploying it, modifying it, forking it, redistributing it, or using it to train or evaluate a model. |
+| **Not granted** | Any patent license. Any trademark license to the AutoR name or marks. |
+| **Contributions** | Assigned to the copyright holder with a relicensable right (LICENSE §6). |
+
+To request permission, open an issue or contact the copyright holder directly. Permission applies only to the specific use, party, and period stated in writing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,12 @@ detail behind it.
 Outside this directory:
 
 - [../README.md](../README.md) — overview, showcase, quick start.
-- [../CONTRIBUTING.md](../CONTRIBUTING.md) — how to propose and land changes.
+- [../LICENSE](../LICENSE) — **AutoR is proprietary software, not open source.**
+  Publication of the repository grants no right to use, run, modify, or fork
+  it; any use requires written permission. [../NOTICE](../NOTICE) is the short
+  form.
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — how to propose and land changes,
+  and the contribution-assignment terms that come with doing so.
 - [../SECURITY.md](../SECURITY.md) — the security model, the sandbox
   trade-offs, and how to report a vulnerability.
 - [../CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) — community expectations.

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,6 +3,11 @@
 How to work on AutoR itself. If you want to *use* AutoR, read the
 [English Guide](tutorial_en.md) instead.
 
+> **AutoR is proprietary software.** Running it — including running it locally
+> to develop against — requires written permission from the copyright holder.
+> Contributions are assigned under Section 6 of the [LICENSE](../LICENSE).
+> Read [CONTRIBUTING.md](../CONTRIBUTING.md) before you start.
+
 ---
 
 ## Setup

--- a/docs/star-activity-notice.md
+++ b/docs/star-activity-notice.md
@@ -10,7 +10,7 @@ We will not report, accuse, or target individual users publicly. Any review of a
 
 AutoR is actively maintained by real developers and contributors. As of May 6, 2026, the repository has handled 15 issues and 37 pull requests, and has 12 contributors. The current number of open issues and pull requests is zero because reported issues have been addressed and useful pull requests have been reviewed, merged, or otherwise resolved. It does not mean that there has been no community engagement.
 
-We appreciate the community members who have opened issues, proposed features, submitted pull requests, reported bugs, reviewed the project, and helped improve AutoR. We want this project to grow through transparent open-source collaboration, real usage, and reproducible research outputs.
+We appreciate the community members who have opened issues, proposed features, submitted pull requests, reported bugs, reviewed the project, and helped improve AutoR. We want this project to grow through transparent collaboration, real usage, and reproducible research outputs.
 
 Harassment, threats, or attempts to pressure maintainers are not acceptable. We will preserve relevant evidence and report abusive behavior through the appropriate platform channels.
 


### PR DESCRIPTION
## Why

The repo had **no LICENSE at all**. GitHub reports the license as `none`, which legally means all rights reserved — while the README, `CONTRIBUTING.md`, and the community channels all read as an invitation to use and fork. This resolves that contradiction in favour of the reserved rights, and makes the terms explicit rather than implied by absence.

## The license

`LICENSE` — **AutoR Proprietary License 1.0**, SPDX `LicenseRef-AutoR-Proprietary-1.0`, copyright **Xiangru Tang** as sole holder, governed by Connecticut law.

| | |
| --- | --- |
| **Grant** | None. Publication of a public repository is stated explicitly not to be a license. |
| **Permitted** | Viewing the repository. Quoting short excerpts for citation, commentary, review, teaching, or news reporting, with attribution. |
| **Requires written permission** | All use, execution, hosting, copying, modification, derivative works, forking, redistribution, and any use of the code to train or evaluate a model. |
| **Patents / trademarks** | Neither granted. |
| **Contributions (§6)** | Perpetual, irrevocable, relicensable grant to the copyright holder. |
| **Termination (§7)** | Revocable at the holder's discretion; automatic on breach, no cure period. |

Sections 8–9 disclaim warranty and liability and name the two risks specific to this project: AutoR runs coding agents with permission prompts disabled, and it emits research artifacts that are not verified for correctness.

`NOTICE` — the short form, plus attribution for the third-party CLIs and services AutoR invokes (Claude Code, Codex CLI, Gemini API), with no affiliation claimed.

## Consistency changes

So the repo does not describe itself two ways at once:

- **README** — license badge, a `## 📜 License` section stating the terms in a table, a nav entry, and a pointer from Contributing to the assignment clause. Dropped "open-source assets" / "open-source clarity" from the roadmap notes.
- **CONTRIBUTING.md** — a *Read this before you start* block covering the two things a contributor must know first: developing against AutoR needs permission, and a PR assigns relicensable rights with no CLA to sign. Says plainly that anyone whose employer IP agreement forbids that should send an issue instead of code. Adds a Licensing section barring per-file SPDX headers, which only create room for the terms to drift from the single canonical LICENSE.
- **docs/development.md** — the same warning placed where someone would actually hit it, directly above the setup command.
- **docs/README.md** — LICENSE and NOTICE added to the project-documents list.
- **docs/star-activity-notice.md** — dropped "open-source" from the collaboration sentence. The substance of that statement is unchanged.

## Verification

- `python -m unittest discover -s tests -p "test_*.py"` — 306 passed
- `python -m py_compile main.py studio.py src/*.py src/*/*.py tests/*.py` — clean
- Every relative link and cross-file anchor resolves (checked programmatically)
- No document still calls AutoR open source, except where it now says it is not
- No source files touched

## Caveat worth recording

AutoR has existing contributors who submitted code when the repo carried no license. Section 6 binds contributions made from now on; it does not retroactively cover commits already in the history. If full clarity of title matters, that needs separate written assignment from those contributors — flagging it rather than papering over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)