### PR TITLE
Do not advertise a search tool that cannot run

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,12 +108,35 @@ overnight job.
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--web-search {auto,gemini,native}` | `auto` | Which search path the operators use. `gemini` routes searches through the Gemini API's Google Search grounding via `tools/web_search.py`; `native` leaves the backend's own tool in charge; `auto` picks Gemini when a Gemini API key is configured and falls back to native otherwise. |
+| `--web-search {auto,gemini,native}` | `auto` | Which search path the operators use. `gemini` routes searches through the Gemini API's Google Search grounding via `tools/web_search.py`; `native` leaves the backend's own tool in charge; `auto` picks Gemini when it can actually run and falls back to native otherwise. |
 
 Set `gemini` on deployments where the built-in `WebSearch` tool is disabled —
 notably **Claude Code on Vertex AI** — otherwise Stage 01 has no way to search
 and will either stall or fabricate citations. See
 [ResearchClawBench → Web search](researchclawbench.md#web-search-on-deployments-where-websearch-is-disabled).
+
+#### What "can actually run" means
+
+Injecting the search block tells every stage prompt that the built-in `WebSearch`
+tool is disabled and `tools/web_search.py` is the replacement. That is a promise,
+and credentials alone do not keep it. Three things are checked:
+
+| Precondition | Why credentials are not enough |
+| --- | --- |
+| A Gemini backend | An API key, or Vertex ADC plus a project. |
+| `google-genai` importable | Not a default dependency. The Vertex probe uses `google.auth`, a **different distribution** that can be installed without it. |
+| The sandbox permits egress | `--operator codex` with `read-only` or `workspace-write` (the default) restricts outbound network access, so the search subprocess cannot reach Gemini. |
+
+`auto` falls back to native search if any of them fails, and says which one at
+startup. `--web-search gemini` **refuses to start** when the backend or the SDK
+is missing — you asked for a tool that provably cannot work, and continuing means
+Stage 01 burns its retry budget on a dead command before falling back to memory.
+The sandbox case only warns, because it is inferred from the requested mode rather
+than observed.
+
+The advertised command names AutoR's own interpreter (`sys.executable`), not a
+bare `python3` — otherwise the interpreter checked for `google-genai` and the one
+that runs the script need not be the same.
 
 ### Output format
 

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -243,9 +243,22 @@ Both `main.py` and `rcb_agent.py` take `--web-search`:
 
 | Value | Behaviour |
 |:---|:---|
-| `auto` (default) | Gemini when a key is configured, native search otherwise |
-| `gemini` | Always Gemini. Use this where `WebSearch` is blocked. |
+| `auto` (default) | Gemini when it can actually run, native search otherwise |
+| `gemini` | Always Gemini. Use this where `WebSearch` is blocked. Refuses to start if Gemini provably cannot work. |
 | `native` | Leave the backend's own search tool in charge |
+
+**"Can actually run" is three checks, not one.** A credential is not a working
+search tool. `google-genai` has to be importable by the interpreter that will run the
+script — it is not a default dependency, and the Vertex probe uses `google.auth`, a
+different distribution that can be installed without it. And the sandbox has to permit
+egress: `--operator codex` with `read-only` or `workspace-write` (the default) restricts
+outbound network access, so the search subprocess cannot reach Gemini at all. `auto` falls
+back to native on any of them and names the blocker at startup; `--web-search gemini`
+refuses to start on the first two, and warns on the third because it is inferred from the
+requested mode rather than observed.
+
+The advertised command names AutoR's own interpreter rather than a bare `python3`, so the
+interpreter checked for the SDK is the one that runs the script.
 
 When Gemini search is active, a `# Web Search Capability` block is injected into every stage
 prompt telling the operator that `WebSearch` is disabled, how to call the replacement, and

--- a/main.py
+++ b/main.py
@@ -11,7 +11,11 @@ from src.operator import ClaudeOperator
 from src.operator_codex import CodexOperator
 from src.operator_protocol import OperatorProtocol
 from src.terminal_ui import TerminalUI
