### PR TITLE
Reach Gemini web search through Vertex AI, not just an API key

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -309,10 +309,18 @@ python tools/web_search.py QUERY... [--json] [--model MODEL] [--max-results N]
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--json` | off | Emit `{query, model, answer, results[]}` instead of markdown. |
-| `--model MODEL` | `gemini-2.5-flash` | Overridable with `AUTOR_WEB_SEARCH_MODEL` or `GEMINI_MODEL`. |
+| `--json` | off | Emit `{query, model, backend, answer, results[]}` instead of markdown. |
+| `--model MODEL` | `gemini-2.5-flash` (API key) / `gemini-3.6-flash` (Vertex) | Overridable with `AUTOR_WEB_SEARCH_MODEL` or `GEMINI_MODEL`. |
 | `--max-results N` | `10` | Maximum number of grounded sources to report. |
+| `--no-resolve-urls` | off | Leave Vertex grounding redirects unresolved. Faster, but the source URLs are opaque stubs that cannot be cited. |
 
-The API key is resolved from `GOOGLE_API_KEY`, then `GEMINI_API_KEY`, then
-`configs/diagram_config.yaml` — the same resolution order diagram generation
-uses. Exits `1` with the reason on stderr when a search cannot be performed.
+Two backends are supported and auto-detected:
+
+- **Gemini Developer API** — key from `GOOGLE_API_KEY`, then `GEMINI_API_KEY`, then
+  `configs/diagram_config.yaml`, the same order diagram generation uses.
+- **Vertex AI** — Application Default Credentials plus a project from
+  `AUTOR_VERTEX_PROJECT`, `GOOGLE_CLOUD_PROJECT`, or `ANTHROPIC_VERTEX_PROJECT_ID`, and a
+  location from `AUTOR_VERTEX_LOCATION` or `GOOGLE_CLOUD_LOCATION` (default `global`).
+
+An explicit API key wins; `AUTOR_WEB_SEARCH_BACKEND=vertex|api_key` forces the choice.
+Exits `1` with the reason on stderr when a search cannot be performed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,16 +144,29 @@ Stage 01 needs real search. Some coding-agent deployments ship with the
 built-in `WebSearch` tool disabled — notably **Claude Code on Vertex AI** —
 which leaves the stage unable to search at all.
 
-`--web-search gemini` routes searches through the Gemini API's Google Search
-grounding instead, using the same key as diagram generation:
+`--web-search gemini` routes searches through Gemini's Google Search grounding
+instead. Two backends work; AutoR picks whichever is configured:
 
 ```bash
+# Vertex AI — no API key, uses Application Default Credentials
+gcloud auth application-default login
+export GOOGLE_CLOUD_PROJECT="your-project"
+python main.py --web-search gemini --goal "..."
+
+# or the Gemini Developer API, using the same key as diagram generation
 export GEMINI_API_KEY="..."
 python main.py --web-search gemini --goal "..."
 
 # The tool is also usable on its own:
 python tools/web_search.py "black hole superradiance constraints" --json
 ```
+
+An explicit API key wins over Vertex; `AUTOR_WEB_SEARCH_BACKEND=vertex|api_key`
+forces the choice. On a box already running Claude Code on Vertex,
+`ANTHROPIC_VERTEX_PROJECT_ID` is inherited as a last-resort project, so
+`--web-search auto` works with no extra configuration — which matters, because
+that is precisely the deployment where the built-in `WebSearch` tool is
+disabled.
 
 `auto` (the default) uses Gemini when a key is configured and falls back to the
 backend's native search otherwise, so it never advertises a tool that would
@@ -216,8 +229,11 @@ AutoR reads very few environment variables of its own.
 | --- | --- | --- |
 | `GOOGLE_API_KEY` | `src/web_search.py` | Gemini key for `--research-diagram` and for `--web-search gemini`. |
 | `GEMINI_API_KEY` | `src/web_search.py` | Same, checked second. |
-| `AUTOR_WEB_SEARCH_MODEL` | `src/web_search.py` | Model for Gemini-backed web search. Defaults to `gemini-2.5-flash`. |
+| `AUTOR_WEB_SEARCH_MODEL` | `src/web_search.py` | Model for Gemini-backed web search. Defaults to `gemini-2.5-flash` on the Gemini API and `gemini-3.6-flash` on Vertex AI. |
 | `GEMINI_MODEL` | `src/web_search.py` | Same, checked second. |
+| `AUTOR_WEB_SEARCH_BACKEND` | `src/web_search.py` | Force `vertex` or `api_key` instead of auto-detecting. |
+| `AUTOR_VERTEX_PROJECT` | `src/web_search.py` | Vertex AI project for web search. Falls back to `GOOGLE_CLOUD_PROJECT`, then `ANTHROPIC_VERTEX_PROJECT_ID`. |
+| `AUTOR_VERTEX_LOCATION` | `src/web_search.py` | Vertex AI location. Falls back to `GOOGLE_CLOUD_LOCATION`, then `global`. |
 | `TERM` | `src/terminal_ui.py` | `TERM=dumb` disables colored output. Useful for CI logs and for piping to a file. |
 
 Everything else — API keys, authentication, model access — belongs to the

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -102,14 +102,44 @@ Stage 01 (Literature Survey) needs real search. Some Claude Code deployments —
 **Claude Code on Vertex AI** — ship with the built-in `WebSearch` tool disabled, which
 quietly guts that stage: the agent cannot search, so it either stalls or invents citations.
 
-AutoR ships a replacement backed by the Gemini API's Google Search grounding:
+AutoR ships a replacement backed by Gemini's Google Search grounding. It reaches Gemini
+two ways, and picks whichever is configured:
 
 ```bash
