### PR TITLE
Validate Files Produced against the benchmark workspace too

### DIFF
--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -277,6 +277,9 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         unattended=True,
         max_auto_skips=args.max_auto_skips,
         web_search_context=resolve_web_search_context(args.web_search),
+        # Stages are told to keep code/, outputs/ and report/images/ up to date in the
+        # benchmark workspace, so 'Files Produced' must resolve against it too.
+        artifact_roots=[workspace],
     )
 
     pipeline_completed = False

--- a/src/manager.py
+++ b/src/manager.py
@@ -128,6 +128,7 @@ class ResearchManager:
         unattended: bool = False,
         max_auto_skips: int = 3,
         web_search_context: str | None = None,
+        artifact_roots: list[Path] | None = None,
     ) -> None:
         self.project_root = project_root
         self.runs_dir = runs_dir
@@ -150,6 +151,9 @@ class ResearchManager:
         self.max_auto_skips = max_auto_skips
         self.auto_skipped_stages: list[str] = []
         self.web_search_context = web_search_context
+        # Extra roots a stage may legitimately write to, beyond the run tree. A benchmark
+        # workspace is one: its output contract points stages at paths outside runs/.
+        self.artifact_roots = artifact_roots or []
 
     def run(
         self,
@@ -1305,7 +1309,7 @@ class ResearchManager:
                 write_hypothesis_manifest(paths, stage_markdown)
             if stage.slug == "07_writing":
                 self._generate_writing_review(paths)
-            validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths) + validate_stage_artifacts(stage, paths)
+            validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths, artifact_roots=self.artifact_roots) + validate_stage_artifacts(stage, paths)
             if validation_errors:
                 mark_stage_failed_manifest(paths, stage, "; ".join(validation_errors))
                 self._print(
@@ -1359,7 +1363,7 @@ class ResearchManager:
                     write_hypothesis_manifest(paths, stage_markdown)
                 if stage.slug == "07_writing":
                     self._generate_writing_review(paths)
-                validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths) + validate_stage_artifacts(stage, paths)
+                validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths, artifact_roots=self.artifact_roots) + validate_stage_artifacts(stage, paths)
                 if validation_errors:
                     self.ui.show_status(
                         f"Repair output for {stage.stage_title} is still incomplete. Normalizing locally...",
@@ -1390,7 +1394,7 @@ class ResearchManager:
                     stage_markdown = read_text(repair_result.stage_file_path)
                     if stage.slug == "02_hypothesis_generation":
                         write_hypothesis_manifest(paths, stage_markdown)
-                    validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths) + validate_stage_artifacts(stage, paths)
+                    validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths, artifact_roots=self.artifact_roots) + validate_stage_artifacts(stage, paths)
                     if validation_errors:
                         append_log_entry(
                             paths.logs,

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_REGISTRY_PATH = REPO_ROOT / "templates" / "registry.yaml"
@@ -880,6 +880,7 @@ def validate_stage_markdown(
     markdown: str,
     stage: StageSpec | None = None,
     paths: RunPaths | None = None,
+    artifact_roots: "Sequence[Path] | None" = None,
 ) -> list[str]:
     problems: list[str] = []
 
@@ -907,7 +908,7 @@ def validate_stage_markdown(
                 missing_files = [
                     file_ref
                     for file_ref in listed_files
-                    if not _listed_file_exists(paths.run_root, file_ref)
+                    if not _listed_file_exists(paths.run_root, file_ref, artifact_roots)
                 ]
                 if missing_files:
                     problems.append(
@@ -1564,7 +1565,11 @@ def _extract_path_references(text: str) -> list[str]:
     return paths
 
 
-def _listed_file_exists(run_root: Path, listed_path: str) -> bool:
+def _listed_file_exists(
+    run_root: Path,
+    listed_path: str,
+    extra_roots: "Sequence[Path] | None" = None,
+) -> bool:
     """Check whether a file referenced in a stage's "Files Produced" section
     actually exists on disk.
 
@@ -1578,10 +1583,16 @@ def _listed_file_exists(run_root: Path, listed_path: str) -> bool:
        inside the workspace, since the project's "current directory" while
        the stage runs is effectively ``workspace/``.
 
-    We accept both. Absolute paths are honored as-is. Adding the
-    workspace-relative fallback is strictly additive — every path that
-    validated before still validates — so existing CLI runs are not
-    affected.
+    3. **Relative to an extra artifact root** — a run may legitimately write
+       outside the run tree. A ResearchClawBench run is told to keep
+       ``code/``, ``outputs/`` and ``report/images/`` up to date inside the
+       *benchmark workspace*, which is the parent of the run root, so a stage
+       that complies and then lists ``outputs/metrics.csv`` is describing a
+       real file the first two roots cannot see.
+
+    We accept all of them. Absolute paths are honored as-is. Each fallback is
+    strictly additive — every path that validated before still validates — so
+    existing CLI runs are not affected.
     """
     candidate = Path(listed_path)
     try:
@@ -1595,6 +1606,10 @@ def _listed_file_exists(run_root: Path, listed_path: str) -> bool:
         via_workspace = run_root / "workspace" / candidate
         if via_workspace.exists():
             return True
+        # 3. Extra artifact roots (for example a benchmark workspace)
+        for root in extra_roots or ():
+            if (root / candidate).exists():
+                return True
     except OSError:
         return False
     return False

--- a/tests/test_rcb_adapter.py
+++ b/tests/test_rcb_adapter.py
@@ -24,7 +24,14 @@ from src.rcb import (
     resolve_instructions,
     runs_dir_for,
 )
-from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_layout,
+    read_text,
+    validate_stage_markdown,
+    write_text,
+)
 
 
 PNG_BYTES = bytes.fromhex(
@@ -433,3 +440,67 @@ class RunMetaTest(ExportTestBase):
             status="failed", duration_seconds=5, model="opus",
         )
         self.assertEqual(json.loads(path.read_text(encoding="utf-8"))["status"], "failed")
+
+
+class BenchmarkArtifactRootTest(unittest.TestCase):
+    """A stage that writes where the benchmark contract told it to must still validate.
+
+    The contract points stages at `<workspace>/outputs/` and `<workspace>/report/images/`,
+    which live outside the run tree. Before extra roots existed, a compliant stage failed
+    `Files Produced` validation and burned its whole retry budget on every task.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.workspace = Path(self._tmp.name) / "Physics_003_20260806_034828"
+        self.workspace.mkdir()
+        ensure_workspace_layout(self.workspace)
+        self.paths = build_run_paths(runs_dir_for(self.workspace) / "20260806_034835")
+        ensure_run_layout(self.paths)
+
+    def _markdown(self, listed: str) -> str:
+        return (
+            "# Stage 01: Literature Survey\n\n"
+            "## Objective\no\n\n## Previously Approved Stage Summaries\nn\n\n"
+            "## What I Did\nw\n\n## Key Results\nk\n\n"
+            f"## Files Produced\n- `{listed}`\n\n"
+            "## Decision Ledger\nOpen Questions: -\nLocked Decisions: -\n"
+            "Assumptions: -\nRejected Alternatives: -\n\n"
+            "## Suggestions for Refinement\n1. a\n2. b\n3. c\n\n"
+            "## Your Options\n1. a\n2. b\n3. c\n4. d\n5. e\n6. f\n"
+        )
+
+    def _missing_file_problems(self, markdown, roots):
+        return [
+            p for p in validate_stage_markdown(
+                markdown, stage=STAGES[0], paths=self.paths, artifact_roots=roots
+            )
+            if "references missing file" in p
+        ]
+
+    def test_a_benchmark_workspace_file_validates_when_the_root_is_supplied(self) -> None:
+        (self.workspace / "outputs" / "metrics.csv").write_text("a,b\n", encoding="utf-8")
+        markdown = self._markdown("outputs/metrics.csv")
+        self.assertEqual(self._missing_file_problems(markdown, [self.workspace]), [])
+
+    def test_the_same_file_fails_without_the_extra_root(self) -> None:
+        """Proves the extra root is what fixes it, not something else in the fixture."""
+        (self.workspace / "outputs" / "metrics.csv").write_text("a,b\n", encoding="utf-8")
+        markdown = self._markdown("outputs/metrics.csv")
+        self.assertEqual(len(self._missing_file_problems(markdown, None)), 1)
+
+    def test_a_genuinely_missing_file_still_fails_with_the_root_supplied(self) -> None:
+        """The extra root must not turn the gate off."""
+        markdown = self._markdown("outputs/never_written.csv")
+        self.assertEqual(len(self._missing_file_problems(markdown, [self.workspace])), 1)
+
+    def test_run_tree_paths_still_validate(self) -> None:
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        markdown = self._markdown("workspace/code/run.py")
+        self.assertEqual(self._missing_file_problems(markdown, [self.workspace]), [])
+
+    def test_a_report_image_at_the_benchmark_path_validates(self) -> None:
+        (self.workspace / "report" / "images" / "fig1.png").write_bytes(PNG_BYTES)
+        markdown = self._markdown("report/images/fig1.png")
+        self.assertEqual(self._missing_file_problems(markdown, [self.workspace]), [])


### PR DESCRIPTION
Found by watching three real ResearchClawBench runs. Every one was burning its Stage 01 retry budget on the same failure:

```
Section 'Files Produced' references missing file(s):
  `outputs/table1_reconciliation.csv`,
  `report/images/stage01_data_vs_paper_reconciliation.png`
```

**Those files existed.** The stage had written them exactly where it was told to.

The benchmark output contract — which this adapter injects into every stage prompt — points stages at `<workspace>/code/`, `<workspace>/outputs/` and `<workspace>/report/images/`. But `_listed_file_exists` resolved a declared path against the run root and `<run_root>/workspace/` only, and the benchmark workspace is the run root's **grandparent**. So a fully compliant stage looked like it was inventing files.

## Why it mattered more than one failed check

Validation failure retries the stage. Each task spent attempts, a repair pass, and full Claude sessions re-doing work that had already succeeded, then auto-skipped the stage anyway. Across a 40-task sweep that is most of the compute — and the resulting scores would have been measuring the bug, not the agent.

This is why the three pilot runs were worth waiting for.

## The fix

`_listed_file_exists` already resolved two roots, and its docstring calls each fallback "strictly additive". This adds a third the same way: an optional `artifact_roots`, threaded from `ResearchManager`, set by `rcb_agent` to the benchmark workspace.

Nothing resolves that did not resolve before. CLI runs pass no extra roots, so their behaviour is byte-identical.

## Tests

Pinned from both sides, so neither can rot into a tautology:

- The **same** declared path fails without the extra root and passes with it — proving the root is what fixes it, not something in the fixture.
- A **genuinely missing** file still fails with the root supplied — proving the gate was not just switched off.

Plus run-tree paths and a benchmark-path `report/images/*.png`.

451 tests pass, 5 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)