### PR TITLE
Stop presenting Gemini's own words as a quotation from a source

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -319,7 +319,7 @@ python tools/web_search.py QUERY... [--json] [--model MODEL] [--max-results N]
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--json` | off | Emit `{query, model, backend, answer, results[]}` instead of markdown. |
+| `--json` | off | Emit `{query, model, backend, answer, grounded, citable_source_count, results[]}` instead of markdown, each result being `{title, url, citable, supported_claims[]}`. |
 | `--model MODEL` | `gemini-2.5-flash` (API key) / `gemini-3.6-flash` (Vertex) | Overridable with `AUTOR_WEB_SEARCH_MODEL` or `GEMINI_MODEL`. |
 | `--max-results N` | `10` | Maximum number of grounded sources to report. |
 | `--no-resolve-urls` | off | Leave Vertex grounding redirects unresolved. Faster, but the source URLs are opaque stubs that cannot be cited. |
@@ -333,4 +333,26 @@ Two backends are supported and auto-detected:
   location from `AUTOR_VERTEX_LOCATION` or `GOOGLE_CLOUD_LOCATION` (default `global`).
 
 An explicit API key wins; `AUTOR_WEB_SEARCH_BACKEND=vertex|api_key` forces the choice.
-Exits `1` with the reason on stderr when a search cannot be performed.
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The search returned at least one citable source. |
+| `2` | The search completed but nothing citable came back — an answer with no resolvable source behind it. Retry with a different query; do not cite the answer. |
+| `1` | The search could not be performed at all. The reason is on stderr. |
+
+`2` is distinct from `1` on purpose: an ungrounded answer is not a broken tool, but
+exiting `0` for it would make it indistinguishable from a real result to anything
+reading only `$?`. The same signal is the `grounded` field in `--json`.
+
+### `supported_claims` is not page text
+
+Each result carries `supported_claims`: sentences from **Gemini's own answer** that the
+source was cited in support of. Grounding asserts that a source supports a claim; it
+never asserts that the page contains that sentence. The markdown renders them as a
+labelled bullet list rather than a blockquote for exactly this reason — a blockquote
+under a source link reads as a quotation, which is how a real paper acquires a sentence
+it never contained.
+
+To quote a source, fetch it and quote what it says.

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -166,7 +166,24 @@ one to its canonical URL (`https://arxiv.org/abs/2606.07591`) before reporting i
 de-duplicates afterwards, since two stubs routinely resolve to the same page. A stub that
 cannot be resolved is kept but labelled **unresolved redirect, not citable**, and the prompt
 tells operators to treat it as a lead rather than a reference. `--no-resolve-urls` skips the
-resolution step.
+resolution step. Following the redirect is already a GET, so the tool also reads the page's
+`<title>` from it and uses that when grounding supplied only a bare domain — the difference
+between a bibliography entry that says `arxiv.org` and one that says what the paper is.
+
+**What a "snippet" is, and why the tool no longer calls it one.** Gemini's grounding
+metadata pairs each source with sentences from *its own generated answer* — it asserts that
+the source **supports** the claim, never that the page **contains** that sentence. Reported
+as a blockquote under a source hyperlink, as the tool originally did, that reads as a
+quotation, and an agent under instruction to cite only what the tool returned will transcribe
+it as one. The field is therefore named `supported_claims`, rendered as a labelled bullet
+list, and the prompt block states outright that it is not text from the page. Every claim a
+source was cited for is kept, rather than only the first.
+
+**Groundedness is a field, not a sentence.** `--json` carries `grounded` and
+`citable_source_count` at the response level and `citable` per result, and the CLI exits `2`
+(distinct from `1`, "the search failed") when nothing citable came back. Before, that
+judgement existed only as prose inside the markdown renderer, invisible to the `--json`
+consumer the prompt tells the agent to parse.
 
 Both `main.py` and `rcb_agent.py` take `--web-search`:
 

--- a/src/web_search.py
+++ b/src/web_search.py
@@ -17,12 +17,15 @@ Command line usage::
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import os
+import re
 import sys
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
+from urllib.parse import urlsplit
 
 
 DEFAULT_SEARCH_MODEL = "gemini-2.5-flash"
@@ -35,6 +38,12 @@ DEFAULT_MAX_RESULTS = 10
 
 #: Seconds allowed for turning one grounding redirect into its canonical URL.
 URL_RESOLVE_TIMEOUT = 10
