### PR TITLE
Require a competent baseline and more than one run before a verdict

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,7 @@ to a CLI directly; the operators never decide what stage runs next.
 | [`src/evidence_ledger.py`](../src/evidence_ledger.py) | Validates the Stage 01 `sources.json`/`claims.json` pair and the Stage 07 `citation_verification.json`. |
 | [`src/hypothesis_manifest.py`](../src/hypothesis_manifest.py) | Parses Stage 02's typed `T*`/`H*`/`C*` identifiers into `hypothesis_manifest.json`. |
 | [`src/preregistration.py`](../src/preregistration.py) | Freezes the hypothesis set before results exist, adjudicates every frozen hypothesis at Stage 06, and traces every manuscript claim back to a supported one at Stage 07. The one part of the pipeline that gates on whether a claim is warranted rather than on whether a file exists. |
+| [`src/experimental_protocol.py`](../src/experimental_protocol.py) | Declares the primary metric, the seed count and each baseline's tuning budget before the experiments run, and refuses a verdict that rests on one run or on an unstated dispersion measure. |
 | [`src/writing_manifest.py`](../src/writing_manifest.py) | Stage 07 support: writing manifest, figure/result scanning, layout review generation and validation. |
 
 ### Inputs
@@ -287,6 +288,7 @@ Ordered by how much of the system you have to understand first.
 | The set of target venues | `templates/registry.yaml` | none |
 | What a stage must produce | `validate_stage_artifacts` in `src/utils.py` | small |
 | What counts as a warranted claim | `src/preregistration.py` | small |
+| What counts as adequate evidence | `src/experimental_protocol.py` | small |
 | The summary contract | `REQUIRED_STAGE_HEADINGS` + `validate_stage_markdown` | small |
 | The stage list | `STAGES` in `src/utils.py`, plus a new prompt template | moderate |
 | The execution backend | implement `OperatorProtocol`, or subclass `ClaudeOperator` | moderate |

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -484,6 +484,36 @@ the result.
 Validated by `validate_preregistration` in
 [`src/preregistration.py`](../src/preregistration.py).
 
+### `workspace/notes/experimental_protocol.json`
+
+What would count as having shown the hypothesis. Declared in Stage 03, before
+any experiment runs, and enforced from Stage 05.
+
+```json
+{
+  "declared_at": "2026-03-30T13:20:04",
+  "primary_metric": "held-out accuracy",
+  "planned_seeds": 5,
+  "baselines": [
+    {
+      "name": "long-context prompting",
+      "why_competent": "the standard approach the method has to beat to matter",
+      "tuning_budget": "same prompt-search budget as the method: 20 configurations"
+    }
+  ]
+}
+```
+
+- The **primary metric** is named in advance. Choosing the metric after seeing
+  the results is the same defect as choosing the hypothesis after seeing them.
+- Every baseline needs `why_competent` and a `tuning_budget` matching the
+  method's. Beating a baseline nobody tried to make strong measures the effort
+  split, not the method — and that asymmetry is invisible in the final number.
+- `planned_seeds` is how many independent runs the comparison uses.
+
+Validated by `validate_experimental_protocol` in
+[`src/experimental_protocol.py`](../src/experimental_protocol.py).
+
 ### `workspace/results/hypothesis_outcomes.json`
 
 Stage 06's verdict on every preregistered hypothesis.
@@ -497,7 +527,8 @@ Stage 06's verdict on every preregistered hypothesis.
       "id": "H1",
       "verdict": "refuted",
       "rationale": "the gap was 2 points, below the rule's 8",
-      "evidence": ["results/main_metrics.json"]
+      "evidence": ["results/main_metrics.json"],
+      "statistics": {"n_seeds": 5, "dispersion": 0.012, "dispersion_type": "std"}
     }
   ],
   "exploratory_findings": [{"statement": "...", "evidence": ["results/..."]}]
@@ -514,7 +545,16 @@ Stage 06's verdict on every preregistered hypothesis.
 - Findings the data suggested but the run did not predict belong in
   `exploratory_findings`, never in `outcomes`.
 
-Validated by `validate_hypothesis_outcomes`.
+- A `supported` or `refuted` verdict needs a `statistics` block naming how many
+  runs it rests on and how the spread was measured. `dispersion_type` is one of
+  `std`, `stderr`, `ci95`, `iqr`, `range`, `none` — an interval whose meaning is
+  unstated cannot be read. A verdict from a single run is refused unless
+  `single_run_justification` says why one run settles it.
+- `inconclusive` and `not_tested` are exempt: they are the honest verdicts when
+  the evidence is thin, and requiring statistics for them would push a run
+  toward claiming more than it measured.
+
+Validated by `validate_hypothesis_outcomes` and `validate_outcome_statistics`.
 
 ### `workspace/artifacts/claim_provenance.json`
 