-export GEMINI_API_KEY=...      # or GOOGLE_API_KEY, or configs/diagram_config.yaml
+# Vertex AI (no API key needed) — the natural fit if you already run Claude Code on Vertex
+gcloud auth application-default login
+export GOOGLE_CLOUD_PROJECT=your-project        # or AUTOR_VERTEX_PROJECT
+
+# or the Gemini Developer API
+export GEMINI_API_KEY=...                       # or GOOGLE_API_KEY, or configs/diagram_config.yaml
 
 python3 tools/web_search.py "black hole superradiance constraints"
 python3 tools/web_search.py "diffusion model scaling laws" --json --max-results 8
 ```
+
+| | Vertex AI | Gemini Developer API |
+|:---|:---|:---|
+| Auth | Application Default Credentials | API key |
+| Project | `AUTOR_VERTEX_PROJECT`, `GOOGLE_CLOUD_PROJECT`, or `ANTHROPIC_VERTEX_PROJECT_ID` | — |
+| Location | `AUTOR_VERTEX_LOCATION`, `GOOGLE_CLOUD_LOCATION`, default `global` | — |
+| Default model | `gemini-3.6-flash` | `gemini-2.5-flash` |
+
+An explicit API key wins over Vertex, because setting one is deliberate whereas the Vertex
+project is often inherited from the host's Claude Code configuration. Force the choice with
+`AUTOR_WEB_SEARCH_BACKEND=vertex|api_key`.
+
+`ANTHROPIC_VERTEX_PROJECT_ID` is consulted last and on purpose: a box already running Claude
+Code on Vertex has it set, and that is exactly the deployment where the built-in `WebSearch`
+tool is disabled and this module is needed. On such a box `--web-search auto` just works
+with no extra configuration.
+
+**Grounding redirects.** Vertex returns citations as opaque
+`vertexaisearch.cloud.google.com/...` stubs rather than source URLs. The tool follows each
+one to its canonical URL (`https://arxiv.org/abs/2606.07591`) before reporting it, and
+de-duplicates afterwards, since two stubs routinely resolve to the same page. A stub that
+cannot be resolved is kept but labelled **unresolved redirect, not citable**, and the prompt
+tells operators to treat it as a lead rather than a reference. `--no-resolve-urls` skips the
+resolution step.
 
 Both `main.py` and `rcb_agent.py` take `--web-search`:
 

--- a/src/web_search.py
+++ b/src/web_search.py
@@ -22,16 +22,43 @@ import os
 import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Iterable
 
 
 DEFAULT_SEARCH_MODEL = "gemini-2.5-flash"
+
+#: Vertex AI serves a different model catalogue than the Gemini Developer API.
+DEFAULT_VERTEX_SEARCH_MODEL = "gemini-3.6-flash"
+DEFAULT_VERTEX_LOCATION = "global"
+
 DEFAULT_MAX_RESULTS = 10
+
+#: Seconds allowed for turning one grounding redirect into its canonical URL.
+URL_RESOLVE_TIMEOUT = 10
 
 #: Environment variables consulted for the Gemini API key, in priority order.
 API_KEY_ENV_VARS = ("GOOGLE_API_KEY", "GEMINI_API_KEY")
 
 #: Environment variables consulted for the search model, in priority order.
 MODEL_ENV_VARS = ("AUTOR_WEB_SEARCH_MODEL", "GEMINI_MODEL")