+
+#: How much of a resolved page to read looking for its <title>. Capped so a large or
+#: hostile page cannot turn one citation lookup into an unbounded download.
+TITLE_SCAN_BYTES = 65536
+
+_HTML_TITLE_RE = re.compile(rb"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
 
 #: Environment variables consulted for the Gemini API key, in priority order.
 API_KEY_ENV_VARS = ("GOOGLE_API_KEY", "GEMINI_API_KEY")
@@ -73,7 +82,23 @@ class WebSearchError(RuntimeError):
 class SearchResult:
     title: str
     url: str
-    snippet: str = ""
+    #: Sentences from Gemini's *own* answer that this source was cited in support of.
+    #: Grounding asserts that the source supports the claim, never that the page contains
+    #: the sentence, so these must never be presented as quotations from the page.
+    supported_claims: list[str] = field(default_factory=list)
+
+    @property
+    def citable(self) -> bool:
+        """False when the URL is still a grounding stub with no usable target."""
+        return not is_unresolved_redirect(self.url)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "title": self.title,
+            "url": self.url,
+            "citable": self.citable,
+            "supported_claims": list(self.supported_claims),
+        }
 
 
 @dataclass(frozen=True)
@@ -84,13 +109,29 @@ class WebSearchResponse:
     backend: str = "api_key"
     results: list[SearchResult] = field(default_factory=list)
 
+    @property
+    def citable_source_count(self) -> int:
+        return sum(1 for result in self.results if result.citable)
+
+    @property
+    def grounded(self) -> bool:
+        """Whether anything here can actually be cited.
+
+        An answer with no citable source is the failure this whole module exists to
+        prevent, so it is a first-class field rather than a line of prose only the
+        markdown renderer emits.
+        """
+        return self.citable_source_count > 0
+
     def to_dict(self) -> dict[str, object]:
         return {
             "query": self.query,
             "model": self.model,
             "backend": self.backend,
             "answer": self.answer,
-            "results": [asdict(result) for result in self.results],
+            "grounded": self.grounded,
+            "citable_source_count": self.citable_source_count,
+            "results": [result.to_dict() for result in self.results],
         }
 
 
@@ -232,39 +273,78 @@ def build_genai_client(backend: SearchBackend):
         return genai.Client(vertexai=True, project=backend.project, location=backend.location)
 
 
-def resolve_source_url(url: str, *, timeout: int = URL_RESOLVE_TIMEOUT) -> str:
-    """Follow a grounding redirect to its canonical URL, best-effort.
+def resolve_source(url: str, *, timeout: int = URL_RESOLVE_TIMEOUT) -> tuple[str, str | None]:
+    """Follow a grounding redirect to its canonical URL and page title, best-effort.
 
     Vertex hands back opaque redirect stubs instead of source URLs. An agent told to cite
     only what the tool returned would otherwise be citing
     `vertexaisearch.cloud.google.com/...`, which is useless in a bibliography. On any
     failure the original URL is returned unchanged rather than dropping the source.
+
+    The page title comes free-ish: following the redirect is already a GET, and grounding
+    labels every source with a bare domain, so reading the first `TITLE_SCAN_BYTES` of the
+    body is what turns "arxiv.org" into something a reader can identify.
     """
     if GROUNDING_REDIRECT_HOST not in url:
-        return url
+        return url, None
     try:
         import urllib.request
 
         request = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
         with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
-            return response.url or url
+            resolved = response.url or url
+            return resolved, _extract_html_title(response.read(TITLE_SCAN_BYTES))
     except Exception:  # noqa: BLE001 - a citation we cannot canonicalize is still a citation
-        return url
+        return url, None
+
+
+def resolve_source_url(url: str, *, timeout: int = URL_RESOLVE_TIMEOUT) -> str:
+    """Follow a grounding redirect to its canonical URL, discarding the page title."""
+    return resolve_source(url, timeout=timeout)[0]
+
+
+def _extract_html_title(head: bytes) -> str | None:
+    match = _HTML_TITLE_RE.search(head)
+    if match is None:
+        return None
+    title = " ".join(html.unescape(match.group(1).decode("utf-8", "replace")).split())
+    return title[:200] or None
+
+
+def _looks_like_bare_domain(title: str, url: str) -> bool:
+    """Whether a grounding title carries no more information than the URL already does."""
+    candidate = title.strip().lower()
+    if not candidate or candidate == url.strip().lower():
+        return True
+    host = urlsplit(url).netloc.lower()
+    host = host[4:] if host.startswith("www.") else host
+    return bool(host) and candidate in {host, f"www.{host}"}
+
+
+def best_title(grounding_title: str, page_title: str | None, url: str) -> str:
+    """Prefer the page's own title when grounding only supplied a bare domain."""
+    if page_title and _looks_like_bare_domain(grounding_title, url):
+        return page_title
+    return grounding_title
 
 
 def dedupe_by_url(results: "Iterable[SearchResult]") -> list[SearchResult]:
-    """Collapse results sharing a URL, keeping the first and the longest snippet.
+    """Collapse results sharing a URL, unioning the claims each copy was cited for.
 
     Two distinct grounding redirects routinely resolve to the same page, so deduplication
