### PR TITLE
Install agent skills into the run directory, where the operator can reach them

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,8 @@ For each stage attempt, AutoR assembles a prompt from:
 
 The assembled prompt is written to `runs/<run_id>/prompt_cache/`, per-stage session IDs are stored in `runs/<run_id>/operator_state/`, and the selected CLI backend is invoked in live streaming mode.
 
+That list is everything the agent is *given*. Alongside it, AutoR installs an agent skill pack from [src/skills/](src/skills) into `runs/<run_id>/.claude/skills/` — the operator's working directory — so the agent can *pull* long-form craft guidance when it needs it: writing principles, citation discipline, venue checklists, LaTeX repair, results tables, reproducibility review. A skill costs nothing in the prompts that do not use it, which is why guidance that matters to one stage in one situation lives there rather than in the templates.
+
 <details>
 <summary><strong>Exact Claude CLI pattern</strong></summary>
 
@@ -623,6 +625,7 @@ The main code lives in:
 - [src/writing_manifest.py](src/writing_manifest.py)
 - [src/platform/foundry.py](src/platform/foundry.py)
 - [src/prompts/](src/prompts)
+- [src/skills/](src/skills)
 
 ```mermaid
 flowchart LR
@@ -636,6 +639,7 @@ flowchart LR
     B --> I[src/writing_manifest.py]
     B --> J[src/platform/foundry.py]
     B --> K[src/prompts/*]
+    B --> L[src/skills/*]
     C --> H
 ```
 
@@ -656,12 +660,13 @@ File boundaries:
 - [src/approval_agent.py](src/approval_agent.py): The strict reviewer agent used by `--full-auto`.
 - [src/backend/](src/backend) and [src/frontend/](src/frontend): AutoR Studio service, HTTP layer, and the browser UI.
 - [src/prompts/](src/prompts): Per-stage prompt templates.
+- [src/skills/](src/skills) and [src/run_skills.py](src/run_skills.py): Agent skills installed into each run's `.claude/skills/`, loaded on demand rather than concatenated into every prompt.
 
 The full module map, the stage attempt loop, how prompts are assembled, and the extension points are in **[docs/architecture.md](docs/architecture.md)**.
 
 ## 🗂️ Run State
 
-Each run contains `user_input.txt`, `memory.md`, `run_manifest.json`, `artifact_index.json`, `prompt_cache/`, `operator_state/`, `stages/`, `workspace/`, `logs.txt`, and `logs_raw.jsonl`. The substantive research payload lives in `workspace/`.
+Each run contains `user_input.txt`, `memory.md`, `run_manifest.json`, `artifact_index.json`, `prompt_cache/`, `operator_state/`, `stages/`, `workspace/`, `.claude/skills/`, `logs.txt`, and `logs_raw.jsonl`. The substantive research payload lives in `workspace/`.
 
 ```mermaid
 flowchart TD

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,6 +114,7 @@ to a CLI directly; the operators never decide what stage runs next.
 | [`src/platform/foundry.py`](../src/platform/foundry.py) | Post-approval packaging: paper package and release package. |
 | [`src/diagram_gen.py`](../src/diagram_gen.py) | Optional Gemini method-diagram generation, injected into `report.md` or `method.tex` depending on the run's output format. The only module with a third-party dependency. |
 | [`src/prompts/`](../src/prompts) | One markdown template per stage, plus intake and bootstrap templates. Editing these changes agent behaviour with no code change. |
+| [`src/skills/`](../src/skills) | Agent skills, installed into each run's `.claude/skills/` by [`src/run_skills.py`](../src/run_skills.py). Pull-based counterpart to the prompt templates: loaded only when the model judges one relevant. The install path is load-bearing — the operator runs with `cwd=run_root`, so skills left in the AutoR checkout are never discovered. |
 
 ### Studio
 
@@ -281,6 +282,7 @@ Ordered by how much of the system you have to understand first.
 | To change… | Edit | Code change needed |
 | --- | --- | --- |
 | What a stage asks the agent to do | `src/prompts/<slug>.md` | none |
+| Craft guidance an agent can pull mid-stage | a new `src/skills/<name>/SKILL.md` | none |
 | The set of target venues | `templates/registry.yaml` | none |
 | What a stage must produce | `validate_stage_artifacts` in `src/utils.py` | small |
 | The summary contract | `REQUIRED_STAGE_HEADINGS` + `validate_stage_markdown` | small |

--- a/docs/development.md
+++ b/docs/development.md
@@ -226,18 +226,38 @@ src/
   diagram_gen.py            optional Gemini diagrams
   platform/foundry.py       paper and release packaging
   prompts/                  per-stage templates
+  skills/                   agent skills installed into each run
+  run_skills.py             installs src/skills/ into <run>/.claude/skills/
   backend/                  Studio service, HTTP, runner, sessions, notebook
   frontend/static/          the Studio SPA (no build step)
 templates/registry.yaml     venue registry
 configs/                    optional diagram config template
 tests/                      unittest suite
 docs/                       this documentation
-.claude/skills/guides/      writing, citation, and venue reference material
 ```
 
