### PR TITLE
Make the approval gate learn from the corrections it demands

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Useful feature | **Automated experiment manifests** | Machine-readable experiment and result files make runs inspectable, comparable, and reusable downstream. |
 | Useful feature | **Citation verification and writing checks** | Writing expects citation verification, figure-link checks, and self-review artifacts before Stage 07 is considered complete. |
 | Useful feature | **Artifact indexing across stages** | `artifact_index.json` and related manifests help later stages find data, results, and figures without guessing from filenames. |
+| Useful feature | **Self-improving review policy** | Every correction the reviewer demands becomes a standing rule checked on all later stages, recorded in an auditable `review_policy.json` with the stage and attempt that produced it. |
 | Useful feature | **Resume, redo, and rollback controls** | Long research runs can continue in place, retry a stage, or roll downstream state back without starting over. |
 | Useful feature | **Two output formats** | Stage 07 writes a benchmark-ready markdown report (`report/report.md` + PNG figures) by default, or a venue-aware LaTeX paper package with a compiled PDF via `--output-format latex`. |
 
@@ -460,6 +461,31 @@ flowchart TD
 - Stages 01-08 use the standard six-action review menu: `1 / 2 / 3` continue with an AI refinement suggestion, `4` continues with custom feedback, `5` approves, and `6` aborts.
 
 The stage loop is controlled by AutoR, not by Claude.
+
+### Self-improving review
+
+The approval gate does not just judge each stage — it **accumulates the corrections it
+demands and applies them to every stage after**. A reviewer that once insisted on a stated
+power analysis keeps insisting, so the same class of weakness cannot recur later in the run:
+
+```
+stage N review  ──demands a correction──▶  standing rule
+                                              │
+stage N+1 review  ◀──rule is now checked──────┘
+```
+
+Two properties keep this honest rather than decorative:
+
+- **It is auditable.** The policy is a plain artifact at `runs/<run_id>/review_policy.json`,
+  and every rule names the stage and attempt that produced it, so the claim can be checked
+  against the record instead of believed.
+- **It cannot inflate.** Rules are deduplicated on normalized text — casing, punctuation and
+  stage numbers collapse — and the set is bounded, so a reviewer restating one complaint
+  does not manufacture the appearance of learning.
+
+A rollback is recorded at higher weight than a routine refinement, because it is the
+strongest evidence a review can produce: an approval already given turned out to be wrong.
+Approvals teach nothing and are not recorded.
 
 ### Unattended runs
 

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -687,3 +687,37 @@ it loses the Studio's project groupings; the runs themselves are unaffected.
   checkpoints gets big.
 - **Read `logs.txt`, then `logs_raw.jsonl`, then `prompt_cache/`.** That is
   the fastest path from "the output is wrong" to "here is why".
+
+## `review_policy.json`
+
+The standing rules the approval gate has learned during this run. Written by
+[`src/review_policy.py`](../src/review_policy.py) whenever the reviewer demands a
+correction, and injected into every subsequent review prompt.
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "rule_id": "R001",
+      "text": "The design lacks a stated power analysis and the sample size is unjustified.",
+      "origin_stage": "03_study_design",
+      "origin_attempt": 2,
+      "source": "refinement"
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `rule_id` | Stable identifier, referenced in the review prompt and the run log. |
+| `text` | The correction verbatim, as the reviewer worded it. |
+| `origin_stage` / `origin_attempt` | Which review produced the rule. This is what makes the mechanism auditable rather than assertable. |
+| `source` | `refinement` for a demanded correction, `rollback` for an approval that later proved wrong. Rollbacks are rendered first in the prompt. |
+
+Absent until the first correction is recorded. Approvals teach nothing and are not
+recorded. Rules are deduplicated on normalized text (casing, punctuation and stage numbers
+collapse) and the set is capped, so a reviewer restating one complaint cannot inflate it.
+A corrupt file is treated as an empty policy: the gate falls back to baseline strictness
+rather than taking the run down.

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .operator import ClaudeOperator
+from .review_policy import format_policy_for_prompt, load_policy
 from .operator_codex import CodexOperator
 from .terminal_ui import TerminalUI
 from .utils import (
@@ -198,7 +199,8 @@ class AutomatedReviewer:
             f"- experiment manifest: `{paths.experiment_manifest.resolve()}`\n"
             f"- stage draft under review: `{paths.stage_tmp_file(stage).resolve()}`\n"
             f"- approved stage path: `{paths.stage_file(stage).resolve()}`\n\n"
-            "# Suggested Refinements\n\n"
+            + self._standing_rules_block(paths)
+            + "# Suggested Refinements\n\n"
             f"1. {suggestions[0]}\n"
             f"2. {suggestions[1]}\n"
             f"3. {suggestions[2]}\n\n"
@@ -217,6 +219,17 @@ class AutomatedReviewer:
             "# Recent Log Excerpt\n\n"
             f"{self._read_excerpt(paths.logs, max_chars=5000, tail=True)}\n"
         )