-    has to happen after resolution as well as before it.
+    has to happen after resolution as well as before it. Claims are unioned rather than
+    chosen between: keeping only one would silently narrow what the source was cited for,
+    and picking by length would pair one chunk's title with another chunk's claim.
     """
     by_url: dict[str, SearchResult] = {}
     for result in results:
         existing = by_url.get(result.url)
         if existing is None:
             by_url[result.url] = result
-        elif len(result.snippet) > len(existing.snippet):
-            by_url[result.url] = SearchResult(existing.title, existing.url, result.snippet)
+            continue
+        merged = list(existing.supported_claims)
+        merged.extend(claim for claim in result.supported_claims if claim not in merged)
+        by_url[result.url] = SearchResult(existing.title, existing.url, merged)
     return list(by_url.values())
 
 
@@ -316,10 +396,7 @@ def gemini_web_search(
 
     results = extract_search_results(response, max_results=max_results)
     if resolve_urls:
-        results = dedupe_by_url(
-            SearchResult(title=r.title, url=resolve_source_url(r.url), snippet=r.snippet)
-            for r in results
-        )
+        results = dedupe_by_url(_resolved(result) for result in results)
 
     return WebSearchResponse(
         query=query,
@@ -327,6 +404,16 @@ def gemini_web_search(
         backend=backend.kind,
         answer=(getattr(response, "text", "") or "").strip(),
         results=results,
+    )
+
+
+def _resolved(result: SearchResult) -> SearchResult:
+    """Turn one grounding stub into a citable source, keeping its claims."""
+    url, page_title = resolve_source(result.url)
+    return SearchResult(
+        title=best_title(result.title, page_title, url),
+        url=url,
+        supported_claims=result.supported_claims,
     )
 
 
@@ -345,8 +432,10 @@ def extract_search_results(response: object, *, max_results: int = DEFAULT_MAX_R
         if metadata is None:
             continue
 
-        snippets = _snippets_by_chunk_index(metadata)
+        claims = _claims_by_chunk_index(metadata)
         for index, chunk in enumerate(getattr(metadata, "grounding_chunks", None) or []):
+            if len(results) >= max_results:
+                return results
             web = getattr(chunk, "web", None)
             if web is None:
                 continue
@@ -358,26 +447,31 @@ def extract_search_results(response: object, *, max_results: int = DEFAULT_MAX_R
                 SearchResult(
                     title=(getattr(web, "title", "") or url).strip(),
                     url=url,
-                    snippet=snippets.get(index, ""),
+                    supported_claims=claims.get(index, []),
                 )
             )
-            if len(results) >= max_results:
-                return results
 
     return results
 
 
-def _snippets_by_chunk_index(metadata: object) -> dict[int, str]:
-    """Map each grounding chunk index to the answer text it supports."""
-    snippets: dict[int, str] = {}
+def _claims_by_chunk_index(metadata: object) -> dict[int, list[str]]:
+    """Map each grounding chunk index to the answer sentences it was cited in support of.
+
+    These are Gemini's own words, not text from the source page. Every distinct claim is
+    kept rather than only the first: a source cited for three statements should not appear
+    to stand behind whichever one happened to come back first.
+    """
+    claims: dict[int, list[str]] = {}
     for support in getattr(metadata, "grounding_supports", None) or []:
         segment = getattr(support, "segment", None)
         text = (getattr(segment, "text", "") or "").strip()
         if not text:
             continue
         for chunk_index in getattr(support, "grounding_chunk_indices", None) or []:
-            snippets.setdefault(chunk_index, text)
-    return snippets
+            bucket = claims.setdefault(chunk_index, [])
+            if text not in bucket:
+                bucket.append(text)
+    return claims
 
 
 def is_unresolved_redirect(url: str) -> bool:
@@ -393,12 +487,26 @@ def format_response_markdown(response: WebSearchResponse) -> str:
     lines.append("")
     if not response.results:
         lines.append("_No grounded sources were returned. Treat the answer as unverified._")
-    else:
-        for index, result in enumerate(response.results, start=1):
-            suffix = " — **unresolved redirect, not citable**" if is_unresolved_redirect(result.url) else ""
-            lines.append(f"{index}. [{result.title}]({result.url}){suffix}")
-            if result.snippet:
-                lines.append(f"   > {result.snippet}")
+        return "\n".join(lines).rstrip() + "\n"
+
+    if not response.grounded:
+        lines.append(
+            "_No source resolved to a citable URL. Treat the answer as unverified._"
+        )
+        lines.append("")
+
+    for index, result in enumerate(response.results, start=1):
+        suffix = "" if result.citable else " — **unresolved redirect, not citable**"
+        lines.append(f"{index}. [{result.title}]({result.url}){suffix}")
+        if result.supported_claims:
+            # Deliberately a bullet list and not a blockquote: these sentences are the
+            # model's, and a blockquote under a hyperlink reads as a quotation from the
+            # page, which is how a real source acquires a claim it never made.
+            lines.append(
+                "   Cited in support of these statements from the answer above "
+                "(Gemini's wording, not text from the page):"
+            )
+            lines.extend(f"   - {claim}" for claim in result.supported_claims)
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -472,15 +580,24 @@ def build_web_search_prompt_section(
         "```\n\n"
         f"- It performs a real, grounded Google search through {provider} "
         "and prints a synthesised answer plus the source URLs it is grounded in.\n"
-        "- Default output is markdown; `--json` gives `{query, model, answer, results[]}` for parsing.\n"
-        "- It exits non-zero and prints the reason on failure. If a search fails, retry with a "
-        "different query rather than fabricating citations.\n"
+        "- Default output is markdown; `--json` gives "
+        "`{query, model, backend, answer, grounded, citable_source_count, results[]}`, "
+        "each result being `{title, url, citable, supported_claims[]}`.\n"
+        "- Exit codes: `0` the search returned at least one citable source, `2` it "
+        "completed but nothing citable came back, `1` it failed outright. On `1` or `2`, "
+        "retry with a different query rather than fabricating citations. Check `grounded` "
+        "in the JSON for the same signal.\n"
+        "- **`supported_claims` is not text from the source page.** It is the model's own "
+        "wording from the answer above, listing what each source was cited in support of. "
+        "Grounding asserts that a source supports a claim, never that the page contains "
+        "that sentence. Never transcribe it as a quotation, and never attribute its "
+        "wording to the source's authors.\n"
         "- Fetching a **known** URL still works normally with `WebFetch` or `curl`. Only the "
-        "search step needs this tool.\n"
+        "search step needs this tool. To quote a source, fetch it and quote what it says.\n"
         "- Every citation you record must come from a URL this tool actually returned. Never "
         "invent a reference, DOI, or arXiv identifier.\n"
-        "- A source marked **unresolved redirect** has no usable URL. Treat its content as a "
-        "lead to verify, not as a citable reference."
+        "- A source marked **unresolved redirect**, or `\"citable\": false` in JSON, has no "
+        "usable URL. Treat its content as a lead to verify, not as a citable reference."
     )
 
 
@@ -535,6 +652,17 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(response.to_dict(), indent=2, ensure_ascii=False))
     else:
         print(format_response_markdown(response), end="")
+
+    if not response.grounded:
+        # Distinct from 1 (the search failed) so the caller can tell "nothing citable came
+        # back, try another query" from "the tool is broken". Exiting 0 here would let an
+        # ungrounded answer look like a successful search to anything reading only $?.
+        print(
+            "web_search: the search returned no citable source; treat the answer as "
+            "unverified and retry with a different query.",
+            file=sys.stderr,
+        )
+        return 2
     return 0
 
 

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -5,18 +5,21 @@ import json
 import os
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
 
 import main as autor_main
+from src import web_search as web_search_module
 from src.utils import STAGES, build_prompt
 from src.web_search import (
     DEFAULT_SEARCH_MODEL,
     DEFAULT_VERTEX_LOCATION,
     DEFAULT_VERTEX_SEARCH_MODEL,
+    best_title,
     dedupe_by_url,
     is_unresolved_redirect,
+    resolve_source,
     resolve_backend,
     resolve_source_url,
     vertex_credentials_available,
@@ -125,9 +128,9 @@ class ExtractResultsTest(unittest.TestCase):
         results = extract_search_results(response)
 
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0], SearchResult("Paper A", "https://example.org/a", "Key finding."))
+        self.assertEqual(results[0], SearchResult("Paper A", "https://example.org/a", ["Key finding."]))
         self.assertEqual(results[1].title, "https://example.org/b")
-        self.assertEqual(results[1].snippet, "")
+        self.assertEqual(results[1].supported_claims, [])
 
     def test_duplicate_urls_are_collapsed(self) -> None:
         chunk = _Chunk(_Web("https://example.org/a", "A"))
@@ -155,13 +158,50 @@ class FormatTest(unittest.TestCase):
             query="q",
             model="gemini-x",
             answer="The answer.",
-            results=[SearchResult("Paper A", "https://example.org/a", "Snippet.")],
+            results=[SearchResult("Paper A", "https://example.org/a", ["A claim."])],
         )
         text = format_response_markdown(response)
         self.assertIn("# Web Search: q", text)
         self.assertIn("The answer.", text)
         self.assertIn("[Paper A](https://example.org/a)", text)
-        self.assertIn("> Snippet.", text)
+        self.assertIn("- A claim.", text)
+
+    def test_a_supported_claim_is_never_rendered_as_a_quotation(self) -> None:
+        """A blockquote under a source link reads as "this page says this". It does not.
+
+        `supported_claims` is Gemini's own wording; grounding only asserts that the source
+        supports the claim. Rendering it as a quotation is how a real paper acquires a
+        sentence it never contained.
+        """
+        text = format_response_markdown(
+            WebSearchResponse(
+                query="q",
+                model="m",
+                answer="The answer.",
+                results=[SearchResult("Paper A", "https://example.org/a", ["A claim."])],
+            )
+        )
+        self.assertNotIn("> A claim.", text)
+        self.assertIn("not text from the page", text)
+
+    def test_every_claim_a_source_was_cited_for_is_shown(self) -> None:
+        text = format_response_markdown(
+            WebSearchResponse(
+                query="q",
+                model="m",
+                answer="a",
+                results=[SearchResult("A", "https://a", ["First claim.", "Second claim."])],
+            )
+        )
+        self.assertIn("- First claim.", text)
+        self.assertIn("- Second claim.", text)
+
+    def test_results_that_are_all_unresolved_are_flagged_as_unverified(self) -> None:
+        stub = "https://vertexaisearch.cloud.google.com/grounding-api-redirect/ABC"
+        text = format_response_markdown(
+            WebSearchResponse("q", "m", "a", "vertex", [SearchResult("x", stub)])
+        )
+        self.assertIn("unverified", text)
 
     def test_no_sources_is_flagged_as_unverified(self) -> None:
         text = format_response_markdown(WebSearchResponse("q", "m", "answer", []))
@@ -203,14 +243,14 @@ class CliTest(unittest.TestCase):
             return WebSearchResponse(query, "m", "a", [])
 
         with patch("src.web_search.gemini_web_search", side_effect=fake_search):
-            with redirect_stdout(io.StringIO()):
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
                 web_search_main(["black", "hole", "superradiance"])
 
         self.assertEqual(captured["query"], "black hole superradiance")
 
     def test_a_failed_search_exits_nonzero(self) -> None:
         with patch("src.web_search.gemini_web_search", side_effect=WebSearchError("no key")):
-            with redirect_stdout(io.StringIO()):
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
                 self.assertEqual(web_search_main(["q"]), 1)
 
 
@@ -423,11 +463,20 @@ class DedupeByUrlTest(unittest.TestCase):
     def test_two_redirects_resolving_to_one_page_collapse(self) -> None:
         """Dedup has to happen after resolution: distinct stubs reach the same source."""
         merged = dedupe_by_url([
-            SearchResult("github.com", "https://github.com/a", ""),
-            SearchResult("github.com", "https://github.com/a", "a longer snippet"),
+            SearchResult("github.com", "https://github.com/a", []),
+            SearchResult("github.com", "https://github.com/a", ["a claim"]),
         ])
         self.assertEqual(len(merged), 1)
-        self.assertEqual(merged[0].snippet, "a longer snippet")
+        self.assertEqual(merged[0].supported_claims, ["a claim"])
+
+    def test_merging_unions_the_claims_rather_than_choosing_between_them(self) -> None:
+        """Keeping only one copy's claims would narrow what the source was cited for."""
+        merged = dedupe_by_url([
+            SearchResult("A", "https://a", ["first", "shared"]),
+            SearchResult("A", "https://a", ["shared", "second"]),
+        ])
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0].supported_claims, ["first", "shared", "second"])
 
     def test_distinct_urls_are_preserved_in_order(self) -> None:
         merged = dedupe_by_url([
@@ -462,3 +511,258 @@ class NoBackendTest(unittest.TestCase):
         message = str(caught.exception)
         self.assertIn("GEMINI_API_KEY", message)
         self.assertIn("application-default", message)
+
+
+class SupportedClaimProvenanceTest(unittest.TestCase):
+    """One GroundingSupport routinely cites several chunks for one generated sentence.
+
+    That is the mechanism by which a model-authored claim gets attached to a source that
+    never made it, so the shape is pinned here rather than assumed.
+    """
+
+    def test_one_support_citing_two_chunks_reaches_both_results(self) -> None:
+        response = _Response([
+            _Candidate(
+                _Metadata(
+                    [_Chunk(_Web("https://arxiv.org/abs/1", "arxiv.org")),
+                     _Chunk(_Web("https://blog.example/x", "blog.example"))],
+                    [_Support("Retrieval cuts hallucination by 40%.", [0, 1])],
+                )
+            )
+        ])
+
+        results = extract_search_results(response)
+
+        self.assertEqual(len(results), 2)
+        for result in results:
+            self.assertEqual(result.supported_claims, ["Retrieval cuts hallucination by 40%."])
+
+    def test_two_supports_on_one_chunk_are_both_kept(self) -> None:
+        response = _Response([
+            _Candidate(
+                _Metadata(
+                    [_Chunk(_Web("https://a", "a"))],
+                    [_Support("First, generic.", [0]), _Support("Second, specific.", [0])],
+                )
+            )
+        ])
+
+        self.assertEqual(
+            extract_search_results(response)[0].supported_claims,
+            ["First, generic.", "Second, specific."],
+        )
+
+    def test_a_repeated_claim_is_not_duplicated(self) -> None:
+        response = _Response([
+            _Candidate(
+                _Metadata(
+                    [_Chunk(_Web("https://a", "a"))],
+                    [_Support("Same.", [0]), _Support("Same.", [0])],
+                )
+            )
+        ])
+        self.assertEqual(extract_search_results(response)[0].supported_claims, ["Same."])
+
+
+class CitabilityInJsonTest(unittest.TestCase):
+    """The prompt tells the agent to parse --json, so every judgement has to survive there.
+
+    A groundedness signal that exists only in the markdown renderer is invisible to the
+    consumer the tool actually advertises.
+    """
+
+    STUB = "https://vertexaisearch.cloud.google.com/grounding-api-redirect/ABC"
+
+    def test_a_citable_result_marks_the_response_grounded(self) -> None:
+        payload = WebSearchResponse(
+            "q", "m", "a", "vertex", [SearchResult("A", "https://arxiv.org/abs/1")]
+        ).to_dict()
+        self.assertTrue(payload["grounded"])
+        self.assertEqual(payload["citable_source_count"], 1)
+        self.assertTrue(payload["results"][0]["citable"])
+
+    def test_an_unresolved_stub_is_not_citable_and_not_grounded(self) -> None:
+        payload = WebSearchResponse(
+            "q", "m", "a", "vertex", [SearchResult("A", self.STUB)]
+        ).to_dict()
+        self.assertFalse(payload["grounded"])
+        self.assertEqual(payload["citable_source_count"], 0)
+        self.assertFalse(payload["results"][0]["citable"])
+
+    def test_an_answer_with_no_sources_is_not_grounded(self) -> None:
+        self.assertFalse(WebSearchResponse("q", "m", "an answer").to_dict()["grounded"])
+
+    def test_the_json_key_does_not_call_model_output_a_snippet(self) -> None:
+        payload = WebSearchResponse(
+            "q", "m", "a", "vertex", [SearchResult("A", "https://a", ["claim"])]
+        ).to_dict()
+        self.assertNotIn("snippet", payload["results"][0])
+        self.assertEqual(payload["results"][0]["supported_claims"], ["claim"])
+
+    def test_the_prompt_advertises_the_schema_it_actually_emits(self) -> None:
+        section = build_web_search_prompt_section()
+        payload = WebSearchResponse(
+            "q", "m", "a", "vertex", [SearchResult("A", "https://a", ["c"])]
+        ).to_dict()
+        for key in payload:
+            self.assertIn(key, section, f"--json emits {key!r} but the prompt never mentions it")
+        for key in payload["results"][0]:
+            self.assertIn(key, section, f"a result carries {key!r} but the prompt never mentions it")
+
+    def test_the_prompt_warns_that_claims_are_not_page_text(self) -> None:
+        section = build_web_search_prompt_section()
+        self.assertIn("not text from the source page", section)
+        self.assertIn("Never transcribe it as a quotation", section)
+
+
+class UngroundedExitCodeTest(unittest.TestCase):
+    """Exiting 0 on an ungrounded answer lets it look like a successful search to `$?`."""
+
+    def _run(self, response, argv):
+        buffer, errors = io.StringIO(), io.StringIO()
+        with patch("src.web_search.gemini_web_search", return_value=response):
+            with redirect_stdout(buffer), redirect_stderr(errors):
+                code = web_search_main(argv)
+        return code, buffer.getvalue(), errors.getvalue()
+
+    def test_a_grounded_answer_exits_zero(self) -> None:
+        code, _, _ = self._run(
+            WebSearchResponse("q", "m", "a", "vertex", [SearchResult("A", "https://arxiv.org/1")]),
+            ["q"],
+        )
+        self.assertEqual(code, 0)
+
+    def test_an_ungrounded_answer_exits_two_and_says_why(self) -> None:
+        code, _, errors = self._run(WebSearchResponse("q", "m", "an answer"), ["q"])
+        self.assertEqual(code, 2)
+        self.assertIn("no citable source", errors)
+
+    def test_the_ungrounded_exit_code_is_distinct_from_outright_failure(self) -> None:
+        with patch("src.web_search.gemini_web_search", side_effect=WebSearchError("boom")):
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                self.assertEqual(web_search_main(["q"]), 1)
+
+    def test_the_prompt_documents_every_exit_code_main_can_return(self) -> None:
+        section = build_web_search_prompt_section()
+        for code in ("`0`", "`1`", "`2`"):
+            self.assertIn(code, section)
+
+
+class MaxResultsFloorTest(unittest.TestCase):
+    def test_a_non_positive_cap_returns_nothing_rather_than_one(self) -> None:
+        chunks = [_Chunk(_Web(f"https://example.org/{i}")) for i in range(3)]
+        response = _Response([_Candidate(_Metadata(chunks))])
+        for cap in (-5, -1, 0):
+            with self.subTest(max_results=cap):
+                self.assertEqual(extract_search_results(response, max_results=cap), [])
+
+    def test_a_positive_cap_is_still_honoured_exactly(self) -> None:
+        chunks = [_Chunk(_Web(f"https://example.org/{i}")) for i in range(10)]
+        response = _Response([_Candidate(_Metadata(chunks))])
+        for cap in (1, 3, 9):
+            with self.subTest(max_results=cap):
+                self.assertEqual(len(extract_search_results(response, max_results=cap)), cap)
+
+    def test_the_cap_holds_across_several_candidates(self) -> None:
+        response = _Response([
+            _Candidate(_Metadata([_Chunk(_Web("https://a")), _Chunk(_Web("https://b"))])),
+            _Candidate(_Metadata([_Chunk(_Web("https://c")), _Chunk(_Web("https://d"))])),
+        ])
+        self.assertEqual(len(extract_search_results(response, max_results=3)), 3)
+
+
+class SourceTitleTest(unittest.TestCase):
+    """Grounding labels every source with a bare domain, which identifies nothing."""
+
+    def test_a_page_title_replaces_a_bare_domain(self) -> None:
+        self.assertEqual(
+            best_title("arxiv.org", "Attention Is All You Need", "https://arxiv.org/abs/1706.03762"),
+            "Attention Is All You Need",
+        )
+
+    def test_a_www_prefixed_domain_is_still_a_bare_domain(self) -> None:
+        self.assertEqual(best_title("nature.com", "A paper", "https://www.nature.com/x"), "A paper")
+
+    def test_a_real_grounding_title_is_kept_over_the_page_title(self) -> None:
+        self.assertEqual(
+            best_title("Attention Is All You Need", "arXiv.org e-Print archive", "https://arxiv.org/abs/1"),
+            "Attention Is All You Need",
+        )
+
+    def test_no_page_title_leaves_the_domain_in_place(self) -> None:
+        self.assertEqual(best_title("arxiv.org", None, "https://arxiv.org/abs/1"), "arxiv.org")
+
+    def test_a_title_equal_to_the_url_counts_as_bare(self) -> None:
+        self.assertEqual(best_title("https://a/b", "Real Title", "https://a/b"), "Real Title")
+
+
+class ResolveSourceTest(unittest.TestCase):
+    STUB = "https://vertexaisearch.cloud.google.com/grounding-api-redirect/ABC"
+
+    class _FakeResponse:
+        def __init__(self, url: str, body: bytes) -> None:
+            self.url = url
+            self._body = body
+
+        def read(self, size: int = -1) -> bytes:
+            return self._body[:size] if size and size > 0 else self._body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc) -> bool:
+            return False
+
+    def test_a_redirect_yields_both_the_target_and_its_title(self) -> None:
+        page = b"<html><head><title>  Attention Is\nAll You Need </title></head>"
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._FakeResponse("https://arxiv.org/abs/1706.03762", page),
+        ):
+            url, title = resolve_source(self.STUB)
+        self.assertEqual(url, "https://arxiv.org/abs/1706.03762")
+        self.assertEqual(title, "Attention Is All You Need")
+
+    def test_html_entities_in_a_title_are_unescaped(self) -> None:
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._FakeResponse("https://a/b", b"<title>A &amp; B</title>"),
+        ):
+            self.assertEqual(resolve_source(self.STUB)[1], "A & B")
+
+    def test_a_runaway_title_is_truncated(self) -> None:
+        """The title goes into a prompt, so an unbounded one is an unbounded token cost."""
+        page = b"<title>" + b"x" * 5000 + b"</title>"
+        with patch("urllib.request.urlopen", return_value=self._FakeResponse("https://a", page)):
+            title = resolve_source(self.STUB)[1]
+        self.assertEqual(len(title), 200)
+
+    def test_a_page_with_no_title_resolves_the_url_anyway(self) -> None:
+        with patch(
+            "urllib.request.urlopen",
+            return_value=self._FakeResponse("https://a/b", b"<html><body>x</body></html>"),
+        ):
+            self.assertEqual(resolve_source(self.STUB), ("https://a/b", None))
+
+    def test_a_failed_resolution_reports_no_title_and_keeps_the_stub(self) -> None:
+        with patch("urllib.request.urlopen", side_effect=OSError("boom")):
+            self.assertEqual(resolve_source(self.STUB), (self.STUB, None))
+
+    def test_a_non_redirect_is_not_fetched(self) -> None:
+        with patch("urllib.request.urlopen", side_effect=AssertionError("should not be called")):
+            self.assertEqual(resolve_source("https://arxiv.org/abs/1"), ("https://arxiv.org/abs/1", None))
+
+    def test_the_body_read_is_capped(self) -> None:
+        """An unbounded read turns one citation lookup into an arbitrary download."""
+        seen: dict[str, int] = {}
+        response = self._FakeResponse("https://a", b"<title>t</title>")
+        original_read = response.read
+
+        def recording_read(size: int = -1) -> bytes:
+            seen["size"] = size
+            return original_read(size)
+
+        response.read = recording_read  # type: ignore[method-assign]
+        with patch("urllib.request.urlopen", return_value=response):
+            resolve_source(self.STUB)
+        self.assertEqual(seen["size"], web_search_module.TITLE_SCAN_BYTES)


