### PR TITLE
Count benchmark-path artifacts toward the stage gates

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -159,6 +159,14 @@ class ResearchManager:
         # Extra roots a stage may legitimately write to, beyond the run tree. A benchmark
         # workspace is one: its output contract points stages at paths outside runs/.
         self.artifact_roots = artifact_roots or []
+        # Where a stage's machine-readable output may legitimately land outside the run
+        # tree. The benchmark's read-only data/ is excluded on purpose: it is always
+        # populated, so counting it would make the stage-03 gate vacuous.
+        self.artifact_dirs: dict[str, list[Path]] = {
+            "data": [root / "outputs" for root in self.artifact_roots],
+            "results": [root / "outputs" for root in self.artifact_roots],
+            "figures": [root / "report" / "images" for root in self.artifact_roots],
+        }
 
     def run(
         self,
@@ -1314,7 +1322,7 @@ class ResearchManager:
                 write_hypothesis_manifest(paths, stage_markdown)
             if stage.slug == "07_writing":
                 self._generate_writing_review(paths)
-            validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths, artifact_roots=self.artifact_roots) + validate_stage_artifacts(stage, paths)
+            validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths, artifact_roots=self.artifact_roots) + validate_stage_artifacts(stage, paths, self.artifact_dirs)
             if validation_errors:
                 mark_stage_failed_manifest(paths, stage, "; ".join(validation_errors))
                 self._print(
@@ -1368,7 +1376,7 @@ class ResearchManager:
                     write_hypothesis_manifest(paths, stage_markdown)
                 if stage.slug == "07_writing":
                     self._generate_writing_review(paths)
-                validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths, artifact_roots=self.artifact_roots) + validate_stage_artifacts(stage, paths)
+                validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths, artifact_roots=self.artifact_roots) + validate_stage_artifacts(stage, paths, self.artifact_dirs)
                 if validation_errors:
                     self.ui.show_status(
                         f"Repair output for {stage.stage_title} is still incomplete. Normalizing locally...",
@@ -1399,7 +1407,7 @@ class ResearchManager:
                     stage_markdown = read_text(repair_result.stage_file_path)
                     if stage.slug == "02_hypothesis_generation":
                         write_hypothesis_manifest(paths, stage_markdown)
-                    validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths, artifact_roots=self.artifact_roots) + validate_stage_artifacts(stage, paths)
+                    validation_errors = validate_stage_markdown(stage_markdown, stage=stage, paths=paths, artifact_roots=self.artifact_roots) + validate_stage_artifacts(stage, paths, self.artifact_dirs)
                     if validation_errors:
                         append_log_entry(
                             paths.logs,

--- a/src/utils.py
+++ b/src/utils.py
@@ -5,7 +5,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_REGISTRY_PATH = REPO_ROOT / "templates" / "registry.yaml"
@@ -1099,9 +1099,36 @@ def validate_markdown_report(paths: RunPaths) -> list[str]:
     return problems
 
 
-def validate_stage_artifacts(stage: StageSpec, paths: RunPaths) -> list[str]:
+def validate_stage_artifacts(
+    stage: StageSpec,
+    paths: RunPaths,
+    artifact_dirs: "Mapping[str, Sequence[Path]] | None" = None,
+) -> list[str]:
+    """Check that a stage produced the machine-readable artifacts its gate requires.
+
+    ``artifact_dirs`` adds extra directories to search per category (``data``, ``results``,
+    ``figures``). A ResearchClawBench run needs them: its output contract points stages at
+    ``<workspace>/outputs/`` and ``<workspace>/report/images/``, which sit outside the run
+    tree, so a compliant stage would otherwise look like it produced nothing.
+
+    The benchmark's own read-only ``data/`` is deliberately *not* one of these. It is always
+    populated, so counting it would make the stage-03 gate pass without the stage producing
+    anything — the gate exists to prove work happened, not that inputs exist.
+    """
     problems: list[str] = []
     freshness_cutoff = stage_execution_started_at(paths, stage)
+
+    def dirs_for(category: str, primary: Path) -> list[Path]:
+        return [primary, *(artifact_dirs or {}).get(category, ())]
+
+    def count_in(category: str, primary: Path, suffixes) -> int:
+        return sum(_count_files_with_suffixes(d, suffixes) for d in dirs_for(category, primary))
+
+    def recent_in(category: str, primary: Path, suffixes, cutoff) -> bool:
+        return any(
+            _has_recent_files_with_suffixes(d, suffixes, cutoff)
+            for d in dirs_for(category, primary)
+        )
 
     if stage.number == 1:
         from .evidence_ledger import validate_literature_evidence
@@ -1110,19 +1137,19 @@ def validate_stage_artifacts(stage: StageSpec, paths: RunPaths) -> list[str]:
             problems.append(f"{stage.stage_title}: {problem}")
 
     if stage.number >= 3:
-        if _count_files_with_suffixes(paths.data_dir, MACHINE_DATA_SUFFIXES) == 0:
+        if count_in("data", paths.data_dir, MACHINE_DATA_SUFFIXES) == 0:
             problems.append(
                 f"{stage.stage_title} requires machine-readable data artifacts under workspace/data, not only markdown notes."
             )
-        elif stage.number == 3 and freshness_cutoff is not None and not _has_recent_files_with_suffixes(
-            paths.data_dir, MACHINE_DATA_SUFFIXES, freshness_cutoff
+        elif stage.number == 3 and freshness_cutoff is not None and not recent_in(
+            "data", paths.data_dir, MACHINE_DATA_SUFFIXES, freshness_cutoff
         ):
             problems.append(
                 f"{stage.stage_title} requires machine-readable data artifacts produced or updated during the current stage execution."
             )
 
     if stage.number >= 5:
-        if _count_files_with_suffixes(paths.results_dir, RESULT_SUFFIXES) == 0:
+        if count_in("results", paths.results_dir, RESULT_SUFFIXES) == 0:
             problems.append(
                 f"{stage.stage_title} requires machine-readable result artifacts under workspace/results."
             )
@@ -1137,12 +1164,12 @@ def validate_stage_artifacts(stage: StageSpec, paths: RunPaths) -> list[str]:
                 problems.append(f"{stage.stage_title}: {problem}")
 
     if stage.number >= 6:
-        if _count_files_with_suffixes(paths.figures_dir, FIGURE_SUFFIXES) == 0:
+        if count_in("figures", paths.figures_dir, FIGURE_SUFFIXES) == 0:
             problems.append(
                 f"{stage.stage_title} requires figure artifacts under workspace/figures."
             )
-        elif stage.number == 6 and freshness_cutoff is not None and not _has_recent_files_with_suffixes(
-            paths.figures_dir, FIGURE_SUFFIXES, freshness_cutoff
+        elif stage.number == 6 and freshness_cutoff is not None and not recent_in(
+            "figures", paths.figures_dir, FIGURE_SUFFIXES, freshness_cutoff
         ):
             problems.append(
                 f"{stage.stage_title} requires figures produced or updated during the current stage execution."

--- a/tests/test_rcb_adapter.py
+++ b/tests/test_rcb_adapter.py
@@ -29,6 +29,7 @@ from src.utils import (
     build_run_paths,
     ensure_run_layout,
     read_text,
+    validate_stage_artifacts,
     validate_stage_markdown,
     write_text,
 )
@@ -504,3 +505,79 @@ class BenchmarkArtifactRootTest(unittest.TestCase):
         (self.workspace / "report" / "images" / "fig1.png").write_bytes(PNG_BYTES)
         markdown = self._markdown("report/images/fig1.png")
         self.assertEqual(self._missing_file_problems(markdown, [self.workspace]), [])
+
+
+class BenchmarkArtifactDirTest(unittest.TestCase):
+    """Stage gates must see artifacts written to the benchmark's output paths.
+
+    Same root cause as the `Files Produced` bug: the benchmark contract points stages at
+    `<workspace>/outputs/` and `<workspace>/report/images/`, outside the run tree. Without
+    the extra directories a compliant stage looks like it produced nothing, and stages 03,
+    05 and 06 burn their whole retry budget.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.workspace = Path(self._tmp.name) / "Physics_003_20260806_043103"
+        self.workspace.mkdir()
+        ensure_workspace_layout(self.workspace)
+        self.paths = build_run_paths(runs_dir_for(self.workspace) / "20260806_043110")
+        ensure_run_layout(self.paths)
+        self.dirs = {
+            "data": [self.workspace / "outputs"],
+            "results": [self.workspace / "outputs"],
+            "figures": [self.workspace / "report" / "images"],
+        }
+
+    def _problems(self, stage_number: int, dirs):
+        stage = next(s for s in STAGES if s.number == stage_number)
+        return validate_stage_artifacts(stage, self.paths, dirs)
+
+    def _has(self, problems, needle):
+        return any(needle in p for p in problems)
+
+    def test_stage_03_accepts_data_written_to_the_benchmark_outputs(self) -> None:
+        (self.workspace / "outputs" / "profile.json").write_text('{"n": 1}', encoding="utf-8")
+        self.assertFalse(self._has(self._problems(3, self.dirs), "machine-readable data artifacts"))
+
+    def test_the_same_file_fails_without_the_extra_dirs(self) -> None:
+        (self.workspace / "outputs" / "profile.json").write_text('{"n": 1}', encoding="utf-8")
+        self.assertTrue(self._has(self._problems(3, None), "machine-readable data artifacts"))
+
+    def test_stage_03_still_fails_when_nothing_was_produced(self) -> None:
+        self.assertTrue(self._has(self._problems(3, self.dirs), "machine-readable data artifacts"))
+
+    def test_stage_06_accepts_figures_at_the_benchmark_path(self) -> None:
+        (self.workspace / "report" / "images" / "fig1.png").write_bytes(PNG_BYTES)
+        self.assertFalse(self._has(self._problems(6, self.dirs), "figure artifacts"))
+
+    def test_stage_06_still_fails_with_no_figures_anywhere(self) -> None:
+        self.assertTrue(self._has(self._problems(6, self.dirs), "figure artifacts"))
+
+    def test_the_benchmark_input_data_is_not_counted(self) -> None:
+        """The gate proves the stage did work; read-only inputs must not satisfy it."""
+        (self.workspace / "data").mkdir(exist_ok=True)
+        (self.workspace / "data" / "given.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+        self.assertTrue(self._has(self._problems(3, self.dirs), "machine-readable data artifacts"))
+
+    def test_run_tree_artifacts_still_satisfy_the_gate(self) -> None:
+        write_text(self.paths.data_dir / "derived.csv", "a,b\n1,2\n")
+        self.assertFalse(self._has(self._problems(3, self.dirs), "machine-readable data artifacts"))
+
+
+class ManagerArtifactDirWiringTest(unittest.TestCase):
+    def test_the_manager_maps_roots_to_the_benchmark_output_paths(self) -> None:
+        from src.manager import ResearchManager
+
+        ws = Path("/tmp/ws")
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=Path("/tmp/runs"),
+            operator=type("Op", (), {"model": "m", "backend_name": "claude"})(),
+            artifact_roots=[ws],
+        )
+        self.assertEqual(manager.artifact_dirs["data"], [ws / "outputs"])
+        self.assertEqual(manager.artifact_dirs["figures"], [ws / "report" / "images"])
+        # The read-only benchmark input must never appear.
+        self.assertNotIn(ws / "data", manager.artifact_dirs["data"])


### PR DESCRIPTION
Same root cause as #114, one layer deeper. That fix taught `Files Produced` about the benchmark workspace; the **stage artifact gates** still only looked inside the run tree:

```
Stage 03 requires machine-readable data artifacts under workspace/data
Stage 05 requires machine-readable result artifacts under workspace/results
Stage 06 requires figure artifacts under workspace/figures
```

The benchmark output contract points stages at `<workspace>/outputs/` and `<workspace>/report/images/`, outside the run tree. A stage that complied produced real CSVs and PNGs and was told it had produced **nothing** — then burned its retry budget and auto-skipped.

Stages 03, 05 and 06 are where the actual science happens. This would have hollowed out every run in the sweep while still emitting a plausible-looking report.

## The fix

`validate_stage_artifacts` takes an optional per-category `artifact_dirs` (`data`, `results`, `figures`), threaded from `ResearchManager`, which derives it from the artifact roots the adapter already supplies.

## The subtle part

The benchmark's own read-only `data/` is **deliberately excluded** from the `data` category. It is always populated, so counting it would let the stage-03 gate pass without the stage producing anything — turning a gate that proves work happened into one that proves inputs exist. There's a test pinning that specific hole shut:

```python
def test_the_benchmark_input_data_is_not_counted(self):
    (self.workspace / "data" / "given.csv").write_text("a,b\n1,2\n")
    self.assertTrue(self._has(self._problems(3, self.dirs), "machine-readable data artifacts"))
```

## Tests

Both directions, as with #114 — the same artifact fails without the extra dirs and passes with them, and an empty run still fails with them supplied. So neither the fix nor the gate can silently stop working.

493 tests pass, 8 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)