-`.claude/skills/guides/` holds long-form reference material — writing
-principles, citation discipline, venue checklists — available to agents
-working in this repository. It is guidance, not code.
+### Agent skills
+
+`src/skills/` holds long-form craft guidance — writing principles, citation
+discipline, venue checklists, LaTeX repair, results tables, reproducibility
+review. Each is a directory with a `SKILL.md` carrying YAML frontmatter
+(`name` matching the directory, plus a `description` specific enough for the
+model to route on) and optionally a `reference.md` for the long tail.
+
+`install_run_skills` copies the pack into `<run_root>/.claude/skills/` when a
+run is created and again on resume. That location is not incidental: the
+operator invokes its agent CLI with `cwd=run_root`, and Claude Code discovers
+project skills at `<cwd>/.claude/skills/<name>/SKILL.md`. Skills left in the
+AutoR checkout are never on that path and are never loaded.
+
+Skills are the pull-based half of prompt assembly. Stage prompts are
+concatenated up front and grow through the run; guidance that one stage needs
+in one situation belongs in a skill, which is read only when the model judges
+it relevant. Adding a skill costs nothing in prompts that do not use it.
+
+To add one: create `src/skills/<name>/SKILL.md` with matching frontmatter.
+`tests/test_run_skills.py` asserts the pack is well-formed and installs, so a
+malformed skill fails the suite rather than silently never loading.
 
 ---
 

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -14,6 +14,7 @@ machine-readable one.
 
 ```text
 runs/<run_id>/
+├── .claude/skills/             # agent skills, installed from src/skills/ (this is the operator's cwd)
 ├── user_input.txt              # the original research goal, verbatim
 ├── memory.md                   # approved cross-stage memory (the only shared context)
 ├── run_config.json             # backend, model, venue, approval mode, sandbox
@@ -167,6 +168,19 @@ work was not done; treat its content as a placeholder, not evidence.
 
 `session_id` is the backend conversation for that stage, which is what makes
 refinement continue a conversation instead of restarting one.
+
+### `.claude/skills/`
+
+The agent skill pack, copied from `src/skills/` when the run is created and
+again on resume. The operator invokes its agent CLI with `cwd=run_root`, and
+Claude Code discovers project skills at `<cwd>/.claude/skills/<name>/SKILL.md`
+— so this directory, not the AutoR checkout's, is what the operator can reach.
+
+Each skill is loaded only when the model judges it relevant to what it is
+doing, which is why long-form craft guidance lives here rather than in the
+stage prompts. `logs.txt` records which skills were installed.
+
+Safe to delete: it is rebuilt on the next resume.
 
 ### `artifact_index.json`
 

--- a/src/manager.py
+++ b/src/manager.py
@@ -41,6 +41,7 @@ from .intake import (
 from .artifact_index import format_artifact_index_for_prompt, write_artifact_index
 from .experiment_manifest import format_experiment_manifest_for_prompt, write_experiment_manifest
 from .hypothesis_manifest import write_hypothesis_manifest
+from .run_skills import install_run_skills
 from .manifest import (
     ensure_run_manifest,
     format_manifest_status,
@@ -133,6 +134,7 @@ class ResearchManager:
         self.operator = operator
         self.reviewer = reviewer
         self.prompt_dir = self.project_root / "src" / "prompts"
+        self.skills_dir = self.project_root / "src" / "skills"
         self.output_stream = output_stream
         self.ui = ui or TerminalUI(output_stream=output_stream)
         self.approval_mode = "agent" if reviewer is not None else "manual"
@@ -212,6 +214,9 @@ class ResearchManager:
         self._research_diagram = research_diagram
         paths = build_run_paths(run_root)
         ensure_run_layout(paths)
+        # Reinstalled on resume so a run picks up skill edits without needing a
+        # fresh run directory.
+        self._install_skills(paths)
         config = ensure_run_config(
             paths,
             model=self.operator.model,
@@ -314,6 +319,7 @@ class ResearchManager:
         run_root = create_run_root(self.runs_dir)
         paths = build_run_paths(run_root)
         ensure_run_layout(paths)
+        self._install_skills(paths)
         write_text(paths.user_input, user_goal)
 
         # Ingest any pre-provided resources into workspace
@@ -2161,6 +2167,35 @@ class ResearchManager:
         if manifest is None:
             raise RuntimeError(f"Could not load run manifest from {paths.run_manifest}")
         return format_manifest_status(manifest)
+
+    def _install_skills(self, paths: RunPaths) -> list[str]:
+        """Put the agent skill pack where the operator's CLI will find it.
+
+        The operator runs with ``cwd=run_root``, so skills have to live in the
+        run's own ``.claude/skills/``. Installing them is best-effort: a run
+        must not fail because a skill file is unreadable, since skills are
+        guidance and every stage has a complete prompt without them.
+        """
+        try:
+            installed = install_run_skills(paths, self.skills_dir)
+        except OSError as exc:
+            append_log_entry(
+                paths.logs,
+                "skills install_failed",
+                f"Could not install the agent skill pack from {self.skills_dir}: {exc}",
+            )
+            return []
+        if installed:
+            append_log_entry(
+                paths.logs,
+                "skills installed",
+                (
+                    f"Installed {len(installed)} agent skills into "
+                    f"{paths.skills_dir.relative_to(paths.run_root).as_posix()}: "
+                    + ", ".join(installed)
+                ),
+            )
+        return installed
 
     def _stage_file_paths(self, stage_markdown: str) -> list[str]:
         from .utils import extract_path_references

--- a/src/operator.py
+++ b/src/operator.py
@@ -289,7 +289,7 @@ Original stderr:
                 session_id,
                 paths=paths,
                 resume=True,
-                tools="Write,Read,Glob,Grep",
+                tools="Skill,Write,Read,Glob,Grep",
             )
         else:
             session_id = self._resolve_stage_session_id(paths, stage, continue_session=False)
@@ -298,7 +298,7 @@ Original stderr:
                 session_id,
                 paths=paths,
                 resume=False,
-                tools="Write,Read,Glob,Grep",
+                tools="Skill,Write,Read,Glob,Grep",
             )
 
         append_jsonl(
@@ -349,7 +349,7 @@ Original stderr:
                 fallback_session_id,
                 paths=paths,
                 resume=False,
-                tools="Write,Read,Glob,Grep",
+                tools="Skill,Write,Read,Glob,Grep",
             )
             append_jsonl(
                 paths.logs_raw,

--- a/src/run_skills.py
+++ b/src/run_skills.py
@@ -1,0 +1,148 @@
+"""Install AutoR's agent skills into a run directory.
+
+The operator runs its agent CLI with ``cwd=run_root`` (see
+``ClaudeOperator._prepare_invocation``), and Claude Code discovers project
+skills at ``<cwd>/.claude/skills/<name>/SKILL.md``. So a skill only reaches the
+operator if it is written into the *run* directory — the AutoR checkout's own
+``.claude/`` is never on that path.
+
+Skills are the pull-based half of prompt assembly. Every stage prompt is
+concatenated up front — artifact index, manifests, decision ledger, researcher
+profile, handoff — and grows monotonically through the run. Long-form craft
+guidance (how to structure a results table, how to read a LaTeX error, what a
+venue's checklist demands) does not belong there: it is needed by one stage, in
+one situation, and paying for it in every prompt is the wrong trade. A skill is
+loaded only when the model decides it is relevant.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from .utils import RunPaths
+
+
+SKILL_FILENAME = "SKILL.md"
+
+
+@dataclass(frozen=True)
+class SkillPackEntry:
+    name: str
+    description: str
+    source_dir: Path
+
+
+def _parse_frontmatter(text: str) -> dict[str, str]:
+    """Read the leading ``---`` block. Deliberately minimal — no YAML dependency.
+
+    AutoR ships no third-party Python dependencies, and skill frontmatter is a
+    flat ``key: value`` block, so a full parser would buy nothing.
+    """
+    if not text.startswith("---"):
+        return {}
+    lines = text.splitlines()
+    fields: dict[str, str] = {}
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        fields[key.strip()] = value.strip().strip('"').strip("'")
+    return fields
+
+
+def read_skill_pack(source_dir: Path) -> list[SkillPackEntry]:
+    """Every well-formed skill under ``source_dir``, sorted by name."""
+    if not source_dir.is_dir():
+        return []
+    entries: list[SkillPackEntry] = []
+    for child in sorted(source_dir.iterdir()):
+        skill_file = child / SKILL_FILENAME
+        if not child.is_dir() or not skill_file.is_file():
+            continue
+        fields = _parse_frontmatter(skill_file.read_text(encoding="utf-8"))
+        name = fields.get("name", "")
+        description = fields.get("description", "")
+        if not name or not description:
+            continue
+        entries.append(SkillPackEntry(name=name, description=description, source_dir=child))
+    return entries
+
+
+def validate_skill_pack(source_dir: Path) -> list[str]:
+    """Problems that would stop a skill being discovered or chosen correctly.
+
+    A malformed skill fails silently: the CLI simply does not list it, and the
+    stage runs without guidance nobody notices is missing.
+    """
+    problems: list[str] = []
+    if not source_dir.is_dir():
+        return [f"Skill pack directory {source_dir} does not exist."]
+
+    seen: set[str] = set()
+    for child in sorted(source_dir.iterdir()):
+        if child.name.startswith(".") or not child.is_dir():
+            continue
+        skill_file = child / SKILL_FILENAME
+        if not skill_file.is_file():
+            problems.append(f"{child.name}/ has no {SKILL_FILENAME}.")
+            continue
+        text = skill_file.read_text(encoding="utf-8")
+        if not text.startswith("---"):
+            problems.append(f"{child.name}/{SKILL_FILENAME} has no YAML frontmatter block.")
+            continue
+        fields = _parse_frontmatter(text)
+        name = fields.get("name", "")
+        description = fields.get("description", "")
+        if not name:
+            problems.append(f"{child.name}/{SKILL_FILENAME} frontmatter has no name.")
+        elif name != child.name:
+            problems.append(
+                f"{child.name}/{SKILL_FILENAME} declares name {name!r}, which does not match its directory."
+            )
+        if not description:
+            problems.append(f"{child.name}/{SKILL_FILENAME} frontmatter has no description.")
+        elif len(description) < 40:
+            # The description is the only thing the model sees when deciding
+            # whether to open a skill. "Writing help" is not a decision input.
+            problems.append(
+                f"{child.name}/{SKILL_FILENAME} description is too short to route on: {description!r}"
+            )
+        if name in seen:
+            problems.append(f"Duplicate skill name {name!r}.")
+        seen.add(name)
+
+    return problems
+
+
+def install_run_skills(paths: RunPaths, source_dir: Path) -> list[str]:
+    """Copy the skill pack into the run's ``.claude/skills/``.
+
+    Idempotent and re-run on resume, so a run picks up skill edits without
+    needing a fresh run directory. Returns the installed skill names.
+    """
+    entries = read_skill_pack(source_dir)
+    paths.skills_dir.mkdir(parents=True, exist_ok=True)
+    installed: list[str] = []
+    for entry in entries:
+        destination = paths.skills_dir / entry.name
+        if destination.exists():
+            shutil.rmtree(destination)
+        shutil.copytree(entry.source_dir, destination)
+        installed.append(entry.name)
+    return installed
+
+
+def format_skills_for_prompt(names: list[str]) -> str:
+    if not names:
+        return ""
+    listed = ", ".join(f"`{name}`" for name in sorted(names))
+    return (
+        "Skills available in this run: "
+        + listed
+        + ".\n\nThese are loaded on demand — read one when the situation it "
+        "describes comes up, not preemptively."
+    )

--- a/src/skills/citation-discipline/SKILL.md
+++ b/src/skills/citation-discipline/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: citation-discipline
+description: Use when adding, verifying or cleaning citations and BibTeX entries in Stage 07 (Writing), when a reference cannot be resolved cleanly from DBLP or CrossRef, when checking that a cited paper actually supports the claim attributed to it, or when filling citation_verification.json.
+---
+
+# Citation discipline
+
+Stage 07 must write `workspace/artifacts/citation_verification.json`, and the
+gate checks it has a non-empty `claim_coverage` list where every entry carries
+a claim and at least one `citation_keys` or `source_ids` value. That file is a
+record of verification, so it is only worth anything if verification happened.
+
+`reference.md` in this directory is the long-form treatment: source APIs, the
+full verification workflow, BibTeX field rules, entry templates by publication
+type, and a troubleshooting table. Read it when a specific reference will not
+resolve.
+
+## The rule that matters most
+
+**Never generate a citation from memory.**
+
+The dangerous failure is not an obviously fake reference. It is one that looks
+plausible: real authors with a fabricated title, a real title with the wrong
+year, a real arXiv ID attached to the wrong venue, a preprint and its published
+version silently merged into one entry. These survive a read-through and
+surface during review.
+
+If a citation cannot be verified programmatically or from the run's own
+`workspace/literature/sources.json`, mark it unresolved and say so. Do not
+produce a plausible-looking BibTeX entry to fill the hole.
+
+## Verification loop
+
+For each citation:
+
+1. **Resolve** the work against a source of record — DBLP for CS venues,
+   CrossRef for DOIs, the publisher page, or arXiv for preprints.
+2. **Match the metadata exactly**: authors, title, year, venue. A mismatch in
+   any one of them means you have the wrong record, not a typo to smooth over.
+3. **Check the claim**. Open enough of the paper to confirm it says what you
+   are attributing to it. A correctly-formatted citation for a claim the paper
+   does not make is still a fabricated citation.
+4. **Record it** in `citation_verification.json` with the claim it supports.
+
+## The run already has evidence — use it
+
+`workspace/literature/sources.json` and `claims.json` were built in Stage 01
+with source IDs. A Stage 07 claim that traces back to a Stage 01 claim should
+reuse its `source_id` rather than re-deriving a citation. If a Stage 07 claim
+has no Stage 01 ancestor, that is worth noticing: it may be a claim the run
+never gathered evidence for.
+
+## BibTeX hygiene
+
+- One entry per work. Prefer the published version; if citing the preprint,
+  cite it *as* a preprint rather than dressing it as a conference paper.
+- Keys are stable and mnemonic (`author2024shorttitle`), never renumbered.
+- Do not leave both a DOI and a conflicting arXiv ID on the same entry.
+- Keep entries compatible with the venue's existing template. Do not migrate a
+  working bibliography to BibLaTeX mid-run.
+
+## Before you finish the stage
+
+- Every `\cite` key resolves to an entry in the `.bib`.
+- Every entry in the `.bib` is cited at least once.
+- `citation_verification.json` covers each substantive claim, not just the
+  easy ones.
+- No entry was written from memory. If any was, it is marked unresolved.

--- a/src/skills/citation-discipline/reference.md
+++ b/src/skills/citation-discipline/reference.md
@@ -1,6 +1,6 @@
 # Citation Discipline and Hallucination Prevention
 
-Use this reference only when the built-in DBLP/CrossRef workflow in `paper-write` is not enough.
+Read this from Stage 07 (Writing) when a citation cannot be settled by a straightforward DBLP/CrossRef lookup. `SKILL.md` in this directory carries the rules you need most often; this file is the full treatment.
 
 This is an intentionally longer reference. It is not meant to replace the main workflow. Instead, it gives stricter standards for handling citations when:
 
@@ -244,7 +244,7 @@ The principle is:
 
 ### BibTeX vs BibLaTeX
 
-This `insleep`-derived workflow still prioritizes compatibility with existing conference templates. It does not force a move to BibLaTeX.
+This workflow prioritizes compatibility with existing conference templates. It does not force a move to BibLaTeX.
 
 Still, you should know the tradeoff:
 

--- a/src/skills/latex-repair/SKILL.md
+++ b/src/skills/latex-repair/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: latex-repair
+description: Use when a LaTeX build fails or produces a broken PDF in Stage 07 (Writing) — undefined control sequences, missing style packages, unresolved citations or references, float placement blowing the page budget, or a build_log.txt full of errors you need to triage.
+---
+
+# LaTeX repair
+
+Stage 07's gate wants `workspace/writing/main.tex`, section files, a
+bibliography, a compiled PDF, and `workspace/artifacts/build_log.txt`. When the
+build fails, the loop to avoid is: change something, recompile, read the same
+error, change something else. LaTeX reports the *first* thing that broke, and
+one real cause usually generates a cascade of downstream errors.
+
+## Triage order
+
+Read `build_log.txt` from the top and fix in this order. Recompile after each
+class, not after each edit.
+
+1. **Missing style package** — `LaTeX Error: File 'neurips_2025.sty' not found`.
+   AutoR does not vendor official style files (`templates/registry.yaml` says so
+   and carries the venue's `official_url`). Either fetch the style package to
+   `workspace/writing/`, or fall back to a standard class and record the
+   substitution honestly in the stage summary. Do **not** silently switch venue.
+2. **Undefined control sequence** — a command from a package that is not loaded,
+   or a typo. Check the preamble before assuming the command is wrong.
+3. **Missing `$` / runaway argument** — almost always an unescaped `_`, `%`, `&`
+   or `#` in prose that came from a variable name or a file path. These are
+   common when text was assembled from JSON results.
+4. **Undefined references and citations** — `LaTeX Warning: Citation 'x'
+   undefined`. Requires a bibtex/biber pass and then two more LaTeX passes.
+   A single compile will always report these.
+5. **Overfull boxes and float drift** — cosmetic until they push the paper past
+   the venue page limit, at which point they are a submission blocker.
+
+## Compile sequence
+
+A one-shot compile cannot resolve cross-references or citations. The minimum is:
+
+```
+pdflatex main.tex   # writes .aux
+bibtex main         # or biber, per the venue's citation_style
+pdflatex main.tex   # resolves citations
+pdflatex main.tex   # resolves page-dependent references
+```
+
+If `latexmk` is available, `latexmk -pdf main.tex` does this correctly and is
+the better default. Whatever you run, tee the full output to
+`workspace/artifacts/build_log.txt` — the gate reads that file, and a log
+containing only the last pass hides the errors from the earlier ones.
+
+## When the toolchain is not installed
+
+If no LaTeX toolchain exists in the environment, say so in the stage summary
+and in `build_log.txt`, and do not fabricate a PDF. A file named `main.pdf`
+that is not a PDF fails later and more confusingly than a missing one. Check
+whether the run should be using `--output-format markdown` instead — that path
+has no LaTeX dependency at all.
+
+## Errors that are really content problems
+
+| Log line | Actual cause |
+| --- | --- |
+| `Citation 'foo2024' undefined` after a full bibtex cycle | The key is not in the `.bib`. Use the `citation-discipline` skill; do not invent the entry. |
+| `Reference 'fig:main' undefined` | The figure was cited before it was written, or the label is on the wrong element. |
+| `File 'figures/main.pdf' not found` | Stage 06 wrote figures under `workspace/figures/`; the path in the `.tex` is relative to the main file, not to the workspace root. |
+| Page count over the venue limit | Not a LaTeX bug. Check `templates/registry.yaml` for `page_limit` and `refs_in_limit`, then cut content rather than shrinking margins — most venues reject the second. |
+
+## Before you finish
+
+- The PDF opens and has the expected number of pages.
+- No `??` or `[?]` markers survive in the rendered text.
+- `build_log.txt` contains the whole build, including the passes that succeeded.
+- If a style package was substituted, the stage summary says which and why.

