### PR TITLE
Stop clipping benchmark runs to a wall clock nothing enforces

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ AI handles execution load; humans steer the research when direction actually mat
 | Seed the run from your own prior papers | `python main.py --paper-corpus ~/papers --goal "..."` |
 | Store runs on another disk | `python main.py --runs-dir /mnt/big-disk/runs --goal "..."` |
 | Raise the per-attempt ceiling for long training runs | `python main.py --stage-timeout 43200 --goal "..."` |
+| Give a stubborn stage more retries | `python main.py --max-attempts 10 --goal "..."` |
 | Skip the intake stage | `python main.py --skip-intake --goal "..."` |
 | Add a generated method diagram to the paper | `python main.py --research-diagram --goal "..."` |
 | Search the web where the agent's own `WebSearch` is disabled | `python main.py --web-search gemini --goal "..."` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -29,7 +29,7 @@ python main.py [--goal GOAL] [--goal-file PATH] [--runs-dir DIR] [--fake-operato
                [--rollback-stage STAGE] [--resources PATH [PATH ...]]
                [--skip-intake] [--research-diagram]
                [--project-root PATH] [--paper-corpus PATH]
-               [--stage-timeout SECONDS]
+               [--stage-timeout SECONDS] [--max-attempts N]
 ```
 
 ### Goal and run location
@@ -49,6 +49,7 @@ python main.py [--goal GOAL] [--goal-file PATH] [--runs-dir DIR] [--fake-operato
 | `--codex-sandbox MODE` | `workspace-write` | Codex CLI sandbox mode. Only meaningful for `--operator codex`. See [the sandbox modes](#codex-sandbox-modes) below. Persisted in `run_config.json` and preserved on resume. |
 | `--fake-operator` | off | Replace the real backend with a deterministic stub that fabricates a valid stage summary and the placeholder artifacts each stage gate requires, so a fake run completes all nine stages. Use this for smoke tests and for exercising the workflow without spending tokens. It does **not** produce real research artifacts — every placeholder says so in its own contents. |
 | `--stage-timeout SECONDS` | `14400` (4 hours) | Wall-clock ceiling for a single stage attempt. Raise it for long training runs; a stage that exceeds it is treated as a failed attempt. |
+| `--max-attempts N` | `5` | Attempts allowed per stage before AutoR escalates or auto-skips. Each retry re-runs the stage with the previous attempt's validation errors attached, so raising this trades wall-clock for a better chance of clearing the gates. |
 
 #### Codex sandbox modes
 
@@ -194,7 +195,8 @@ control commands are accepted where the UI offers a recovery prompt:
 Anything else is rejected with
 `Unknown control command. Supported commands are '/skip' and '/back <stage>'.`
 
-A stage gets at most `MAX_STAGE_ATTEMPTS` (5, in [`src/utils.py`](../src/utils.py))
+A stage gets at most `--max-attempts` attempts (default `MAX_STAGE_ATTEMPTS`, 5, in
+[`src/utils.py`](../src/utils.py))
 attempts before AutoR stops and escalates to you.
 
 ### Examples
@@ -283,7 +285,8 @@ python rcb_agent.py [--workspace PATH] [--prompt TEXT | --prompt-file PATH]
                     [--operator {claude,codex}] [--model MODEL]
                     [--review-operator {claude,codex}] [--review-model MODEL]
                     [--codex-sandbox MODE] [--venue VENUE]
-                    [--stage-timeout SECONDS] [--max-auto-skips N]
+                    [--stage-timeout SECONDS] [--max-attempts N]
+                    [--max-auto-skips N]
                     [--intake] [--web-search {auto,gemini,native}]
                     [--no-synthesis] [--export-only] [--fake-operator]
 ```
@@ -293,7 +296,8 @@ python rcb_agent.py [--workspace PATH] [--prompt TEXT | --prompt-file PATH]
 | `--workspace PATH` | `.` | Benchmark workspace. The harness runs the agent with this as its working directory, so the default is usually right. |
 | `--prompt TEXT` | — | Benchmark instructions as a literal string. This is what the harness's `<PROMPT>` placeholder expands to. |
 | `--prompt-file PATH` | `<workspace>/INSTRUCTIONS.md` | Read the instructions from a file instead. |