+
+#: Vertex project, in priority order. ANTHROPIC_VERTEX_PROJECT_ID is last and is a
+#: convenience: a box already running Claude Code on Vertex has it set, and that is exactly
+#: the deployment where the built-in WebSearch tool is disabled and this module is needed.
+VERTEX_PROJECT_ENV_VARS = (
+    "AUTOR_VERTEX_PROJECT",
+    "GOOGLE_CLOUD_PROJECT",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+)
+
+VERTEX_LOCATION_ENV_VARS = ("AUTOR_VERTEX_LOCATION", "GOOGLE_CLOUD_LOCATION")
+
+#: Forces a backend instead of auto-detecting: "vertex", "api_key", or "auto".
+BACKEND_ENV_VAR = "AUTOR_WEB_SEARCH_BACKEND"
+
+#: Vertex returns grounding citations as redirect stubs under this host rather than the
+#: source URL, so they have to be followed before they are usable as references.
+GROUNDING_REDIRECT_HOST = "vertexaisearch.cloud.google.com"
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DIAGRAM_CONFIG_PATH = REPO_ROOT / "configs" / "diagram_config.yaml"
@@ -54,12 +81,14 @@ class WebSearchResponse:
     query: str
     model: str
     answer: str
+    backend: str = "api_key"
     results: list[SearchResult] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
         return {
             "query": self.query,
             "model": self.model,
+            "backend": self.backend,
             "answer": self.answer,
             "results": [asdict(result) for result in self.results],
         }
@@ -89,14 +118,154 @@ def resolve_gemini_api_key() -> str | None:
     return None
 
 
-def resolve_search_model(explicit: str | None = None) -> str:
+def resolve_vertex_project() -> str | None:
+    for env_var in VERTEX_PROJECT_ENV_VARS:
+        value = os.environ.get(env_var, "").strip()
+        if value:
+            return value
+    return None
+
+
+def resolve_vertex_location() -> str:
+    for env_var in VERTEX_LOCATION_ENV_VARS:
+        value = os.environ.get(env_var, "").strip()
+        if value:
+            return value
+    return DEFAULT_VERTEX_LOCATION
+
+
+def vertex_credentials_available() -> bool:
+    """Report whether Application Default Credentials can be loaded.
+
+    Never materializes or logs the token — only whether one could be obtained.
+    """
+    try:
+        import google.auth
+
+        google.auth.default()
+    except Exception:  # noqa: BLE001 - any auth failure means "not available"
+        return False
+    return True
+
+
+def resolve_search_model(explicit: str | None = None, *, backend_kind: str | None = None) -> str:
     if explicit and explicit.strip():
         return explicit.strip()
     for env_var in MODEL_ENV_VARS:
         value = os.environ.get(env_var, "").strip()
         if value:
             return value