--- a/src/skills/paper-writing/SKILL.md
+++ b/src/skills/paper-writing/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: paper-writing
+description: Use when drafting, structuring or revising the manuscript or report in Stage 07 (Writing) — shaping the contribution into one story, writing the abstract and introduction, fixing prose that reads generic or templated, ordering sentences for clarity, or deciding what Figure 1 should show.
+---
+
+# Paper writing
+
+Stage 07 turns approved stage summaries into a manuscript. The failure mode is
+not bad grammar — it is a draft that reports what was done instead of arguing
+one claim. This skill is the correction for that.
+
+`reference.md` in this directory is the long-form treatment: reviewer reading
+order, the seven sentence-level principles from Gopen and Swan, mathematical
+notation habits, figure design, and a pre-submission checklist. Read it when a
+specific problem below is the one you have.
+
+## Start here: the one-sentence contribution
+
+Before drafting anything, write the paper's claim as one sentence:
+
+- "We prove that X converges under assumption Y."
+- "We show that method A improves B by 15% on benchmark C."
+- "We identify failure mode D and propose mechanism E that removes it."
+
+If you cannot write it, the framing has not converged, and no amount of prose
+will fix that. Go back to the Stage 02 hypothesis manifest and the Stage 06
+analysis and find out which claim the evidence actually supports. Writing
+around a claim the results do not support is the most expensive mistake
+available at this stage.
+
+Every section then serves that one claim. Related work, experiments and
+discussion support it; they are not independent mini-papers.
+
+## The abstract, in five sentences
+
+1. What is the general problem area, in one line a non-specialist follows.
+2. What is the specific gap or failure this paper addresses.
+3. What did you do — the method, named and characterised.
+4. What did you find — the headline number or result, stated concretely.
+5. Why it matters — what changes for someone in the field.
+
+Delete openings that carry no information: "With the rapid development of…",
+"In recent years, X has attracted increasing attention…". Start at sentence 1.
+
+## Introduction
+
+By the end of the introduction the reader must have:
+
+- **The what** — the 1-3 specific claims,
+- **The why** — the evidence backing them,
+- **The so what** — why the community should care.
+
+Contribution bullets state results, not activities. "We conduct extensive
+experiments on three datasets" is an activity. "We show retrieval recovers 12
+points of accuracy that long-context prompting loses when evidence is diffuse"
+is a result.
+
+## Prose that reads as generic
+
+Symptoms and fixes, in order of how often they apply:
+
+| Symptom | Fix |
+| --- | --- |
+| Hedging stacked on hedging ("may potentially suggest") | State the claim, or state the limitation. Not both in one clause. |
+| Vague quantifiers ("significantly better", "a variety of") | Replace with the number. If there is no number, say what you actually observed. |
+| Ambiguous pronouns ("this shows…") | Name the referent: "this gap shows…". |
+| Verb buried at the end of a long sentence | Move the verb early; readers hold the subject in memory until they get it. |
+| Terminology drifting across sections | Pick one term per concept and use it everywhere. Synonyms read as different concepts. |
+| Every paragraph the same length and shape | Vary it. Uniform paragraph shape is the strongest tell of generated prose. |
+
+## Where to spend the effort
+
+Roughly equal time on: the title and abstract; the introduction; the figures;
+and everything else combined. Reviewers usually read title → abstract →
+figures → introduction → results, and form a verdict before the method
+section. Front-load accordingly.
+
+## Before you finish the stage
+
+- Does the abstract's claim match what Stage 06 actually measured?
+- Does every claim in the introduction have a pointer to evidence in the run?
+- Are limitations stated, in the paper's own voice, rather than implied?
+- Would the paper survive a reader who reads only the figures and captions?
+
+For citation handling use the `citation-discipline` skill. For venue-specific
+required sections use `venue-checklist`.