### PR DESCRIPTION
Found by an adversarial review of the web-search feature; this is the highest-impact of the twelve findings that survived verification against current `main`.

## The defect

Gemini's grounding metadata pairs each source with sentences from **its own generated answer**. Grounding asserts that a source *supports* a claim; it never asserts that the page *contains* that sentence. The SDK docs say so directly — `Segment.text` is "the text corresponding to the segment from the response".

The tool stored that text in a field called `snippet` and rendered it as an **unlabelled markdown blockquote directly under the source hyperlink**. Both conventions mean "quoted from this page".

Reproduced on the shipped code — one `GroundingSupport` citing two chunks:

```
1. [Attention Is All You Need](https://arxiv.org/abs/1706.03762)
   > Retrieval cuts hallucination by roughly 40%.
2. [someblog.example](https://someblog.example/x)
   > Retrieval cuts hallucination by roughly 40%.
```

Neither page contains that sentence. Gemini wrote it. An agent operating under the prompt block's own rule — *"every citation you record must come from a URL this tool actually returned"* — transcribes it into the Stage 01 survey attributed to a real paper.

**That is a fabricated statistic bound to a real DOI, which is worse than an invented reference: it survives every URL-exists check a reviewer would run.** For a project whose premise is artifact-backed verifiable research, it is the worst available failure mode.