-| `--stage-timeout SECONDS` | `3600` | Lower than `main.py`'s default, because benchmark runs are wall-clock bound. |
+| `--stage-timeout SECONDS` | `14400` | The benchmark harness imposes no timeout of its own — neither the UI runner nor the batch CLI puts one on the agent subprocess — so this is the only thing that can cut a stage short. |
+| `--max-attempts N` | `8` | Higher than `main.py`'s default. An exhausted stage is auto-skipped, and a skipped stage costs real score, so the extra retries are worth their wall-clock. |
 | `--intake` | off | Run Stage 00. Off by default: the benchmark instructions are already a complete task specification. |
 | `--no-synthesis` | off | Skip the operator-backed report synthesis pass and use only the deterministic fallback. |
 | `--export-only` | off | Re-export the most recent run in the workspace without re-running the pipeline. Use this to recover deliverables from an interrupted job. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,7 +263,7 @@ Change them in source if you must, and expect the tests to have an opinion.
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
-| `MAX_STAGE_ATTEMPTS` | 5 | Attempts before a stage escalates to you. |
+| `MAX_STAGE_ATTEMPTS` | 5 | Default attempts before a stage escalates to you. This one *is* overridable per run, with `--max-attempts`. |
 | `DEFAULT_VENUE` | `neurips_2025` | Venue when `--venue` is omitted. |
 | `DEFAULT_CODEX_SANDBOX` | `workspace-write` | Codex sandbox when unspecified. |
 | stage timeout | 14400 s | Per-attempt ceiling — this one *is* a flag, `--stage-timeout`. |

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -159,7 +159,17 @@ carries a figure reference that is absolute, remote, unrenderable, or points at 
 is not there, or publishes more than five figures. A broken figure link is the expensive
 defect here: the judge reads the prose promising a figure and is shown nothing.
 
-### 3. Streams progress
+### 3. Spends the time it is given
+
+Neither the UI runner nor the batch CLI puts a timeout on the agent subprocess — the
+`max_runtime_seconds` in the shipped configs is a ResearchHarness-internal setting, not
+something the harness enforces. Nothing outside AutoR will stop a run, so the adapter's own
+ceilings are the only ones that bind, and they are set for quality rather than thrift:
+`--stage-timeout 14400` and `--max-attempts 8`. Every retry re-runs the stage with its
+validation errors attached, and an exhausted stage is auto-skipped, which is the expensive
+outcome.
+
+### 4. Streams progress
 
 `rcb_agent.py` writes JSON lines to stdout, which the harness captures into
 `_agent_output.jsonl`. The first line carries the model name so the run browser can display
@@ -259,8 +269,11 @@ The search model defaults to `gemini-2.5-flash` and is overridable with
 --review-operator {claude,codex}  Reviewer backend. Default: the execution backend.
 --review-model NAME             Reviewer model. Default: the backend default.
 
---stage-timeout SECONDS  Per stage attempt. Default: 3600, lower than AutoR's interactive
-                         default because benchmark runs are wall-clock bound.
+--stage-timeout SECONDS  Per stage attempt. Default: 14400. The harness enforces no wall
+                         clock of its own, so this is the only thing that can cut a stage
+                         short.
+--max-attempts N         Attempts per stage before it is auto-skipped. Default: 8, higher
+                         than the interactive default because a skipped stage costs score.
 --max-auto-skips N       Stages that may be auto-skipped before aborting. Default: 3.
 --intake                 Run the intake stage. Off by default: the benchmark instructions
                          are already a complete task specification.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -127,7 +127,8 @@ Read the validation errors — they name the exact requirement. The
 
 ### `Stage X failed after 5 attempts. Escalating to user.`
 