--- a/src/skills/paper-writing/reference.md
+++ b/src/skills/paper-writing/reference.md
@@ -1,8 +1,8 @@
-# Orchestra-Adapted Writing Principles
+# Writing Principles (long-form reference)
 
-Use this reference when `paper-plan` needs help shaping the paper's story or when `paper-write` needs stronger drafting and revision guidance.
+Read this from Stage 07 (Writing) when the story needs shaping or the draft needs stronger revision guidance. `SKILL.md` in this directory carries the rules you need most often; this file is the full treatment.
 
-This is the expanded English counterpart to the detailed Chinese version. It is not a new workflow phase. Its purpose is to provide a stronger writing model on top of the existing `insleep` pipeline.
+This is reference material, not a workflow phase. AutoR's stages are unchanged; this only gives Stage 07 a stronger writing model to work from.
 
 ## Contents
 

--- a/src/skills/reproducibility-check/SKILL.md
+++ b/src/skills/reproducibility-check/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: reproducibility-check
+description: Use in Stage 08 (Dissemination) when assembling the release or submission bundle — auditing whether the run's code, data, results and figures are actually reproducible by someone else, writing the readiness checklist and threats-to-validity notes, or deciding what has to be disclosed as not verified.
+---
+
+# Reproducibility check
+
+Stage 08 must write review and readiness artifacts under `workspace/reviews/`.
+The purpose is to state honestly what a third party could reproduce from this
+run's directory alone — not to assert that everything is fine.
+
+The output of this check is a record of what was **verified**, what was
+**not verified**, and what is **known not to reproduce**. All three categories
+are legitimate. Only a fourth is not: recording an unchecked item as verified.
+
+## Audit the run directory as a stranger would
+
+Work from `runs/<run_id>/` and assume no access to the conversation, the
+operator's memory, or the environment the run happened in.
+
+| Question | Where the answer must live |
+| --- | --- |
+| What was the research goal? | `user_input.txt` |
+| What was actually run? | `workspace/code/` — scripts, not descriptions |
+| What data went in? | `workspace/data/`, with provenance for anything downloaded |
+| What came out? | `workspace/results/`, indexed by `experiment_manifest.json` |
+| How do the figures relate to the results? | a script under `workspace/code/` that regenerates them |
+| What decisions were made and why? | the decision ledger in the stage summaries |
+| Which stages actually completed? | `run_manifest.json` — see below |
+
+## Read the manifest before claiming the run is complete
+
+`run_manifest.json` distinguishes stages that were **approved** from stages
+that were **skipped**. A skipped stage has `skipped: true` and a `skip_kind`
+of `human` or `auto`; an `auto` skip means the stage exhausted its retry budget
+in an unattended run with nobody in the loop, and its work was never done.
+
+A readiness review that reports a run as complete when a stage was auto-skipped
+is wrong in the most damaging direction. List every skipped stage in the
+readiness artifact, with its `skip_reason`, and say what downstream claim is
+weakened by the gap.
+
+## The checklist
+
+For each item, record `verified`, `not_verified`, or `fails`, with a one-line
+reason. Never leave an item without evidence for its status.
+
+- **Environment** — is there a record of the Python version and any
+  dependencies? A script that imports a package the run never declares is not
+  reproducible.
+- **Determinism** — are seeds set and recorded? If results vary run to run,
+  say by how much.
+- **Data provenance** — for each file in `workspace/data/`, where did it come
+  from, and can someone else obtain it? "Generated synthetically" is a complete
+  answer only if the generator is in `workspace/code/`.
+- **Results regeneration** — does a script take the data to the results, or is
+  there a gap where a manual step happened?
+- **Figures** — same question, from results to figures.
+- **Claims to evidence** — does every claim in the manuscript point at a file
+  in the run? `citation_verification.json` covers external claims; this covers
+  the run's own.
+- **Compute** — what hardware and how long. Venues ask; see the
+  `venue-checklist` skill.
+
+## Threats to validity
+
+Write these in the paper's own voice, not as a disclaimer appendix nobody
+reads. The ones that matter most in an AutoR run:
+
+- **Single-seed results** presented as if replicated.
+- **A skipped or thin stage** upstream of the claim — especially Stage 05.
+- **Baselines that were not tuned** to the same effort as the proposed method.
+- **Evaluation on the data the method was developed against**, with no held-out
+  split.
+- **Claims that outran the experiment**: check the Stage 02 hypothesis
+  manifest against what Stage 06 actually measured, and flag anything the
+  manuscript asserts more strongly than the analysis supports.
+
+## Before you finish
+
+- Every checklist item has a status and a reason.
+- Every skipped stage is named, with its kind and reason.
+- Nothing is marked verified that you did not actually run or read.
+- The bundle under `workspace/artifacts/` contains what the checklist says it
+  contains.