## The fix

`snippet: str` → `supported_claims: list[str]`, rendered as a labelled bullet list:

```
1. [Attention Is All You Need](https://arxiv.org/abs/1706.03762)
   Cited in support of these statements from the answer above (Gemini's wording, not text from the page):
   - Retrieval cuts hallucination by roughly 40%.
   - Second claim.
```

- The prompt block states it outright, and adds *"to quote a source, fetch it and quote what it says"*.
- `_claims_by_chunk_index` accumulates instead of `setdefault`, so a source cited for three statements no longer appears to stand behind whichever one arrived first.
- `dedupe_by_url` unions the claim lists. It previously kept *"the longest snippet"*, which paired one chunk's title and URL with a **different chunk's** sentence.

## Groundedness becomes data, not prose

Every citability judgement lived only inside `format_response_markdown` — while the prompt tells the agent to parse `--json`.

- `SearchResult.citable`, `WebSearchResponse.grounded`, `citable_source_count` are now properties emitted in `to_dict()`.
- The CLI exits **`2`** when nothing citable came back — distinct from `1` (the search failed), because exiting `0` made an ungrounded answer indistinguishable from a real result to anything reading `$?`.
- Markdown now flags the all-unresolved case, which previously only had a message for the zero-results case.

## Two smaller fixes in the same code