-from src.web_search import resolve_web_search_context, web_search_notice
+from src.web_search import (
+    assess_search_readiness,
+    resolve_web_search_context,
+    web_search_notice,
+)
 from src.utils import (
     CODEX_SANDBOX_CHOICES,
     DEFAULT_CODEX_SANDBOX,
@@ -337,11 +341,25 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parent
     runs_dir = repo_root / args.runs_dir
     unattended = resolve_unattended(args)
-    web_search_context = resolve_web_search_context(args.web_search)
     ui = TerminalUI(interactive=not unattended)
     ui.show_banner()
-    notice, level = web_search_notice(args.web_search)
+
+    # Assessed against the operator this run will actually use, because the sandbox the
+    # search subprocess inherits is part of whether the tool can run at all. Resolved
+    # before the resume branch reads run_config, so a resumed run that switches backends
+    # re-derives it below.
+    readiness = assess_search_readiness(
+        operator=(args.operator or "claude"),
+        codex_sandbox=args.codex_sandbox,
+    )
+    web_search_context = resolve_web_search_context(args.web_search, readiness=readiness)
+    notice, level = web_search_notice(args.web_search, readiness=readiness)
     ui.show_status(notice, level=level)
+    if args.web_search == "gemini" and readiness.hard_blocker:
+        raise ValueError(
+            f"--web-search gemini cannot work here: {readiness.hard_blocker} "
+            "Fix it, or use --web-search auto to fall back to native search."
+        )
 
     if args.resume_run:
         start_stage = resolve_stage(args.redo_stage)

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -58,7 +58,11 @@ from src.utils import (  # noqa: E402
     resolve_stage,
     resolve_venue_key,
 )
-from src.web_search import resolve_web_search_context, web_search_notice  # noqa: E402
+from src.web_search import (  # noqa: E402
+    assess_search_readiness,
+    resolve_web_search_context,
+    web_search_notice,
+)
 
 
 #: The harness enforces no wall clock of its own — neither the UI runner nor the batch CLI
@@ -234,9 +238,20 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         }
     )
 
-    notice, level = web_search_notice(args.web_search)
+    readiness = assess_search_readiness(
+        operator=operator_backend,
+        codex_sandbox=args.codex_sandbox,
+    )
+    notice, level = web_search_notice(args.web_search, readiness=readiness)
     emit_event({"type": "progress", "stage": "web_search", "level": level, "message": notice})
     ui.show_status(notice, level=level)
