### PR TITLE
Put a room at the approval gate instead of one reviewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Useful feature | **Citation verification and writing checks** | Writing expects citation verification, figure-link checks, and self-review artifacts before Stage 07 is considered complete. |
 | Useful feature | **Artifact indexing across stages** | `artifact_index.json` and related manifests help later stages find data, results, and figures without guessing from filenames. |
 | Useful feature | **Resume, redo, and rollback controls** | Long research runs can continue in place, retry a stage, or roll downstream state back without starting over. |
+| Useful feature | **Deliberating review panel** | Instead of one reviewer agent at the approval gate, `--review-panel` seats a PI, domain expert, methodologist, reproducibility engineer and adversarial reviewer who review independently, cross-examine, then converge — and a blocking objection cannot be approved over. |
 | Useful feature | **Two output formats** | Stage 07 writes a benchmark-ready markdown report (`report/report.md` + PNG figures) by default, or a venue-aware LaTeX paper package with a compiled PDF via `--output-format latex`. |
 
 In practice, that means AutoR is useful not only because of the high-level framing, but also because it handles real research chores: literature organization, experiment manifests, citation verification, artifact indexing, manuscript packaging, and recoverable long-running workflows.
@@ -287,6 +288,8 @@ AI handles execution load; humans steer the research when direction actually mat
 | Start with preloaded resources | `python main.py --goal "Your research goal here" --resources paper.pdf refs.bib data.csv` |
 | Run a local smoke test without a real agent backend | `python main.py --fake-operator --goal "Smoke test"` |
 | Run with the automated reviewer gate | `python main.py --full-auto --goal "Your research goal here"` |
+| Replace the single reviewer with a deliberating panel | `python main.py --review-panel --goal "..."` |
+| Give the panel a researcher persona to stand in for | `python main.py --review-panel --persona docs/persona-example.md --goal "..."` |
 | Choose the execution backend | `python main.py --operator claude` or `python main.py --operator codex` |
 | Choose the reviewer backend separately | `python main.py --full-auto --review-operator claude --review-model opus` |
 | Choose a Claude model | `python main.py --operator claude --model sonnet` or `python main.py --operator claude --model opus` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ detail behind it.
 | Run AutoR unattended, or benchmark it on ResearchClawBench | [ResearchClawBench](researchclawbench.md) |
 | Understand what a run leaves on disk | [Run Artifacts](run-artifacts.md) |
 | Know exactly what a stage must produce to be accepted | [Stage Contract](stage-contract.md) |