-`MAX_STAGE_ATTEMPTS` is exhausted. You are offered skip, roll back, or abort.
+The attempt ceiling is exhausted. You are offered skip, roll back, or abort. Raise it with
+`--max-attempts` when the stage is close but keeps missing one gate.
 
 Repeated failure at the same stage usually means the goal is too broad for the
 stage to complete, or a dependency is missing (no dataset, no GPU, no LaTeX).

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from src.utils import (
     DEFAULT_OUTPUT_FORMAT,
     DEFAULT_VENUE,
     OUTPUT_FORMAT_CLI_CHOICES,
+    MAX_STAGE_ATTEMPTS,
     STAGES,
     build_run_paths,
     load_run_config,
@@ -95,6 +96,14 @@ def parse_args() -> argparse.Namespace:
         default=3,
         help="In unattended mode, the maximum number of stages that may be auto-skipped after "
              "exhausting their retry budget before the run aborts. Defaults to 3.",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=MAX_STAGE_ATTEMPTS,
+        help="Attempts allowed per stage before AutoR escalates or auto-skips. Each retry "
+             "re-runs the stage with the previous attempt's validation errors attached. "
+             f"Defaults to {MAX_STAGE_ATTEMPTS}.",
     )
     parser.add_argument(
         "--review-operator",
@@ -403,6 +412,7 @@ def main() -> int:
             review_model=review_model,
             unattended=unattended,
             max_auto_skips=args.max_auto_skips,
+            max_stage_attempts=args.max_attempts,
             web_search_context=web_search_context,
         )
         return 0 if manager.resume_run(
@@ -452,6 +462,7 @@ def main() -> int:
         review_model=review_model,
         unattended=unattended,
         max_auto_skips=args.max_auto_skips,
+        max_stage_attempts=args.max_attempts,
         web_search_context=web_search_context,
     )
 

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -61,7 +61,13 @@ from src.utils import (  # noqa: E402
 from src.web_search import resolve_web_search_context, web_search_notice  # noqa: E402
 
 
-DEFAULT_STAGE_TIMEOUT = 3600
+#: The harness enforces no wall clock of its own — neither the UI runner nor the batch CLI
+#: puts a timeout on the agent subprocess — so a stage is only ever cut short by this value.
+#: Clipping it buys nothing back except a thinner report.
+DEFAULT_STAGE_TIMEOUT = 14400
+#: More retries than the interactive default: every retry re-runs the stage with its
+#: validation errors attached, and an exhausted stage is auto-skipped, which costs real score.
+DEFAULT_MAX_ATTEMPTS = 8
 #: The benchmark scores report/report.md, which Stage 07 writes. Everything after it is
 #: wall-clock spent on artifacts the judge never opens.
 DEFAULT_FINAL_STAGE = "07_writing"
@@ -135,8 +141,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--stage-timeout",
         type=int,
         default=DEFAULT_STAGE_TIMEOUT,
-        help=f"Seconds allowed per stage attempt. Defaults to {DEFAULT_STAGE_TIMEOUT} "
-             "(lower than AutoR's interactive default, because benchmark runs are wall-clock bound).",
+        help=f"Seconds allowed per stage attempt. Defaults to {DEFAULT_STAGE_TIMEOUT}. "
+             "The benchmark harness imposes no timeout of its own, so this is the only thing "
+             "that can cut a stage short.",
+    )
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=DEFAULT_MAX_ATTEMPTS,
+        help="Attempts allowed per stage before it is auto-skipped. Each retry re-runs the "
+             f"stage with the previous attempt's validation errors attached. Defaults to "
+             f"{DEFAULT_MAX_ATTEMPTS}.",
     )
     parser.add_argument(
         "--max-auto-skips",
@@ -276,6 +291,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         review_model=review_model,
         unattended=True,
         max_auto_skips=args.max_auto_skips,
+        max_stage_attempts=args.max_attempts,
         web_search_context=resolve_web_search_context(args.web_search),
         # Stages are told to keep code/, outputs/ and report/images/ up to date in the
         # benchmark workspace, so 'Files Produced' must resolve against it too.

--- a/src/manager.py
+++ b/src/manager.py
@@ -127,6 +127,7 @@ class ResearchManager:
         review_model: str | None = None,
         unattended: bool = False,
         max_auto_skips: int = 3,
+        max_stage_attempts: int = MAX_STAGE_ATTEMPTS,
         web_search_context: str | None = None,
         artifact_roots: list[Path] | None = None,
     ) -> None:
@@ -149,6 +150,10 @@ class ResearchManager:
         self._jump_target_stage: StageSpec | None = None
         self.unattended = unattended
         self.max_auto_skips = max_auto_skips
+        # Retries are the cheapest quality lever there is: each one re-runs the stage with the
+        # previous attempt's validation errors attached. The ceiling exists to bound a runaway
+        # loop, not to save money, so callers with time to spend should raise it.
+        self.max_stage_attempts = max_stage_attempts
         self.auto_skipped_stages: list[str] = []
         self.web_search_context = web_search_context
         # Extra roots a stage may legitimately write to, beyond the run tree. A benchmark