--- a/src/skills/result-table/SKILL.md
+++ b/src/skills/result-table/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: result-table
+description: Use when turning measured results into a table or figure for the paper — building a LaTeX or markdown results table from workspace/results/*.json, deciding what uncertainty to report, choosing which baselines and ablations belong in the main table, or writing a caption that stands alone.
+---
+
+# Results tables
+
+By Stage 06 the run has machine-readable results under `workspace/results/`
+and an `experiment_manifest.json` indexing them with schema metadata. The table
+in the paper must be derived from those files, not retyped. A number that
+appears in the manuscript and nowhere in `workspace/results/` is unsupported,
+and it is the single easiest thing for a reviewer to catch.
+
+## Build the table from the artifacts
+
+1. Read `workspace/results/experiment_manifest.json` for the result artifacts
+   and their schemas.
+2. Generate the table with a script written to `workspace/code/`, not by hand.
+   A regenerable table survives a Stage 06 rerun; a hand-typed one silently
+   goes stale the moment a result changes.
+3. Write the generated table to a file the manuscript inputs
+   (`workspace/writing/tables.tex`, or an inline markdown table in the report),
+   so the paper and the artifact cannot drift.
+
+## What goes in the main table
+
+The main table answers the paper's one claim. Everything else goes to the
+appendix.
+
+- **Rows**: the methods being compared, with the proposed method last so the
+  eye lands on it after the baselines.
+- **Columns**: the metrics the claim is about. Adding metrics the claim does
+  not concern dilutes it and invites reviewers to find a column where you lose.
+- **Baselines**: the strongest available, not the most convenient. A table
+  whose baselines are weak reads as a weak result regardless of the margin.
+- **Ablations**: in the main table only if the claim is about the mechanism.
+
+## Reporting uncertainty
+
+State what the spread means, every time. `0.74 ± 0.03` is meaningless without
+knowing whether that is a standard deviation, a standard error, or a confidence
+interval, and over how many seeds.
+
+- Give **n** (seeds or folds) in the caption or a column.
+- Say which dispersion measure you used. NeurIPS and ICML both ask for this
+  explicitly — see the `venue-checklist` skill.
+- A single run has no error bar. Report it as a single run and say so; do not
+  present it in a format that implies replication.
+- Bold the best result only if the margin exceeds the spread. Bolding a
+  within-noise win is the most common quiet overclaim in a results table.
+
+## Captions that stand alone
+
+Reviewers read figures and tables before the body. The caption must carry:
+what is being compared, on what data, with what metric, over how many runs, and
+what the reader should conclude. "Table 2: Results." fails all five.
+
+Good: *"Table 2: Accuracy on the held-out split of BENCHMARK, mean ± standard
+deviation over 5 seeds. Retrieval recovers 12 points that long-context
+prompting loses when the relevant evidence is diffuse."*
+
+## Figures
+
+The same rules apply, plus:
+
+- In markdown output mode, figures must be `.png` (or another renderable
+  raster format) under `report/images/` and embedded with a
+  report-relative path — `![Caption](images/name.png)`. A `.pdf` figure shows
+  the report viewer nothing, and the Stage 07 gate rejects it.
+- In LaTeX mode, figures live in `workspace/figures/` and are included with a
+  path relative to `main.tex`.
+- Every figure referenced in prose must exist, and every figure that exists
+  should be referenced. An unreferenced figure is either dead weight or a
+  missing paragraph.
+
+## Before you finish
+
+- Every number in the table traces to a file under `workspace/results/`.
+- The dispersion measure and the number of runs are stated.
+- Nothing is bolded that is within noise.
+- Each caption is readable with the body text covered up.

--- a/src/skills/venue-checklist/SKILL.md
+++ b/src/skills/venue-checklist/SKILL.md
@@ -1,6 +1,11 @@
-# Venue Checklists for ICLR, NeurIPS, and ICML
+---
+name: venue-checklist
+description: Use when the target venue's submission requirements matter — checking a draft against NeurIPS, ICML or ICLR expectations, deciding which required sections (checklist, broader impact, reproducibility, LLM disclosure) the paper needs, or running the Stage 08 submission-readiness review.
+---
 
-Use this reference near the end of `paper-plan` and during the final checks in `paper-write`.
+# Venue checklists: NeurIPS, ICML, ICLR
+
+Read this when the target venue is set in Stage 03, when locking the Stage 07 outline, and again during the Stage 08 readiness review. The run's venue is in `run_config.json` and is rendered into every stage prompt under **Run Configuration**.
 
 ## When to Read
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -83,6 +83,10 @@ class RunPaths:
     bootstrap_dir: Path
     profile_dir: Path
     intake_context: Path
+    #: Where the operator's agent CLI looks for project skills. The operator is
+    #: invoked with ``cwd=run_root``, so this is the run's own ``.claude/skills``
+    #: and not the AutoR checkout's.
+    skills_dir: Path
 
     def stage_file(self, stage: StageSpec) -> Path:
         return self.stages_dir / stage.filename
@@ -216,6 +220,7 @@ def build_run_paths(run_root: Path) -> RunPaths:
         artifact_index=run_root / "artifact_index.json",
         logs=run_root / "logs.txt",
         logs_raw=run_root / "logs_raw.jsonl",
+        skills_dir=run_root / ".claude" / "skills",
         prompt_cache_dir=run_root / "prompt_cache",
         operator_state_dir=run_root / "operator_state",
         stages_dir=run_root / "stages",
@@ -244,6 +249,7 @@ def build_run_paths(run_root: Path) -> RunPaths:
 def ensure_run_layout(paths: RunPaths) -> None:
     paths.run_root.mkdir(parents=True, exist_ok=True)
     paths.prompt_cache_dir.mkdir(parents=True, exist_ok=True)
+    paths.skills_dir.mkdir(parents=True, exist_ok=True)
     paths.operator_state_dir.mkdir(parents=True, exist_ok=True)
     paths.stages_dir.mkdir(parents=True, exist_ok=True)
     paths.handoff_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_fake_pipeline_end_to_end.py
+++ b/tests/test_fake_pipeline_end_to_end.py
@@ -99,6 +99,21 @@ class FakePipelineEndToEndTest(unittest.TestCase):
             with self.subTest(stage=stage.slug):
                 self.assertEqual(validate_stage_artifacts(stage, self.paths), [])
 
+    def test_the_agent_skill_pack_reached_the_run(self) -> None:
+        """Installed by the real CLI path, not just by the unit test's own call.
+
+        The operator's cwd is the run root, so a skill only exists for the
+        operator if it is here.
+        """
+        installed = sorted(
+            child.name for child in self.paths.skills_dir.iterdir() if child.is_dir()
+        )
+        self.assertEqual(self.paths.skills_dir, self.run_root / ".claude" / "skills")
+        self.assertIn("paper-writing", installed)
+        for name in installed:
+            with self.subTest(skill=name):
+                self.assertTrue((self.paths.skills_dir / name / "SKILL.md").is_file())
+
     def test_the_manuscript_package_is_a_real_pdf(self) -> None:
         pdf = self.paths.writing_dir / "main.pdf"
         self.assertTrue(pdf.exists())

--- a/tests/test_run_skills.py
+++ b/tests/test_run_skills.py
@@ -1,0 +1,160 @@
+"""The skill pack has to be well-formed, and it has to land where the CLI looks.
+
+Both halves fail silently in production. A skill with broken frontmatter is
+simply not listed by the agent CLI, and a skill installed to the wrong
+directory is not either — in both cases the stage runs without guidance nobody
+notices is missing. Before this test existed, the repository shipped 1029 lines
+of writing, citation and venue reference material as loose ``.md`` files under
+``.claude/skills/guides/``, which is neither a valid skill layout nor on the
+path the operator's CLI searches. It was referenced by no code and had never
+been loaded.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.run_skills import (
+    install_run_skills,
+    read_skill_pack,
+    validate_skill_pack,
+)
+from src.utils import build_run_paths, ensure_run_layout
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_PACK = REPO_ROOT / "src" / "skills"
+
+
+class SkillPackShapeTest(unittest.TestCase):
+    def test_the_shipped_pack_is_valid(self) -> None:
+        self.assertEqual(validate_skill_pack(SKILL_PACK), [])
+
+    def test_the_pack_is_not_empty(self) -> None:
+        self.assertGreater(len(read_skill_pack(SKILL_PACK)), 0)
+
+    def test_every_skill_directory_is_picked_up(self) -> None:
+        """A directory that exists but is not readable as a skill is the silent case."""
+        on_disk = {
+            child.name
+            for child in SKILL_PACK.iterdir()
+            if child.is_dir() and not child.name.startswith(".")
+        }
+        parsed = {entry.name for entry in read_skill_pack(SKILL_PACK)}
+        self.assertEqual(on_disk, parsed)
+
+    def test_descriptions_name_the_situation_that_triggers_the_skill(self) -> None:
+        """The description is the only routing signal the model gets.
+
+        It has to describe *when* to reach for the skill, not what the skill is
+        about. "Writing guidance" is a topic; "use when the draft reads
+        generic" is a trigger.
+        """
+        for entry in read_skill_pack(SKILL_PACK):
+            with self.subTest(skill=entry.name):
+                lowered = entry.description.lower()
+                self.assertTrue(lowered.startswith("use "), entry.description)
+                self.assertIn("when", lowered)
+
+    def test_no_skill_refers_to_another_project_workflow(self) -> None:
+        """The pack was ported from a different project; its vocabulary was too.
+
+        A skill that tells the operator to run ``paper-plan`` names a stage
+        AutoR does not have.
+        """
+        foreign = ("paper-plan", "paper-write", "insleep", "Orchestra")
+        for path in SKILL_PACK.rglob("*.md"):
+            text = path.read_text(encoding="utf-8")
+            for token in foreign:
+                with self.subTest(file=path.name, token=token):
+                    self.assertNotIn(token, text)
+
+
+class SkillInstallTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+
+    def test_skills_install_where_the_agent_cli_looks(self) -> None:
+        """``.claude/skills`` under the run root, because that is the operator's cwd."""
+        installed = install_run_skills(self.paths, SKILL_PACK)
+
+        self.assertEqual(
+            self.paths.skills_dir,
+            self.paths.run_root / ".claude" / "skills",
+        )
+        self.assertEqual(sorted(installed), sorted(entry.name for entry in read_skill_pack(SKILL_PACK)))
+        for name in installed:
+            with self.subTest(skill=name):
+                self.assertTrue((self.paths.skills_dir / name / "SKILL.md").is_file())
+
+    def test_reference_files_come_along(self) -> None:
+        install_run_skills(self.paths, SKILL_PACK)
+        self.assertTrue((self.paths.skills_dir / "paper-writing" / "reference.md").is_file())
+
+    def test_installing_twice_replaces_rather_than_accumulates(self) -> None:
+        install_run_skills(self.paths, SKILL_PACK)
+        stray = self.paths.skills_dir / "paper-writing" / "stale.md"
+        stray.write_text("left over from an older version", encoding="utf-8")
+
+        install_run_skills(self.paths, SKILL_PACK)
+
+        self.assertFalse(stray.exists())
+        self.assertTrue((self.paths.skills_dir / "paper-writing" / "SKILL.md").is_file())
+
+    def test_a_missing_pack_installs_nothing_rather_than_raising(self) -> None:
+        self.assertEqual(install_run_skills(self.paths, REPO_ROOT / "no-such-dir"), [])
+
+
+class SkillPackValidationTest(unittest.TestCase):
+    """The validator is the gate, so it has to actually reject things."""
+
+    def _pack(self, name: str, body: str) -> Path:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        (root / name).mkdir(parents=True)
+        (root / name / "SKILL.md").write_text(body, encoding="utf-8")
+        return root
+
+    def test_a_name_that_does_not_match_its_directory_is_rejected(self) -> None:
+        pack = self._pack(
+            "venue-checklist",
+            "---\nname: venue-checklists\ndescription: "
+            "Use when checking a paper against venue submission requirements.\n---\n\nbody\n",
+        )
+        problems = validate_skill_pack(pack)
+        self.assertTrue(any("does not match its directory" in problem for problem in problems), problems)
+
+    def test_a_missing_frontmatter_block_is_rejected(self) -> None:
+        problems = validate_skill_pack(self._pack("thing", "# Thing\n\nno frontmatter\n"))
+        self.assertTrue(any("frontmatter" in problem for problem in problems), problems)
+
+    def test_a_description_too_short_to_route_on_is_rejected(self) -> None:
+        problems = validate_skill_pack(
+            self._pack("thing", "---\nname: thing\ndescription: Writing help.\n---\n\nbody\n")
+        )
+        self.assertTrue(any("too short to route on" in problem for problem in problems), problems)
+
+    def test_a_directory_without_a_skill_file_is_rejected(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        (Path(tmp.name) / "empty-skill").mkdir()
+        problems = validate_skill_pack(Path(tmp.name))
+        self.assertTrue(any("has no SKILL.md" in problem for problem in problems), problems)
+
+    def test_a_valid_skill_produces_no_problems(self) -> None:
+        pack = self._pack(
+            "thing",
+            "---\nname: thing\ndescription: "
+            "Use when a specific and clearly described situation comes up during a stage.\n---\n\nbody\n",
+        )
+        self.assertEqual(validate_skill_pack(pack), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The skills we already had were never loaded

`.claude/skills/guides/` held 1029 lines of writing, citation and venue reference material, referenced by zero Python. It could never have been loaded, for two independent reasons:

1. **Wrong shape.** Claude Code discovers project skills at `.claude/skills/<name>/SKILL.md` with YAML frontmatter. Loose `.md` files in a `guides/` subdirectory are not skills. I checked this against the CLI rather than assuming: a run in a directory containing `.claude/skills/guides/venue-checklists.md` lists no such skill.
2. **Wrong place.** The operator invokes its agent CLI with `cwd=paths.run_root` ([operator.py:1014](../blob/main/src/operator.py#L1014)), not the AutoR checkout. The run root had no `.claude/` at all — so even a correctly-shaped repo-level skill would have been off the search path.

The material was also written in another project's vocabulary — `paper-plan`, `paper-write`, `insleep`, Orchestra — naming stages AutoR does not have. And `docs/development.md` said the guides were *"available to agents working in this repository"*, which was false in both directions.

## Wiring

`src/run_skills.py` installs `src/skills/` into `<run_root>/.claude/skills/` at run creation and again on resume, so a run picks up skill edits without needing a fresh run directory. Installation is best-effort and logged — skills are guidance, and every stage has a complete prompt without them.

`Skill` is added to the repair pass's tool allowlist (was `Write,Read,Glob,Grep`), or a repair turn could not open a skill the stage turn could.

## Why a skill rather than more prompt

Stage prompts are concatenated up front — artifact index, manifests, decision ledger, researcher profile, handoff — and grow monotonically. Measured on a real run, before any of this material: 1175 words at stage 01 rising to 2562 at stage 06. `07_writing.md` is already the largest template at 230 lines. Guidance that one stage needs in one situation is the wrong thing to pay for in every prompt. A skill is read only when the model judges it relevant, and costs nothing in the prompts that do not use it.

## The pack

Three ported and retargeted to AutoR's stages, paths and artifact gates, with the long tails kept as `reference.md` beside each `SKILL.md`:

| Skill | Triggers on |
| --- | --- |
| `paper-writing` | drafting/structuring/revising in Stage 07 |
| `citation-discipline` | citations that will not resolve; filling `citation_verification.json` |
| `venue-checklist` | NeurIPS/ICML/ICLR required sections and readiness |

Three new, each aimed at a place the pipeline actually gets stuck:

| Skill | What it carries |
| --- | --- |
| `latex-repair` | triage order for a failed build, the four-pass compile sequence, and what to do when no toolchain exists — say so, do not fabricate a PDF |
| `result-table` | build the table from `workspace/results/` with a script not by hand; state the dispersion measure and n; do not bold a within-noise win |
| `reproducibility-check` | audit the run directory as a stranger would, and read `run_manifest.json` for auto-skipped stages before reporting a run complete |

## Verification

Against the live CLI, in a real run directory produced by `main.py`:

```
$ cd runs/20260806_035326 && claude --tools "Skill,Read,Glob,Grep" -p "List the project skills available to you..."
Project skills: citation-discipline, latex-repair, paper-writing,
reproducibility-check, result-table, venue-checklist.
For a failed pdflatex build: latex-repair.
```

## Tests

`tests/test_run_skills.py` — the pack is well-formed (name matches directory, description long enough to route on, no foreign vocabulary), installs to `.claude/skills` under the run root *specifically*, reinstalling replaces rather than accumulates, and the validator rejects each malformed shape. The end-to-end fake run asserts the pack reached the run through the real CLI path.

Mutation-checked: pointing `skills_dir` at `run_root/skills` fails three tests.

425 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)