+| Replace the reviewer agent with a panel that argues before it decides | [Review Panel](review-panel.md) |
 | Configure venues, backends, sandboxes, or API keys | [Configuration](configuration.md) |
 | Use or script the browser UI | [Studio Guide & HTTP API](studio.md) |
 | Understand how the code is organized | [Architecture](architecture.md) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -148,6 +148,18 @@ The two modes differ in which Stage 07 prompt is loaded, which artifacts the
 stage gate requires, and whether a `paper_package/` bundle is produced after
 approval. See [Stage Contract](stage-contract.md#artifact-requirements).
 
+### Review panel
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--review-panel` | off | Replace the single reviewer agent with a deliberating panel: independent round, cross-examination on disagreement, then a chair synthesis. Implies `--approval-mode agent`. |
+| `--panel-roles ROLE...` | all five | Seat only these roles, in this order: `pi`, `domain`, `method`, `repro`, `skeptic`. The first seat chairs unless `pi` is present. An unknown name is an error. |
+| `--panel-rounds N` | `2` | Maximum deliberation rounds. Round 1 is always independent; later rounds run only on disagreement. |
+| `--persona PATH` | — | Markdown description of the researcher the panel stands in for, injected into every seat so they hold one consistent bar. |
+
+A blocking objection from any member cannot be approved over — the chair's approval is
+converted to a refinement in code. Full description in [Review Panel](review-panel.md).
+
 ### Stopping early
 
 | Flag | Default | Description |

--- a/docs/persona-example.md
+++ b/docs/persona-example.md
@@ -1,0 +1,47 @@
+# Researcher Persona (example)
+
+Copy this file, edit it, and pass it with `--persona docs/persona-example.md`. It is injected into
+every panelist so the simulated humans hold one consistent bar across all eight stages instead
+of improvising a new one at each gate.
+
+Write it as a description of a person, not as a list of rules. The panel reads it the way a
+new postdoc reads their advisor: to work out what this particular researcher will and will not
+sign their name to.
+
+---
+
+## Who I am
+
+I run a small empirical group. I publish four or five papers a year and I referee about thirty.
+I have been burned twice by results that did not survive a careful reviewer, so I am
+constitutionally suspicious of anything that looks clean on the first try.
+
+## What I am trying to find out
+
+State the actual question, not the topic. "Whether X causes Y under Z" is a question.
+"Investigating X" is a topic, and a topic cannot be answered, so it cannot be finished.
+
+## What I will not sign my name to
+
+- A number without an uncertainty next to it.
+- A comparison without a baseline I would have chosen myself.
+- A figure I cannot trace back to the file that produced it.
+- A claim in the abstract that is not settled somewhere in the results.
+- "Promising", "significant improvement", or "state of the art" standing in for a measurement.
+
+## Where I will trade rigour for speed
+
+Early stages. I would rather see a rough but honest Stage 03 than a polished one that has
+quietly narrowed the question to something easy. Tighten later; do not narrow early.
+
+## Where I will not
+
+Anything that reaches the write-up. By Stage 06 I want every number reproducible from the
+repository, and by Stage 07 I want to be able to hand the report to a hostile reviewer without
+rereading it first.
+
+## How I want to be disagreed with
+
+Directly, with the artifact open. "The summary says accuracy improved but results/metrics.json
+has one run at n=40" is worth more to me than three paragraphs of hedging. If you think a stage
+is not ready, say so and say what would make it ready.

--- a/docs/review-panel.md
+++ b/docs/review-panel.md
@@ -1,0 +1,136 @@
+# The review panel
+
+AutoR's premise is that a human owns direction while an agent owns execution. For unattended
+runs that human is replaced by a reviewer agent standing at each stage gate. One model, asked
+once, with one framing, is a thin stand-in for the thing it replaces.
+
+`--review-panel` replaces it with a room.
+
+```bash
+python main.py --review-panel --goal "..."
+python main.py --review-panel --persona docs/persona-example.md --goal "..."
+python rcb_agent.py --review-panel          # benchmark runs
+```
+
+`--review-panel` implies `--approval-mode agent`.
+
+---
+
+## Why a panel rather than a longer prompt
+
+Asking one reviewer to "consider multiple perspectives" produces one voice listing
+perspectives it already agreed with. The disagreement is simulated inside a single forward
+pass, and a model that has already decided will find reasons rather than objections.
+
+Independent reviewers, each with a distinct mandate, a distinct model, and no sight of each
+other, produce genuinely different reads. **The disagreement between them is information a
+single reviewer cannot generate.** That is the whole argument for the design, and it is why
+round one is blind on purpose.
+
+## The seats
+
+| Role | Key | Owns | Skill |
+| --- | --- | --- | --- |
+| Principal Investigator | `pi` | Does this advance the central claim? Has the story drifted? Chairs the panel. | — |
+| Domain Expert | `domain` | Field correctness, prior work, whether the claim is actually novel. | `citation-discipline` |
+| Methodologist | `method` | Design validity: confounds, baselines, ablations, leakage, sample size. | `result-table` |
+| Reproducibility Engineer | `repro` | Do the numbers trace to files that exist and could be rerun. | `reproducibility-check` |
+| Adversarial Reviewer | `skeptic` | Reviewer 2. Finds the strongest reason to reject. | — |
+
+Each seat is told to review *its part* properly and trust the panel for the rest, rather than
+five members each writing a mediocre whole review.
+
+Seat a subset with `--panel-roles method repro skeptic`. The first seat chairs unless the PI is
+present. An unknown role name is an error, not a silent drop — a panel whose composition
+nobody can trust is worse than no panel.
+
+`PanelRole` carries optional `backend` and `model` overrides. **A verdict from a different
+harness is the only kind that is genuinely uncorrelated**, so mixing `claude` and `codex` seats
+is where the panel earns the most. Both fall back to the run's reviewer defaults so a
+single-backend deployment still gets the benefit of distinct mandates.
+
+## The protocol
+
+1. **Round 1 — independent.** Every member reviews blind. No member sees another's position.
+2. **Round 2 — cross-examination.** Only runs if the panel disagreed. Each member is shown what
+   the others concluded and may revise. They are told explicitly that converging to be
+   agreeable is the failure mode this round exists to avoid, and that a lone correct objection
+   beats a comfortable consensus.
+3. **Chair synthesis.** The chair reads every position and issues the single decision the
+   workflow acts on, required to address the dissent rather than ignore it.
+
+A unanimous, unblocked room skips both the second round and the chair. There is nothing to
+deliberate about, and a second round would only invite the panel to talk itself out of an
+agreement it already reached.
+
+Raise or lower the ceiling with `--panel-rounds N`.
+
+## The blocking rule
+
+Any member may mark an objection `blocking`. **If a blocking objection survives the final
+round, approval is refused in code** — the chair's approval is converted into a refinement and
+the conversion is recorded.
+
+This is deliberately mechanical. The chair is a model, and a model asked to weigh dissent can
+be argued into discounting it. A prompt-level rule the chair can talk itself out of is not a
+rule, and a gate that cannot say no is not a gate.
+
+Two guards sit alongside it:
+
+- A member that could not be reached is **not** counted as agreeing. It breaks unanimity and
+  forces deliberation.
+- An unparseable answer degrades to `abort`, and cannot also count as a blocking veto — one
+  malformed response should not be able to stop a run.
+
+## The persona
+
+`--persona PATH` takes a markdown description of the researcher the panel is standing in for,
+and injects it into every seat. Without it, five simulated humans improvise five slightly
+different bars, and the bar drifts across eight stages. With it, they hold one.
+
+[`docs/persona-example.md`](persona-example.md) is a starting point. Write it as a description
+of a person rather than a list of rules — the panel reads it the way a new postdoc reads their
+advisor, to work out what this particular researcher will and will not sign their name to.
+
+## What it leaves behind
+
+```
+workspace/reviews/panel/
+├── 03_study_design_attempt_01.json
+└── 03_study_design_attempt_01.md
+```
+
+Every position from every round, including **dissent that lost** and any chair override.
+Stage 08 reads `workspace/reviews/`, and a run's auditability is the product's whole claim: a
+panel that reported only its verdict would be less inspectable than the single reviewer it
+replaced.
+
+The run log gets a one-line summary per gate:
+
+```
+03_study_design attempt 1 panel_decision
+rounds: 2
+positions: Principal Investigator=approve; Domain Expert=approve; Methodologist=custom_feedback; ...
+chair_overridden: True
+final_choice: 4
+```
+
+## Cost
+
+A panel costs roughly `seats x rounds + 1` reviewer calls per gate instead of one. With the
+default five seats that is 5 calls when the room agrees and 11 when it does not, per stage
+attempt. Nothing about the panel is cheap; it buys a gate that can actually refuse.
+
+Reduce it by seating fewer roles (`--panel-roles repro skeptic` keeps the two that catch the
+most), or by `--panel-rounds 1` to skip cross-examination.
+
+## Limits worth knowing
+
+- **Correlated seats.** Five prompts against one model are less independent than they look.
+  Mixed backends are the real fix; distinct mandates are a partial one.
+- **The panel reviews summaries, not the world.** Members are told to open artifacts, and the
+  reproducibility seat exists to enforce that, but a determined stage summary can still
+  describe a file more favourably than the file reads.
+- **Deliberation can converge on a shared error.** Round two makes members more consistent with
+  each other, which is a gain when someone is right and a loss when nobody is. The blocking
+  flag is what keeps a single correct dissenter from being smoothed away.

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 from src.approval_agent import AutomatedReviewer
+from src.review_panel import DEFAULT_PANEL, ReviewPanel, load_persona, resolve_roles
 from src.intake import ResourceEntry, classify_resource, collect_resource_paths_from_ui
 from src.manager import ResearchManager
 from src.operator import ClaudeOperator
@@ -100,6 +101,37 @@ def parse_args() -> argparse.Namespace:
         default=3,
         help="In unattended mode, the maximum number of stages that may be auto-skipped after "
              "exhausting their retry budget before the run aborts. Defaults to 3.",
+    )
+    parser.add_argument(
+        "--review-panel",
+        action="store_true",
+        help="Replace the single reviewer agent with a deliberating panel of role-differentiated "
+             "reviewers (PI, domain expert, methodologist, reproducibility engineer, adversarial "
+             "reviewer). They review independently, then cross-examine, then a chair synthesizes "
+             "one decision. A blocking objection cannot be approved over. Implies "
+             "--approval-mode agent.",
+    )
+    parser.add_argument(
+        "--panel-roles",
+        nargs="+",
+        metavar="ROLE",
+        help="Seat only these roles on the panel, in this order: "
+             + ", ".join(role.key for role in DEFAULT_PANEL)
+             + ". The first seat chairs unless the PI is present. Defaults to all five.",
+    )
+    parser.add_argument(
+        "--panel-rounds",
+        type=int,
+        default=2,
+        help="Maximum deliberation rounds. Round 1 is always independent; later rounds are only "
+             "run when the panel disagreed. Defaults to 2.",
+    )
+    parser.add_argument(
+        "--persona",
+        metavar="PATH",
+        help="Path to a markdown description of the researcher the panel is standing in for "
+             "(their priorities, standards, risk tolerance). Injected into every panelist so the "
+             "simulated humans hold a consistent bar instead of improvising one per stage.",
     )
     parser.add_argument(
         "--max-attempts",
@@ -241,7 +273,26 @@ def create_reviewer(
     fake_mode: bool,
     ui: TerminalUI,
     stage_timeout: int,
-) -> AutomatedReviewer:
+    panel_roles: list[str] | None = None,
+    use_panel: bool = False,
+    persona_text: str = "",
+    deliberation_rounds: int = 2,
+):
+    """Build the approval gate: one reviewer, or a panel that deliberates first.
+
+    Both satisfy the same ``review_stage`` contract, so the manager never learns which it got.
+    """
+    if use_panel:
+        return ReviewPanel(
+            resolve_roles(panel_roles),
+            backend_name=backend_name,
+            model=model,
+            fake_mode=fake_mode,
+            ui=ui,
+            stage_timeout=stage_timeout,
+            persona_text=persona_text,
+            deliberation_rounds=deliberation_rounds,
+        )
     return AutomatedReviewer(
         backend_name,
         model=model,
@@ -267,10 +318,15 @@ def resolve_resume_run(runs_dir: Path, value: str) -> Path:
 def resolve_unattended(args: argparse.Namespace) -> bool:
     """Decide whether this invocation is allowed to block on terminal input.
 
-    `--full-auto` and `--approval-mode agent` both replace the human approval gate with a
-    reviewer agent, so neither has anyone left to answer a prompt.
+    `--full-auto`, `--approval-mode agent` and `--review-panel` all replace the human approval
+    gate with an agent, so none of them has anyone left to answer a prompt.
     """
-    return bool(args.unattended or args.full_auto or args.approval_mode == "agent")
+    return bool(
+        args.unattended
+        or args.full_auto
+        or getattr(args, "review_panel", False)
+        or args.approval_mode == "agent"
+    )
 
 
 def resolve_goal(args: argparse.Namespace, *, unattended: bool) -> str:
@@ -341,6 +397,7 @@ def main() -> int:
     repo_root = Path(__file__).resolve().parent
     runs_dir = repo_root / args.runs_dir
     unattended = resolve_unattended(args)
+    persona_text = load_persona(args.persona)
     ui = TerminalUI(interactive=not unattended)
     ui.show_banner()
 
@@ -386,7 +443,11 @@ def main() -> int:
         else:
             model = (existing_model if existing_model != "unknown" else None) or default_model_for_operator(operator_name)
         codex_sandbox = args.codex_sandbox or existing_config.get("codex_sandbox") or DEFAULT_CODEX_SANDBOX
-        approval_mode = "agent" if args.full_auto else (args.approval_mode or existing_config.get("approval_mode") or "manual")
+        approval_mode = (
+            "agent"
+            if (args.full_auto or args.review_panel)
+            else (args.approval_mode or existing_config.get("approval_mode") or "manual")
+        )
         if approval_mode == "agent":
             unattended = True
             ui.interactive = False
@@ -418,6 +479,10 @@ def main() -> int:
                 fake_mode=args.fake_operator,
                 ui=ui,
                 stage_timeout=args.stage_timeout,
+                use_panel=args.review_panel,
+                panel_roles=args.panel_roles,
+                persona_text=persona_text,
+                deliberation_rounds=args.panel_rounds,
             )
         manager = ResearchManager(
             project_root=repo_root,
@@ -446,7 +511,7 @@ def main() -> int:
     operator_name = (args.operator or "claude").strip().lower()
     model = args.model or default_model_for_operator(operator_name)
     codex_sandbox = args.codex_sandbox or DEFAULT_CODEX_SANDBOX
-    approval_mode = "agent" if args.full_auto else (args.approval_mode or "manual")
+    approval_mode = "agent" if (args.full_auto or args.review_panel) else (args.approval_mode or "manual")
     review_operator = (args.review_operator or operator_name).strip().lower()
     review_model = args.review_model or default_model_for_operator(review_operator)
     venue = resolve_venue_key(args.venue or DEFAULT_VENUE)
@@ -468,6 +533,10 @@ def main() -> int:
             fake_mode=args.fake_operator,
             ui=ui,
             stage_timeout=args.stage_timeout,
+            use_panel=args.review_panel,
+            panel_roles=args.panel_roles,
+            persona_text=persona_text,
+            deliberation_rounds=args.panel_rounds,
         )
     manager = ResearchManager(
         project_root=repo_root,

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -32,6 +32,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from src.approval_agent import AutomatedReviewer  # noqa: E402
+from src.review_panel import DEFAULT_PANEL, ReviewPanel, load_persona, resolve_roles  # noqa: E402
 from src.manager import ResearchManager  # noqa: E402
 from src.operator import ClaudeOperator  # noqa: E402
 from src.operator_codex import CodexOperator  # noqa: E402
@@ -148,6 +149,33 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=f"Seconds allowed per stage attempt. Defaults to {DEFAULT_STAGE_TIMEOUT}. "
              "The benchmark harness imposes no timeout of its own, so this is the only thing "
              "that can cut a stage short.",
+    )
+    parser.add_argument(
+        "--review-panel",
+        action="store_true",
+        help="Replace the single reviewer agent with a deliberating panel of role-differentiated "
+             "reviewers ("
+             + ", ".join(role.key for role in DEFAULT_PANEL)
+             + "). They review independently, cross-examine, then a chair decides; a blocking "
+             "objection cannot be approved over.",
+    )
+    parser.add_argument(
+        "--panel-roles",
+        nargs="+",
+        metavar="ROLE",
+        help="Seat only these panel roles, in this order. Defaults to all of them.",
+    )
+    parser.add_argument(
+        "--panel-rounds",
+        type=int,
+        default=2,
+        help="Maximum deliberation rounds. Later rounds run only on disagreement. Defaults to 2.",
+    )
+    parser.add_argument(
+        "--persona",
+        metavar="PATH",
+        help="Markdown description of the researcher the panel stands in for, injected into "
+             "every panelist so the simulated humans hold one consistent bar.",
     )
     parser.add_argument(
         "--max-attempts",
@@ -288,13 +316,25 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
     output_format = resolve_output_format(args.output_format)
     goal = build_benchmark_goal(workspace, instructions, output_format=output_format)
 
-    reviewer = AutomatedReviewer(
-        review_backend,
-        model=review_model,
-        fake_mode=args.fake_operator,
-        ui=ui,
-        stage_timeout=args.stage_timeout,
-    )
+    if args.review_panel:
+        reviewer = ReviewPanel(
+            resolve_roles(args.panel_roles),
+            backend_name=review_backend,
+            model=review_model,
+            fake_mode=args.fake_operator,
+            ui=ui,
+            stage_timeout=args.stage_timeout,
+            persona_text=load_persona(args.persona),
+            deliberation_rounds=args.panel_rounds,
+        )
+    else:
+        reviewer = AutomatedReviewer(
+            review_backend,
+            model=review_model,
+            fake_mode=args.fake_operator,
+            ui=ui,
+            stage_timeout=args.stage_timeout,
+        )
     manager = ResearchManager(
         project_root=REPO_ROOT,
         runs_dir=runs_dir_for(workspace),

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -89,7 +89,6 @@ class AutomatedReviewer:
                 raw_response='{"decision":"approve","reason":"fake reviewer"}',
             )
 
-        prompt_path = paths.prompt_cache_dir / f"{stage.slug}_review_attempt_{attempt_no:02d}.prompt.md"
         prompt = self._build_review_prompt(
             paths=paths,
             stage=stage,
@@ -97,6 +96,43 @@ class AutomatedReviewer:
             stage_markdown=stage_markdown,
             suggestions=suggestions,
         )
+        exit_code, stdout_text, stderr_text = self.run_prompt(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            prompt=prompt,
+            label="review",
+        )
+
+        if exit_code != 0:
+            return ReviewDecision(
+                choice="6",
+                decision_token="abort",
+                reason=(
+                    f"Automated reviewer failed with exit code {exit_code}. "
+                    "AutoR stopped instead of approving blindly."
+                ),
+                raw_response=stdout_text or stderr_text,
+            )
+
+        return self._parse_decision(stdout_text)
+
+    def run_prompt(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        prompt: str,
+        label: str,
+    ) -> tuple[int, str, str]:
+        """Run one reviewer-style prompt through this backend and return its raw output.
+
+        Split out from :meth:`review_stage` so a deliberating panel can reuse the invocation,
+        logging and transcript plumbing for a member's own prompt rather than reimplementing
+        it, and so every panel member is recorded on the same path a solo reviewer is.
+        """
+        prompt_path = paths.prompt_cache_dir / f"{stage.slug}_{label}_attempt_{attempt_no:02d}.prompt.md"
         write_text(prompt_path, prompt)
 
         session_id = str(uuid.uuid4())
@@ -112,7 +148,7 @@ class AutomatedReviewer:
                 "_meta": {
                     "stage": stage.slug,
                     "attempt": attempt_no,
-                    "mode": "review_start",
+                    "mode": f"{label}_start",
                     "review_backend": self.backend_name,
                     "review_model": self.model,
                     "command": command,
@@ -127,15 +163,16 @@ class AutomatedReviewer:
             stage=stage,
             attempt_no=attempt_no,
             paths=paths,
-            mode="review",
+            mode=label,
             stdin_text=stdin_text,
         )
 
-        review_record = {
+        record = {
             "backend": self.backend_name,
             "model": self.model,
             "attempt": attempt_no,
             "stage": stage.slug,
+            "label": label,
             "prompt_path": str(prompt_path),
             "exit_code": exit_code,
             "session_id": observed_session_id or session_id,
@@ -143,21 +180,13 @@ class AutomatedReviewer:
             "stderr_excerpt": stderr_text[-1000:] if stderr_text else "",
             "stream_meta": stream_meta,
         }
-        record_path = paths.operator_state_dir / f"{stage.slug}.review_attempt_{attempt_no:02d}.json"
-        write_text(record_path, json.dumps(review_record, indent=2, ensure_ascii=False))
+        record_path = paths.operator_state_dir / f"{stage.slug}.{label}_attempt_{attempt_no:02d}.json"
+        write_text(record_path, json.dumps(record, indent=2, ensure_ascii=False))
+        return exit_code, stdout_text, stderr_text
 
-        if exit_code != 0:
-            return ReviewDecision(
-                choice="6",
-                decision_token="abort",
-                reason=(
-                    f"Automated reviewer failed with exit code {exit_code}. "
-                    "AutoR stopped instead of approving blindly."
-                ),
-                raw_response=stdout_text or stderr_text,
-            )
-
-        return self._parse_decision(stdout_text)
+    def parse_decision(self, raw_response: str) -> ReviewDecision:
+        """Public alias: panel members parse the same decision grammar."""
+        return self._parse_decision(raw_response)
 
     def _build_review_prompt(
         self,

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -1,0 +1,838 @@
+"""A deliberating review panel in place of a single approval agent.
+
+AutoR's thesis is that a human owns direction while an agent owns execution. The reviewer
+agent (:mod:`src.approval_agent`) exists so an unattended run still has *something* standing
+at the stage gate — but one model, asked once, with one framing, is a weak stand-in for the
+thing it replaces. Real research is not approved by one reader. It is argued over by people
+who want different things from it: the PI wants the claim to land, the methodologist wants
+the design to hold, the reproducibility engineer wants to be able to rerun it, and Reviewer 2
+wants to reject it.
+
+This module simulates that room.
+
+**Why a panel and not just more tokens.** Asking one reviewer to "consider many perspectives"
+produces one voice listing perspectives it already agreed with. Independent reviewers, each
+given a distinct mandate, a distinct model, and no sight of the others, produce genuinely
+different reads — and the disagreement between them is information a single reviewer cannot
+generate. So round one is blind on purpose.
+
+**Why deliberation and not just voting.** A vote throws away the reasons. Round two shows each
+member what the others found and lets them revise, which is where a domain expert's objection
+teaches the methodologist something and vice versa. Only then does the chair decide.
+
+**What stops the panel rubber-stamping.** A member may mark an objection ``blocking``. If any
+blocking objection survives the final round, approval is refused *in code* — not by asking the
+chair nicely. A prompt-level rule that the chair can talk itself out of is not a rule, and a
+gate that cannot say no is not a gate.
+
+Every position, including dissent that lost, is written to ``workspace/reviews/panel/``. A
+panel that hides how it split is less auditable than the single reviewer it replaced.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .approval_agent import AutomatedReviewer, ReviewDecision
+from .terminal_ui import TerminalUI
+from .utils import RunPaths, StageSpec, append_log_entry, read_text, truncate_text, write_text
+
+
+#: Choices that leave the stage unapproved. Used to decide whether a panel actually converged.
+_REFINEMENT_CHOICES = {"1", "2", "3", "4"}
+
+
+@dataclass(frozen=True)
+class PanelRole:
+    """One seat at the table.
+
+    ``backend`` and ``model`` are what make the panel more than one model in five hats: a
+    verdict from a different harness is the only kind that is genuinely uncorrelated. Both are
+    optional and fall back to the run's reviewer defaults, because a single-backend deployment
+    should still get the benefit of distinct mandates.
+    """
+
+    key: str
+    title: str
+    charter: str
+    looks_for: tuple[str, ...]
+    skill: str | None = None
+    backend: str | None = None
+    model: str | None = None
+    #: A chair breaks ties and writes the final decision. Exactly one role must have it.
+    chair: bool = False
+
+
+DEFAULT_PANEL: tuple[PanelRole, ...] = (
+    PanelRole(
+        key="pi",
+        title="Principal Investigator",
+        chair=True,
+        charter=(
+            "You own the research question and the go/no-go. You care whether this stage moves "
+            "the central claim forward, whether the story still holds together, and whether the "
+            "run is spending its effort on the thing that matters. You are the one who has to "
+            "defend this work publicly."
+        ),
+        looks_for=(
+            "Does this stage advance the central claim, or is it busywork?",
+            "Has the narrative drifted from what earlier stages committed to?",
+            "Is the strongest available result being buried or oversold?",
+        ),
+    ),
+    PanelRole(
+        key="domain",
+        title="Domain Expert",
+        charter=(
+            "You know this field. You care whether the framing, terminology, and prior work are "
+            "right, whether the claim is actually novel, and whether a specialist reading this "
+            "would find an obvious error or an obvious missing reference."
+        ),
+        looks_for=(
+            "Is anything stated as fact that a specialist would dispute?",
+            "Is the prior work represented accurately, and is anything load-bearing missing?",
+            "Is the terminology used the way the field uses it?",
+        ),
+        skill="citation-discipline",
+    ),
+    PanelRole(
+        key="method",
+        title="Methodologist",
+        charter=(
+            "You own study design and statistical validity. You care about confounds, sample "
+            "size, baselines, ablations, leakage between train and test, and whether the "
+            "measurement actually measures the thing being claimed."
+        ),
+        looks_for=(
+            "Does the design support the causal or comparative claim being made?",
+            "Are baselines, controls, and ablations present and fair?",
+            "Are uncertainties, sample sizes, and failure cases reported?",
+        ),
+        skill="result-table",
+    ),
+    PanelRole(
+        key="repro",
+        title="Reproducibility Engineer",
+        charter=(
+            "You care about whether someone else could rerun this. Numbers must trace to files, "
+            "files must exist, code must be runnable, and figures must come from the data they "
+            "claim to. You open the artifacts rather than trusting the summary's description "
+            "of them."
+        ),
+        looks_for=(
+            "Does every number in the summary trace to a file in the run?",
+            "Do the listed artifacts actually exist, and are they non-trivial?",
+            "Could a stranger rerun this stage from what is on disk?",
+        ),
+        skill="reproducibility-check",
+    ),
+    PanelRole(
+        key="skeptic",
+        title="Adversarial Reviewer",
+        charter=(
+            "You are Reviewer 2. Your job is to find the reason this should be rejected. Assume "
+            "the work is weaker than it looks and go looking for the evidence. You are not being "
+            "unfair; you are the reason the other four have to be right. Do not manufacture "
+            "objections — but do not soften a real one to be agreeable."
+        ),
+        looks_for=(
+            "What is the strongest argument that this stage's conclusion is wrong?",
+            "Which claim has the thinnest evidence behind it?",
+            "What would an unsympathetic reviewer attack first?",
+        ),
+    ),
+)
+
+PANEL_ROLES_BY_KEY = {role.key: role for role in DEFAULT_PANEL}
+
+
+@dataclass(frozen=True)
+class PanelVerdict:
+    role_key: str
+    role_title: str
+    backend: str
+    model: str
+    choice: str
+    decision_token: str
+    blocking: bool
+    reason: str
+    feedback: str
+    concerns: tuple[str, ...] = ()
+    failed: bool = False
+
+    @property
+    def approves(self) -> bool:
+        return self.choice == "5" and not self.blocking
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "role": self.role_key,
+            "title": self.role_title,
+            "backend": self.backend,
+            "model": self.model,
+            "choice": self.choice,
+            "decision": self.decision_token,
+            "blocking": self.blocking,
+            "reason": self.reason,
+            "feedback": self.feedback,
+            "concerns": list(self.concerns),
+            "failed": self.failed,
+        }
+
+
+@dataclass
+class PanelDeliberation:
+    stage_slug: str
+    attempt_no: int
+    rounds: list[list[PanelVerdict]] = field(default_factory=list)
+    decision: ReviewDecision | None = None
+    chair_overridden: bool = False
+    override_reason: str = ""
+
+    @property
+    def final_round(self) -> list[PanelVerdict]:
+        return self.rounds[-1] if self.rounds else []
+
+    def blocking_verdicts(self) -> list[PanelVerdict]:
+        return [verdict for verdict in self.final_round if verdict.blocking]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage_slug,
+            "attempt": self.attempt_no,
+            "rounds": [[verdict.to_dict() for verdict in group] for group in self.rounds],
+            "blocking_after_deliberation": [v.role_key for v in self.blocking_verdicts()],
+            "chair_overridden": self.chair_overridden,
+            "override_reason": self.override_reason,
+            "final_choice": self.decision.choice if self.decision else None,
+            "final_reason": self.decision.reason if self.decision else "",
+            "final_feedback": self.decision.feedback if self.decision else "",
+        }
+
+
+def resolve_roles(keys: list[str] | None) -> tuple[PanelRole, ...]:
+    """Resolve a roster from role keys, preserving the caller's order.
+
+    An unknown key is an error rather than a silent drop: a panel that quietly seats four
+    members when five were asked for is a panel whose composition nobody can trust.
+    """
+    if not keys:
+        return DEFAULT_PANEL
+
+    roles: list[PanelRole] = []
+    for key in keys:
+        normalized = key.strip().lower()
+        if normalized not in PANEL_ROLES_BY_KEY:
+            known = ", ".join(sorted(PANEL_ROLES_BY_KEY))
+            raise ValueError(f"Unknown panel role: {key}. Known roles: {known}.")
+        role = PANEL_ROLES_BY_KEY[normalized]
+        if role not in roles:
+            roles.append(role)
+
+    if not any(role.chair for role in roles):
+        # Somebody has to write the final decision; the first seat takes the gavel.
+        first = roles[0]
+        roles[0] = PanelRole(**{**first.__dict__, "chair": True})
+    return tuple(roles)
+
+
+class ReviewPanel:
+    """A drop-in for :class:`~src.approval_agent.AutomatedReviewer` that deliberates first.
+
+    Duck-types ``review_stage`` plus the ``backend_name``/``model`` attributes the manager
+    reads, so the approval loop does not need to know whether it is talking to one reviewer or
+    five.
+    """
+
+    def __init__(
+        self,
+        roles: tuple[PanelRole, ...] = DEFAULT_PANEL,
+        *,
+        backend_name: str,
+        model: str,
+        fake_mode: bool = False,
+        ui: TerminalUI | None = None,
+        stage_timeout: int = 14400,
+        persona_text: str = "",
+        deliberation_rounds: int = 2,
+    ) -> None:
+        if not roles:
+            raise ValueError("A review panel needs at least one role.")
+        self.roles = roles
+        self.backend_name = backend_name
+        self.model = model
+        self.fake_mode = fake_mode
+        self.ui = ui or TerminalUI()
+        self.persona_text = persona_text.strip()
+        self.deliberation_rounds = max(1, deliberation_rounds)
+        self._members: dict[str, AutomatedReviewer] = {
+            role.key: AutomatedReviewer(
+                role.backend or backend_name,
+                model=role.model or model,
+                fake_mode=fake_mode,
+                ui=self.ui,
+                stage_timeout=stage_timeout,
+            )
+            for role in roles
+        }
+        self.chair = next(role for role in roles if role.chair)
+
+    # -- the manager-facing contract -----------------------------------------
+
+    def review_stage(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        stage_markdown: str,
+        suggestions: list[str],
+    ) -> ReviewDecision:
+        if self.fake_mode:
+            return ReviewDecision(
+                choice="5",
+                decision_token="approve",
+                reason="Fake panel mode auto-approved this stage for smoke validation.",
+                raw_response='{"decision":"approve","reason":"fake panel"}',
+            )
+
+        deliberation = PanelDeliberation(stage_slug=stage.slug, attempt_no=attempt_no)
+
+        verdicts = self._round(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            stage_markdown=stage_markdown,
+            suggestions=suggestions,
+            previous=None,
+            round_no=1,
+        )
+        deliberation.rounds.append(verdicts)
+
+        # A unanimous, unblocked room has nothing to deliberate about, and a second round
+        # would only invite it to talk itself out of an agreement it already reached.
+        for round_no in range(2, self.deliberation_rounds + 1):
+            if self._is_unanimous(verdicts):
+                break
+            verdicts = self._round(
+                paths=paths,
+                stage=stage,
+                attempt_no=attempt_no,
+                stage_markdown=stage_markdown,
+                suggestions=suggestions,
+                previous=verdicts,
+                round_no=round_no,
+            )
+            deliberation.rounds.append(verdicts)
+
+        decision = self._synthesize(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            stage_markdown=stage_markdown,
+            suggestions=suggestions,
+            deliberation=deliberation,
+        )
+        deliberation.decision = decision
+
+        decision = self._enforce_blocking_objections(deliberation)
+        self._record(paths, deliberation)
+        self._render(deliberation)
+        return decision
+
+    # -- rounds ---------------------------------------------------------------
+
+    def _round(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        stage_markdown: str,
+        suggestions: list[str],
+        previous: list[PanelVerdict] | None,
+        round_no: int,
+    ) -> list[PanelVerdict]:
+        verdicts: list[PanelVerdict] = []
+        for role in self.roles:
+            member = self._members[role.key]
+            self.ui.show_status(
+                f"Panel round {round_no}: {role.title} is reviewing {stage.stage_title}...",
+                level="info",
+            )
+            prompt = self._build_member_prompt(
+                paths=paths,
+                stage=stage,
+                attempt_no=attempt_no,
+                stage_markdown=stage_markdown,
+                suggestions=suggestions,
+                role=role,
+                previous=previous,
+                round_no=round_no,
+            )
+            exit_code, stdout_text, stderr_text = member.run_prompt(
+                paths=paths,
+                stage=stage,
+                attempt_no=attempt_no,
+                prompt=prompt,
+                label=f"panel_{role.key}_r{round_no}",
+            )
+            verdicts.append(
+                self._verdict_from_output(
+                    role=role,
+                    member=member,
+                    exit_code=exit_code,
+                    stdout_text=stdout_text,
+                    stderr_text=stderr_text,
+                )
+            )
+        return verdicts
+
+    def _verdict_from_output(
+        self,
+        *,
+        role: PanelRole,
+        member: AutomatedReviewer,
+        exit_code: int,
+        stdout_text: str,
+        stderr_text: str,
+    ) -> PanelVerdict:
+        if exit_code != 0:
+            # A member that could not be reached does not get to be counted as agreeing.
+            return PanelVerdict(
+                role_key=role.key,
+                role_title=role.title,
+                backend=member.backend_name,
+                model=member.model,
+                choice="4",
+                decision_token="custom_feedback",
+                blocking=False,
+                reason=f"{role.title} could not be reached (exit code {exit_code}).",
+                feedback="",
+                failed=True,
+            )
+
+        decision = member.parse_decision(stdout_text)
+        payload = self._payload(stdout_text)
+        blocking = bool(payload.get("blocking")) if isinstance(payload, dict) else False
+        concerns: tuple[str, ...] = ()
+        if isinstance(payload, dict) and isinstance(payload.get("concerns"), list):
+            concerns = tuple(str(item).strip() for item in payload["concerns"] if str(item).strip())
+
+        return PanelVerdict(
+            role_key=role.key,
+            role_title=role.title,
+            backend=member.backend_name,
+            model=member.model,
+            choice=decision.choice,
+            decision_token=decision.decision_token,
+            # An unparseable answer degrades to abort in `parse_decision`; treat that as a
+            # non-blocking failure rather than letting one bad response veto the run.
+            blocking=blocking and decision.choice != "6",
+            reason=decision.reason,
+            feedback=decision.feedback,
+            concerns=concerns,
+        )
+
+    def _payload(self, raw_response: str) -> dict[str, Any] | None:
+        member = next(iter(self._members.values()))
+        return member._extract_json_payload(raw_response)  # noqa: SLF001
+
+    @staticmethod
+    def _is_unanimous(verdicts: list[PanelVerdict]) -> bool:
+        if any(verdict.failed for verdict in verdicts):
+            return False
+        return all(verdict.approves for verdict in verdicts) or len({v.choice for v in verdicts}) == 1
+
+    # -- synthesis and enforcement -------------------------------------------
+
+    def _synthesize(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        stage_markdown: str,
+        suggestions: list[str],
+        deliberation: PanelDeliberation,
+    ) -> ReviewDecision:
+        verdicts = deliberation.final_round
+        if self._is_unanimous(verdicts) and verdicts and verdicts[0].approves:
+            return ReviewDecision(
+                choice="5",
+                decision_token="approve",
+                reason=f"All {len(verdicts)} panel members approved without a blocking objection.",
+                raw_response=json.dumps(deliberation.to_dict()),
+            )
+
+        chair = self._members[self.chair.key]
+        self.ui.show_status(f"Panel chair ({self.chair.title}) is synthesizing the decision...", level="info")
+        exit_code, stdout_text, stderr_text = chair.run_prompt(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            prompt=self._build_chair_prompt(
+                paths=paths,
+                stage=stage,
+                attempt_no=attempt_no,
+                stage_markdown=stage_markdown,
+                suggestions=suggestions,
+                deliberation=deliberation,
+            ),
+            label="panel_chair",
+        )
+        if exit_code != 0:
+            return self._decision_from_dissent(
+                verdicts,
+                reason=f"Panel chair could not be reached (exit code {exit_code}); "
+                "falling back to the panel's own objections.",
+            )
+        return chair.parse_decision(stdout_text)
+
+    def _enforce_blocking_objections(self, deliberation: PanelDeliberation) -> ReviewDecision:
+        """Refuse approval while a blocking objection stands.
+
+        This is deliberately mechanical. The chair is a model, and a model asked to weigh
+        dissent can be argued into discounting it; the point of a blocking flag is that it
+        cannot be. If the chair approves anyway, the approval is converted into refinement and
+        the conversion is recorded.
+        """
+        decision = deliberation.decision
+        assert decision is not None
+        blockers = deliberation.blocking_verdicts()
+        if not blockers or decision.choice != "5":
+            return decision
+
+        objections = "\n".join(
+            f"- **{verdict.role_title}**: {verdict.reason or verdict.feedback or 'blocking objection'}"
+            for verdict in blockers
+        )
+        names = ", ".join(verdict.role_title for verdict in blockers)
+        feedback = (
+            "The panel chair moved to approve, but the following blocking objections were "
+            "unresolved. Address each one concretely before this stage can be approved.\n\n"
+            f"{objections}"
+        )
+        deliberation.chair_overridden = True
+        deliberation.override_reason = f"Blocking objection from {names} outranks the chair's approval."
+        overridden = ReviewDecision(
+            choice="4",
+            decision_token="custom_feedback",
+            reason=deliberation.override_reason,
+            feedback=feedback,
+            raw_response=decision.raw_response,
+        )
+        deliberation.decision = overridden
+        return overridden
+
+    def _decision_from_dissent(self, verdicts: list[PanelVerdict], *, reason: str) -> ReviewDecision:
+        objections = [v for v in verdicts if not v.approves and not v.failed]
+        if not objections:
+            return ReviewDecision(choice="5", decision_token="approve", reason=reason)
+        feedback = "\n".join(
+            f"- **{verdict.role_title}**: {verdict.feedback or verdict.reason}"
+            for verdict in objections
+            if verdict.feedback or verdict.reason
+        )
+        return ReviewDecision(
+            choice="4",
+            decision_token="custom_feedback",
+            reason=reason,
+            feedback=feedback or "The panel did not converge on approval.",
+        )
+
+    # -- prompts --------------------------------------------------------------
+
+    def _persona_block(self) -> str:
+        if not self.persona_text:
+            return ""
+        return (
+            "\n# The Researcher You Are Standing In For\n\n"
+            "This run has a named human owner. Their standards are the standards you apply; "
+            "where the charter and this description disagree, this description wins.\n\n"
+            f"{truncate_text(self.persona_text, max_chars=4000)}\n"
+        )
+
+    def _build_member_prompt(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        stage_markdown: str,
+        suggestions: list[str],
+        role: PanelRole,
+        previous: list[PanelVerdict] | None,
+        round_no: int,
+    ) -> str:
+        looks_for = "\n".join(f"- {item}" for item in role.looks_for)
+        skill_line = (
+            f"\nA skill named `{role.skill}` is installed in this run. Use it — it encodes the "
+            "checks your seat is responsible for.\n"
+            if role.skill
+            else ""
+        )
+
+        if previous is None:
+            round_block = (
+                "## Round 1 of the panel: independent review\n\n"
+                "You have not seen the other members' views and you should not speculate about "
+                "them. Form your own judgement from the artifacts. Disagreement between members "
+                "is useful to this run; agreement you did not actually reach is not.\n"
+            )
+        else:
+            positions = "\n\n".join(
+                f"**{verdict.role_title}** -> {verdict.decision_token}"
+                + (" (BLOCKING)" if verdict.blocking else "")
+                + (f"\nReason: {verdict.reason}" if verdict.reason else "")
+                + (f"\nConcerns: {'; '.join(verdict.concerns)}" if verdict.concerns else "")
+                for verdict in previous
+                if verdict.role_key != role.key
+            )
+            own = next((v for v in previous if v.role_key == role.key), None)
+            round_block = (
+                f"## Round {round_no} of the panel: cross-examination\n\n"
+                "The panel did not agree. Below is what every other member concluded. Read them "
+                "as colleagues who looked at the same artifacts and saw something you did not.\n\n"
+                "Change your position if they found something real. Hold it if they did not — "
+                "converging to be agreeable is the failure mode this round exists to avoid, and "
+                "a lone correct objection is worth more than a comfortable consensus.\n\n"
+                f"{positions}\n"
+                + (
+                    f"\nYour own round-1 position was `{own.decision_token}`"
+                    + (f": {own.reason}" if own.reason else "")
+                    + "\n"
+                    if own
+                    else ""
+                )
+            )
+
+        return (
+            f"# AutoR Review Panel: {role.title}\n\n"
+            f"You are the **{role.title}** on the review panel for {stage.stage_title}. You are a "
+            "simulated human reviewer standing at an approval gate, not the execution agent. Do "
+            "not edit files. Inspect and judge.\n\n"
+            f"## Your Charter\n\n{role.charter}\n\n"
+            f"## What Your Seat Is Responsible For\n\n{looks_for}\n"
+            f"{skill_line}\n"
+            "Other seats cover other concerns. Do not try to cover the whole review — review "
+            "your part of it properly and trust the panel for the rest.\n\n"
+            f"{round_block}\n"
+            "## Review Policy\n\n"
+            "- Approve only if this stage is materially complete for its current milestone.\n"
+            "- Do not demand final-paper quality from early stages, but do demand real progress "
+            "and real artifacts.\n"
+            "- Open the artifacts. A summary's description of a file is not evidence the file "
+            "says what it claims.\n"
+            "- Mark `blocking` true only for a defect that must be fixed before this stage can "
+            "be approved at all. A blocking objection cannot be overruled by the chair, so use "
+            "it for real defects and not for preferences.\n\n"
+            "## Return Format\n\n"
+            "Return JSON only, with no prose outside the JSON object:\n"
+            '{"decision":"approve|suggestion_1|suggestion_2|suggestion_3|custom_feedback|abort",'
+            '"blocking":false,"concerns":["..."],"feedback":"","reason":""}\n\n'
+            "- `feedback` must be non-empty when `decision` is `custom_feedback`.\n"
+            "- `concerns` is a short list of the specific things you checked and found wanting.\n"
+            "- `reason` should be concise and specific to your seat.\n"
+            f"{self._persona_block()}\n"
+            "# Suggested Refinements Available To The Panel\n\n"
+            f"1. {suggestions[0]}\n2. {suggestions[1]}\n3. {suggestions[2]}\n\n"
+            f"{self._context_block(paths=paths, stage=stage, attempt_no=attempt_no, stage_markdown=stage_markdown)}"
+        )
+
+    def _build_chair_prompt(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        stage_markdown: str,
+        suggestions: list[str],
+        deliberation: PanelDeliberation,
+    ) -> str:
+        transcript_parts: list[str] = []
+        for index, group in enumerate(deliberation.rounds, start=1):
+            lines = [f"### Round {index}", ""]
+            for verdict in group:
+                lines.append(
+                    f"**{verdict.role_title}** ({verdict.backend}/{verdict.model}) -> "
+                    f"`{verdict.decision_token}`" + ("  **BLOCKING**" if verdict.blocking else "")
+                )
+                if verdict.reason:
+                    lines.append(f"- Reason: {verdict.reason}")
+                if verdict.concerns:
+                    lines.extend(f"- Concern: {item}" for item in verdict.concerns)
+                if verdict.feedback:
+                    lines.append(f"- Requested change: {verdict.feedback}")
+                if verdict.failed:
+                    lines.append("- (this member could not be reached)")
+                lines.append("")
+            transcript_parts.append("\n".join(lines))
+        transcript = "\n".join(transcript_parts)
+
+        blockers = deliberation.blocking_verdicts()
+        blocking_note = (
+            "\n**There are unresolved blocking objections from: "
+            + ", ".join(verdict.role_title for verdict in blockers)
+            + ". You cannot approve over them — if you try, the decision will be converted to "
+            "a refinement automatically. Fold their requirements into your feedback instead.**\n"
+            if blockers
+            else ""
+        )
+
+        return (
+            f"# AutoR Review Panel: Chair Synthesis\n\n"
+            f"You are the **{self.chair.title}**, chairing the review panel for "
+            f"{stage.stage_title}. The panel has deliberated and did not simply agree. Your job "
+            "is to turn their positions into the single decision the workflow will act on.\n\n"
+            "## How To Decide\n\n"
+            "- Weigh the objections on their evidence, not on how many members raised them. One "
+            "member who opened the artifacts and found a real problem outranks three who did not.\n"
+            "- Address the dissent explicitly in your reason. A synthesis that ignores a member's "
+            "objection is not a synthesis.\n"
+            "- If the objections are concrete and fixable, choose `custom_feedback` and write "
+            "instructions that would satisfy the members who raised them.\n"
+            "- If a built-in suggestion already captures the panel's ask, select it instead.\n"
+            "- Use `abort` only if continuing automatically would be irresponsible.\n"
+            f"{blocking_note}\n"
+            "## Return Format\n\n"
+            "Return JSON only, with no prose outside the JSON object:\n"
+            '{"decision":"approve|suggestion_1|suggestion_2|suggestion_3|custom_feedback|abort",'
+            '"feedback":"","reason":""}\n\n'
+            f"{self._persona_block()}\n"
+            "# Panel Transcript\n\n"
+            f"{transcript}\n"
+            "# Suggested Refinements Available To The Panel\n\n"
+            f"1. {suggestions[0]}\n2. {suggestions[1]}\n3. {suggestions[2]}\n\n"
+            f"{self._context_block(paths=paths, stage=stage, attempt_no=attempt_no, stage_markdown=stage_markdown)}"
+        )
+
+    def _context_block(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        stage_markdown: str,
+    ) -> str:
+        def excerpt(path: Path, max_chars: int, tail: bool = False) -> str:
+            if not path.exists():
+                return "(missing)"
+            text = read_text(path).strip()
+            if not text:
+                return "(empty)"
+            if len(text) <= max_chars:
+                return text
+            return ("..." + text[-(max_chars - 3):].lstrip()) if tail else truncate_text(text, max_chars=max_chars)
+
+        return (
+            "# Run Context\n\n"
+            f"- run root: `{paths.run_root.resolve()}`\n"
+            f"- current attempt: {attempt_no}\n"
+            f"- stage draft under review: `{paths.stage_tmp_file(stage).resolve()}`\n"
+            f"- artifact index: `{paths.artifact_index.resolve()}`\n"
+            f"- experiment manifest: `{paths.experiment_manifest.resolve()}`\n"
+            f"- workspace root: `{paths.workspace_root.resolve()}`\n\n"
+            "# Original Goal\n\n"
+            f"{excerpt(paths.user_input, 3000)}\n\n"
+            "# Approved Memory\n\n"
+            f"{excerpt(paths.memory, 10000)}\n\n"
+            "# Current Stage Summary\n\n"
+            f"{truncate_text(stage_markdown, max_chars=16000)}\n\n"
+            "# Artifact Index Excerpt\n\n"
+            f"{excerpt(paths.artifact_index, 5000)}\n\n"
+            "# Experiment Manifest Excerpt\n\n"
+            f"{excerpt(paths.experiment_manifest, 5000)}\n"
+        )
+
+    # -- recording ------------------------------------------------------------
+
+    def _record(self, paths: RunPaths, deliberation: PanelDeliberation) -> None:
+        """Persist the whole room, including the dissent that lost.
+
+        Stage 08 reads ``workspace/reviews/``, and a run's auditability is the product's whole
+        claim. A panel that reported only its verdict would be less inspectable than the single
+        reviewer it replaced.
+        """
+        panel_dir = paths.reviews_dir / "panel"
+        panel_dir.mkdir(parents=True, exist_ok=True)
+        stem = f"{deliberation.stage_slug}_attempt_{deliberation.attempt_no:02d}"
+
+        write_text(
+            panel_dir / f"{stem}.json",
+            json.dumps(deliberation.to_dict(), indent=2, ensure_ascii=False),
+        )
+        write_text(panel_dir / f"{stem}.md", self._render_markdown(deliberation))
+
+        summary = "; ".join(
+            f"{verdict.role_title}={verdict.decision_token}" + ("(blocking)" if verdict.blocking else "")
+            for verdict in deliberation.final_round
+        )
+        append_log_entry(
+            paths.logs,
+            f"{deliberation.stage_slug} attempt {deliberation.attempt_no} panel_decision",
+            (
+                f"rounds: {len(deliberation.rounds)}\n"
+                f"positions: {summary}\n"
+                f"chair_overridden: {deliberation.chair_overridden}\n"
+                f"final_choice: {deliberation.decision.choice if deliberation.decision else '?'}"
+            ),
+        )
+
+    def _render_markdown(self, deliberation: PanelDeliberation) -> str:
+        lines = [
+            f"# Review Panel: {deliberation.stage_slug} (attempt {deliberation.attempt_no})",
+            "",
+        ]
+        for index, group in enumerate(deliberation.rounds, start=1):
+            lines.extend([f"## Round {index}", ""])
+            for verdict in group:
+                flag = " **BLOCKING**" if verdict.blocking else ""
+                lines.append(f"### {verdict.role_title} -> `{verdict.decision_token}`{flag}")
+                lines.append(f"_{verdict.backend} / {verdict.model}_")
+                lines.append("")
+                if verdict.reason:
+                    lines.extend([verdict.reason, ""])
+                if verdict.concerns:
+                    lines.extend([f"- {item}" for item in verdict.concerns] + [""])
+                if verdict.feedback:
+                    lines.extend(["Requested change:", "", verdict.feedback, ""])
+                if verdict.failed:
+                    lines.extend(["_This member could not be reached._", ""])
+        decision = deliberation.decision
+        lines.extend(["## Outcome", ""])
+        if deliberation.chair_overridden:
+            lines.extend([f"> Chair approval overridden: {deliberation.override_reason}", ""])
+        if decision is not None:
+            lines.append(f"- Decision: `{decision.decision_token}` (choice {decision.choice})")
+            if decision.reason:
+                lines.append(f"- Reason: {decision.reason}")
+            if decision.feedback:
+                lines.extend(["", "### Feedback to the execution agent", "", decision.feedback])
+        return "\n".join(lines).rstrip() + "\n"
+
+    def _render(self, deliberation: PanelDeliberation) -> None:
+        body = [f"Rounds   : {len(deliberation.rounds)}"]
+        for verdict in deliberation.final_round:
+            flag = "  [BLOCKING]" if verdict.blocking else ""
+            body.append(f"{verdict.role_title:<26}: {verdict.decision_token}{flag}")
+        if deliberation.chair_overridden:
+            body.extend(["", f"Chair approval overridden: {deliberation.override_reason}"])
+        if deliberation.decision is not None:
+            body.extend(["", f"Decision : {deliberation.decision.decision_token}"])
+            if deliberation.decision.reason:
+                body.append(f"Reason   : {deliberation.decision.reason}")
+        self.ui.panel("Review Panel", body, color=self.ui.FG_MAGENTA)
+
+
+def load_persona(path: Path | str | None) -> str:
+    """Read a persona description, or return empty when none is configured."""
+    if not path:
+        return ""
+    resolved = Path(path).expanduser()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Persona file not found: {resolved}")
+    return read_text(resolved).strip()

--- a/tests/test_review_panel.py
+++ b/tests/test_review_panel.py
@@ -1,0 +1,485 @@
+"""The panel is a gate, so the thing worth pinning is whether it can say no.
+
+Most of these tests drive real `AutomatedReviewer` members with only their transport stubbed,
+so the JSON grammar, the decision mapping and the blocking-objection rule are all exercised
+for real rather than against a mock of themselves.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.approval_agent import ReviewDecision
+from src.review_panel import (
+    DEFAULT_PANEL,
+    PanelRole,
+    ReviewPanel,
+    load_persona,
+    resolve_roles,
+)
+from src.terminal_ui import TerminalUI
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    read_text,
+    write_text,
+)
+
+
+STAGE_01 = next(stage for stage in STAGES if stage.slug == "01_literature_survey")
+SUGGESTIONS = ["Tighten the scope.", "Strengthen the evidence.", "Clarify the risks."]
+
+
+def _verdict_json(decision: str, *, blocking: bool = False, reason: str = "", feedback: str = "",
+                  concerns: list[str] | None = None) -> str:
+    return json.dumps(
+        {
+            "decision": decision,
+            "blocking": blocking,
+            "reason": reason or f"{decision} from a panel member",
+            "feedback": feedback,
+            "concerns": concerns or [],
+        }
+    )
+
+
+class _ScriptedPanel:
+    """A panel whose members answer from a script instead of a subprocess."""
+
+    def __init__(self, testcase: unittest.TestCase, script: dict[str, list[str]], **kwargs):
+        self.calls: list[tuple[str, str]] = []
+        tmp_dir = tempfile.TemporaryDirectory()
+        testcase.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "Study the thing.")
+        write_text(self.paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(self.paths, model="sonnet", venue="neurips_2025")
+
+        self.panel = ReviewPanel(
+            kwargs.pop("roles", DEFAULT_PANEL),
+            backend_name="claude",
+            model="sonnet",
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+            **kwargs,
+        )
+
+        remaining = {key: list(values) for key, values in script.items()}
+
+        def make(label_key: str, member):
+            def run_prompt(*, paths, stage, attempt_no, prompt, label):
+                self.calls.append((label_key, label))
+                queue = remaining.get(label_key)
+                if not queue:
+                    raise AssertionError(f"No scripted response left for {label_key} ({label})")
+                response = queue.pop(0)
+                if response == "__FAIL__":
+                    return 1, "", "backend exploded"
+                return 0, response, ""
+
+            member.run_prompt = run_prompt
+            return member
+
+        for role in self.panel.roles:
+            make(role.key, self.panel._members[role.key])
+        # The chair's synthesis call reuses the chair member, so its script is keyed separately.
+        chair_member = self.panel._members[self.panel.chair.key]
+        chair_queue = list(script.get("__chair__", []))
+        member_run = chair_member.run_prompt
+
+        def chair_aware_run(*, paths, stage, attempt_no, prompt, label):
+            if label == "panel_chair":
+                self.calls.append(("__chair__", label))
+                if not chair_queue:
+                    raise AssertionError("No scripted chair response left")
+                response = chair_queue.pop(0)
+                if response == "__FAIL__":
+                    return 1, "", "chair exploded"
+                return 0, response, ""
+            return member_run(paths=paths, stage=stage, attempt_no=attempt_no, prompt=prompt, label=label)
+
+        chair_member.run_prompt = chair_aware_run
+
+    def review(self, attempt_no: int = 1) -> ReviewDecision:
+        return self.panel.review_stage(
+            paths=self.paths,
+            stage=STAGE_01,
+            attempt_no=attempt_no,
+            stage_markdown="# Stage 01\n\n## Key Results\n\nSomething happened.\n",
+            suggestions=SUGGESTIONS,
+        )
+
+    def rounds_for(self, role_key: str) -> int:
+        return sum(1 for key, _label in self.calls if key == role_key)
+
+    def record(self, attempt_no: int = 1) -> dict:
+        path = self.paths.reviews_dir / "panel" / f"{STAGE_01.slug}_attempt_{attempt_no:02d}.json"
+        return json.loads(read_text(path))
+
+
+class RosterTests(unittest.TestCase):
+    def test_the_default_roster_is_five_seats_with_one_chair(self) -> None:
+        self.assertEqual(len(DEFAULT_PANEL), 5)
+        self.assertEqual([role.key for role in DEFAULT_PANEL if role.chair], ["pi"])
+
+    def test_every_seat_has_a_distinct_mandate(self) -> None:
+        charters = {role.charter for role in DEFAULT_PANEL}
+        self.assertEqual(len(charters), len(DEFAULT_PANEL))
+        for role in DEFAULT_PANEL:
+            self.assertTrue(role.looks_for, role.key)
+
+    def test_a_subset_keeps_the_callers_order(self) -> None:
+        roles = resolve_roles(["skeptic", "method"])
+        self.assertEqual([role.key for role in roles], ["skeptic", "method"])
+
+    def test_a_roster_without_the_pi_still_gets_a_chair(self) -> None:
+        roles = resolve_roles(["method", "repro"])
+        self.assertEqual([role.key for role in roles if role.chair], ["method"])
+
+    def test_duplicate_keys_do_not_seat_the_same_member_twice(self) -> None:
+        self.assertEqual([role.key for role in resolve_roles(["pi", "pi"])], ["pi"])
+
+    def test_an_unknown_role_is_refused_rather_than_dropped(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            resolve_roles(["methodologist"])
+        self.assertIn("Unknown panel role", str(ctx.exception))
+
+    def test_an_empty_roster_falls_back_to_the_default(self) -> None:
+        self.assertEqual(resolve_roles(None), DEFAULT_PANEL)
+        self.assertEqual(resolve_roles([]), DEFAULT_PANEL)
+
+
+class DeliberationTests(unittest.TestCase):
+    def test_a_unanimous_approval_needs_no_second_round_and_no_chair(self) -> None:
+        script = {role.key: [_verdict_json("approve")] for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(self, script)
+
+        decision = harness.review()
+
+        self.assertEqual(decision.choice, "5")
+        for role in DEFAULT_PANEL:
+            self.assertEqual(harness.rounds_for(role.key), 1, role.key)
+        # Nothing to deliberate and nothing to synthesize.
+        self.assertEqual(harness.rounds_for("__chair__"), 0)
+        self.assertEqual(len(harness.record()["rounds"]), 1)
+
+    def test_disagreement_triggers_a_cross_examination_round(self) -> None:
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("custom_feedback", feedback="Add a baseline."),
+                       _verdict_json("approve")],
+            "repro": [_verdict_json("approve"), _verdict_json("approve")],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [_verdict_json("approve", reason="Objection resolved in round 2.")],
+        }
+        harness = _ScriptedPanel(self, script)
+
+        decision = harness.review()
+
+        self.assertEqual(harness.rounds_for("method"), 2)
+        self.assertEqual(len(harness.record()["rounds"]), 2)
+        self.assertEqual(decision.choice, "5")
+
+    def test_round_one_members_are_not_shown_each_others_positions(self) -> None:
+        seen: list[str] = []
+        script = {role.key: [_verdict_json("approve")] for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(self, script)
+        original = harness.panel._build_member_prompt
+
+        def capture(**kwargs):
+            prompt = original(**kwargs)
+            seen.append(prompt)
+            return prompt
+
+        harness.panel._build_member_prompt = capture
+        harness.review()
+
+        for prompt in seen:
+            self.assertIn("independent review", prompt)
+            self.assertNotIn("cross-examination", prompt)
+
+    def test_the_second_round_shows_a_member_what_the_others_concluded(self) -> None:
+        prompts: list[str] = []
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("custom_feedback", reason="No baseline anywhere."),
+                       _verdict_json("approve")],
+            "repro": [_verdict_json("approve"), _verdict_json("approve")],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [_verdict_json("approve")],
+        }
+        harness = _ScriptedPanel(self, script)
+        original = harness.panel._build_member_prompt
+
+        def capture(**kwargs):
+            prompt = original(**kwargs)
+            prompts.append(prompt)
+            return prompt
+
+        harness.panel._build_member_prompt = capture
+        harness.review()
+
+        second_round = [p for p in prompts if "cross-examination" in p]
+        self.assertEqual(len(second_round), len(DEFAULT_PANEL))
+        self.assertTrue(any("No baseline anywhere." in p for p in second_round))
+        # A member is not shown its own verdict as somebody else's position.
+        methodologist = next(p for p in second_round if "You are the **Methodologist**" in p)
+        self.assertIn("Your own round-1 position", methodologist)
+
+
+class BlockingObjectionTests(unittest.TestCase):
+    """The rule that makes this a gate rather than a formality."""
+
+    def _panel_with_blocker(self, chair_decision: str):
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("approve"), _verdict_json("approve")],
+            "repro": [
+                _verdict_json("custom_feedback", blocking=True,
+                              reason="metrics.json does not exist.",
+                              feedback="Produce the results file the summary cites."),
+                _verdict_json("custom_feedback", blocking=True,
+                              reason="metrics.json still does not exist.",
+                              feedback="Produce the results file the summary cites."),
+            ],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [chair_decision],
+        }
+        return _ScriptedPanel(self, script)
+
+    def test_a_chair_cannot_approve_over_a_blocking_objection(self) -> None:
+        harness = self._panel_with_blocker(
+            _verdict_json("approve", reason="Minor gap; proceeding.")
+        )
+
+        decision = harness.review()
+
+        self.assertEqual(decision.choice, "4")
+        self.assertEqual(decision.decision_token, "custom_feedback")
+        self.assertIn("Reproducibility Engineer", decision.feedback)
+        self.assertIn("metrics.json", decision.feedback)
+
+    def test_the_override_is_recorded_rather_than_silent(self) -> None:
+        harness = self._panel_with_blocker(_verdict_json("approve"))
+        harness.review()
+
+        record = harness.record()
+        self.assertTrue(record["chair_overridden"])
+        self.assertIn("Reproducibility Engineer", record["override_reason"])
+        self.assertEqual(record["blocking_after_deliberation"], ["repro"])
+
+    def test_a_chair_that_already_refines_is_left_alone(self) -> None:
+        harness = self._panel_with_blocker(
+            _verdict_json("custom_feedback", feedback="Rebuild the results file.",
+                          reason="Agreeing with the reproducibility objection.")
+        )
+
+        decision = harness.review()
+
+        self.assertEqual(decision.choice, "4")
+        self.assertEqual(decision.feedback, "Rebuild the results file.")
+        self.assertFalse(harness.record()["chair_overridden"])
+
+    def test_a_blocking_objection_withdrawn_in_round_two_stops_blocking(self) -> None:
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("approve"), _verdict_json("approve")],
+            "repro": [
+                _verdict_json("custom_feedback", blocking=True, reason="Cannot find metrics.json."),
+                _verdict_json("approve", reason="Found it under results/; withdrawing."),
+            ],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [_verdict_json("approve", reason="Objection withdrawn.")],
+        }
+        harness = _ScriptedPanel(self, script)
+
+        decision = harness.review()
+
+        self.assertEqual(decision.choice, "5")
+        self.assertFalse(harness.record()["chair_overridden"])
+        self.assertEqual(harness.record()["blocking_after_deliberation"], [])
+
+    def test_an_unparseable_answer_cannot_masquerade_as_a_veto(self) -> None:
+        # parse_decision degrades junk to abort; that must not also count as a blocking veto.
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("approve"), _verdict_json("approve")],
+            "repro": ['{"decision":"nonsense","blocking":true}', _verdict_json("approve")],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [_verdict_json("approve")],
+        }
+        harness = _ScriptedPanel(self, script)
+        harness.review()
+        self.assertEqual(harness.record()["rounds"][0][3]["blocking"], False)
+
+
+class MemberFailureTests(unittest.TestCase):
+    def test_an_unreachable_member_is_not_counted_as_agreeing(self) -> None:
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": ["__FAIL__", _verdict_json("approve")],
+            "repro": [_verdict_json("approve"), _verdict_json("approve")],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [_verdict_json("approve")],
+        }
+        harness = _ScriptedPanel(self, script)
+        harness.review()
+
+        # A failure breaks unanimity, so the panel deliberates rather than waving it through.
+        self.assertEqual(len(harness.record()["rounds"]), 2)
+        self.assertTrue(harness.record()["rounds"][0][2]["failed"])
+
+    def test_an_unreachable_chair_falls_back_to_the_panels_own_objections(self) -> None:
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [
+                _verdict_json("custom_feedback", feedback="Add an ablation."),
+                _verdict_json("custom_feedback", feedback="Add an ablation."),
+            ],
+            "repro": [_verdict_json("approve"), _verdict_json("approve")],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": ["__FAIL__"],
+        }
+        harness = _ScriptedPanel(self, script)
+
+        decision = harness.review()
+
+        self.assertEqual(decision.choice, "4")
+        self.assertIn("Add an ablation.", decision.feedback)
+
+
+class RecordTests(unittest.TestCase):
+    def test_dissent_that_lost_is_still_written_down(self) -> None:
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("approve"), _verdict_json("approve")],
+            "repro": [_verdict_json("approve"), _verdict_json("approve")],
+            "skeptic": [
+                _verdict_json("custom_feedback", reason="The claim outruns the evidence.",
+                              concerns=["No baseline", "n is tiny"]),
+                _verdict_json("custom_feedback", reason="The claim outruns the evidence."),
+            ],
+            "__chair__": [_verdict_json("approve", reason="Overruling: the claim is hedged already.")],
+        }
+        harness = _ScriptedPanel(self, script)
+        harness.review()
+
+        markdown = read_text(harness.paths.reviews_dir / "panel" / f"{STAGE_01.slug}_attempt_01.md")
+        self.assertIn("Adversarial Reviewer", markdown)
+        self.assertIn("The claim outruns the evidence.", markdown)
+        self.assertIn("No baseline", markdown)
+        self.assertIn("Overruling", markdown)
+
+    def test_the_record_lands_where_stage_08_reads_reviews(self) -> None:
+        script = {role.key: [_verdict_json("approve")] for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(self, script)
+        harness.review(attempt_no=3)
+
+        panel_dir = harness.paths.reviews_dir / "panel"
+        self.assertTrue((panel_dir / f"{STAGE_01.slug}_attempt_03.json").exists())
+        self.assertTrue((panel_dir / f"{STAGE_01.slug}_attempt_03.md").exists())
+
+
+class PersonaTests(unittest.TestCase):
+    def test_a_persona_reaches_every_panelist(self) -> None:
+        prompts: list[str] = []
+        script = {role.key: [_verdict_json("approve")] for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(
+            self, script, persona_text="I care about effect sizes, not p-values."
+        )
+        original = harness.panel._build_member_prompt
+
+        def capture(**kwargs):
+            prompt = original(**kwargs)
+            prompts.append(prompt)
+            return prompt
+
+        harness.panel._build_member_prompt = capture
+        harness.review()
+
+        self.assertEqual(len(prompts), len(DEFAULT_PANEL))
+        for prompt in prompts:
+            self.assertIn("I care about effect sizes, not p-values.", prompt)
+
+    def test_no_persona_adds_no_section(self) -> None:
+        script = {role.key: [_verdict_json("approve")] for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(self, script)
+        prompt = harness.panel._build_member_prompt(
+            paths=harness.paths, stage=STAGE_01, attempt_no=1,
+            stage_markdown="x", suggestions=SUGGESTIONS,
+            role=DEFAULT_PANEL[0], previous=None, round_no=1,
+        )
+        self.assertNotIn("The Researcher You Are Standing In For", prompt)
+
+    def test_a_missing_persona_file_is_an_error_not_a_silent_empty(self) -> None:
+        self.assertEqual(load_persona(None), "")
+        with self.assertRaises(FileNotFoundError):
+            load_persona("/nonexistent/persona.md")
+
+    def test_a_persona_file_is_read(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        path = Path(tmp_dir.name) / "persona.md"
+        path.write_text("# PI\n\nRigour over speed.\n", encoding="utf-8")
+        self.assertIn("Rigour over speed.", load_persona(path))
+
+
+class DropInContractTests(unittest.TestCase):
+    def test_the_panel_satisfies_what_the_manager_reads_off_a_reviewer(self) -> None:
+        panel = ReviewPanel(
+            DEFAULT_PANEL,
+            backend_name="claude",
+            model="sonnet",
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        self.assertEqual(panel.backend_name, "claude")
+        self.assertEqual(panel.model, "sonnet")
+        self.assertTrue(callable(panel.review_stage))
+
+    def test_fake_mode_approves_so_smoke_runs_still_finish(self) -> None:
+        script: dict[str, list[str]] = {}
+        harness = _ScriptedPanel(self, script, fake_mode=True)
+        decision = harness.review()
+        self.assertEqual(decision.choice, "5")
+        self.assertEqual(harness.calls, [])
+
+    def test_a_single_seat_panel_is_legal(self) -> None:
+        harness = _ScriptedPanel(
+            self, {"skeptic": [_verdict_json("approve")]}, roles=resolve_roles(["skeptic"])
+        )
+        self.assertEqual(harness.review().choice, "5")
+
+    def test_an_empty_roster_is_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            ReviewPanel((), backend_name="claude", model="sonnet")
+
+    def test_roles_can_carry_their_own_backend_and_model(self) -> None:
+        role = PanelRole(
+            key="skeptic", title="Adversarial Reviewer", charter="c", looks_for=("x",),
+            backend="codex", model="opus", chair=True,
+        )
+        panel = ReviewPanel(
+            (role,), backend_name="claude", model="sonnet",
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        member = panel._members["skeptic"]
+        self.assertEqual(member.backend_name, "codex")
+        self.assertEqual(member.model, "opus")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
AutoR's premise is that a human owns direction while an agent owns execution. For unattended runs that human is a single reviewer agent — one model, asked once, with one framing. That is a thin stand-in for the thing it replaces.

`--review-panel` seats a room instead.

```bash
python main.py --review-panel --goal "..."
python main.py --review-panel --persona docs/persona-example.md --goal "..."
python rcb_agent.py --review-panel
```

## Why a panel and not a longer prompt

Asking one reviewer to "consider multiple perspectives" produces one voice listing perspectives it already agreed with — the disagreement is simulated inside a single forward pass, and a model that has already decided finds reasons rather than objections.

Independent reviewers with distinct mandates produce genuinely different reads, and **the disagreement between them is information a single reviewer cannot generate.** That is the whole argument, and it is why round one is blind on purpose.

## The seats

| Role | Owns | Skill |
|:---|:---|:---|
| Principal Investigator (chair) | Does this advance the central claim? Has the story drifted? | — |
| Domain Expert | Field correctness, prior work, actual novelty | `citation-discipline` |
| Methodologist | Confounds, baselines, ablations, leakage, sample size | `result-table` |
| Reproducibility Engineer | Do the numbers trace to files that exist | `reproducibility-check` |
| Adversarial Reviewer | Reviewer 2 — finds the strongest reason to reject | — |

Each seat reviews *its part* properly and trusts the panel for the rest. `PanelRole` carries optional `backend`/`model` overrides: a verdict from a different harness is the only genuinely uncorrelated kind, so mixing `claude` and `codex` seats is where the panel earns most.

## The protocol

1. **Round 1 — blind.** No member sees another's position.
2. **Round 2 — cross-examination.** Only on disagreement. Members are told explicitly that converging to be agreeable is the failure mode this round exists to avoid.
3. **Chair synthesis**, required to address the dissent.

A unanimous unblocked room skips both — nothing to deliberate, and a second round would only invite it to talk itself out of an agreement it already reached.

## What keeps it a gate

Any member may mark an objection `blocking`. **A surviving blocking objection refuses approval in code** — the chair's approval is converted to a refinement and the conversion is recorded. The chair is a model, and a model asked to weigh dissent can be argued into discounting it; a prompt-level rule the chair can talk itself out of is not a rule.

Two guards alongside: an unreachable member is not counted as agreeing (it breaks unanimity), and an unparseable answer cannot masquerade as a veto.

## Auditability

Every position from every round — including dissent that lost and any chair override — lands in `workspace/reviews/panel/*.{json,md}`, where Stage 08 already reads. A panel that reported only its verdict would be less inspectable than the reviewer it replaced.

## Integration

`ReviewPanel` duck-types `AutomatedReviewer`, so the manager never learns which it got. `review_stage`'s operator plumbing is extracted to `run_prompt` so members reuse the existing invocation, logging and transcript path.

## Verification

612 tests pass, 29 new. Mutation-verified rather than assumed:

- removing the blocking-objection enforcement → 2 tests fail
- removing the unanimity short-circuit → 5 tests fail
- control run passes

Also driven end to end through a real `ReviewPanel` with scripted members: a blocking reproducibility objection correctly overrode a chair approval, produced `choice=4`, and wrote both record files.

## Cost, stated plainly

Roughly `seats x rounds + 1` reviewer calls per gate — 5 when the room agrees, 11 when it does not. Reduce with `--panel-roles repro skeptic` or `--panel-rounds 1`. Off by default.

Known limits are written down in [docs/review-panel.md](docs/review-panel.md): correlated seats when all five share a model, members reviewing summaries rather than the world, and deliberation's ability to converge on a shared error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)