+
+    def _standing_rules_block(self, paths: RunPaths) -> str:
+        """Render the rules earlier reviews produced, so this review inherits them.
+
+        This is what makes the gate strictly harder as a run proceeds: a correction demanded
+        once is checked on every stage after it.
+        """
+        rendered = format_policy_for_prompt(load_policy(paths))
+        if not rendered:
+            return ""
+        return "# Standing Review Rules (learned earlier in this run)\n\n" + rendered + "\n\n"
 
     def _read_excerpt(self, path: Path, *, max_chars: int, tail: bool = False) -> str:
         if not path.exists():

--- a/src/manager.py
+++ b/src/manager.py
@@ -15,6 +15,7 @@ from .bootstrap import (
     scan_corpus,
 )
 from .approval_agent import AutomatedReviewer, ReviewDecision
+from .review_policy import load_policy, policy_summary, record_correction
 from .project_bootstrap import (
     format_project_context_for_prompt,
     format_project_scan_for_prompt,
@@ -1848,7 +1849,48 @@ class ResearchManager:
         if decision.raw_response:
             log_body.append("raw_response_excerpt:\n" + truncate_text(decision.raw_response, max_chars=2000))
         append_log_entry(paths.logs, f"{stage.slug} attempt {attempt_no} reviewer_choice", "\n".join(log_body))
+        self._record_review_correction(
+            paths=paths, stage=stage, attempt_no=attempt_no, decision=decision, suggestions=suggestions
+        )
         return decision.choice, decision.feedback or None
+
+    def _record_review_correction(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        decision: ReviewDecision,
+        suggestions: list[str],
+    ) -> None:
+        """Promote a demanded correction into a standing rule for every later review.
+
+        Only refusals teach anything: an approval says the stage met the bar, which the
+        existing rules already encode. The text recorded is what the reviewer actually
+        asked for, so the rule is traceable to the decision that produced it.
+        """
+        if decision.choice not in {"1", "2", "3", "4"}:
+            return
+
+        if decision.choice in {"1", "2", "3"}:
+            index = int(decision.choice) - 1
+            text = suggestions[index] if index < len(suggestions) else ""
+        else:
+            text = decision.feedback or decision.reason
+
+        rule = record_correction(paths, stage=stage, attempt_no=attempt_no, text=text)
+        if rule is None:
+            return
+
+        append_log_entry(
+            paths.logs,
+            f"{stage.slug} attempt {attempt_no} review_rule_learned",
+            f"{rule.rule_id} ({rule.source}): {rule.text}",
+        )
+        self.ui.show_status(
+            f"Review policy learned {rule.rule_id}; {policy_summary(load_policy(paths))}.",
+            level="info",
+        )
 
     def _render_review_decision(self, decision: ReviewDecision) -> None:
         label_map = {
@@ -2136,6 +2178,19 @@ class ResearchManager:
         reason: str,
     ) -> None:
         rollback_to_stage(paths, target_stage, reason=reason)
+        # A rollback is the strongest evidence a review can produce: an approval that was
+        # already given turned out to be wrong. Recorded at higher weight than a routine
+        # refinement so later reviews treat it as such.
+        record_correction(
+            paths,
+            stage=current_stage,
+            attempt_no=0,
+            text=(
+                f"{current_stage.stage_title} was rolled back to {target_stage.stage_title}. "
+                f"Reason: {reason}"
+            ),
+            source="rollback",
+        )
         append_log_entry(
             paths.logs,
             f"{current_stage.slug} rollback_requested",

--- a/src/review_policy.py
+++ b/src/review_policy.py
@@ -1,0 +1,212 @@
+"""A review policy that improves itself from the reviewer's own corrections.
+
+The approval gate in :mod:`src.approval_agent` judges each stage against a fixed prompt.
+That makes it stateless: if the reviewer demands a power analysis at Stage 03, nothing stops
+Stage 05 from shipping without one, and nothing stops the same omission recurring on the
+next run. A human reviewer does not work that way — having once been burned, they keep
+checking.
+
+This module closes that loop. Every correction the reviewer demands is recorded as a
+**standing rule**, and every later review is judged against the accumulated set. The
+review capability is therefore produced by review and governs subsequent review, so the
+gate gets strictly harder as a run proceeds:
+
+    stage N review  ──demands a correction──▶  rule
+                                                │
+    stage N+1 review  ◀──rule is now checked────┘
+
+Two properties make this more than a slogan:
+
+* **It is auditable.** The policy is a plain JSON artifact at the run root, and every rule
+  names the stage and attempt that produced it, so any claim about "self-improvement" can
+  be checked against the record rather than believed.
+* **It cannot silently inflate.** Rules are deduplicated on normalized text and the set is
+  bounded, so a reviewer that repeats itself does not manufacture the appearance of
+  learning.
+
+Rules are stored verbatim rather than being generalized by an extra model call. A recorded
+rule keeps the stage it came from, and the reviewing model generalizes at read time, which
+avoids spending a call per correction to paraphrase text a model is about to read anyway.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from .utils import RunPaths, StageSpec
+
+
+POLICY_VERSION = 1
+
+#: Upper bound on standing rules. A review prompt has to stay readable, and past this many
+#: corrections the marginal rule is noise rather than signal.
+MAX_RULES = 40
+
+#: Corrections shorter than this carry no checkable content ("improve it", "more detail").
+MIN_RULE_CHARS = 25
+
+#: How rules are grouped in the prompt, strongest evidence first.
+SOURCE_LABELS = {
+    "rollback": "A stage was rolled back after this was missed",
+    "refinement": "The reviewer demanded this correction",
+}
+
+
+@dataclass(frozen=True)
+class ReviewRule:
+    rule_id: str
+    text: str
+    origin_stage: str
+    origin_attempt: int
+    source: str = "refinement"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ReviewPolicy:
+    version: int = POLICY_VERSION
+    rules: list[ReviewRule] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"version": self.version, "rules": [rule.to_dict() for rule in self.rules]}
+
+    @classmethod
+    def from_dict(cls, payload: Any) -> "ReviewPolicy":
+        if not isinstance(payload, dict):
+            return cls()
+        rules: list[ReviewRule] = []
+        for entry in payload.get("rules") or []:
+            if not isinstance(entry, dict):
+                continue
+            text = str(entry.get("text") or "").strip()
+            if not text:
+                continue
+            rules.append(
+                ReviewRule(
+                    rule_id=str(entry.get("rule_id") or f"R{len(rules) + 1:03d}"),
+                    text=text,
+                    origin_stage=str(entry.get("origin_stage") or "unknown"),
+                    origin_attempt=int(entry.get("origin_attempt") or 0),
+                    source=str(entry.get("source") or "refinement"),
+                )
+            )
+        return cls(version=int(payload.get("version") or POLICY_VERSION), rules=rules)
+
+
+def policy_path(paths: RunPaths) -> Path:
+    return paths.run_root / "review_policy.json"
+
+
+def load_policy(paths: RunPaths) -> ReviewPolicy:
+    path = policy_path(paths)
+    if not path.exists():
+        return ReviewPolicy()
+    try:
+        return ReviewPolicy.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError):
+        # A corrupt policy must not take the run down with it: the gate still works
+        # without its learned rules, it is just back to its baseline strictness.
+        return ReviewPolicy()
+
+
+def save_policy(paths: RunPaths, policy: ReviewPolicy) -> Path:
+    path = policy_path(paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(policy.to_dict(), indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path
+
+
+def normalize_rule_text(text: str) -> str:
+    """Collapse a correction to a comparison key.
+
+    Reviewers restate the same demand with different punctuation, casing and stage numbers
+    across attempts. Without this, one recurring complaint would fill the policy and look
+    like accumulated learning.
+    """
+    lowered = re.sub(r"\s+", " ", (text or "").strip().lower())
+    lowered = re.sub(r"\bstage\s*\d+\b", "stage", lowered)
+    return re.sub(r"[^a-z0-9 ]+", "", lowered).strip()
+
+
+def record_correction(
+    paths: RunPaths,
+    *,
+    stage: StageSpec,
+    attempt_no: int,
+    text: str,
+    source: str = "refinement",
+) -> ReviewRule | None:
+    """Turn one demanded correction into a standing rule.
+
+    Returns the new rule, or None when the correction was empty, too thin to check, or a
+    restatement of a rule already held.
+    """
+    cleaned = " ".join((text or "").split())
+    if len(cleaned) < MIN_RULE_CHARS:
+        return None
+
+    policy = load_policy(paths)
+    key = normalize_rule_text(cleaned)
+    if not key:
+        return None
+    if any(normalize_rule_text(rule.text) == key for rule in policy.rules):
+        return None
+    if len(policy.rules) >= MAX_RULES:
+        return None
+
+    rule = ReviewRule(
+        rule_id=f"R{len(policy.rules) + 1:03d}",
+        text=cleaned,
+        origin_stage=stage.slug,
+        origin_attempt=attempt_no,
+        source=source if source in SOURCE_LABELS else "refinement",
+    )
+    policy.rules.append(rule)
+    save_policy(paths, policy)
+    return rule
+
+
+def format_policy_for_prompt(policy: ReviewPolicy) -> str:
+    """Render the standing rules for injection into a review prompt."""
+    if not policy.rules:
+        return ""
+
+    lines = [
+        "These corrections were demanded earlier in this run. They are now standing "
+        "requirements: check this stage against every one of them, not only against the "
+        "stage's own objectives. A stage that repeats a mistake already corrected once "
+        "must not be approved.",
+        "",
+    ]
+    for source in ("rollback", "refinement"):
+        group = [rule for rule in policy.rules if rule.source == source]
+        if not group:
+            continue
+        lines.append(f"**{SOURCE_LABELS[source]}:**")
+        for rule in group:
+            lines.append(f"- `{rule.rule_id}` (from {rule.origin_stage}, attempt {rule.origin_attempt}): {rule.text}")
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def policy_summary(policy: ReviewPolicy) -> str:
+    """One line describing the policy, for the run log and the terminal."""
+    if not policy.rules:
+        return "no standing review rules yet"
+    by_source = {
+        source: sum(1 for rule in policy.rules if rule.source == source)
+        for source in SOURCE_LABELS
+    }
+    parts = [f"{count} from {source}" for source, count in by_source.items() if count]
+    return f"{len(policy.rules)} standing review rule(s) ({', '.join(parts)})"
+
+
+def rules_from(policy: ReviewPolicy, sources: Iterable[str]) -> list[ReviewRule]:
+    wanted = set(sources)
+    return [rule for rule in policy.rules if rule.source in wanted]

--- a/tests/test_review_policy.py
+++ b/tests/test_review_policy.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.approval_agent import ReviewDecision
+from src.manager import ResearchManager
+from src.review_policy import (
+    MAX_RULES,
+    MIN_RULE_CHARS,
+    ReviewPolicy,
+    ReviewRule,
+    format_policy_for_prompt,
+    load_policy,
+    normalize_rule_text,
+    policy_path,
+    policy_summary,
+    record_correction,
+    save_policy,
+)
+from src.terminal_ui import TerminalUI
+from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
+
+
+STAGE_01, STAGE_03 = STAGES[0], STAGES[2]
+LONG = "The design lacks a stated power analysis and the sample size is unjustified."
+OTHER = "Every reported metric must carry a confidence interval computed from the raw data."
+
+
+class PolicyTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.memory, "# Memory\n")
+
+
+class RecordCorrectionTest(PolicyTestBase):
+    def test_a_correction_becomes_a_standing_rule(self) -> None:
+        rule = record_correction(self.paths, stage=STAGE_01, attempt_no=2, text=LONG)
+        self.assertIsNotNone(rule)
+        self.assertEqual(rule.origin_stage, STAGE_01.slug)
+        self.assertEqual(rule.origin_attempt, 2)
+        self.assertEqual(load_policy(self.paths).rules[0].text, LONG)
+
+    def test_the_policy_is_an_auditable_artifact_at_the_run_root(self) -> None:
+        record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=LONG)
+        payload = json.loads(policy_path(self.paths).read_text(encoding="utf-8"))
+        self.assertEqual(payload["rules"][0]["origin_stage"], STAGE_01.slug)
+        self.assertEqual(payload["rules"][0]["source"], "refinement")
+
+    def test_a_restatement_does_not_manufacture_learning(self) -> None:
+        record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=LONG)
+        again = record_correction(
+            self.paths, stage=STAGE_03, attempt_no=1, text="  The DESIGN lacks a stated power analysis, and the sample size is unjustified!!  "
+        )
+        self.assertIsNone(again)
+        self.assertEqual(len(load_policy(self.paths).rules), 1)
+
+    def test_a_stage_number_does_not_make_two_rules_distinct(self) -> None:
+        record_correction(self.paths, stage=STAGE_01, attempt_no=1, text="Stage 03 must report an effect size for each comparison made.")
+        again = record_correction(self.paths, stage=STAGE_03, attempt_no=1, text="Stage 05 must report an effect size for each comparison made.")
+        self.assertIsNone(again)
+
+    def test_a_thin_correction_is_not_a_rule(self) -> None:
+        self.assertIsNone(record_correction(self.paths, stage=STAGE_01, attempt_no=1, text="improve it"))
+        self.assertIsNone(record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=""))
+        self.assertIsNone(record_correction(self.paths, stage=STAGE_01, attempt_no=1, text="   "))
+        self.assertEqual(load_policy(self.paths).rules, [])
+
+    def test_the_rule_set_is_bounded(self) -> None:
+        for index in range(MAX_RULES + 5):
+            record_correction(
+                self.paths, stage=STAGE_01, attempt_no=1,
+                text=f"Distinct standing requirement number {index} that is long enough to be checkable.",
+            )
+        self.assertEqual(len(load_policy(self.paths).rules), MAX_RULES)
+
+    def test_a_rollback_is_recorded_at_its_own_weight(self) -> None:
+        rule = record_correction(
+            self.paths, stage=STAGE_03, attempt_no=0, text=LONG, source="rollback"
+        )
+        self.assertEqual(rule.source, "rollback")
+
+    def test_an_unknown_source_falls_back_rather_than_being_stored(self) -> None:
+        rule = record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=LONG, source="wishful")
+        self.assertEqual(rule.source, "refinement")
+
+    def test_a_corrupt_policy_does_not_take_the_run_down(self) -> None:
+        policy_path(self.paths).write_text("not json", encoding="utf-8")
+        self.assertEqual(load_policy(self.paths).rules, [])
+        self.assertIsNotNone(record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=LONG))
+
+    def test_min_rule_chars_is_actually_enforced_at_the_boundary(self) -> None:
+        just_under = "x" * (MIN_RULE_CHARS - 1)
+        just_over = "y" * MIN_RULE_CHARS
+        self.assertIsNone(record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=just_under))
+        self.assertIsNotNone(record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=just_over))
+
+
+class NormalizeTest(unittest.TestCase):
+    def test_casing_spacing_and_punctuation_collapse(self) -> None:
+        self.assertEqual(normalize_rule_text("  A  B,  c! "), normalize_rule_text("a b c"))
+
+    def test_stage_numbers_collapse(self) -> None:
+        self.assertEqual(normalize_rule_text("Stage 03 needs x"), normalize_rule_text("Stage 07 needs x"))
+
+    def test_genuinely_different_text_stays_different(self) -> None:
+        self.assertNotEqual(normalize_rule_text(LONG), normalize_rule_text(OTHER))
+
+
+class PromptRenderingTest(PolicyTestBase):
+    def test_an_empty_policy_renders_nothing(self) -> None:
+        self.assertEqual(format_policy_for_prompt(ReviewPolicy()), "")
+
+    def test_rules_are_rendered_with_their_provenance(self) -> None:
+        record_correction(self.paths, stage=STAGE_01, attempt_no=2, text=LONG)
+        rendered = format_policy_for_prompt(load_policy(self.paths))
+        self.assertIn(LONG, rendered)
+        self.assertIn("R001", rendered)
+        self.assertIn(STAGE_01.slug, rendered)
+        self.assertIn("must not be approved", rendered)
+
+    def test_rollbacks_are_grouped_above_routine_refinements(self) -> None:
+        record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=OTHER)
+        record_correction(self.paths, stage=STAGE_03, attempt_no=0, text=LONG, source="rollback")
+        rendered = format_policy_for_prompt(load_policy(self.paths))
+        self.assertLess(rendered.index("rolled back"), rendered.index("demanded this correction"))
+
+    def test_summary_counts_by_source(self) -> None:
+        self.assertIn("no standing review rules", policy_summary(ReviewPolicy()))
+        record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=LONG)
+        self.assertIn("1 standing review rule", policy_summary(load_policy(self.paths)))
+
+
+class ReviewerPromptTest(PolicyTestBase):
+    """The loop only closes if the learned rules actually reach the next review."""
+
+    def _reviewer(self):
+        from src.approval_agent import AutomatedReviewer
+
+        return AutomatedReviewer("claude", model="opus", fake_mode=True,
+                                 ui=TerminalUI(output_stream=io.StringIO(), interactive=False))
+
+    def test_a_learned_rule_reaches_the_next_review_prompt(self) -> None:
+        record_correction(self.paths, stage=STAGE_01, attempt_no=2, text=LONG)
+        prompt = self._reviewer()._build_review_prompt(
+            paths=self.paths, stage=STAGE_03, attempt_no=1,
+            stage_markdown="# Stage 03: Study Design\n", suggestions=["a", "b", "c"],
+        )
+        self.assertIn("Standing Review Rules", prompt)
+        self.assertIn(LONG, prompt)
+
+    def test_no_rules_means_no_section(self) -> None:
+        prompt = self._reviewer()._build_review_prompt(
+            paths=self.paths, stage=STAGE_01, attempt_no=1,
+            stage_markdown="# Stage 01: Literature Survey\n", suggestions=["a", "b", "c"],
+        )
+        self.assertNotIn("Standing Review Rules", prompt)
+
+
+class StubOperator:
+    model = "stub"
+    backend_name = "claude"
+
+
+class ManagerRecordingTest(PolicyTestBase):
+    """Corrections must be recorded from the real decision funnel, not a test-only path."""
+
+    def _manager(self) -> ResearchManager:
+        return ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=self.paths.run_root.parent,
+            operator=StubOperator(),
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+
+    def _record(self, choice, *, feedback="", reason="", suggestions=None):
+        self._manager()._record_review_correction(
+            paths=self.paths, stage=STAGE_01, attempt_no=2,
+            decision=ReviewDecision(choice=choice, decision_token="t", reason=reason, feedback=feedback),
+            suggestions=suggestions or [LONG, OTHER, "third suggestion that is long enough to count"],
+        )
+        return load_policy(self.paths).rules
+
+    def test_a_selected_suggestion_is_recorded(self) -> None:
+        self.assertEqual(self._record("1")[0].text, LONG)
+
+    def test_the_second_suggestion_is_recorded_when_chosen(self) -> None:
+        self.assertEqual(self._record("2")[0].text, OTHER)
+
+    def test_custom_feedback_is_recorded(self) -> None:
+        self.assertEqual(self._record("4", feedback=OTHER)[0].text, OTHER)
+
+    def test_an_approval_teaches_nothing(self) -> None:
+        self.assertEqual(self._record("5", reason="looks good"), [])
+
+    def test_an_abort_teaches_nothing(self) -> None:
+        self.assertEqual(self._record("6", reason="blocked"), [])
+
+    def test_the_learned_rule_is_written_to_the_run_log(self) -> None:
+        self._record("1")
+        self.assertIn("review_rule_learned", read_text(self.paths.logs))
+
+    def test_an_out_of_range_suggestion_index_does_not_crash(self) -> None:
+        self.assertEqual(self._record("3", suggestions=["only one"]), [])
+
+
+class RecursionTest(PolicyTestBase):
+    def test_the_gate_is_monotonically_harder_across_stages(self) -> None:
+        """The defining property: each correction permanently raises the bar."""
+        rendered_sizes = []
+        for index, stage in enumerate(STAGES[:4]):
+            record_correction(
+                self.paths, stage=stage, attempt_no=1,
+                text=f"Requirement {index}: every claim must cite an artifact produced in this run.".replace(
+                    "every claim", f"every claim of kind {index}"
+                ),
+            )
+            rendered_sizes.append(len(format_policy_for_prompt(load_policy(self.paths))))
+        self.assertEqual(rendered_sizes, sorted(rendered_sizes))
+        self.assertEqual(len(load_policy(self.paths).rules), 4)
+
+    def test_rules_survive_a_reload_so_later_stages_inherit_them(self) -> None:
+        record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=LONG)
+        reloaded = ReviewPolicy.from_dict(load_policy(self.paths).to_dict())
+        self.assertEqual(reloaded.rules[0].text, LONG)
+
+    def test_a_hand_written_policy_round_trips(self) -> None:
+        policy = ReviewPolicy(rules=[ReviewRule("R001", LONG, STAGE_01.slug, 1, "rollback")])
+        save_policy(self.paths, policy)
+        self.assertEqual(load_policy(self.paths).rules[0].source, "rollback")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The reviewer was **stateless**. If it demanded a power analysis at Stage 03, nothing stopped Stage 05 shipping without one, and nothing stopped the same omission recurring on the next run. A human reviewer does not work that way — having once been burned, they keep checking.

Every correction the reviewer demands now becomes a **standing rule**, and every later review is judged against the accumulated set. The reviewing capability is produced by review and governs subsequent review, so the gate gets strictly harder as a run proceeds:

```
stage N review  ──demands a correction──▶  standing rule
                                              │
stage N+1 review  ◀──rule is now checked──────┘
```

## Built so the claim can be checked, not believed

Self-improvement is easy to assert and hard to verify, so the design targets falsifiability:

- **Auditable.** `runs/<run_id>/review_policy.json` is a plain artifact and every rule names the stage and attempt that produced it. Nothing rests on trusting a log line.
- **Cannot inflate.** Rules deduplicate on normalized text — casing, punctuation and *stage numbers* all collapse — and the set is bounded. A reviewer restating one complaint across five attempts yields **one** rule, so "more rules" genuinely means "more distinct defects caught".
- **Only refusals teach.** An approval says the stage met a bar the existing rules already encode, so it records nothing. Otherwise the policy would fill with noise on every successful stage.
- **A rollback outranks a refinement.** It is the strongest evidence a review can produce — an approval already given turned out to be wrong — so it gets its own source and renders first in the prompt.

Rules are stored **verbatim** rather than paraphrased by an extra model call. The rule keeps its origin stage and the reviewing model generalizes at read time, which avoids spending a call per correction to reword text a model is about to read anyway.

A corrupt policy is treated as empty: the gate falls back to baseline strictness rather than taking the run down.

## What the tests pin

Properties, not plumbing:

- A restatement, and a difference of *only* a stage number, each fail to create a second rule — so the dedup claim is load-bearing.
- The cap holds under 45 distinct corrections.
- An approval and an abort record nothing.
- A learned rule **actually reaches the next review prompt** — otherwise the loop is open and the feature is cosmetic.
- The rendered policy grows monotonically across stages, which is the defining claim.
- `MIN_RULE_CHARS` is exercised at the boundary, both sides.

587 tests pass, 29 new.

## Honest limitation

I have no live evidence of the loop closing yet. The fake reviewer auto-approves by design, so a fake run learns nothing, and the three real pilot runs have not yet reached a stage boundary where a reviewer demands a correction. I'll attach a real `review_policy.json` when they do rather than claim it works from unit tests alone.

This also does not fix reviewer *independence* — opus still judges opus. That is a separate weakness and a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)