-    return DEFAULT_SEARCH_MODEL
+    return DEFAULT_VERTEX_SEARCH_MODEL if backend_kind == "vertex" else DEFAULT_SEARCH_MODEL
+
+
+@dataclass(frozen=True)
+class SearchBackend:
+    """How to reach Gemini: a Developer API key, or Vertex AI with ADC."""
+
+    kind: str  # "api_key" | "vertex"
+    model: str
+    api_key: str | None = None
+    project: str | None = None
+    location: str | None = None
+
+    def describe(self) -> str:
+        if self.kind == "vertex":
+            return f"Vertex AI ({self.model}, project {self.project}, location {self.location})"
+        return f"Gemini API ({self.model})"
+
+
+def resolve_backend(model: str | None = None) -> SearchBackend | None:
+    """Pick a Gemini backend from the environment, or None if none is usable.
+
+    An explicit API key wins over Vertex: setting one is a deliberate act, whereas the
+    Vertex project may just be inherited from the host's Claude Code configuration.
+    ``AUTOR_WEB_SEARCH_BACKEND`` overrides the choice entirely.
+    """
+    requested = os.environ.get(BACKEND_ENV_VAR, "").strip().lower() or "auto"
+    api_key = resolve_gemini_api_key()
+    project = resolve_vertex_project()
+
+    def _vertex() -> SearchBackend | None:
+        if not project or not vertex_credentials_available():
+            return None
+        return SearchBackend(
+            kind="vertex",
+            model=resolve_search_model(model, backend_kind="vertex"),
+            project=project,
+            location=resolve_vertex_location(),
+        )
+
+    def _api_key() -> SearchBackend | None:
+        if not api_key:
+            return None
+        return SearchBackend(
+            kind="api_key",
+            model=resolve_search_model(model, backend_kind="api_key"),
+            api_key=api_key,
+        )
+
+    if requested == "vertex":
+        return _vertex()
+    if requested in {"api_key", "api-key", "apikey"}:
+        return _api_key()
+    return _api_key() or _vertex()
+
+
+def build_genai_client(backend: SearchBackend):
+    """Construct a google-genai client for the chosen backend."""
+    try:
+        from google import genai
+    except ImportError as exc:  # pragma: no cover - exercised only without the SDK
+        raise WebSearchError(
+            "The google-genai package is required for Gemini web search. "
+            "Install it with: pip install google-genai"
+        ) from exc
+
+    if backend.kind != "vertex":
+        return genai.Client(api_key=backend.api_key)
+
+    # `enterprise` is the current spelling; `vertexai` is the older one. Accept either so a
+    # pinned older SDK still works.
+    try:
+        return genai.Client(enterprise=True, project=backend.project, location=backend.location)
+    except TypeError:
+        return genai.Client(vertexai=True, project=backend.project, location=backend.location)
+
+
+def resolve_source_url(url: str, *, timeout: int = URL_RESOLVE_TIMEOUT) -> str:
+    """Follow a grounding redirect to its canonical URL, best-effort.
+
+    Vertex hands back opaque redirect stubs instead of source URLs. An agent told to cite
+    only what the tool returned would otherwise be citing
+    `vertexaisearch.cloud.google.com/...`, which is useless in a bibliography. On any
+    failure the original URL is returned unchanged rather than dropping the source.
+    """
+    if GROUNDING_REDIRECT_HOST not in url:
+        return url
+    try:
+        import urllib.request
+
+        request = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            return response.url or url
+    except Exception:  # noqa: BLE001 - a citation we cannot canonicalize is still a citation
+        return url
+
+
+def dedupe_by_url(results: "Iterable[SearchResult]") -> list[SearchResult]:
+    """Collapse results sharing a URL, keeping the first and the longest snippet.
+
+    Two distinct grounding redirects routinely resolve to the same page, so deduplication
+    has to happen after resolution as well as before it.
+    """
+    by_url: dict[str, SearchResult] = {}
+    for result in results:
+        existing = by_url.get(result.url)
+        if existing is None:
+            by_url[result.url] = result
+        elif len(result.snippet) > len(existing.snippet):
+            by_url[result.url] = SearchResult(existing.title, existing.url, result.snippet)
+    return list(by_url.values())
 
 
 def gemini_web_search(
@@ -105,48 +274,59 @@ def gemini_web_search(
     model: str | None = None,
     api_key: str | None = None,
     max_results: int = DEFAULT_MAX_RESULTS,
+    resolve_urls: bool = True,
 ) -> WebSearchResponse:
-    """Run one grounded web search through the Gemini API."""
+    """Run one grounded web search through Gemini, on Vertex AI or the Developer API."""
     query = query.strip()
     if not query:
         raise WebSearchError("Search query cannot be empty.")
 
-    resolved_key = api_key or resolve_gemini_api_key()
-    if not resolved_key:
+    if api_key:
+        backend = SearchBackend(
+            kind="api_key",
+            model=resolve_search_model(model, backend_kind="api_key"),
+            api_key=api_key,
+        )
+    else:
+        backend = resolve_backend(model)
+
+    if backend is None:
         raise WebSearchError(
-            "Gemini API key not found. Set GOOGLE_API_KEY or GEMINI_API_KEY in the "
-            "environment, or add api_keys.google_api_key to configs/diagram_config.yaml."
+            "No Gemini backend is configured. Either set GOOGLE_API_KEY / GEMINI_API_KEY "
+            "for the Gemini Developer API, or configure Vertex AI by setting a project "
+            "(GOOGLE_CLOUD_PROJECT) with working Application Default Credentials "
+            "(gcloud auth application-default login)."
         )
 
-    try:
-        from google import genai
-        from google.genai import types
-    except ImportError as exc:  # pragma: no cover - exercised only without the SDK
-        raise WebSearchError(
-            "The google-genai package is required for Gemini web search. "
-            "Install it with: pip install google-genai"
-        ) from exc
+    from google.genai import types
 
-    resolved_model = resolve_search_model(model)
-    client = genai.Client(api_key=resolved_key)
+    client = build_genai_client(backend)
     config = types.GenerateContentConfig(
         tools=[types.Tool(google_search=types.GoogleSearch())],
     )
 
     try:
         response = client.models.generate_content(
-            model=resolved_model,
+            model=backend.model,
             contents=query,
             config=config,
         )
     except Exception as exc:  # noqa: BLE001 - surface any SDK/transport failure uniformly
-        raise WebSearchError(f"Gemini web search failed: {exc}") from exc
+        raise WebSearchError(f"Gemini web search failed on {backend.describe()}: {exc}") from exc
+
+    results = extract_search_results(response, max_results=max_results)
+    if resolve_urls:
+        results = dedupe_by_url(
+            SearchResult(title=r.title, url=resolve_source_url(r.url), snippet=r.snippet)
+            for r in results
+        )
 
     return WebSearchResponse(
         query=query,
-        model=resolved_model,
+        model=backend.model,
+        backend=backend.kind,
         answer=(getattr(response, "text", "") or "").strip(),
-        results=extract_search_results(response, max_results=max_results),
+        results=results,
     )
 
 
@@ -200,8 +380,14 @@ def _snippets_by_chunk_index(metadata: object) -> dict[int, str]:
     return snippets
 
 
+def is_unresolved_redirect(url: str) -> bool:
+    """True when a grounding stub could not be turned into a citable source URL."""
+    return GROUNDING_REDIRECT_HOST in url
+
+
 def format_response_markdown(response: WebSearchResponse) -> str:
-    lines = [f"# Web Search: {response.query}", "", f"_Provider: Gemini ({response.model})_", ""]
+    provider = "Vertex AI" if response.backend == "vertex" else "Gemini API"
+    lines = [f"# Web Search: {response.query}", "", f"_Provider: {provider} ({response.model})_", ""]
     lines.extend(["## Answer", "", response.answer or "_The search returned no answer text._", ""])
     lines.append("## Sources")
     lines.append("")
@@ -209,7 +395,8 @@ def format_response_markdown(response: WebSearchResponse) -> str:
         lines.append("_No grounded sources were returned. Treat the answer as unverified._")
     else:
         for index, result in enumerate(response.results, start=1):
-            lines.append(f"{index}. [{result.title}]({result.url})")
+            suffix = " — **unresolved redirect, not citable**" if is_unresolved_redirect(result.url) else ""
+            lines.append(f"{index}. [{result.title}]({result.url}){suffix}")
             if result.snippet:
                 lines.append(f"   > {result.snippet}")
     return "\n".join(lines).rstrip() + "\n"
@@ -223,7 +410,7 @@ def resolve_web_search_context(mode: str) -> str | None:
     """
     if mode == "native":
         return None
-    if mode == "auto" and not resolve_gemini_api_key():
+    if mode == "auto" and resolve_backend() is None:
         return None
     return build_web_search_prompt_section()
 
@@ -237,29 +424,31 @@ def web_search_notice(mode: str) -> tuple[str, str]:
     startup is the difference between a diagnosable run and one that quietly invents
     citations.
     """
-    has_key = bool(resolve_gemini_api_key())
-
     if mode == "native":
         return ("Web search: the backend's native tool.", "info")
 
+    backend = resolve_backend()
+
     if mode == "gemini":
-        if not has_key:
+        if backend is None:
             return (
-                "Web search: --web-search gemini was requested but no Gemini API key is "
+                "Web search: --web-search gemini was requested but no Gemini backend is "
                 "configured. Operators will be told to use tools/web_search.py and it will "
-                "fail on first use. Set GOOGLE_API_KEY or GEMINI_API_KEY.",
+                "fail on first use. Set GOOGLE_API_KEY / GEMINI_API_KEY, or configure Vertex "
+                "AI (GOOGLE_CLOUD_PROJECT plus `gcloud auth application-default login`).",
                 "error",
             )
-        return (f"Web search: Gemini ({resolve_search_model(None)}).", "info")
+        return (f"Web search: {backend.describe()}.", "info")
 
-    if has_key:
-        return (f"Web search: Gemini ({resolve_search_model(None)}), selected automatically.", "info")
+    if backend is not None:
+        return (f"Web search: {backend.describe()}, selected automatically.", "info")
 
     return (
-        "Web search: no Gemini API key found, falling back to the backend's native search. "
+        "Web search: no Gemini backend found, falling back to the backend's native search. "
         "If this deployment has WebSearch disabled (for example Claude Code on Vertex AI), "
-        "Stage 01 has no way to search at all. Set GOOGLE_API_KEY or GEMINI_API_KEY, or pass "
-        "--web-search native to silence this.",
+        "Stage 01 has no way to search at all. Set GOOGLE_API_KEY / GEMINI_API_KEY, or "
+        "configure Vertex AI (GOOGLE_CLOUD_PROJECT plus `gcloud auth application-default "
+        "login`), or pass --web-search native to silence this.",
         "warn",
     )
 
@@ -271,7 +460,8 @@ def build_web_search_prompt_section(
 ) -> str:
     """Build the prompt block that redirects operators away from the native search tool."""
     resolved_script = (script_path or WEB_SEARCH_SCRIPT).resolve()
-    resolved_model = resolve_search_model(model)
+    backend = resolve_backend(model)
+    provider = backend.describe() if backend else f"Gemini ({resolve_search_model(model)})"
     return (
         "The built-in `WebSearch` tool is **disabled** in this deployment. Calling it will "
         "fail or silently return nothing, so do not rely on it.\n\n"
@@ -280,7 +470,7 @@ def build_web_search_prompt_section(
         f'python3 "{resolved_script}" "your search query here"\n'
         f'python3 "{resolved_script}" "your search query here" --json --max-results 8\n'
         "```\n\n"
-        f"- It performs a real, grounded Google search through the Gemini API (`{resolved_model}`) "
+        f"- It performs a real, grounded Google search through {provider} "
         "and prints a synthesised answer plus the source URLs it is grounded in.\n"
         "- Default output is markdown; `--json` gives `{query, model, answer, results[]}` for parsing.\n"
         "- It exits non-zero and prints the reason on failure. If a search fails, retry with a "
@@ -288,7 +478,9 @@ def build_web_search_prompt_section(
         "- Fetching a **known** URL still works normally with `WebFetch` or `curl`. Only the "
         "search step needs this tool.\n"
         "- Every citation you record must come from a URL this tool actually returned. Never "
-        "invent a reference, DOI, or arXiv identifier."
+        "invent a reference, DOI, or arXiv identifier.\n"
+        "- A source marked **unresolved redirect** has no usable URL. Treat its content as a "
+        "lead to verify, not as a citable reference."
     )
 
 
@@ -304,7 +496,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         dest="as_json",
         help="Emit machine-readable JSON instead of markdown.",
     )
-    parser.add_argument("--model", help=f"Gemini model to use. Defaults to {DEFAULT_SEARCH_MODEL}.")
+    parser.add_argument(
+        "--model",
+        help=f"Gemini model to use. Defaults to {DEFAULT_SEARCH_MODEL} on the Gemini API "
+             f"and {DEFAULT_VERTEX_SEARCH_MODEL} on Vertex AI.",
+    )
+    parser.add_argument(
+        "--no-resolve-urls",
+        action="store_true",
+        help="Leave Vertex grounding redirects unresolved. Faster, but the source URLs are "
+             "opaque redirect stubs that cannot be cited.",
+    )
     parser.add_argument(
         "--max-results",
         type=int,
@@ -323,6 +525,7 @@ def main(argv: list[str] | None = None) -> int:
             query,
             model=args.model,
             max_results=args.max_results,
+            resolve_urls=not args.no_resolve_urls,
         )
     except WebSearchError as exc:
         print(f"web_search error: {exc}", file=sys.stderr)

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -13,6 +13,13 @@ import main as autor_main
 from src.utils import STAGES, build_prompt
 from src.web_search import (
     DEFAULT_SEARCH_MODEL,
+    DEFAULT_VERTEX_LOCATION,
+    DEFAULT_VERTEX_SEARCH_MODEL,
+    dedupe_by_url,
+    is_unresolved_redirect,
+    resolve_backend,
+    resolve_source_url,
+    vertex_credentials_available,
     resolve_web_search_context,
     web_search_notice,
     SearchResult,
@@ -319,3 +326,139 @@ class WebSearchModeTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class VertexBackendTest(unittest.TestCase):
+    """Vertex AI is the path that matters on deployments where WebSearch is disabled."""
+
+    def _no_key(self):
+        return patch("src.web_search.DIAGRAM_CONFIG_PATH", Path("/nonexistent/diagram.yaml"))
+
+    def _adc(self, available: bool):
+        return patch("src.web_search.vertex_credentials_available", return_value=available)
+
+    def test_vertex_is_used_when_a_project_and_adc_exist_but_no_key(self) -> None:
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "p1"}, clear=True), self._no_key(), self._adc(True):
+            backend = resolve_backend()
+        self.assertIsNotNone(backend)
+        self.assertEqual(backend.kind, "vertex")
+        self.assertEqual(backend.project, "p1")
+        self.assertEqual(backend.location, DEFAULT_VERTEX_LOCATION)
+        self.assertEqual(backend.model, DEFAULT_VERTEX_SEARCH_MODEL)
+
+    def test_an_explicit_api_key_wins_over_an_inherited_vertex_project(self) -> None:
+        env = {"GEMINI_API_KEY": "k", "GOOGLE_CLOUD_PROJECT": "p1"}
+        with patch.dict(os.environ, env, clear=True), self._adc(True):
+            backend = resolve_backend()
+        self.assertEqual(backend.kind, "api_key")
+        self.assertEqual(backend.model, DEFAULT_SEARCH_MODEL)
+
+    def test_backend_env_var_forces_vertex_over_a_key(self) -> None:
+        env = {"GEMINI_API_KEY": "k", "GOOGLE_CLOUD_PROJECT": "p1", "AUTOR_WEB_SEARCH_BACKEND": "vertex"}
+        with patch.dict(os.environ, env, clear=True), self._adc(True):
+            self.assertEqual(resolve_backend().kind, "vertex")
+
+    def test_backend_env_var_forces_the_api_key_over_vertex(self) -> None:
+        env = {"GEMINI_API_KEY": "k", "GOOGLE_CLOUD_PROJECT": "p1", "AUTOR_WEB_SEARCH_BACKEND": "api_key"}
+        with patch.dict(os.environ, env, clear=True), self._adc(True):
+            self.assertEqual(resolve_backend().kind, "api_key")
+
+    def test_a_project_without_credentials_is_not_a_backend(self) -> None:
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "p1"}, clear=True), self._no_key(), self._adc(False):
+            self.assertIsNone(resolve_backend())
+
+    def test_the_claude_vertex_project_is_inherited_as_a_last_resort(self) -> None:
+        with patch.dict(os.environ, {"ANTHROPIC_VERTEX_PROJECT_ID": "sercan"}, clear=True), self._no_key(), self._adc(True):
+            self.assertEqual(resolve_backend().project, "sercan")
+
+    def test_an_explicit_project_var_beats_the_inherited_one(self) -> None:
+        env = {"AUTOR_VERTEX_PROJECT": "mine", "ANTHROPIC_VERTEX_PROJECT_ID": "inherited"}
+        with patch.dict(os.environ, env, clear=True), self._no_key(), self._adc(True):
+            self.assertEqual(resolve_backend().project, "mine")
+
+    def test_an_explicit_model_overrides_the_vertex_default(self) -> None:
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "p"}, clear=True), self._no_key(), self._adc(True):
+            self.assertEqual(resolve_backend("gemini-x").model, "gemini-x")
+
+    def test_the_notice_reports_vertex_rather_than_warning(self) -> None:
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "p1"}, clear=True), self._no_key(), self._adc(True):
+            message, level = web_search_notice("auto")
+        self.assertEqual(level, "info")
+        self.assertIn("Vertex AI", message)
+        self.assertIn("p1", message)
+
+    def test_auto_injects_the_prompt_block_on_a_vertex_only_box(self) -> None:
+        """The regression this whole path exists for: no API key, but search does work."""
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "p1"}, clear=True), self._no_key(), self._adc(True):
+            self.assertIsNotNone(resolve_web_search_context("auto"))
+
+    def test_credentials_probe_never_returns_a_token(self) -> None:
+        self.assertIsInstance(vertex_credentials_available(), bool)
+
+
+class RedirectResolutionTest(unittest.TestCase):
+    STUB = "https://vertexaisearch.cloud.google.com/grounding-api-redirect/ABC"
+
+    def test_a_non_redirect_url_is_returned_untouched_without_a_request(self) -> None:
+        with patch("urllib.request.urlopen", side_effect=AssertionError("should not be called")):
+            self.assertEqual(resolve_source_url("https://arxiv.org/abs/1"), "https://arxiv.org/abs/1")
+
+    def test_a_failed_resolution_keeps_the_source_rather_than_dropping_it(self) -> None:
+        with patch("urllib.request.urlopen", side_effect=OSError("boom")):
+            self.assertEqual(resolve_source_url(self.STUB), self.STUB)
+
+    def test_an_unresolved_stub_is_flagged_as_not_citable(self) -> None:
+        self.assertTrue(is_unresolved_redirect(self.STUB))
+        self.assertFalse(is_unresolved_redirect("https://arxiv.org/abs/1"))
+        body = format_response_markdown(
+            WebSearchResponse("q", "m", "a", "vertex", [SearchResult("x", self.STUB)])
+        )
+        self.assertIn("not citable", body)
+
+    def test_the_prompt_tells_operators_not_to_cite_an_unresolved_stub(self) -> None:
+        self.assertIn("unresolved redirect", build_web_search_prompt_section())
+
+
+class DedupeByUrlTest(unittest.TestCase):
+    def test_two_redirects_resolving_to_one_page_collapse(self) -> None:
+        """Dedup has to happen after resolution: distinct stubs reach the same source."""
+        merged = dedupe_by_url([
+            SearchResult("github.com", "https://github.com/a", ""),
+            SearchResult("github.com", "https://github.com/a", "a longer snippet"),
+        ])
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0].snippet, "a longer snippet")
+
+    def test_distinct_urls_are_preserved_in_order(self) -> None:
+        merged = dedupe_by_url([
+            SearchResult("a", "https://a"),
+            SearchResult("b", "https://b"),
+        ])
+        self.assertEqual([r.url for r in merged], ["https://a", "https://b"])
+
+
+class BackendJsonTest(unittest.TestCase):
+    def test_json_output_records_which_backend_answered(self) -> None:
+        payload = WebSearchResponse("q", "gemini-3.6-flash", "a", "vertex", []).to_dict()
+        self.assertEqual(payload["backend"], "vertex")
+        self.assertEqual(payload["model"], "gemini-3.6-flash")
+
+    def test_markdown_names_vertex_as_the_provider(self) -> None:
+        body = format_response_markdown(WebSearchResponse("q", "m", "a", "vertex", []))
+        self.assertIn("Vertex AI", body)
+
+    def test_markdown_names_the_gemini_api_for_key_backed_runs(self) -> None:
+        body = format_response_markdown(WebSearchResponse("q", "m", "a", "api_key", []))
+        self.assertIn("Gemini API", body)
+
+
+class NoBackendTest(unittest.TestCase):
+    def test_the_error_names_both_ways_to_configure_search(self) -> None:
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("src.web_search.DIAGRAM_CONFIG_PATH", Path("/nonexistent/diagram.yaml")), \
+             patch("src.web_search.vertex_credentials_available", return_value=False):
+            with self.assertRaises(WebSearchError) as caught:
+                gemini_web_search("anything")
+        message = str(caught.exception)
+        self.assertIn("GEMINI_API_KEY", message)
+        self.assertIn("application-default", message)