--- a/src/experiment_manifest.py
+++ b/src/experiment_manifest.py
@@ -72,6 +72,7 @@ RECORD_ARTIFACTS = frozenset(
         "results/hypothesis_outcomes.json",
         "notes/hypothesis_manifest.json",
         "notes/preregistration.json",
+        "notes/experimental_protocol.json",
     }
 )
 

--- a/src/experimental_protocol.py
+++ b/src/experimental_protocol.py
@@ -1,0 +1,234 @@
+"""What makes a verdict trustworthy: a real baseline and enough runs to see noise.
+
+Preregistration fixes *what* the run predicted. This fixes *what would count as
+having shown it*. Both failures it guards against produce a clean-looking
+`supported` verdict:
+
+- **A baseline nobody tried to make strong.** Beating an untuned comparison is
+  not evidence about the method, it is evidence about the effort split. The
+  protocol makes each baseline declare a tuning budget in advance, and Stage 05
+  records what each one actually got — so an asymmetry is on the record instead
+  of buried in a number.
+- **One run.** A single seed cannot distinguish an effect from variance. The
+  gate refuses `supported` or `refuted` from one run unless the outcome says
+  why one run is enough — some things genuinely are deterministic, and that is
+  a claim worth making explicitly rather than by omission.
+
+Before this, ``significan``, ``variance``, ``p-value`` and ``n_seeds`` appeared
+zero times across AutoR's prompt corpus; ``baseline`` was a word in a list of
+things Stage 03 might mention.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+
+from .utils import RunPaths
+
+
+#: How a spread was computed. Reporting `0.74 ± 0.03` without saying which of
+#: these it is makes the interval unreadable, and every venue asks.
+DISPERSION_TYPES = ("std", "stderr", "ci95", "iqr", "range", "none")
+
+#: Below this, an effect and its noise are not separable by inspection. Not a
+#: statistical threshold — a floor under "we ran it more than once".
+MIN_SEEDS_FOR_A_VERDICT = 2
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _load_json(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+@dataclass(frozen=True)
+class Baseline:
+    name: str
+    why_competent: str
+    tuning_budget: str
+
+
+@dataclass(frozen=True)
+class ExperimentalProtocol:
+    declared_at: str
+    primary_metric: str
+    planned_seeds: int
+    baselines: list[Baseline]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "declared_at": self.declared_at,
+            "primary_metric": self.primary_metric,
+            "planned_seeds": self.planned_seeds,
+            "baselines": [
+                {
+                    "name": item.name,
+                    "why_competent": item.why_competent,
+                    "tuning_budget": item.tuning_budget,
+                }
+                for item in self.baselines
+            ],
+        }
+
+
+def load_experimental_protocol(paths: RunPaths) -> ExperimentalProtocol | None:
+    payload = _load_json(paths.experimental_protocol)
+    if not isinstance(payload, dict):
+        return None
+    baselines = [
+        Baseline(
+            name=str(item.get("name") or "").strip(),
+            why_competent=str(item.get("why_competent") or "").strip(),
+            tuning_budget=str(item.get("tuning_budget") or "").strip(),
+        )
+        for item in payload.get("baselines", [])
+        if isinstance(item, dict)
+    ]
+    try:
+        planned_seeds = int(payload.get("planned_seeds") or 0)
+    except (TypeError, ValueError):
+        planned_seeds = 0
+    return ExperimentalProtocol(
+        declared_at=str(payload.get("declared_at") or ""),
+        primary_metric=str(payload.get("primary_metric") or "").strip(),
+        planned_seeds=planned_seeds,
+        baselines=baselines,
+    )
+
+
+def validate_experimental_protocol(paths: RunPaths) -> list[str]:
+    """Runs from Stage 05 on, alongside the preregistration check."""
+    protocol = load_experimental_protocol(paths)
+    if protocol is None:
+        return [
+            "requires an experimental protocol at workspace/notes/experimental_protocol.json "
+            "declaring, before the experiments run, the primary metric, how many seeds are "
+            "planned, and which baselines the method will be compared against with what "
+            "tuning budget each."
+        ]
+
+    problems: list[str] = []
+    if not protocol.primary_metric:
+        problems.append(
+            "experimental_protocol.json declares no primary_metric. Choosing the metric after "
+            "seeing the results is the same defect as choosing the hypothesis after seeing them."
+        )
+    if protocol.planned_seeds < 1:
+        problems.append("experimental_protocol.json must declare planned_seeds as a positive integer.")
+    if not protocol.baselines:
+        problems.append(
+            "experimental_protocol.json declares no baselines. A result with nothing to compare "
+            "against cannot be evidence that the method did anything."
+        )
+    for baseline in protocol.baselines:
+        if not baseline.name:
+            problems.append("experimental_protocol.json contains a baseline with no name.")
+            continue
+        if not baseline.why_competent:
+            problems.append(
+                f"experimental_protocol.json baseline `{baseline.name}` does not say why it is a "
+                "competent comparison. Beating a baseline nobody argued for is not a result."
+            )
+        if not baseline.tuning_budget:
+            problems.append(
+                f"experimental_protocol.json baseline `{baseline.name}` declares no tuning budget. "
+                "State it in advance, so an effort asymmetry between the method and its baseline "
+                "is on the record rather than inside the number."
+            )
+    return problems
+
+
+# ----------------------------------------------------------------------------
+# Statistical backing for a verdict
+# ----------------------------------------------------------------------------
+
+
+def validate_outcome_statistics(paths: RunPaths) -> list[str]:
+    """Runs from Stage 06 on, on top of the hypothesis-outcome checks.
+
+    Only ``supported`` and ``refuted`` are held to this. ``inconclusive`` and
+    ``not_tested`` are the honest verdicts when the evidence is thin, and
+    forcing statistics onto them would push a run toward claiming more than it
+    measured — the opposite of the point.
+    """
+    payload = _load_json(paths.hypothesis_outcomes)
+    if not isinstance(payload, dict):
+        return []
+
+    problems: list[str] = []
+    for entry in payload.get("outcomes", []):
+        if not isinstance(entry, dict):
+            continue
+        identifier = str(entry.get("id") or "").strip() or "an outcome"
+        verdict = str(entry.get("verdict") or "").strip()
+        if verdict not in ("supported", "refuted"):
+            continue
+
+        statistics = entry.get("statistics")
+        if not isinstance(statistics, dict):
+            problems.append(
+                f"hypothesis_outcomes.json outcome {identifier} is {verdict} with no `statistics` "
+                "block. A verdict has to say how many runs it rests on and how the spread was "
+                "measured."
+            )
+            continue
+
+        raw_seeds = statistics.get("n_seeds")
+        seeds = raw_seeds if isinstance(raw_seeds, int) and not isinstance(raw_seeds, bool) else None
+        if seeds is None or seeds < 1:
+            problems.append(
+                f"hypothesis_outcomes.json outcome {identifier} must record `statistics.n_seeds` "
+                "as a positive integer."
+            )
+        elif seeds < MIN_SEEDS_FOR_A_VERDICT and not str(
+            statistics.get("single_run_justification") or ""
+        ).strip():
+            problems.append(
+                f"hypothesis_outcomes.json outcome {identifier} is {verdict} on a single run. "
+                "Either run it again, or record `statistics.single_run_justification` saying why "
+                "one run settles it — a deterministic procedure is a legitimate reason, and it is "
+                "a claim worth making out loud."
+            )
+
+        dispersion_type = str(statistics.get("dispersion_type") or "").strip()
+        if dispersion_type not in DISPERSION_TYPES:
+            problems.append(
+                f"hypothesis_outcomes.json outcome {identifier} has dispersion_type "
+                f"{dispersion_type!r}; expected one of {', '.join(DISPERSION_TYPES)}. "
+                "An interval whose meaning is unstated cannot be read."
+            )
+        elif dispersion_type == "none" and (seeds or 0) >= MIN_SEEDS_FOR_A_VERDICT:
+            problems.append(
+                f"hypothesis_outcomes.json outcome {identifier} reports {seeds} runs but no "
+                "dispersion. If it was run more than once, say how much it varied."
+            )
+    return problems
+
+
+def format_protocol_for_prompt(protocol: ExperimentalProtocol) -> str:
+    lines = [
+        f"Declared at: {protocol.declared_at}",
+        f"Primary metric: {protocol.primary_metric}",
+        f"Planned seeds: {protocol.planned_seeds}",
+        "",
+        "This protocol was declared before the experiments ran. Report the primary metric",
+        "whatever it shows; do not switch to a metric that came out better.",
+        "",
+        "Baselines:",
+    ]
+    for baseline in protocol.baselines:
+        lines.append(f"- **{baseline.name}** — {baseline.why_competent}")
+        lines.append(f"  - Tuning budget: {baseline.tuning_budget}")
+    lines.append("")
+    lines.append(
+        "Give each baseline the tuning budget declared above. If you cannot, record the "
+        "shortfall rather than reporting the comparison as though the budgets matched."
+    )
+    return "\n".join(lines)

--- a/src/operator.py
+++ b/src/operator.py
@@ -671,6 +671,25 @@ Original stderr:
         def _write_json(path: Path, payload: object) -> None:
             _write(path, json.dumps(payload, indent=2) + "\n")
 
+        # Stage 03+: the experimental protocol, declared before results exist.
+        _write_json(
+            paths.experimental_protocol,
+            {
+                "declared_at": self._now(),
+                "primary_metric": "placeholder accuracy on a two-row synthetic split",
+                "planned_seeds": 1,
+                "baselines": [
+                    {
+                        "name": "placeholder baseline",
+                        "why_competent": (
+                            "Stand-in declared by fake-operator mode. Not a real comparison."
+                        ),
+                        "tuning_budget": "none; fake mode runs no tuning",
+                    }
+                ],
+            },
+        )
+
         # Stage 03+: machine-readable data under workspace/data.
         _write_json(
             paths.data_dir / "fake_dataset.json",
@@ -741,6 +760,16 @@ Original stderr:
                                     "no real measurement was taken."
                                 ),
                                 "evidence": ["results/fake_results.json"],
+                                "statistics": {
+                                    "n_seeds": 1,
+                                    "dispersion": 0.0,
+                                    "dispersion_type": "none",
+                                    "single_run_justification": (
+                                        "fake-operator mode writes a fixed placeholder rather "
+                                        "than measuring anything, so repeating it would change "
+                                        "nothing. This is not a claim about a real procedure."
+                                    ),
+                                },
                             }
                             for identifier in prereg.adjudicated_ids
                         ],

--- a/src/prompts/03_study_design.md
+++ b/src/prompts/03_study_design.md
@@ -33,6 +33,36 @@ Convert the approved hypotheses into a concrete study or experimental design tha
 - Avoid under-specified experimental plans.
 - If multiple designs are viable, explain which one is primary and why.
 
+## Experimental Protocol (required)
+
+Write `{{WORKSPACE_NOTES_DIR}}/experimental_protocol.json` before the design stage ends:
+
+```json
+{
+  "declared_at": "<ISO timestamp>",
+  "primary_metric": "held-out accuracy",
+  "planned_seeds": 5,
+  "baselines": [
+    {
+      "name": "long-context prompting",
+      "why_competent": "the standard approach for this task and the one the method must beat to matter",
+      "tuning_budget": "same prompt-search budget as the method: 20 configurations"
+    }
+  ]
+}
+```
+
+Rules:
+
+- Name the **primary metric** now. Choosing the metric after seeing the results is the
+  same defect as choosing the hypothesis after seeing them.
+- `planned_seeds` is how many independent runs the comparison will use. One run cannot
+  separate an effect from variance, and Stage 06 will refuse a verdict that rests on one
+  without an explicit justification.
+- Every baseline needs `why_competent` — an argument that this is a comparison worth
+  beating — and a `tuning_budget` equal in effort to what the method will get. Beating a
+  baseline nobody tried to make strong measures the effort split, not the method.
+
 ## Stage Output Requirements
 
 The markdown at `{{STAGE_OUTPUT_PATH}}` must follow the required output structure exactly.

--- a/src/prompts/05_experimentation.md
+++ b/src/prompts/05_experimentation.md
@@ -32,6 +32,21 @@ Run or define credible experiments that test the approved hypotheses using the i
 - Failures and anomalies are part of the evidence.
 - Make it easy to see which experiments were completed and which remain blocked.
 
+## Protocol Discipline (required)
+
+`workspace/notes/experimental_protocol.json` was declared in Stage 03, before any result
+existed.
+
+- Run the number of seeds it planned. If you run fewer, say so in `Key Results` with the
+  reason; do not quietly report a single run.
+- Give each baseline the tuning budget it declared. If a baseline got less, record the
+  shortfall — an effort asymmetry that is on the record is a limitation, and one that is
+  not is a misleading comparison.
+- Report the primary metric it named, whatever it shows. Additional metrics are welcome;
+  replacing the primary one with a metric that came out better is not.
+- Record per-condition spread, not just means. Stage 06 has to state how the spread was
+  measured and over how many runs, and it can only do that if this stage saved it.
+
 ## Stage Output Requirements
 
 The markdown at `{{STAGE_OUTPUT_PATH}}` must follow the required output structure exactly.

--- a/src/prompts/06_analysis.md
+++ b/src/prompts/06_analysis.md
@@ -61,7 +61,13 @@ Write `{{WORKSPACE_RESULTS_DIR}}/hypothesis_outcomes.json`:
       "id": "H1",
       "verdict": "supported | refuted | inconclusive | not_tested",
       "rationale": "why the evidence produces this verdict, against H1's own decision rule",
-      "evidence": ["results/main_metrics.json"]
+      "evidence": ["results/main_metrics.json"],
+      "statistics": {
+        "n_seeds": 5,
+        "dispersion": 0.012,
+        "dispersion_type": "std | stderr | ci95 | iqr | range | none",
+        "single_run_justification": "only when n_seeds is 1"
+      }
     }
   ],
   "exploratory_findings": [
@@ -84,6 +90,14 @@ Rules:
   that was arranged.
 - Findings the data suggested but the run did not predict go in `exploratory_findings`,
   never in `outcomes`.
+- A `supported` or `refuted` verdict needs a `statistics` block: how many runs it rests
+  on, and how the spread was measured. `dispersion_type` must name the measure — an
+  interval whose meaning is unstated cannot be read, and every venue asks.
+- A verdict from a single run is refused unless `single_run_justification` says why one
+  run settles it. A deterministic procedure is a legitimate reason; it is a claim worth
+  making out loud rather than by omission.
+- If the measured gap is inside the spread, the verdict is `inconclusive`, however good
+  the mean looks.
 - `Suggestions for Refinement` should focus on claim calibration, extra validation, or improved analysis clarity.
 
 ## Important Constraints

--- a/src/utils.py
+++ b/src/utils.py
@@ -73,6 +73,7 @@ class RunPaths:
     experiment_manifest: Path
     hypothesis_manifest: Path
     preregistration: Path
+    experimental_protocol: Path
     hypothesis_outcomes: Path
     claim_provenance: Path
     writing_dir: Path
@@ -246,6 +247,7 @@ def build_run_paths(run_root: Path) -> RunPaths:
         experiment_manifest=workspace_root / "results" / "experiment_manifest.json",
         hypothesis_manifest=workspace_root / "notes" / "hypothesis_manifest.json",
         preregistration=workspace_root / "notes" / "preregistration.json",
+        experimental_protocol=workspace_root / "notes" / "experimental_protocol.json",
         hypothesis_outcomes=workspace_root / "results" / "hypothesis_outcomes.json",
         claim_provenance=workspace_root / "artifacts" / "claim_provenance.json",
         writing_dir=workspace_root / "writing",
@@ -1134,9 +1136,12 @@ def validate_stage_artifacts(stage: StageSpec, paths: RunPaths) -> list[str]:
         # manuscript makes traces to a supported hypothesis or is labelled
         # exploratory (07). Without these, nothing in the pipeline notices a
         # hypothesis that was quietly rewritten to match the result.
+        from .experimental_protocol import validate_experimental_protocol
         from .preregistration import validate_preregistration
 
         for problem in validate_preregistration(paths):
+            problems.append(f"{stage.stage_title} {problem}")
+        for problem in validate_experimental_protocol(paths):
             problems.append(f"{stage.stage_title} {problem}")
 
         if _count_files_with_suffixes(paths.results_dir, RESULT_SUFFIXES) == 0:
@@ -1154,9 +1159,12 @@ def validate_stage_artifacts(stage: StageSpec, paths: RunPaths) -> list[str]:
                 problems.append(f"{stage.stage_title}: {problem}")
 
     if stage.number >= 6:
+        from .experimental_protocol import validate_outcome_statistics
         from .preregistration import validate_hypothesis_outcomes
 
         for problem in validate_hypothesis_outcomes(paths):
+            problems.append(f"{stage.stage_title} {problem}")
+        for problem in validate_outcome_statistics(paths):
             problems.append(f"{stage.stage_title} {problem}")
 
         if _count_files_with_suffixes(paths.figures_dir, FIGURE_SUFFIXES) == 0:

--- a/tests/prereg_support.py
+++ b/tests/prereg_support.py
@@ -55,6 +55,26 @@ def write_hypothesis_manifest(paths: RunPaths) -> None:
     )
 
 
+def write_experimental_protocol(paths: RunPaths, *, planned_seeds: int = 5) -> None:
+    write_text(
+        paths.experimental_protocol,
+        json.dumps(
+            {
+                "declared_at": "2026-04-08T00:00:00",
+                "primary_metric": "held-out accuracy",
+                "planned_seeds": planned_seeds,
+                "baselines": [
+                    {
+                        "name": "standard baseline",
+                        "why_competent": "the established approach the method has to beat to matter",
+                        "tuning_budget": "the same search budget the method receives",
+                    }
+                ],
+            }
+        ),
+    )
+
+
 def write_validity_chain(paths: RunPaths, *, evidence: str = "results/metrics.json") -> None:
     """Freeze hypotheses, adjudicate them, and trace one claim to the verdict.
 