+    if args.web_search == "gemini" and readiness.hard_blocker:
+        # The benchmark scores a report, and a keyless search tool produces one built on
+        # citations the agent had to invent. Refuse the run instead of spending hours on it.
+        raise ValueError(
+            f"--web-search gemini cannot work here: {readiness.hard_blocker} "
+            "Fix it, or use --web-search auto to fall back to native search."
+        )
 
     operator = create_operator(
         operator_backend,
@@ -292,7 +307,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         unattended=True,
         max_auto_skips=args.max_auto_skips,
         max_stage_attempts=args.max_attempts,
-        web_search_context=resolve_web_search_context(args.web_search),
+        web_search_context=resolve_web_search_context(args.web_search, readiness=readiness),
         # Stages are told to keep code/, outputs/ and report/images/ up to date in the
         # benchmark workspace, so 'Files Produced' must resolve against it too.
         artifact_roots=[workspace],

--- a/src/web_search.py
+++ b/src/web_search.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 import argparse
 import html
+import importlib.util
 import json
 import os
 import re
+import shlex
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -173,6 +175,32 @@ def resolve_vertex_location() -> str:
         if value:
             return value
     return DEFAULT_VERTEX_LOCATION
+
+
+def genai_sdk_available() -> bool:
+    """Whether `google-genai` can actually be imported by *this* interpreter.
+
+    Credentials alone are not enough to promise the agent a working search tool:
+    `google-genai` is not a default dependency, and the Vertex path probes `google.auth`,
+    which ships in a different distribution and can be present without it.
+
+    `find_spec` imports the parent package to search it, so a missing `google` namespace
+    raises instead of returning None -- the exact case this function exists to detect.
+    """
+    try:
+        return importlib.util.find_spec("google.genai") is not None
+    except (ImportError, AttributeError, ValueError):
+        return False
+
+
+def search_command_prefix() -> str:
+    """The interpreter to advertise for `tools/web_search.py`.
+
+    `python3` is whatever the agent's PATH resolves it to, which need not be the
+    interpreter AutoR checked for `google-genai`. Naming our own makes the check and the
+    command that gets run refer to the same site-packages.
+    """
+    return shlex.quote(sys.executable or "python3")
 
 
 def vertex_credentials_available() -> bool:
@@ -510,20 +538,117 @@ def format_response_markdown(response: WebSearchResponse) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def resolve_web_search_context(mode: str) -> str | None:
+#: Codex sandbox modes that restrict outbound network access, so a search subprocess
+#: launched inside them cannot reach Gemini. `danger-full-access` is the only mode that
+#: does not.
+NETWORK_RESTRICTED_CODEX_SANDBOXES = frozenset({"read-only", "workspace-write"})
+
+#: Imported rather than re-declared so the default cannot drift from the CLI's.
+#: `src.utils` takes the search block as a parameter and never imports this module, so
+#: there is no cycle.
+from .utils import DEFAULT_CODEX_SANDBOX as DEFAULT_CODEX_SANDBOX_NAME  # noqa: E402
+
+_FIX_CREDENTIALS = (
+    "Set GOOGLE_API_KEY / GEMINI_API_KEY, or configure Vertex AI "
+    "(GOOGLE_CLOUD_PROJECT plus `gcloud auth application-default login`)."
+)
+
+
+@dataclass(frozen=True)
+class SearchReadiness:
+    """Whether `tools/web_search.py` can actually run, and what stops it if not.
+
+    Telling an operator "the built-in WebSearch tool is disabled, use this script instead"
+    is a promise. Credentials alone do not keep it: the SDK has to be importable by the
+    interpreter that will run the script, and the sandbox the operator runs in has to let
+    the process reach the network.
+    """
+
+    backend: SearchBackend | None
+    sdk_available: bool
+    sandbox_blocker: str | None = None
+
+    @property
+    def usable(self) -> bool:
+        return self.backend is not None and self.sdk_available and self.sandbox_blocker is None
+
+    @property
+    def blocker(self) -> str | None:
+        """The first reason the tool cannot run, as a sentence, or None."""
+        if self.backend is None:
+            return f"no Gemini backend is configured. {_FIX_CREDENTIALS}"
+        if not self.sdk_available:
+            return (
+                "the google-genai package is not importable by this interpreter "
+                f"({sys.executable}). Install it with: pip install google-genai"
+            )
+        return self.sandbox_blocker
+
+    @property
+    def hard_blocker(self) -> str | None:
+        """A blocker AutoR is certain about, so it is safe to fail a run on.
+
+        The sandbox blocker is deliberately excluded: it is inferred from the requested
+        Codex mode rather than observed, so it warns instead of aborting.
+        """
+        if self.backend is None or not self.sdk_available:
+            return self.blocker
+        return None
+
+
+def assess_search_readiness(
+    *,
+    operator: str | None = None,
+    codex_sandbox: str | None = None,
+    model: str | None = None,
+) -> SearchReadiness:
+    sandbox_blocker = None
+    if (operator or "").strip().lower() == "codex":
+        sandbox = (codex_sandbox or DEFAULT_CODEX_SANDBOX_NAME).strip().lower()
+        if sandbox in NETWORK_RESTRICTED_CODEX_SANDBOXES:
+            sandbox_blocker = (
+                f"the Codex sandbox `{sandbox}` restricts outbound network access, so the "
+                "search subprocess cannot reach Gemini. Use --codex-sandbox "
+                "danger-full-access, switch to --operator claude, or pass --web-search "
+                "native."
+            )
+    return SearchReadiness(
+        backend=resolve_backend(model),
+        sdk_available=genai_sdk_available(),
+        sandbox_blocker=sandbox_blocker,
+    )
+
+
+def resolve_web_search_context(
+    mode: str,
+    *,
+    readiness: SearchReadiness | None = None,
+    operator: str | None = None,
+    codex_sandbox: str | None = None,
+) -> str | None:
     """Return the prompt block for the Gemini search tool, or None to keep native search.
 
-    'auto' degrades to native search when no Gemini key is configured, so the default path
-    never advertises a tool that would fail on first use.
+    'auto' degrades to native search whenever the tool could not actually run, so the
+    default path never advertises a tool that would fail on first use. An explicit
+    `gemini` still injects — the caller is expected to have refused the run already if
+    :attr:`SearchReadiness.hard_blocker` is set.
     """
     if mode == "native":
         return None
-    if mode == "auto" and resolve_backend() is None:
+    if readiness is None:
+        readiness = assess_search_readiness(operator=operator, codex_sandbox=codex_sandbox)
+    if mode == "auto" and not readiness.usable:
         return None
     return build_web_search_prompt_section()
 
 
-def web_search_notice(mode: str) -> tuple[str, str]:
+def web_search_notice(
+    mode: str,
+    *,
+    readiness: SearchReadiness | None = None,
+    operator: str | None = None,
+    codex_sandbox: str | None = None,
+) -> tuple[str, str]:
     """Describe the resolved search path as a ``(message, level)`` pair.
 
     `auto` silently falling back to native search is the dangerous case: on a deployment
@@ -535,28 +660,26 @@ def web_search_notice(mode: str) -> tuple[str, str]:
     if mode == "native":
         return ("Web search: the backend's native tool.", "info")
 
-    backend = resolve_backend()
+    if readiness is None:
+        readiness = assess_search_readiness(operator=operator, codex_sandbox=codex_sandbox)
+    blocker = readiness.blocker
 
     if mode == "gemini":
-        if backend is None:
-            return (
-                "Web search: --web-search gemini was requested but no Gemini backend is "
-                "configured. Operators will be told to use tools/web_search.py and it will "
-                "fail on first use. Set GOOGLE_API_KEY / GEMINI_API_KEY, or configure Vertex "
-                "AI (GOOGLE_CLOUD_PROJECT plus `gcloud auth application-default login`).",
-                "error",
-            )
-        return (f"Web search: {backend.describe()}.", "info")
+        if blocker is None:
+            return (f"Web search: {readiness.backend.describe()}.", "info")
+        return (
+            f"Web search: --web-search gemini was requested but {blocker} Operators will be "
+            "told to use tools/web_search.py and it will fail on first use.",
+            "error",
+        )
 
-    if backend is not None:
-        return (f"Web search: {backend.describe()}, selected automatically.", "info")
+    if blocker is None:
+        return (f"Web search: {readiness.backend.describe()}, selected automatically.", "info")
 
     return (
-        "Web search: no Gemini backend found, falling back to the backend's native search. "
+        f"Web search: falling back to the backend's native search because {blocker} "
         "If this deployment has WebSearch disabled (for example Claude Code on Vertex AI), "
-        "Stage 01 has no way to search at all. Set GOOGLE_API_KEY / GEMINI_API_KEY, or "
-        "configure Vertex AI (GOOGLE_CLOUD_PROJECT plus `gcloud auth application-default "
-        "login`), or pass --web-search native to silence this.",
+        "Stage 01 has no way to search at all. Pass --web-search native to silence this.",
         "warn",
     )
 
@@ -568,6 +691,7 @@ def build_web_search_prompt_section(
 ) -> str:
     """Build the prompt block that redirects operators away from the native search tool."""
     resolved_script = (script_path or WEB_SEARCH_SCRIPT).resolve()
+    interpreter = search_command_prefix()
     backend = resolve_backend(model)
     provider = backend.describe() if backend else f"Gemini ({resolve_search_model(model)})"
     return (
@@ -575,8 +699,8 @@ def build_web_search_prompt_section(
         "fail or silently return nothing, so do not rely on it.\n\n"
         "Use this Gemini-backed replacement instead, through a shell command:\n\n"
         "```bash\n"
-        f'python3 "{resolved_script}" "your search query here"\n'
-        f'python3 "{resolved_script}" "your search query here" --json --max-results 8\n'
+        f'{interpreter} "{resolved_script}" "your search query here"\n'
+        f'{interpreter} "{resolved_script}" "your search query here" --json --max-results 8\n'
         "```\n\n"
         f"- It performs a real, grounded Google search through {provider} "
         "and prints a synthesised answer plus the source URLs it is grounded in.\n"

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import tempfile
+import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
@@ -16,6 +17,7 @@ from src.web_search import (
     DEFAULT_SEARCH_MODEL,
     DEFAULT_VERTEX_LOCATION,
     DEFAULT_VERTEX_SEARCH_MODEL,
+    assess_search_readiness,
     best_title,
     dedupe_by_url,
     is_unresolved_redirect,
@@ -283,6 +285,16 @@ class PromptSectionTest(unittest.TestCase):
 
 
 class WebSearchNoticeTest(unittest.TestCase):
+    @staticmethod
+    def _sdk(available: bool = True):
+        """State the SDK assumption explicitly.
+
+        Credentials alone no longer mean `auto` injects: `google-genai` also has to be
+        importable, and it is not installed in CI. Without this, these tests pass on a dev
+        box and fail in CI for a reason that has nothing to do with what they check.
+        """
+        return patch("src.web_search.genai_sdk_available", return_value=available)
+
     """The notice exists so a silent fallback cannot hide a dead Stage 01."""
 
     def _no_key(self):
@@ -296,7 +308,7 @@ class WebSearchNoticeTest(unittest.TestCase):
         self.assertIn("GEMINI_API_KEY", message)
 
     def test_auto_with_a_key_is_informational(self) -> None:
-        with patch.dict(os.environ, {"GEMINI_API_KEY": "k"}, clear=True):
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "k"}, clear=True), self._sdk():
             message, level = web_search_notice("auto")
         self.assertEqual(level, "info")
         self.assertIn("Gemini", message)
@@ -336,6 +348,16 @@ class WebSearchNoticeTest(unittest.TestCase):
 
 
 class WebSearchModeTest(unittest.TestCase):
+    @staticmethod
+    def _sdk(available: bool = True):
+        """State the SDK assumption explicitly.
+
+        Credentials alone no longer mean `auto` injects: `google-genai` also has to be
+        importable, and it is not installed in CI. Without this, these tests pass on a dev
+        box and fail in CI for a reason that has nothing to do with what they check.
+        """
+        return patch("src.web_search.genai_sdk_available", return_value=available)
+
     def test_native_never_injects(self) -> None:
         with patch.dict(os.environ, {"GOOGLE_API_KEY": "k"}, clear=True):
             self.assertIsNone(autor_main.resolve_web_search_context("native"))
@@ -351,7 +373,7 @@ class WebSearchModeTest(unittest.TestCase):
                 self.assertIsNone(autor_main.resolve_web_search_context("auto"))
 
     def test_auto_uses_gemini_when_a_key_exists(self) -> None:
-        with patch.dict(os.environ, {"GEMINI_API_KEY": "k"}, clear=True):
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "k"}, clear=True), self._sdk():
             self.assertIsNotNone(autor_main.resolve_web_search_context("auto"))
 
     def test_the_rcb_adapter_resolves_the_same_way(self) -> None:
@@ -369,6 +391,16 @@ if __name__ == "__main__":
 
 
 class VertexBackendTest(unittest.TestCase):
+    @staticmethod
+    def _sdk(available: bool = True):
+        """State the SDK assumption explicitly.
+
+        Credentials alone no longer mean `auto` injects: `google-genai` also has to be
+        importable, and it is not installed in CI. Without this, these tests pass on a dev
+        box and fail in CI for a reason that has nothing to do with what they check.
+        """
+        return patch("src.web_search.genai_sdk_available", return_value=available)
+
     """Vertex AI is the path that matters on deployments where WebSearch is disabled."""
 
     def _no_key(self):
@@ -421,7 +453,7 @@ class VertexBackendTest(unittest.TestCase):
             self.assertEqual(resolve_backend("gemini-x").model, "gemini-x")
 
     def test_the_notice_reports_vertex_rather_than_warning(self) -> None:
-        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "p1"}, clear=True), self._no_key(), self._adc(True):
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "p1"}, clear=True), self._no_key(), self._adc(True), self._sdk():
             message, level = web_search_notice("auto")
         self.assertEqual(level, "info")
         self.assertIn("Vertex AI", message)
@@ -429,7 +461,7 @@ class VertexBackendTest(unittest.TestCase):
 
     def test_auto_injects_the_prompt_block_on_a_vertex_only_box(self) -> None:
         """The regression this whole path exists for: no API key, but search does work."""
-        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "p1"}, clear=True), self._no_key(), self._adc(True):
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_PROJECT": "p1"}, clear=True), self._no_key(), self._adc(True), self._sdk():
             self.assertIsNotNone(resolve_web_search_context("auto"))
 
     def test_credentials_probe_never_returns_a_token(self) -> None:
@@ -766,3 +798,287 @@ class ResolveSourceTest(unittest.TestCase):
         with patch("urllib.request.urlopen", return_value=response):
             resolve_source(self.STUB)
         self.assertEqual(seen["size"], web_search_module.TITLE_SCAN_BYTES)
+
+
+class SearchReadinessTest(unittest.TestCase):
+    """Credentials alone are not a promise that the tool can run.
+
+    The prompt block tells the operator "the built-in WebSearch tool is disabled, use this
+    script instead". Three further things have to be true for that to be honest.
+    """
+
+    KEY = {"GEMINI_API_KEY": "k"}
+
+    def _readiness(self, *, env=None, sdk=True, **kwargs):
+        with patch.dict(os.environ, env if env is not None else self.KEY, clear=True), \
+             patch("src.web_search.DIAGRAM_CONFIG_PATH", Path("/nonexistent/diagram.yaml")), \
+             patch("src.web_search.genai_sdk_available", return_value=sdk):
+            return assess_search_readiness(**kwargs)
+
+    def test_a_key_and_the_sdk_and_no_sandbox_is_usable(self) -> None:
+        readiness = self._readiness()
+        self.assertTrue(readiness.usable)
+        self.assertIsNone(readiness.blocker)
+        self.assertIsNone(readiness.hard_blocker)
+
+    def test_a_missing_sdk_blocks_even_with_a_key(self) -> None:
+        """google-genai is not a default dependency, and the Vertex probe uses google.auth
+        — a different distribution that can be installed without it."""
+        readiness = self._readiness(sdk=False)
+        self.assertFalse(readiness.usable)
+        self.assertIn("google-genai", readiness.blocker)
+        self.assertIn("pip install google-genai", readiness.hard_blocker)
+
+    def test_no_credentials_blocks(self) -> None:
+        with patch("src.web_search.vertex_credentials_available", return_value=False):
+            readiness = self._readiness(env={})
+        self.assertFalse(readiness.usable)
+        self.assertIn("no Gemini backend", readiness.blocker)
+
+    def test_the_missing_backend_is_reported_before_the_missing_sdk(self) -> None:
+        with patch("src.web_search.vertex_credentials_available", return_value=False):
+            readiness = self._readiness(env={}, sdk=False)
+        self.assertIn("no Gemini backend", readiness.blocker)
+
+    def test_a_network_restricted_codex_sandbox_blocks(self) -> None:
+        for sandbox in ("read-only", "workspace-write"):
+            with self.subTest(sandbox=sandbox):
+                readiness = self._readiness(operator="codex", codex_sandbox=sandbox)
+                self.assertFalse(readiness.usable)
+                self.assertIn("Codex sandbox", readiness.blocker)
+                self.assertIn(sandbox, readiness.blocker)
+
+    def test_the_codex_default_sandbox_is_the_restricted_one(self) -> None:
+        """Passing no --codex-sandbox is the common case, and its default blocks egress."""
+        self.assertIn("workspace-write", self._readiness(operator="codex").blocker)
+
+    def test_full_access_codex_is_not_blocked(self) -> None:
+        readiness = self._readiness(operator="codex", codex_sandbox="danger-full-access")
+        self.assertTrue(readiness.usable)
+
+    def test_claude_is_never_sandbox_blocked(self) -> None:
+        readiness = self._readiness(operator="claude", codex_sandbox="workspace-write")
+        self.assertTrue(readiness.usable)
+
+    def test_the_sandbox_blocker_is_not_hard_enough_to_abort_a_run(self) -> None:
+        """It is inferred from the requested mode, not observed, so it warns rather than
+        failing a run that might actually have worked."""
+        readiness = self._readiness(operator="codex", codex_sandbox="workspace-write")
+        self.assertIsNotNone(readiness.blocker)
+        self.assertIsNone(readiness.hard_blocker)
+
+    def test_every_blocker_names_a_remedy(self) -> None:
+        cases = [
+            self._readiness(sdk=False),
+            self._readiness(operator="codex", codex_sandbox="workspace-write"),
+        ]
+        with patch("src.web_search.vertex_credentials_available", return_value=False):
+            cases.append(self._readiness(env={}))
+        for readiness in cases:
+            with self.subTest(blocker=readiness.blocker):
+                self.assertRegex(readiness.blocker, r"Set |Install |Use |pip install|--")
+
+
+class ReadinessDrivesTheDecisionTest(unittest.TestCase):
+    USABLE = web_search_module.SearchReadiness(
+        backend=web_search_module.SearchBackend(kind="api_key", model="m", api_key="k"),
+        sdk_available=True,
+    )
+    NO_SDK = web_search_module.SearchReadiness(
+        backend=web_search_module.SearchBackend(kind="api_key", model="m", api_key="k"),
+        sdk_available=False,
+    )
+    SANDBOXED = web_search_module.SearchReadiness(
+        backend=web_search_module.SearchBackend(kind="api_key", model="m", api_key="k"),
+        sdk_available=True,
+        sandbox_blocker="the Codex sandbox `workspace-write` restricts outbound network access.",
+    )
+
+    def test_auto_falls_back_when_the_sdk_is_missing(self) -> None:
+        self.assertIsNone(resolve_web_search_context("auto", readiness=self.NO_SDK))
+
+    def test_auto_falls_back_when_the_sandbox_blocks_egress(self) -> None:
+        self.assertIsNone(resolve_web_search_context("auto", readiness=self.SANDBOXED))
+
+    def test_auto_injects_when_everything_checks_out(self) -> None:
+        self.assertIsNotNone(resolve_web_search_context("auto", readiness=self.USABLE))
+
+    def test_native_never_injects(self) -> None:
+        for readiness in (self.USABLE, self.NO_SDK, self.SANDBOXED):
+            self.assertIsNone(resolve_web_search_context("native", readiness=readiness))
+
+    def test_the_notice_names_the_specific_blocker_not_just_the_key(self) -> None:
+        message, level = web_search_notice("auto", readiness=self.NO_SDK)
+        self.assertEqual(level, "warn")
+        self.assertIn("google-genai", message)
+
+    def test_an_explicit_gemini_request_reports_the_blocker_at_error_level(self) -> None:
+        message, level = web_search_notice("gemini", readiness=self.NO_SDK)
+        self.assertEqual(level, "error")
+        self.assertIn("google-genai", message)
+
+    def test_a_usable_backend_is_reported_at_info_level(self) -> None:
+        for mode in ("auto", "gemini"):
+            message, level = web_search_notice(mode, readiness=self.USABLE)
+            self.assertEqual(level, "info")
+            self.assertIn("Gemini API", message)
+
+
+class AdvertisedInterpreterTest(unittest.TestCase):
+    def test_the_section_names_this_interpreter_not_a_bare_python3(self) -> None:
+        """`python3` is whatever the agent's PATH resolves it to, which need not be the
+        interpreter whose site-packages we checked for google-genai."""
+        section = build_web_search_prompt_section()
+        self.assertIn(sys.executable, section)
+
+    def test_an_interpreter_path_with_spaces_is_quoted(self) -> None:
+        with patch.object(web_search_module.sys, "executable", "/opt/my env/bin/python"):
+            section = build_web_search_prompt_section()
+        self.assertIn("'/opt/my env/bin/python'", section)
+
+    def test_it_falls_back_to_python3_when_the_interpreter_is_unknown(self) -> None:
+        with patch.object(web_search_module.sys, "executable", ""):
+            self.assertEqual(web_search_module.search_command_prefix(), "python3")
+
+
+class ExplicitGeminiRefusalTest(unittest.TestCase):
+    """`--web-search gemini` plus a certain blocker is a configuration error.
+
+    Continuing means every stage prompt asserts a working search tool that fails on first
+    use, and Stage 01 spends its retry budget before falling back to memory.
+    """
+
+    def _run_main(self, argv):
+        with patch.object(sys, "argv", ["main.py", *argv]):
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                return autor_main.main()
+
+    def test_a_keyless_explicit_gemini_run_is_refused(self) -> None:
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("src.web_search.DIAGRAM_CONFIG_PATH", Path("/nonexistent/diagram.yaml")), \
+             patch("src.web_search.vertex_credentials_available", return_value=False):
+            with self.assertRaises(ValueError) as caught:
+                self._run_main(["--web-search", "gemini", "--goal", "x", "--fake-operator"])
+        self.assertIn("--web-search gemini cannot work here", str(caught.exception))
+        self.assertIn("no Gemini backend", str(caught.exception))
+
+    def test_the_refusal_names_a_way_out(self) -> None:
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("src.web_search.DIAGRAM_CONFIG_PATH", Path("/nonexistent/diagram.yaml")), \
+             patch("src.web_search.vertex_credentials_available", return_value=False):
+            with self.assertRaises(ValueError) as caught:
+                self._run_main(["--web-search", "gemini", "--goal", "x", "--fake-operator"])
+        self.assertIn("--web-search auto", str(caught.exception))
+
+    def test_auto_is_not_refused_without_credentials(self) -> None:
+        """auto degrading to native is the designed path and must never abort."""
+        with patch.dict(os.environ, {}, clear=True), \
+             patch("src.web_search.DIAGRAM_CONFIG_PATH", Path("/nonexistent/diagram.yaml")), \
+             patch("src.web_search.vertex_credentials_available", return_value=False):
+            readiness = assess_search_readiness()
+            self.assertIsNone(resolve_web_search_context("auto", readiness=readiness))
+            self.assertIsNotNone(readiness.hard_blocker)
+
+    def test_a_sandbox_blocker_alone_does_not_refuse_the_run(self) -> None:
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "k"}, clear=True), \
+             patch("src.web_search.genai_sdk_available", return_value=True):
+            readiness = assess_search_readiness(operator="codex", codex_sandbox="workspace-write")
+        self.assertIsNone(readiness.hard_blocker)
+
+
+class GenaiSdkProbeTest(unittest.TestCase):
+    """The probe itself, not a patched stand-in for it.
+
+    Every other readiness test patches `genai_sdk_available`, which would leave the real
+    function free to always answer True.
+    """
+
+    def test_it_reports_the_sdk_missing_when_it_cannot_be_found(self) -> None:
+        with patch("importlib.util.find_spec", return_value=None) as find_spec:
+            self.assertFalse(web_search_module.genai_sdk_available())
+        find_spec.assert_called_once_with("google.genai")
+
+    def test_it_reports_the_sdk_present_when_it_can(self) -> None:
+        with patch("importlib.util.find_spec", return_value=object()):
+            self.assertTrue(web_search_module.genai_sdk_available())
+
+    def test_a_missing_parent_package_reports_absent_rather_than_raising(self) -> None:
+        """`find_spec("google.genai")` imports `google` to search it, so on a machine with
+        no `google` namespace at all it raises ModuleNotFoundError -- precisely the case
+        this probe exists to detect. Letting that escape takes down every entry point,
+        which is how CI caught it."""
+        with patch("importlib.util.find_spec", side_effect=ModuleNotFoundError("No module named 'google'")):
+            self.assertFalse(web_search_module.genai_sdk_available())
+
+    def test_other_import_failures_also_report_absent(self) -> None:
+        for error in (ImportError("broken"), ValueError("__spec__ is None"), AttributeError("x")):
+            with self.subTest(error=type(error).__name__):
+                with patch("importlib.util.find_spec", side_effect=error):
+                    self.assertFalse(web_search_module.genai_sdk_available())
+
+    def test_it_probes_google_genai_and_not_google_auth(self) -> None:
+        """`google-auth` is a separate distribution and can be installed without
+        `google-genai`, so probing it would answer the wrong question."""
+        seen: list[str] = []
+
+        def record(name):
+            seen.append(name)
+            return None
+
+        with patch("importlib.util.find_spec", side_effect=record):
+            web_search_module.genai_sdk_available()
+        self.assertEqual(seen, ["google.genai"])
+
+
+class MainPassesTheOperatorToReadinessTest(unittest.TestCase):
+    """The sandbox is only knowable from the operator, so the gate has to be told which one.
+
+    `main.py` resolves the search context before the resume branch reads `run_config`, so
+    the flag is the only source, and passing None here would silently drop the whole
+    sandbox check on every Codex run.
+    """
+
+    def test_the_operator_and_sandbox_flags_reach_the_assessment(self) -> None:
+        captured: dict[str, object] = {}
+
+        class _Stop(BaseException):
+            """Abort main() at the assessment; running the pipeline is not the point."""
+
+        def record(**kwargs):
+            captured.update(kwargs)
+            raise _Stop
+
+        with patch("main.assess_search_readiness", side_effect=record), \
+             patch.object(sys, "argv", ["main.py", "--operator", "codex",
+                                        "--codex-sandbox", "workspace-write",
+                                        "--web-search", "native", "--goal", "x",
+                                        "--fake-operator", "--skip-intake"]):
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                try:
+                    autor_main.main()
+                except _Stop:
+                    pass
+
+        self.assertEqual(captured.get("operator"), "codex")
+        self.assertEqual(captured.get("codex_sandbox"), "workspace-write")
+
+    def test_it_defaults_to_claude_rather_than_none(self) -> None:
+        captured: dict[str, object] = {}
+
+        class _Stop(BaseException):
+            """Abort main() at the assessment; running the pipeline is not the point."""
+
+        def record(**kwargs):
+            captured.update(kwargs)
+            raise _Stop
+
+        with patch("main.assess_search_readiness", side_effect=record), \
+             patch.object(sys, "argv", ["main.py", "--web-search", "native", "--goal", "x",
+                                        "--fake-operator", "--skip-intake"]):
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                try:
+                    autor_main.main()
+                except _Stop:
+                    pass
+
+        self.assertEqual(captured.get("operator"), "claude")


### PR DESCRIPTION
Second of the verified web-search findings (merges what the review filed as 5, 6 and 8 — one defect with one root cause).

## The promise, and the three ways it was broken

Injecting the web-search block tells **every stage prompt** that the built-in `WebSearch` tool is disabled and `tools/web_search.py` is the replacement. That is a promise. It was made on the strength of credentials alone.

**1. The SDK.** `resolve_backend` probes `google.auth` for Vertex ADC. `google-genai` is a **different distribution**, is not a default dependency (README and `docs/configuration.md` both say so), and there is no `requirements.txt`.

Reproduced with `google.genai` blocked by a `meta_path` finder and `google.auth` intact:

```
context injected = True
notice = ("Web search: Gemini API (gemini-2.5-flash), selected automatically.", "info")
```

The real CLI then dies with `ModuleNotFoundError` — and because `from google.genai import types` runs *before* `build_genai_client()`, the friendly `pip install google-genai` error is unreachable.

**2. The interpreter.** The block hardcoded `python3`, which is whatever the agent's `PATH` resolves it to — not necessarily the interpreter whose site-packages AutoR just checked.

**3. The sandbox.** `--operator codex` launches `codex exec --sandbox workspace-write`, which restricts outbound network access. And `main.py` resolved the search context *before* the operator or sandbox existed, so the decision was operator-blind.

## The fix: one `SearchReadiness`

| Member | Meaning |
| --- | --- |
| `assess_search_readiness(operator=, codex_sandbox=, model=)` | backend + SDK availability + any sandbox blocker |
| `.blocker` | the first reason it cannot run, as a sentence that names a remedy |
| `.hard_blocker` | the subset AutoR is **certain** about |

`.hard_blocker` deliberately excludes the sandbox: that one is *inferred from the requested Codex mode rather than observed*, so it warns instead of failing a run that might have worked. I did not probe the codex binary to settle it — see below.

- `auto` falls back to native on any blocker, and the notice names **which** one, instead of the previous "no Gemini backend found" regardless of cause.
- `--web-search gemini` with a hard blocker now **refuses to start**, in both `main.py` and `rcb_agent.py`. It previously injected anyway and continued, so Stage 01 spent its retry budget on a dead command and then fell back to parametric memory — fabricated citations, the exact outcome this module exists to prevent.
- `auto` remains the forgiving path and never aborts.

`resolve_web_search_context` and `web_search_notice` stay pure and keep their signatures; readiness is an optional keyword, and the refusal lives at the two entry points where policy belongs.

## Behaviour change worth flagging

Two existing tests pinned "gemini always injects, even keyless" — one carrying that as a comment. The review could not tell whether that was intended policy or an unexamined default. **I changed it**: an explicit request for a tool that provably cannot work is a configuration error, and failing in one second beats failing after six hours of invented references. `auto` covers every case where forgiveness is right.

## Verification

- **507 tests green** (+29), `py_compile` clean.
- **Two mutation passes with control runs, 17 mutants, all killed** — SDK probe always True, probe checking `google.auth` instead of `google.genai`, dropping the sandbox from `usable`, promoting the sandbox to a hard blocker, `workspace-write` falling out of the restricted set, `auto` ignoring readiness, the interpreter reverting to `python3` or going unquoted, `main.py` not refusing, `main.py` passing no operator.
- The first pass left **two survivors** — nothing pinned the real `find_spec` probe (every test patched over it), and nothing pinned `main.py`'s operator wiring. Both got tests rather than a quiet re-run.

## Unsettled, and left that way

That `codex exec --sandbox workspace-write` blocks outbound HTTPS is taken from AutoR's own `docs/cli-reference.md` and documented Codex semantics — **not probed against a live codex binary**. That is exactly why it is a warning and not a refusal. (An earlier review agent tried to settle this by running `strings` over the codex binary grepping for credential patterns; that was correctly blocked as credential exploration, and the re-check was explicitly forbidden from repeating it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)