- **`--max-results` off-by-one.** The cap was tested *after* appending, so any `max_results <= 0` returned one result instead of none — reachable from the CLI, which declares `--max-results` as `type=int` with no floor. The check moved to the top of the loop.
- **Bare-domain titles.** Grounding labels every source with its domain (`arxiv.org`), which identifies nothing once several results share a host. Following the redirect is already a GET, so `resolve_source` now also reads the page `<title>` from it — capped at 64 KiB of body and 200 characters — and uses it only when the grounding title is the bare host. `resolve_source_url` is unchanged for existing callers.

## Verification

- **457 tests green** (+31), `py_compile` clean across all packages.
- **Mutation swept with a control run**, 13 mutants over the changed seams, **all killed**: rendering a claim as a blockquote, `grounded` always true, `citable` always true, dropping `citable`/`grounded` from the JSON, exiting 0 when ungrounded, the cap off-by-one, never using the page title, an uncapped body read, dropping the "not page text" warning, dropping the exit-code documentation, and the `www.` strip.
- The first sweep left **one survivor** — nothing pinned the 200-character title cap — and a test was added for it. Reported rather than quietly re-run.

## Docs

The JSON schema and exit codes are a contract the agent is told to rely on, so `docs/cli-reference.md` gains an exit-code table and a *"`supported_claims` is not page text"* section, and `docs/researchclawbench.md` explains what a grounding snippet actually is and why the field was renamed.

## Not in this PR

Ten further verified findings, to follow separately: the prompt block asserts "WebSearch is disabled, use this script" without checking that `google-genai` is importable / the interpreter matches / the Codex sandbox permits egress; `--web-search` is the only mode flag not persisted to `run_config.json`; no retry, backoff or timeout on the Gemini call; a bare `import yaml` on the startup path; and four test-quality gaps including **zero coverage of the SDK call path**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)