@@ -69,6 +89,7 @@ def write_validity_chain(paths: RunPaths, *, evidence: str = "results/metrics.js
         write_text(evidence_path, json.dumps({"baseline": 0.61, "treatment": 0.74}))
 
     write_hypothesis_manifest(paths)
+    write_experimental_protocol(paths)
     prereg = freeze_preregistration(paths)
     if prereg is None:  # pragma: no cover - only if the manifest write failed
         raise AssertionError("preregistration did not freeze from the test manifest")
@@ -85,6 +106,11 @@ def write_validity_chain(paths: RunPaths, *, evidence: str = "results/metrics.js
                         "verdict": "supported",
                         "rationale": "The measured gap clears the preregistered decision rule.",
                         "evidence": [evidence],
+                        "statistics": {
+                            "n_seeds": 5,
+                            "dispersion": 0.011,
+                            "dispersion_type": "std",
+                        },
                     }
                     for identifier in prereg.adjudicated_ids
                 ],

--- a/tests/test_experimental_protocol.py
+++ b/tests/test_experimental_protocol.py
@@ -1,0 +1,226 @@
+"""Baseline competence and replication: what makes a `supported` verdict mean something.
+
+Both failures these gates catch produce a clean-looking positive result. Beating
+an untuned baseline measures the effort split, not the method. A single run
+cannot separate an effect from variance. Neither is visible in the finished
+artifacts, which is why they are gates rather than advice.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.experimental_protocol import (
+    MIN_SEEDS_FOR_A_VERDICT,
+    format_protocol_for_prompt,
+    load_experimental_protocol,
+    validate_experimental_protocol,
+    validate_outcome_statistics,
+)
+from src.utils import STAGES, build_run_paths, ensure_run_layout, validate_stage_artifacts, write_text
+from tests.prereg_support import write_experimental_protocol, write_validity_chain
+
+
+STAGE_04 = next(stage for stage in STAGES if stage.number == 4)
+STAGE_05 = next(stage for stage in STAGES if stage.number == 5)
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+
+
+class ProtocolTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    def write_protocol(self, **overrides) -> None:
+        payload = {
+            "declared_at": "2026-04-08T00:00:00",
+            "primary_metric": "held-out accuracy",
+            "planned_seeds": 5,
+            "baselines": [
+                {
+                    "name": "standard baseline",
+                    "why_competent": "the established approach the method has to beat",
+                    "tuning_budget": "the same search budget the method receives",
+                }
+            ],
+        }
+        payload.update(overrides)
+        write_text(self.paths.experimental_protocol, json.dumps(payload))
+
+    def write_outcome(self, statistics, verdict="supported") -> None:
+        entry = {
+            "id": "H1",
+            "verdict": verdict,
+            "rationale": "clears the rule",
+            "evidence": ["results/metrics.json"],
+        }
+        if statistics is not None:
+            entry["statistics"] = statistics
+        write_text(
+            self.paths.hypothesis_outcomes,
+            json.dumps({"preregistration_digest": "x", "outcomes": [entry]}),
+        )
+
+
+class ProtocolDeclarationTest(ProtocolTestCase):
+    def test_a_complete_protocol_passes(self) -> None:
+        self.write_protocol()
+        self.assertEqual(validate_experimental_protocol(self.paths), [])
+
+    def test_a_missing_protocol_is_refused(self) -> None:
+        problems = validate_experimental_protocol(self.paths)
+        self.assertTrue(any("experimental_protocol.json" in problem for problem in problems), problems)
+
+    def test_no_baseline_is_refused(self) -> None:
+        self.write_protocol(baselines=[])
+        problems = validate_experimental_protocol(self.paths)
+        self.assertTrue(any("declares no baselines" in problem for problem in problems), problems)
+
+    def test_a_baseline_with_no_competence_argument_is_refused(self) -> None:
+        """A baseline nobody argued for is a strawman with a name."""
+        self.write_protocol(
+            baselines=[{"name": "weak thing", "why_competent": "", "tuning_budget": "none"}]
+        )
+        problems = validate_experimental_protocol(self.paths)
+        self.assertTrue(any("why it is a competent comparison" in p for p in problems), problems)
+
+    def test_a_baseline_with_no_tuning_budget_is_refused(self) -> None:
+        self.write_protocol(
+            baselines=[{"name": "thing", "why_competent": "standard", "tuning_budget": ""}]
+        )
+        problems = validate_experimental_protocol(self.paths)
+        self.assertTrue(any("declares no tuning budget" in p for p in problems), problems)
+
+    def test_no_primary_metric_is_refused(self) -> None:
+        """Picking the metric after seeing results is the same defect as picking the hypothesis."""
+        self.write_protocol(primary_metric="")
+        problems = validate_experimental_protocol(self.paths)
+        self.assertTrue(any("no primary_metric" in problem for problem in problems), problems)
+
+    def test_planned_seeds_must_be_positive(self) -> None:
+        self.write_protocol(planned_seeds=0)
+        problems = validate_experimental_protocol(self.paths)
+        self.assertTrue(any("planned_seeds" in problem for problem in problems), problems)
+
+    def test_a_non_integer_seed_count_does_not_crash_the_gate(self) -> None:
+        self.write_protocol(planned_seeds="five")
+        problems = validate_experimental_protocol(self.paths)
+        self.assertTrue(any("planned_seeds" in problem for problem in problems), problems)
+
+    def test_the_prompt_renders_the_budget_and_forbids_metric_switching(self) -> None:
+        self.write_protocol()
+        protocol = load_experimental_protocol(self.paths)
+        assert protocol is not None
+        rendered = format_protocol_for_prompt(protocol)
+        self.assertIn("standard baseline", rendered)
+        self.assertIn("Tuning budget:", rendered)
+        self.assertIn("do not switch to a metric that came out better", rendered)
+
+
+class VerdictStatisticsTest(ProtocolTestCase):
+    def test_a_verdict_with_full_statistics_passes(self) -> None:
+        self.write_outcome({"n_seeds": 5, "dispersion": 0.01, "dispersion_type": "std"})
+        self.assertEqual(validate_outcome_statistics(self.paths), [])
+
+    def test_a_verdict_with_no_statistics_block_is_refused(self) -> None:
+        self.write_outcome(None)
+        problems = validate_outcome_statistics(self.paths)
+        self.assertTrue(any("no `statistics` block" in problem for problem in problems), problems)
+
+    def test_a_single_run_verdict_is_refused_without_a_justification(self) -> None:
+        self.write_outcome({"n_seeds": 1, "dispersion": 0.0, "dispersion_type": "none"})
+        problems = validate_outcome_statistics(self.paths)
+        self.assertTrue(any("single run" in problem for problem in problems), problems)
+
+    def test_a_single_run_verdict_passes_when_it_says_why(self) -> None:
+        """Deterministic procedures exist. Saying so out loud is the requirement."""
+        self.write_outcome(
+            {
+                "n_seeds": 1,
+                "dispersion": 0.0,
+                "dispersion_type": "none",
+                "single_run_justification": "the procedure is deterministic given the fixed split",
+            }
+        )
+        self.assertEqual(validate_outcome_statistics(self.paths), [])
+
+    def test_an_unstated_dispersion_measure_is_refused(self) -> None:
+        self.write_outcome({"n_seeds": 5, "dispersion": 0.01, "dispersion_type": ""})
+        problems = validate_outcome_statistics(self.paths)
+        self.assertTrue(any("dispersion_type" in problem for problem in problems), problems)
+
+    def test_an_unknown_dispersion_measure_is_refused(self) -> None:
+        self.write_outcome({"n_seeds": 5, "dispersion": 0.01, "dispersion_type": "vibes"})
+        problems = validate_outcome_statistics(self.paths)
+        self.assertTrue(any("expected one of" in problem for problem in problems), problems)
+
+    def test_multiple_runs_reporting_no_dispersion_is_refused(self) -> None:
+        self.write_outcome({"n_seeds": 5, "dispersion": 0.0, "dispersion_type": "none"})
+        problems = validate_outcome_statistics(self.paths)
+        self.assertTrue(any("no dispersion" in problem for problem in problems), problems)
+
+    def test_a_boolean_is_not_a_seed_count(self) -> None:
+        self.write_outcome({"n_seeds": True, "dispersion": 0.0, "dispersion_type": "std"})
+        problems = validate_outcome_statistics(self.paths)
+        self.assertTrue(any("positive integer" in problem for problem in problems), problems)
+
+    def test_inconclusive_is_not_held_to_the_statistics_requirement(self) -> None:
+        """Forcing statistics onto a hedge would push the run toward overclaiming."""
+        self.write_outcome(None, verdict="inconclusive")
+        self.assertEqual(validate_outcome_statistics(self.paths), [])
+
+    def test_not_tested_is_not_held_to_the_statistics_requirement(self) -> None:
+        self.write_outcome(None, verdict="not_tested")
+        self.assertEqual(validate_outcome_statistics(self.paths), [])
+
+    def test_a_refutation_is_held_to_the_same_bar_as_a_confirmation(self) -> None:
+        """A refutation from one noisy run is as unfounded as a confirmation from one."""
+        self.write_outcome(None, verdict="refuted")
+        problems = validate_outcome_statistics(self.paths)
+        self.assertTrue(any("no `statistics` block" in problem for problem in problems), problems)
+
+    def test_the_replication_floor_is_more_than_one(self) -> None:
+        self.assertGreater(MIN_SEEDS_FOR_A_VERDICT, 1)
+
+
+class StageGateWiringTest(ProtocolTestCase):
+    def test_stage_05_reports_a_missing_protocol(self) -> None:
+        problems = validate_stage_artifacts(STAGE_05, self.paths)
+        self.assertTrue(any("experimental_protocol.json" in p for p in problems), problems)
+
+    def test_stage_04_is_not_held_to_the_protocol(self) -> None:
+        """It is declared during design and enforced once experiments can run."""
+        problems = validate_stage_artifacts(STAGE_04, self.paths)
+        self.assertFalse(any("experimental_protocol" in p for p in problems), problems)
+
+    def test_stage_06_reports_a_verdict_with_no_statistics(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"acc": 0.9}')
+        write_validity_chain(self.paths)
+        outcomes = json.loads(self.paths.hypothesis_outcomes.read_text(encoding="utf-8"))
+        for entry in outcomes["outcomes"]:
+            entry.pop("statistics", None)
+        write_text(self.paths.hypothesis_outcomes, json.dumps(outcomes))
+
+        problems = validate_stage_artifacts(STAGE_06, self.paths)
+        self.assertTrue(any("no `statistics` block" in p for p in problems), problems)
+
+    def test_a_fully_disciplined_run_clears_stage_06(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"acc": 0.9}')
+        write_experimental_protocol(self.paths)
+        write_validity_chain(self.paths)
+        problems = [
+            p
+            for p in validate_stage_artifacts(STAGE_06, self.paths)
+            if "protocol" in p or "statistics" in p or "hypothes" in p
+        ]
+        self.assertEqual(problems, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manager_smoke.py
+++ b/tests/test_manager_smoke.py
@@ -248,6 +248,26 @@ class ScriptedSmokeOperator:
             produced.append(relative_to_run(paths.hypothesis_manifest, paths.run_root))
 
         if stage.number >= 3:
+            write_text(
+                paths.experimental_protocol,
+                json.dumps(
+                    {
+                        "declared_at": "2026-04-08T00:00:00",
+                        "primary_metric": "held-out benchmark accuracy",
+                        "planned_seeds": 5,
+                        "baselines": [
+                            {
+                                "name": "retrieval-off long-context prompting",
+                                "why_competent": "the standard approach this method has to beat",
+                                "tuning_budget": "the same 20-configuration search the method gets",
+                            }
+                        ],
+                    }
+                ),
+            )
+            produced.append(relative_to_run(paths.experimental_protocol, paths.run_root))
+
+        if stage.number >= 3:
             data_path = paths.data_dir / "study_design.json"
             write_text(
                 data_path,
@@ -285,6 +305,11 @@ class ScriptedSmokeOperator:
                                     "verdict": "supported",
                                     "rationale": "Smoke adjudication against the frozen decision rule.",
                                     "evidence": ["results/metrics.json"],
+                                    "statistics": {
+                                        "n_seeds": 5,
+                                        "dispersion": 0.011,
+                                        "dispersion_type": "std",
+                                    },
                                 }
                                 for identifier in prereg.adjudicated_ids
                             ],

--- a/tests/test_rcb_scoring.py
+++ b/tests/test_rcb_scoring.py
@@ -90,7 +90,13 @@ class FigureBudgetTests(unittest.TestCase):
         # the numbers should also be able to see which hypothesis they settle.
         self.assertEqual(
             exported,
-            ["hypothesis_manifest.json", "hypothesis_outcomes.json", "metrics.json", "preregistration.json"],
+            [
+                "experimental_protocol.json",
+                "hypothesis_manifest.json",
+                "hypothesis_outcomes.json",
+                "metrics.json",
+                "preregistration.json",
+            ],
         )
         # outputs/ is swept before report/, so an image there would take a judge slot.
         self.assertEqual(


### PR DESCRIPTION
Follow-on to #116. Preregistration fixed **what** the run predicted; this fixes **what would count as having shown it**.

Both failures below produce a clean-looking `supported` verdict that nothing in the pipeline could question.

## A baseline nobody tried to make strong

Before this, `baseline` was a word in a list of things Stage 03 *might* mention. Beating an untuned comparison measures the effort split, not the method — and the asymmetry is invisible in the final number.

Stage 03 now declares `workspace/notes/experimental_protocol.json`:

```json
{
  "primary_metric": "held-out accuracy",
  "planned_seeds": 5,
  "baselines": [{
    "name": "long-context prompting",
    "why_competent": "the standard approach the method has to beat to matter",
    "tuning_budget": "same prompt-search budget as the method: 20 configurations"
  }]
}
```

A baseline with no `why_competent` is a strawman with a name; a baseline with no `tuning_budget` cannot be shown to have had a fair chance. Both are refused. Stage 05 is told to honour the declared budgets and record any shortfall rather than report the comparison as though they matched.

## One run

`significan`, `variance`, `p-value` and `n_seeds` appeared **zero times** across the prompt corpus. A `supported` or `refuted` verdict now needs:

```json
"statistics": {"n_seeds": 5, "dispersion": 0.012, "dispersion_type": "std"}
```

`dispersion_type` has to name the measure — `0.74 ± 0.03` is unreadable without knowing whether that is a standard deviation, a standard error or a confidence interval, and every venue asks for it explicitly. A verdict from a single run is refused unless `single_run_justification` says why one run settles it; deterministic procedures exist, and saying so out loud is the requirement rather than leaving it to be inferred.

## The primary metric is named in advance

Same reason the hypothesis is. Choosing the metric after seeing the results is the same defect wearing different clothes.

## Two deliberate exemptions

- `inconclusive` and `not_tested` are **not** held to the statistics requirement. They are the honest verdicts when the evidence is thin, and demanding statistics for them would push a run toward claiming more than it measured.
- A refutation **is** held to the same bar as a confirmation, because a refutation from one noisy run is equally unfounded.

## Tests

25 in `tests/test_experimental_protocol.py`. Mutation-checked: disarming the replication floor, the tuning-budget requirement, or the dispersion-type check each fails tests.

583 tests green, including against the merge with `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)