### PR DESCRIPTION
## The gap

The Gemini-backed search shipped in #102 only spoke to the Gemini **Developer API**, which needs an API key. That misses the deployment it was written for: a box running Claude Code on Vertex AI has no Gemini key, has `WebSearch` disabled, and therefore ends up with **no search at all** — the exact failure #103 added a warning for.

Before, on this machine:

```
[warn] Web search: no Gemini API key found, falling back to the backend's native search...
```

After, with no new configuration:

```
[info] Web search: Vertex AI (gemini-3.6-flash, project sercan-v1, location global), selected automatically.
```

## Backend resolution

`resolve_backend()` returns whichever of two backends is usable:

| | Vertex AI | Gemini Developer API |
|:---|:---|:---|
| Auth | Application Default Credentials | API key |
| Project | `AUTOR_VERTEX_PROJECT` → `GOOGLE_CLOUD_PROJECT` → `ANTHROPIC_VERTEX_PROJECT_ID` | — |
| Location | `AUTOR_VERTEX_LOCATION` → `GOOGLE_CLOUD_LOCATION` → `global` | — |
| Default model | `gemini-3.6-flash` | `gemini-2.5-flash` |

An explicit API key wins, because setting one is deliberate whereas the Vertex project is often inherited. `AUTOR_WEB_SEARCH_BACKEND=vertex\|api_key` forces the choice.