@@ -424,13 +429,13 @@ class ResearchManager:
         mark_stage_execution_started(paths, stage)
 
         while True:
-            if attempt_no > MAX_STAGE_ATTEMPTS:
+            if attempt_no > self.max_stage_attempts:
                 self.ui.show_status(
-                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts. Escalating to user.",
+                    f"{stage.stage_title} failed after {self.max_stage_attempts} attempts. Escalating to user.",
                     level="error",
                 )
                 append_log_entry(paths.logs, f"{stage.slug} max_attempts_exceeded",
-                                 f"Stopped after {MAX_STAGE_ATTEMPTS} attempts.")
+                                 f"Stopped after {self.max_stage_attempts} attempts.")
                 return False
             self.ui.show_stage_start(stage.stage_title, attempt_no, continue_session)
             prompt = self._build_stage_prompt(paths, stage, revision_feedback, continue_session)
@@ -706,13 +711,13 @@ class ResearchManager:
         continue_session = False
 
         while True:
-            if attempt_no > MAX_STAGE_ATTEMPTS:
+            if attempt_no > self.max_stage_attempts:
                 self.ui.show_status(
-                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts. Escalating to user.",
+                    f"{stage.stage_title} failed after {self.max_stage_attempts} attempts. Escalating to user.",
                     level="error",
                 )
                 append_log_entry(paths.logs, f"project_bootstrap max_attempts_exceeded",
-                                 f"Stopped after {MAX_STAGE_ATTEMPTS} attempts.")
+                                 f"Stopped after {self.max_stage_attempts} attempts.")
                 return None
             self.ui.show_stage_start(stage.stage_title, attempt_no, continue_session)
             prompt = self._build_project_bootstrap_prompt(
@@ -867,13 +872,13 @@ class ResearchManager:
         continue_session = False
 
         while True:
-            if attempt_no > MAX_STAGE_ATTEMPTS:
+            if attempt_no > self.max_stage_attempts:
                 self.ui.show_status(
-                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts. Escalating to user.",
+                    f"{stage.stage_title} failed after {self.max_stage_attempts} attempts. Escalating to user.",
                     level="error",
                 )
                 append_log_entry(paths.logs, f"bootstrap max_attempts_exceeded",
-                                 f"Stopped after {MAX_STAGE_ATTEMPTS} attempts.")
+                                 f"Stopped after {self.max_stage_attempts} attempts.")
                 return False
             self.ui.show_stage_start(stage.stage_title, attempt_no, continue_session)
             prompt = self._build_bootstrap_prompt(paths, stage, corpus_prompt_section, revision_feedback, continue_session)
@@ -1196,13 +1201,13 @@ class ResearchManager:
                 pass
 
         while True:
-            if loop_attempts >= MAX_STAGE_ATTEMPTS:
+            if loop_attempts >= self.max_stage_attempts:
                 error = (
-                    f"Exceeded {MAX_STAGE_ATTEMPTS} attempts in the current stage run. "
+                    f"Exceeded {self.max_stage_attempts} attempts in the current stage run. "
                     f"Last validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
                 )
                 self.ui.show_status(
-                    f"{stage.stage_title} failed after {MAX_STAGE_ATTEMPTS} attempts in this run.",
+                    f"{stage.stage_title} failed after {self.max_stage_attempts} attempts in this run.",
                     level="error",
                 )
                 append_log_entry(

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -224,11 +224,53 @@ class TestRunStageMaxAttempts(unittest.TestCase):
         self.operator.run_stage.assert_called_once()
         self.assertTrue(self.paths.stage_file(stage).exists())
 
+    def test_the_attempt_ceiling_defaults_to_the_module_value_and_can_be_raised(self):
+        from src.manager import ResearchManager
+
+        default = ResearchManager(
+            project_root=self.repo_root,
+            runs_dir=self.runs_dir,
+            operator=self.operator,
+            ui=self.ui,
+        )
+        self.assertEqual(default.max_stage_attempts, MAX_STAGE_ATTEMPTS)
+
+        # A caller with time to spend can buy more retries, which is the whole point: each one
+        # re-runs the stage with the previous attempt's validation errors attached.
+        raised = ResearchManager(
+            project_root=self.repo_root,
+            runs_dir=self.runs_dir,
+            operator=self.operator,
+            ui=self.ui,
+            max_stage_attempts=MAX_STAGE_ATTEMPTS + 4,
+        )
+        self.assertEqual(raised.max_stage_attempts, MAX_STAGE_ATTEMPTS + 4)
+
+    def test_the_recorded_ceiling_is_the_instance_value_not_a_constant(self):
+        # Pinning a value other than 0 is what proves the loop reads self.max_stage_attempts:
+        # a hardcoded constant would report 5 here, and the old module-level patch would too.
+        stage = STAGES[0]
+        self.manager.max_stage_attempts = 2
+        self.manager._ask_choice = MagicMock(return_value="3")
+
+        from src.utils import write_attempt_count
+
+        write_attempt_count(self.paths, stage, 2)
+
+        self.manager._run_stage(self.paths, stage)
+
+        manifest = load_run_manifest(self.paths.run_manifest)
+        self.assertIsNotNone(manifest)
+        entry = next(item for item in manifest.stages if item.slug == stage.slug)
+        self.assertIn("Exceeded 2 attempts", entry.last_error or "")
+
     def test_run_stage_marks_manifest_failed_when_attempt_window_is_exhausted(self):
         stage = STAGES[0]
 
-        with patch("src.manager.MAX_STAGE_ATTEMPTS", 0):
-            result = self.manager._run_stage(self.paths, stage)
+        # The ceiling is per-manager, not a module global: patching the constant would no
+        # longer reach the loop that reads it.
+        self.manager.max_stage_attempts = 0
+        result = self.manager._run_stage(self.paths, stage)
 
         self.assertFalse(result)
         manifest = load_run_manifest(self.paths.run_manifest)

--- a/tests/test_manager_smoke.py
+++ b/tests/test_manager_smoke.py
@@ -729,8 +729,8 @@ class ManagerSmokeTests(unittest.TestCase):
             manager.ui.input_stream = DummyTTY()
             manager.ui.read_single_line = MagicMock(return_value="1")
 
-            with patch("src.manager.MAX_STAGE_ATTEMPTS", 0):
-                approved = manager._run_stage(paths, STAGE_01)
+            manager.max_stage_attempts = 0
+            approved = manager._run_stage(paths, STAGE_01)
 
             self.assertTrue(approved)
             stage_markdown = read_text(paths.stage_file(STAGE_01))


### PR DESCRIPTION
`rcb_agent.py` capped a stage attempt at 3600s *"because benchmark runs are wall-clock bound"*. They are not.

Neither ResearchClawBench's UI runner (`evaluation/run_task.py`) nor its batch CLI (`evaluation/cli_eval.py`) puts a timeout on the agent subprocess — I checked both. The `max_runtime_seconds: 10800` in the shipped `eval_configs/*.yaml` is a ResearchHarness-internal setting passed through as an env var, not something the harness enforces. Nothing outside AutoR stops a run, so the only effect of the low ceiling was a thinner report.

## Changes

- `--stage-timeout` defaults to `14400` for benchmark runs, matching the interactive default.
- **`--max-attempts`** is now a flag on both entry points: `MAX_STAGE_ATTEMPTS` (5) interactively, `8` for benchmark runs. Every retry re-runs the stage with the previous attempt's validation errors attached, and an exhausted stage is auto-skipped — which is the outcome that actually costs score.

The ceiling moves from a module constant read directly by four retry loops to `ResearchManager.max_stage_attempts`.

## On the tests

Two existing tests forced exhaustion by patching `src.manager.MAX_STAGE_ATTEMPTS`. That reached through a module global rather than the seam the loops read, so they broke — correctly. They now pass the ceiling through the constructor.

Verified by mutation: reverting the four loops to the constant kills three tests (`test_run_stage_marks_manifest_failed_when_attempt_window_is_exhausted`, `test_the_recorded_ceiling_is_the_instance_value_not_a_constant`, `test_stage_can_be_skipped_after_exhausted_retries`); the control run passes. The new ceiling test pins a value other than `0` on purpose — a hardcoded constant would report `5` there, and so would the old module-level patch.

485 tests pass.

## Not changed

The five-figure budget from #111. That is a scoring constraint — the judge is shown at most five images — not a resource one, and raising it would lose score rather than buy any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)