Reading `ANTHROPIC_VERTEX_PROJECT_ID` **last** is the point of the change: a box already running Claude Code on Vertex has it set, and that is precisely the deployment where the built-in `WebSearch` is disabled. `vertex_credentials_available()` probes ADC without ever materializing the token.

## Grounding redirects

Vertex returns citations as opaque `vertexaisearch.cloud.google.com/...` stubs, not source URLs. An agent told to "cite only what the tool returned" would have been citing redirect stubs. Each is now followed to its canonical URL first.

Two consequences, both found by actually running it:

- **Dedup has to happen again after resolution.** Distinct stubs routinely resolve to the same page — the first live run returned `github.com/tangxiangru/AutoR` twice.
- **An unresolvable stub is kept, not dropped, but labelled** `unresolved redirect, not citable`, and the prompt tells operators to treat it as a lead rather than a reference. Silently dropping it would lose a source; silently keeping it would launder an uncitable URL into a bibliography.

`--no-resolve-urls` skips the step.

## Verification

Live against project `sercan-v1` with `gemini-3.6-flash`:

```
$ python3 tools/web_search.py "ResearchClawBench benchmark" --max-results 4
_Provider: Vertex AI (gemini-3.6-flash)_
## Sources
1. [github.com](https://github.com/InternScience/ResearchClawBench)
2. [arxiv.org](https://arxiv.org/html/2606.07591v1)
3. [benchlm.ai](https://benchlm.ai/blog/posts/researchclawbench-ai-science-agents)
4. [huggingface.co](https://huggingface.co/papers/2606.07591)
```

333 tests pass, 21 new — including that `--web-search auto` injects the prompt block on a key-less Vertex box, that the ADC probe returns a bool and never a token, and that a failed resolution keeps the source rather than dropping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)