### PR TITLE
Add a reviewer whose job is to attack the result

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@ File boundaries:
 - [src/bootstrap.py](src/bootstrap.py) and [src/project_bootstrap.py](src/project_bootstrap.py): `--paper-corpus` and `--project-root` scanning.
 - [src/approval_agent.py](src/approval_agent.py): The strict reviewer agent used by `--full-auto`.
 - [src/backend/](src/backend) and [src/frontend/](src/frontend): AutoR Studio service, HTTP layer, and the browser UI.
+- [src/validity_review.py](src/validity_review.py): The adversarial pass after Stages 05 and 06 — asks why the result is wrong, and requires the next stage to answer every objection.
 - [src/preregistration.py](src/preregistration.py): Freezes the hypotheses before the experiments, adjudicates each one at Stage 06, and traces each manuscript claim back to a supported hypothesis at Stage 07.
 - [src/prompts/](src/prompts): Per-stage prompt templates.
 - [src/skills/](src/skills) and [src/run_skills.py](src/run_skills.py): Agent skills installed into each run's `.claude/skills/`, loaded on demand rather than concatenated into every prompt.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,6 +99,7 @@ to a CLI directly; the operators never decide what stage runs next.
 | [`src/hypothesis_manifest.py`](../src/hypothesis_manifest.py) | Parses Stage 02's typed `T*`/`H*`/`C*` identifiers into `hypothesis_manifest.json`. |
 | [`src/preregistration.py`](../src/preregistration.py) | Freezes the hypothesis set before results exist, adjudicates every frozen hypothesis at Stage 06, and traces every manuscript claim back to a supported one at Stage 07. The one part of the pipeline that gates on whether a claim is warranted rather than on whether a file exists. |
 | [`src/experimental_protocol.py`](../src/experimental_protocol.py) | Declares the primary metric, the seed count and each baseline's tuning budget before the experiments run, and refuses a verdict that rests on one run or on an unstated dispersion measure. |
+| [`src/validity_review.py`](../src/validity_review.py) | The adversarial pass after Stages 05 and 06. Asks why the result is wrong rather than whether the stage is complete, and requires the next stage to answer every finding it raises. Has no authority to approve or reject. |
 | [`src/writing_manifest.py`](../src/writing_manifest.py) | Stage 07 support: writing manifest, figure/result scanning, layout review generation and validation. |
 
 ### Inputs
@@ -289,6 +290,7 @@ Ordered by how much of the system you have to understand first.
 | What a stage must produce | `validate_stage_artifacts` in `src/utils.py` | small |
 | What counts as a warranted claim | `src/preregistration.py` | small |
 | What counts as adequate evidence | `src/experimental_protocol.py` | small |
+| What a hostile reviewer would object to | `VALIDITY_CATEGORIES` in `src/validity_review.py` | none |
 | The summary contract | `REQUIRED_STAGE_HEADINGS` + `validate_stage_markdown` | small |
 | The stage list | `STAGES` in `src/utils.py`, plus a new prompt template | moderate |
 | The execution backend | implement `OperatorProtocol`, or subclass `ClaudeOperator` | moderate |

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -556,6 +556,50 @@ Stage 06's verdict on every preregistered hypothesis.
 
 Validated by `validate_hypothesis_outcomes` and `validate_outcome_statistics`.
 
+### `workspace/reviews/validity_review_<stage>.json` and `validity_response_<stage>.json`
+
+The adversarial pass. After Stage 05 and Stage 06 are approved, a reviewer with
+the opposite instruction from the approval gate — *explain why this result is
+wrong* — reads the run and files specific, checkable objections.
+
+```json
+{
+  "reviewed_stage": "05_experimentation",
+  "reviewer_failed": false,
+  "findings": [
+    {
+      "id": "V1",
+      "category": "confound",
+      "severity": "critical",
+      "finding": "Both conditions were tuned on the split that reports the headline number.",
+      "why_it_matters": "The gap may be selection, not the intervention.",
+      "what_would_settle_it": "Re-tune on a development split and re-report."
+    }
+  ]
+}
+```
+
+The reviewer cannot approve, reject or edit anything. What it produces is owed
+an answer: Stage 06 must write `validity_response_05_experimentation.json`, and
+Stage 07 must answer Stage 06's review.
+
+```json
+{"responses": [{"id": "V1", "status": "addressed | rebutted | accepted_limitation",
+  "explanation": "what changed, or why the objection does not hold",
+  "evidence": "the artifact or change (required when addressed)"}]}
+```
+
+Dismissing an objection is legitimate and deliberately cheap — `rebutted` with
+an argument is a complete answer, and so is `accepted_limitation`. There is no
+`noted`. What is refused is silence, because a finding nobody responded to is
+indistinguishable in the run directory from one nobody raised.
+
+A reviewer that crashed records `reviewer_failed: true`. An empty finding list
+from a failed critique would read as "nothing wrong".
+
+Validated by `validate_validity_response` in
+[`src/validity_review.py`](../src/validity_review.py).
+
 ### `workspace/artifacts/claim_provenance.json`
 
 Stage 07's map from each claim in the manuscript to what established it.

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -597,6 +597,14 @@ indistinguishable in the run directory from one nobody raised.
 A reviewer that crashed records `reviewer_failed: true`. An empty finding list
 from a failed critique would read as "nothing wrong".
 
+**When `--review-panel` is on**, the panel's own Methodologist and Reviewer 2
+already cover these categories, so no second critic runs: the concerns still
+standing after the panel's final round *become* the findings, and the next stage
+owes them the same answer. A concern a member withdrew during deliberation was
+answered inside the panel and is not re-raised. What this adds on top of the
+panel is the part the panel does not have — an obligation on the **next** stage,
+in its own artifacts, rather than a decision at this one's gate.
+
 Validated by `validate_validity_response` in
 [`src/validity_review.py`](../src/validity_review.py).
 

--- a/src/manager.py
+++ b/src/manager.py
@@ -41,6 +41,7 @@ from .intake import (
 from .artifact_index import format_artifact_index_for_prompt, write_artifact_index
 from .experiment_manifest import format_experiment_manifest_for_prompt, write_experiment_manifest
 from .hypothesis_manifest import write_hypothesis_manifest
+from .validity_review import ValidityReviewer, format_findings_for_prompt
 from .preregistration import (
     amend_preregistration,
     format_outcomes_for_prompt,
@@ -1538,6 +1539,7 @@ class ResearchManager:
                 )
                 if stage.slug == "04_implementation":
                     self._freeze_preregistration(paths)
+                self._run_validity_review(paths, stage, stage_markdown)
                 if stage.slug == "07_writing":
                     output_format = selected_output_format(paths)
                     if self._research_diagram:
@@ -1750,6 +1752,15 @@ class ResearchManager:
                 + format_preregistration_for_prompt(prereg)
                 + "\n"
             )
+        findings_context = format_findings_for_prompt(paths, stage)
+        if findings_context:
+            stage_template = (
+                stage_template.rstrip()
+                + "\n\n# Adversarial Validity Findings (each must be answered)\n\n"
+                + findings_context
+                + "\n"
+            )
+
         outcomes_context = format_outcomes_for_prompt(paths) if stage.number >= 7 else ""
         if outcomes_context:
             stage_template = (
@@ -2259,6 +2270,54 @@ class ResearchManager:
         if manifest is None:
             raise RuntimeError(f"Could not load run manifest from {paths.run_manifest}")
         return format_manifest_status(manifest)
+
+    def _run_validity_review(self, paths: RunPaths, stage: StageSpec, stage_markdown: str) -> None:
+        """Attack the result once the stage that produced it is approved.
+
+        Separate from the approval gate on purpose: that one asks whether the
+        stage did its work, and an agent asked to do both jobs at once reliably
+        does the easier one. This has no authority to approve or reject — the
+        next stage simply has to answer what it raises.
+        """
+        from .validity_review import REVIEWED_STAGE_NUMBERS
+
+        if stage.number not in REVIEWED_STAGE_NUMBERS:
+            return
+        self.ui.show_status(
+            f"Adversarial validity review of {stage.stage_title}...", level="info"
+        )
+        try:
+            findings = ValidityReviewer(self.operator, ui=self.ui).review(
+                paths=paths, stage=stage, stage_markdown=stage_markdown
+            )
+        except Exception as exc:  # noqa: BLE001 - a failed critique must not lose the stage
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} validity_review_failed",
+                f"The adversarial validity review did not run: {exc}",
+            )
+            self.ui.show_status(
+                "Validity review did not run; the stage stands unchallenged.", level="warn"
+            )
+            return
+        append_log_entry(
+            paths.logs,
+            f"{stage.slug} validity_review",
+            (
+                f"Adversarial review raised {len(findings)} findings.\n"
+                + "\n".join(
+                    f"- {item.identifier} ({item.severity} {item.category}): {item.finding}"
+                    for item in findings
+                )
+            ),
+        )
+        if findings:
+            critical = sum(1 for item in findings if item.severity == "critical")
+            self.ui.show_status(
+                f"Validity review raised {len(findings)} findings ({critical} critical). "
+                "The next stage must answer each one.",
+                level="warn",
+            )
 
     def _freeze_preregistration(self, paths: RunPaths) -> None:
         """Fix the hypothesis set before any result exists.

--- a/src/operator.py
+++ b/src/operator.py
@@ -644,6 +644,50 @@ Original stderr:
             + chunk(b"IEND", b"")
         )
 
+    @staticmethod
+    def _answer_validity_findings(paths: RunPaths, stage: StageSpec) -> None:
+        """Answer the previous stage's validity findings, honestly.
+
+        Fake mode's single finding — one run of a two-row synthetic split — is
+        entirely correct and the stub cannot fix it, so the honest disposition
+        is `accepted_limitation`. A stub that rebutted a true objection would
+        model the failure the reviewer exists to catch.
+        """
+        from .validity_review import (
+            load_findings,
+            reviewed_stage_for,
+            validity_response_path,
+        )
+
+        reviewed = reviewed_stage_for(stage)
+        if reviewed is None:
+            return
+        findings = load_findings(paths, reviewed)
+        if not findings:
+            return
+        write_text(
+            validity_response_path(paths, reviewed),
+            json.dumps(
+                {
+                    "responses": [
+                        {
+                            "id": item.identifier,
+                            "status": "accepted_limitation",
+                            "explanation": (
+                                "fake-operator mode cannot address this objection, and the "
+                                "objection is correct: nothing in this run was measured. "
+                                "Recorded as a standing limitation rather than rebutted."
+                            ),
+                            "evidence": "",
+                        }
+                        for item in findings
+                    ]
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
     def _write_fake_stage_artifacts(self, stage: StageSpec, paths: RunPaths) -> list[Path]:
         """Produce the artifacts ``validate_stage_artifacts`` requires at this stage.
 
@@ -777,6 +821,12 @@ Original stderr:
                     },
                 )
 
+            # Stage 06+: answer whatever the adversarial reviewer raised against
+            # the previous stage. The fake response is `accepted_limitation`,
+            # because the fake finding (a single run of a two-row split) is
+            # entirely correct and the stub cannot fix it.
+            self._answer_validity_findings(paths, stage)
+
             # Stage 06+: figures. SVG keeps this a text write with no encoder.
             _write(
                 paths.figures_dir / "fig1_fake_comparison.svg",
@@ -788,6 +838,8 @@ Original stderr:
             )
 
         if stage.number >= 7:
+            self._answer_validity_findings(paths, stage)
+
             # Every claim traces to evidence. With the fake hypothesis refuted,
             # the only honest status left is exploratory — which is the point:
             # the stub cannot manufacture a confirmatory claim.

--- a/src/utils.py
+++ b/src/utils.py
@@ -1144,6 +1144,13 @@ def validate_stage_artifacts(
         for problem in validate_literature_evidence(paths):
             problems.append(f"{stage.stage_title}: {problem}")
 
+    # Answering the previous stage's adversarial review. Self-selecting: only
+    # Stage 06 (answering 05) and Stage 07 (answering 06) owe anything.
+    from .validity_review import validate_validity_response
+
+    for problem in validate_validity_response(paths, stage):
+        problems.append(f"{stage.stage_title} {problem}")
+
     if stage.number >= 3:
         if count_in("data", paths.data_dir, MACHINE_DATA_SUFFIXES) == 0:
             problems.append(

--- a/src/validity_review.py
+++ b/src/validity_review.py
@@ -248,6 +248,62 @@ def format_findings_for_prompt(paths: RunPaths, stage: StageSpec) -> str:
     return "\n".join(lines)
 
 
+def findings_from_panel(paths: RunPaths, stage: StageSpec) -> list[ValidityFinding]:
+    """Convert a review panel's surviving concerns into answerable findings.
+
+    The panel (:mod:`src.review_panel`) already fields a Methodologist and a
+    Reviewer 2 whose mandates overlap this module's categories, so running a
+    separate critic on top of it would ask the same questions twice and pay for
+    both. When a panel deliberated over this stage, its concerns *are* the
+    findings — what this module adds is the part the panel does not have: an
+    obligation on the **next** stage to answer them.
+
+    Only the final round counts. A concern that a member withdrew during
+    deliberation was answered inside the panel, and re-raising it would punish
+    the deliberation for working.
+    """
+    panel_dir = paths.reviews_dir / "panel"
+    if not panel_dir.is_dir():
+        return []
+
+    latest = None
+    for candidate in sorted(panel_dir.glob(f"{stage.slug}*.json")):
+        payload = _load_json(candidate)
+        if isinstance(payload, dict) and payload.get("stage") == stage.slug:
+            latest = payload
+    if latest is None:
+        return []
+
+    rounds = latest.get("rounds")
+    if not isinstance(rounds, list) or not rounds:
+        return []
+    final_round = rounds[-1]
+    if not isinstance(final_round, list):
+        return []
+
+    findings: list[ValidityFinding] = []
+    for verdict in final_round:
+        if not isinstance(verdict, dict) or verdict.get("failed"):
+            continue
+        role = str(verdict.get("title") or verdict.get("role") or "panel member").strip()
+        blocking = bool(verdict.get("blocking"))
+        for concern in verdict.get("concerns", []):
+            text = str(concern).strip()
+            if not text:
+                continue
+            findings.append(
+                ValidityFinding(
+                    identifier=f"V{len(findings) + 1}",
+                    category="overclaim",
+                    severity="critical" if blocking else "major",
+                    finding=text,
+                    why_it_matters=f"Raised by the {role} and still standing after deliberation.",
+                    what_would_settle_it=str(verdict.get("feedback") or "").strip(),
+                )
+            )
+    return findings
+
+
 class ValidityReviewer:
     """Runs the red-team pass. Shares the operator machinery with the approval gate."""
 
@@ -262,6 +318,16 @@ class ValidityReviewer:
     def review(self, *, paths: RunPaths, stage: StageSpec, stage_markdown: str) -> list[ValidityFinding]:
         if stage.number not in REVIEWED_STAGE_NUMBERS:
             return []
+
+        # If a panel already deliberated over this stage, its surviving concerns
+        # are the findings. Running a second critic would ask the Methodologist's
+        # questions twice and pay for both.
+        from_panel = findings_from_panel(paths, stage)
+        if from_panel:
+            self._write_review(
+                paths, stage, from_panel, note="carried from the review panel's final round"
+            )
+            return from_panel
 
         if self.fake_mode:
             findings = [

--- a/src/validity_review.py
+++ b/src/validity_review.py
@@ -1,0 +1,446 @@
+"""A reviewer whose job is to attack the result, not to check that it exists.
+
+AutoR's existing ``AutomatedReviewer`` is a completeness gate. Its policy is
+"materially complete", "looks toy", "missing concrete files" — it asks whether
+the stage did work, never whether the work supports what it says. Nothing in
+the pipeline ever asked *why is this result wrong*.
+
+This runs after Stage 05 and Stage 06, with the opposite instruction: assume the
+result is an artifact and find the mechanism. It has no authority to approve or
+reject — that stays with the approval gate — and it does not edit anything. What
+it produces is a list of specific, checkable objections, and the next stage is
+required to answer every one of them, either by addressing it or by rebutting it
+in writing.
+
+That asymmetry is deliberate. A reviewer that can block creates a deadlock
+between two agents; a reviewer whose findings must be *answered* creates a
+record of what was considered and dismissed, which is the thing a reader of the
+run actually needs.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from .terminal_ui import TerminalUI
+from .utils import (
+    RunPaths,
+    StageSpec,
+    append_jsonl,
+    read_text,
+    truncate_text,
+    write_text,
+)
+
+
+#: The stages worth attacking. Before 05 there is no result to be wrong about;
+#: after 07 the manuscript is written and an objection arrives too late to change
+#: anything but the prose.
+REVIEWED_STAGE_NUMBERS = (5, 6)
+
+#: Failure modes that produce a clean-looking positive result. Naming them beats
+#: asking for "any problems": an open-ended critique reliably returns prose
+#: quality, which is not what is dangerous here.
+VALIDITY_CATEGORIES = (
+    "confound",
+    "weak_baseline",
+    "insufficient_replication",
+    "leakage",
+    "metric_cherry_picking",
+    "effect_within_noise",
+    "overclaim",
+    "unsupported_generalization",
+    "missing_ablation",
+    "irreproducible_procedure",
+)
+
+SEVERITIES = ("critical", "major", "minor")
+
+#: How the next stage may dispose of a finding. There is no third option, and in
+#: particular there is no "noted".
+RESPONSE_STATUSES = ("addressed", "rebutted", "accepted_limitation")
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _load_json(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def validity_review_path(paths: RunPaths, stage_slug: str):
+    return paths.reviews_dir / f"validity_review_{stage_slug}.json"
+
+
+def validity_response_path(paths: RunPaths, reviewed_stage_slug: str):
+    return paths.reviews_dir / f"validity_response_{reviewed_stage_slug}.json"
+
+
+def reviewed_stage_for(stage: StageSpec) -> str | None:
+    """Which earlier stage's validity review this stage has to answer."""
+    if stage.number == 6:
+        return "05_experimentation"
+    if stage.number == 7:
+        return "06_analysis"
+    return None
+
+
+@dataclass(frozen=True)
+class ValidityFinding:
+    identifier: str
+    category: str
+    severity: str
+    finding: str
+    why_it_matters: str
+    what_would_settle_it: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "id": self.identifier,
+            "category": self.category,
+            "severity": self.severity,
+            "finding": self.finding,
+            "why_it_matters": self.why_it_matters,
+            "what_would_settle_it": self.what_would_settle_it,
+        }
+
+
+def load_findings(paths: RunPaths, stage_slug: str) -> list[ValidityFinding]:
+    payload = _load_json(validity_review_path(paths, stage_slug))
+    if not isinstance(payload, dict):
+        return []
+    findings: list[ValidityFinding] = []
+    for entry in payload.get("findings", []):
+        if not isinstance(entry, dict):
+            continue
+        findings.append(
+            ValidityFinding(
+                identifier=str(entry.get("id") or "").strip(),
+                category=str(entry.get("category") or "").strip(),
+                severity=str(entry.get("severity") or "").strip(),
+                finding=str(entry.get("finding") or "").strip(),
+                why_it_matters=str(entry.get("why_it_matters") or "").strip(),
+                what_would_settle_it=str(entry.get("what_would_settle_it") or "").strip(),
+            )
+        )
+    return findings
+
+
+def validate_validity_response(paths: RunPaths, stage: StageSpec) -> list[str]:
+    """Every finding from the previous stage's review must be answered.
+
+    Answering is cheap and dismissing is allowed — ``rebutted`` with an argument
+    is a complete response, and so is ``accepted_limitation``. What is not
+    allowed is silence, because a finding nobody responded to is
+    indistinguishable in the record from one nobody raised.
+    """
+    reviewed = reviewed_stage_for(stage)
+    if reviewed is None:
+        return []
+
+    findings = load_findings(paths, reviewed)
+    if not findings:
+        # No review ran, or it found nothing. Either way there is nothing owed.
+        return []
+
+    response_path = validity_response_path(paths, reviewed)
+    payload = _load_json(response_path)
+    if payload is None:
+        return [
+            f"requires {response_path.name} under workspace/reviews answering each of the "
+            f"{len(findings)} validity findings raised against {reviewed}. A finding nobody "
+            "responded to is indistinguishable from one nobody raised."
+        ]
+    if not isinstance(payload, dict):
+        return [f"{response_path.name} must contain a JSON object."]
+
+    responses = payload.get("responses")
+    if not isinstance(responses, list):
+        return [f"{response_path.name} must contain a responses list."]
+
+    by_id: dict[str, dict] = {}
+    for entry in responses:
+        if isinstance(entry, dict):
+            identifier = str(entry.get("id") or "").strip()
+            if identifier:
+                by_id[identifier] = entry
+
+    problems: list[str] = []
+    for finding in findings:
+        entry = by_id.get(finding.identifier)
+        if entry is None:
+            problems.append(
+                f"{response_path.name} does not answer validity finding {finding.identifier} "
+                f"({finding.severity} {finding.category}): {finding.finding[:90]}"
+            )
+            continue
+        status = str(entry.get("status") or "").strip()
+        if status not in RESPONSE_STATUSES:
+            problems.append(
+                f"{response_path.name} answers {finding.identifier} with status {status!r}; "
+                f"expected one of {', '.join(RESPONSE_STATUSES)}."
+            )
+        explanation = str(entry.get("explanation") or "").strip()
+        if len(explanation) < 40:
+            problems.append(
+                f"{response_path.name} answers {finding.identifier} with no substantive "
+                "explanation. Say what changed, or why the objection does not hold."
+            )
+        if status == "addressed" and not str(entry.get("evidence") or "").strip():
+            problems.append(
+                f"{response_path.name} marks {finding.identifier} addressed but points at "
+                "nothing. Name the artifact or the change that addresses it."
+            )
+
+    unknown = set(by_id) - {finding.identifier for finding in findings}
+    for identifier in sorted(unknown):
+        problems.append(
+            f"{response_path.name} answers {identifier}, which is not a finding in "
+            f"{validity_review_path(paths, reviewed).name}."
+        )
+    return problems
+
+
+def format_findings_for_prompt(paths: RunPaths, stage: StageSpec) -> str:
+    reviewed = reviewed_stage_for(stage)
+    if reviewed is None:
+        return ""
+    findings = load_findings(paths, reviewed)
+    if not findings:
+        return ""
+
+    response_path = validity_response_path(paths, reviewed)
+    lines = [
+        f"An adversarial reviewer attacked {reviewed} and raised {len(findings)} findings.",
+        "Its job was to explain why the result is wrong, so treat these as the objections a",
+        "hostile reviewer will make. You must answer every one.",
+        "",
+    ]
+    for finding in findings:
+        lines.append(f"- **{finding.identifier}** ({finding.severity} · {finding.category}) {finding.finding}")
+        if finding.why_it_matters:
+            lines.append(f"  - Why it matters: {finding.why_it_matters}")
+        if finding.what_would_settle_it:
+            lines.append(f"  - What would settle it: {finding.what_would_settle_it}")
+    lines.extend(
+        [
+            "",
+            f"Write `{response_path.resolve()}`:",
+            "",
+            "```json",
+            '{"responses": [{"id": "V1", "status": "addressed | rebutted | accepted_limitation",',
+            '  "explanation": "what changed, or why the objection does not hold",',
+            '  "evidence": "the artifact or change (required when addressed)"}]}',
+            "```",
+            "",
+            "`rebutted` is a complete answer when you have an argument. So is",
+            "`accepted_limitation` when the objection stands and the run cannot fix it — say so",
+            "in the manuscript too. What is not acceptable is leaving a finding unanswered.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+class ValidityReviewer:
+    """Runs the red-team pass. Shares the operator machinery with the approval gate."""
+
+    def __init__(self, operator, *, ui: TerminalUI | None = None) -> None:
+        self._operator = operator
+        self.ui = ui or TerminalUI()
+
+    @property
+    def fake_mode(self) -> bool:
+        return bool(getattr(self._operator, "fake_mode", False))
+
+    def review(self, *, paths: RunPaths, stage: StageSpec, stage_markdown: str) -> list[ValidityFinding]:
+        if stage.number not in REVIEWED_STAGE_NUMBERS:
+            return []
+
+        if self.fake_mode:
+            findings = [
+                ValidityFinding(
+                    identifier="V1",
+                    category="insufficient_replication",
+                    severity="critical",
+                    finding="The reported comparison rests on a single run of a two-row synthetic split.",
+                    why_it_matters=(
+                        "A single run cannot separate the effect from variance, so the gap is "
+                        "not evidence about the method."
+                    ),
+                    what_would_settle_it="Repeat the comparison across at least five seeds and report the spread.",
+                )
+            ]
+            self._write_review(paths, stage, findings, note="fake-operator mode")
+            return findings
+
+        prompt_path = paths.prompt_cache_dir / f"{stage.slug}_validity_review.prompt.md"
+        write_text(prompt_path, self._build_prompt(paths=paths, stage=stage, stage_markdown=stage_markdown))
+
+        session_id = str(uuid.uuid4())
+        command, invocation_cwd, stdin_text = self._operator._prepare_invocation(  # noqa: SLF001
+            prompt_path, session_id, paths=paths, resume=False
+        )
+        append_jsonl(
+            paths.logs_raw,
+            {
+                "_meta": {
+                    "stage": stage.slug,
+                    "mode": "validity_review_start",
+                    "command": command,
+                    "prompt_path": str(prompt_path),
+                    "session_id": session_id,
+                }
+            },
+        )
+        exit_code, stdout_text, stderr_text, _observed, _meta = self._operator._run_streaming_command(  # noqa: SLF001
+            command=command,
+            cwd=invocation_cwd,
+            stage=stage,
+            attempt_no=1,
+            paths=paths,
+            mode="validity_review",
+            stdin_text=stdin_text,
+        )
+        if exit_code != 0:
+            # A red-team pass that did not run is recorded as not having run.
+            # Writing an empty finding list would read as "nothing wrong".
+            self._write_review(
+                paths,
+                stage,
+                [],
+                note=f"the validity reviewer failed with exit code {exit_code} and raised nothing",
+                failed=True,
+            )
+            return []
+
+        findings = self._parse(stdout_text)
+        self._write_review(paths, stage, findings)
+        return findings
+
+    def _write_review(
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        findings: list[ValidityFinding],
+        *,
+        note: str = "",
+        failed: bool = False,
+    ) -> None:
+        payload = {
+            "generated_at": _now(),
+            "reviewed_stage": stage.slug,
+            "reviewer_failed": failed,
+            "note": note,
+            "findings": [item.to_dict() for item in findings],
+        }
+        write_text(
+            validity_review_path(paths, stage.slug),
+            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        )
+
+    def _parse(self, raw: str) -> list[ValidityFinding]:
+        payload = self._extract_json(raw)
+        if not isinstance(payload, dict):
+            return []
+        findings: list[ValidityFinding] = []
+        for index, entry in enumerate(payload.get("findings", []), start=1):
+            if not isinstance(entry, dict):
+                continue
+            finding = str(entry.get("finding") or "").strip()
+            if not finding:
+                continue
+            category = str(entry.get("category") or "").strip()
+            severity = str(entry.get("severity") or "").strip()
+            findings.append(
+                ValidityFinding(
+                    identifier=str(entry.get("id") or "").strip() or f"V{index}",
+                    category=category if category in VALIDITY_CATEGORIES else "overclaim",
+                    severity=severity if severity in SEVERITIES else "major",
+                    finding=finding,
+                    why_it_matters=str(entry.get("why_it_matters") or "").strip(),
+                    what_would_settle_it=str(entry.get("what_would_settle_it") or "").strip(),
+                )
+            )
+        return findings
+
+    @staticmethod
+    def _extract_json(raw: str):
+        if not raw:
+            return None
+        text = raw.strip()
+        start = text.find("{")
+        end = text.rfind("}")
+        if start < 0 or end <= start:
+            return None
+        for candidate in (text, text[start : end + 1]):
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+        return None
+
+    def _build_prompt(self, *, paths: RunPaths, stage: StageSpec, stage_markdown: str) -> str:
+        def excerpt(path, limit: int = 6000) -> str:
+            return truncate_text(read_text(path), max_chars=limit) if path.exists() else "(absent)"
+
+        return (
+            "# Adversarial Validity Review\n\n"
+            f"You are reviewing {stage.stage_title} of an automated research run.\n\n"
+            "**Your job is to explain why this result is wrong.** Assume it is an artifact and "
+            "find the mechanism. You are not assessing completeness, effort, writing quality or "
+            "presentation — another reviewer does that, and duplicating it wastes this pass.\n\n"
+            "You cannot approve, reject, or edit anything. You produce objections; the next "
+            "stage has to answer them.\n\n"
+            "## What to look for\n\n"
+            "- `confound` — something other than the intervention explains the difference.\n"
+            "- `weak_baseline` — the comparison was not given a fair chance. Check the tuning "
+            "budgets declared in the experimental protocol against what the run actually did.\n"
+            "- `insufficient_replication` — the effect cannot be separated from run-to-run "
+            "variance at the reported seed count.\n"
+            "- `leakage` — test information reached training, tuning, or model selection.\n"
+            "- `metric_cherry_picking` — the reported metric is not the preregistered primary "
+            "one, or a metric appeared after the results did.\n"
+            "- `effect_within_noise` — the gap is smaller than the spread.\n"
+            "- `overclaim` — the conclusion is stronger than the measurement supports.\n"
+            "- `unsupported_generalization` — a claim about a population that was not sampled.\n"
+            "- `missing_ablation` — the mechanism is asserted but not isolated.\n"
+            "- `irreproducible_procedure` — a step exists only in prose, not in code.\n\n"
+            "## Discipline\n\n"
+            "- Every finding must be **specific and checkable**. \"The evaluation could be more "
+            "rigorous\" is not a finding. \"Both conditions were tuned on the same split that "
+            "reports the headline number\" is.\n"
+            "- Cite the artifact you read. If you cannot point at something in the run, you are "
+            "speculating, and speculation crowds out the real objections.\n"
+            "- Raising nothing is a legitimate outcome. Do not pad the list; a fabricated "
+            "objection costs the next stage a real answer.\n"
+            "- Rank by how much the conclusion moves if you are right, not by how easy the fix is.\n\n"
+            "## Output\n\n"
+            "Return JSON only, no prose outside the object:\n\n"
+            "```json\n"
+            '{"findings": [{"id": "V1", "category": "<one of the categories above>", '
+            '"severity": "critical|major|minor", "finding": "...", "why_it_matters": "...", '
+            '"what_would_settle_it": "..."}]}\n'
+            "```\n\n"
+            "# Original Goal\n\n"
+            f"{excerpt(paths.user_input, 3000)}\n\n"
+            "# Preregistered Hypotheses\n\n"
+            f"{excerpt(paths.preregistration)}\n\n"
+            "# Experimental Protocol\n\n"
+            f"{excerpt(paths.experimental_protocol)}\n\n"
+            "# Hypothesis Outcomes\n\n"
+            f"{excerpt(paths.hypothesis_outcomes)}\n\n"
+            "# Experiment Manifest\n\n"
+            f"{excerpt(paths.experiment_manifest)}\n\n"
+            "# Artifact Index\n\n"
+            f"{excerpt(paths.artifact_index, 4000)}\n\n"
+            "# Stage Summary Under Review\n\n"
+            f"{truncate_text(stage_markdown, max_chars=16000)}\n\n"
+            f"The run directory is `{paths.run_root.resolve()}`. Read whatever you need from it.\n"
+        )

--- a/tests/test_validity_review.py
+++ b/tests/test_validity_review.py
@@ -288,3 +288,77 @@ class ReviewerFailureTest(ValidityTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PanelBridgeTest(ValidityTestCase):
+    """When a review panel deliberated, its concerns are the findings.
+
+    The panel already fields a Methodologist and a Reviewer 2 whose mandates
+    cover these categories. Running a second critic on top would ask the same
+    questions twice; what this module adds on top of the panel is the
+    obligation on the *next* stage to answer what survived.
+    """
+
+    def _panel_file(self, *rounds: list[dict]) -> None:
+        panel_dir = self.paths.reviews_dir / "panel"
+        panel_dir.mkdir(parents=True, exist_ok=True)
+        write_text(
+            panel_dir / f"{STAGE_05.slug}_attempt_01.json",
+            json.dumps({"stage": STAGE_05.slug, "rounds": [list(group) for group in rounds]}),
+        )
+
+    def _verdict(self, *concerns: str, blocking: bool = False, failed: bool = False) -> dict:
+        return {
+            "role": "method",
+            "title": "Methodologist",
+            "blocking": blocking,
+            "failed": failed,
+            "feedback": "Re-tune both conditions on a development split.",
+            "concerns": list(concerns),
+        }
+
+    def test_surviving_concerns_become_findings(self) -> None:
+        self._panel_file([self._verdict("Both arms were tuned on the reporting split.", blocking=True)])
+        reviewer = ValidityReviewer(_FakeOperator())
+
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="# Stage 05")
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].severity, "critical")
+        self.assertIn("Methodologist", findings[0].why_it_matters)
+
+    def test_a_nonblocking_concern_is_major_rather_than_critical(self) -> None:
+        self._panel_file([self._verdict("Only three seeds were run.")])
+        reviewer = ValidityReviewer(_FakeOperator())
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x")
+        self.assertEqual(findings[0].severity, "major")
+
+    def test_only_the_final_round_counts(self) -> None:
+        """A concern withdrawn during deliberation was answered inside the panel."""
+        self._panel_file(
+            [self._verdict("Withdrawn after round one.")],
+            [self._verdict("Still standing.")],
+        )
+        reviewer = ValidityReviewer(_FakeOperator())
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x")
+        self.assertEqual([item.finding for item in findings], ["Still standing."])
+
+    def test_a_failed_panel_member_contributes_nothing(self) -> None:
+        self._panel_file([self._verdict("Never actually produced.", failed=True)])
+        reviewer = ValidityReviewer(_FakeOperator())
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x")
+        # Falls through to the standalone critic rather than reporting a clean panel.
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].category, "insufficient_replication")
+
+    def test_with_no_panel_the_standalone_critic_runs(self) -> None:
+        reviewer = ValidityReviewer(_FakeOperator())
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x")
+        self.assertEqual(findings[0].category, "insufficient_replication")
+
+    def test_panel_findings_are_owed_the_same_answer(self) -> None:
+        self._panel_file([self._verdict("Both arms were tuned on the reporting split.", blocking=True)])
+        ValidityReviewer(_FakeOperator()).review(paths=self.paths, stage=STAGE_05, stage_markdown="x")
+
+        problems = validate_stage_artifacts(STAGE_06, self.paths)
+        self.assertTrue(any("validity_response" in problem for problem in problems), problems)

--- a/tests/test_validity_review.py
+++ b/tests/test_validity_review.py
@@ -1,0 +1,290 @@
+"""The adversarial pass: findings that must be answered, not noted.
+
+The existing approval gate asks whether a stage did its work. This asks why the
+result is wrong. The tests below are mostly about the response contract, because
+that is where the value is: a critique nobody had to answer is a critique that
+changes nothing, and it looks identical in the run directory to one that was
+never raised.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.validity_review import (
+    REVIEWED_STAGE_NUMBERS,
+    RESPONSE_STATUSES,
+    ValidityFinding,
+    ValidityReviewer,
+    format_findings_for_prompt,
+    load_findings,
+    reviewed_stage_for,
+    validate_validity_response,
+    validity_response_path,
+    validity_review_path,
+)
+from src.utils import STAGES, build_run_paths, ensure_run_layout, validate_stage_artifacts, write_text
+
+
+STAGE_05 = next(stage for stage in STAGES if stage.number == 5)
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+STAGE_07 = next(stage for stage in STAGES if stage.number == 7)
+
+
+class _FakeOperator:
+    fake_mode = True
+
+
+class ValidityTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    def write_review(self, *findings: dict, stage_slug: str = "05_experimentation") -> None:
+        write_text(
+            validity_review_path(self.paths, stage_slug),
+            json.dumps({"reviewed_stage": stage_slug, "findings": list(findings)}),
+        )
+
+    def a_finding(self, identifier: str = "V1", **overrides) -> dict:
+        payload = {
+            "id": identifier,
+            "category": "confound",
+            "severity": "critical",
+            "finding": "Both conditions were tuned on the split that reports the headline number.",
+            "why_it_matters": "The gap may be selection, not the intervention.",
+            "what_would_settle_it": "Re-tune on a development split and re-report.",
+        }
+        payload.update(overrides)
+        return payload
+
+    def write_response(self, *responses: dict, stage_slug: str = "05_experimentation") -> None:
+        write_text(
+            validity_response_path(self.paths, stage_slug),
+            json.dumps({"responses": list(responses)}),
+        )
+
+    def a_response(self, identifier: str = "V1", **overrides) -> dict:
+        payload = {
+            "id": identifier,
+            "status": "addressed",
+            "explanation": "Re-tuned both conditions on a held-out development split and re-ran.",
+            "evidence": "results/retuned_metrics.json",
+        }
+        payload.update(overrides)
+        return payload
+
+
+class RoutingTest(ValidityTestCase):
+    def test_stage_06_answers_stage_05(self) -> None:
+        self.assertEqual(reviewed_stage_for(STAGE_06), "05_experimentation")
+
+    def test_stage_07_answers_stage_06(self) -> None:
+        self.assertEqual(reviewed_stage_for(STAGE_07), "06_analysis")
+
+    def test_earlier_stages_owe_nothing(self) -> None:
+        for stage in STAGES:
+            if stage.number in (6, 7):
+                continue
+            with self.subTest(stage=stage.slug):
+                self.assertIsNone(reviewed_stage_for(stage))
+
+    def test_the_reviewed_stages_are_the_ones_with_a_result_to_attack(self) -> None:
+        self.assertEqual(REVIEWED_STAGE_NUMBERS, (5, 6))
+
+
+class ResponseContractTest(ValidityTestCase):
+    def test_a_complete_response_passes(self) -> None:
+        self.write_review(self.a_finding())
+        self.write_response(self.a_response())
+        self.assertEqual(validate_validity_response(self.paths, STAGE_06), [])
+
+    def test_an_unanswered_finding_is_refused(self) -> None:
+        """The whole point: silence is not a disposition."""
+        self.write_review(self.a_finding())
+        problems = validate_validity_response(self.paths, STAGE_06)
+        self.assertTrue(any("validity_response" in problem for problem in problems), problems)
+
+    def test_answering_only_some_findings_is_refused(self) -> None:
+        self.write_review(self.a_finding("V1"), self.a_finding("V2"))
+        self.write_response(self.a_response("V1"))
+        problems = validate_validity_response(self.paths, STAGE_06)
+        self.assertTrue(any("V2" in problem for problem in problems), problems)
+
+    def test_a_rebuttal_is_a_complete_answer(self) -> None:
+        """Dismissing an objection with an argument is legitimate and must stay cheap."""
+        self.write_review(self.a_finding())
+        self.write_response(
+            self.a_response(
+                status="rebutted",
+                explanation="Tuning used a separate development split; the reviewer misread the config.",
+                evidence="",
+            )
+        )
+        self.assertEqual(validate_validity_response(self.paths, STAGE_06), [])
+
+    def test_an_accepted_limitation_is_a_complete_answer(self) -> None:
+        self.write_review(self.a_finding())
+        self.write_response(
+            self.a_response(
+                status="accepted_limitation",
+                explanation="The objection stands and this run cannot re-tune; recorded as a limitation.",
+                evidence="",
+            )
+        )
+        self.assertEqual(validate_validity_response(self.paths, STAGE_06), [])
+
+    def test_there_is_no_noted_status(self) -> None:
+        self.write_review(self.a_finding())
+        self.write_response(self.a_response(status="noted"))
+        problems = validate_validity_response(self.paths, STAGE_06)
+        self.assertTrue(any("expected one of" in problem for problem in problems), problems)
+        self.assertNotIn("noted", RESPONSE_STATUSES)
+
+    def test_an_empty_explanation_is_refused(self) -> None:
+        self.write_review(self.a_finding())
+        self.write_response(self.a_response(explanation="ok"))
+        problems = validate_validity_response(self.paths, STAGE_06)
+        self.assertTrue(any("no substantive explanation" in problem for problem in problems), problems)
+
+    def test_addressed_must_point_at_something(self) -> None:
+        self.write_review(self.a_finding())
+        self.write_response(self.a_response(evidence=""))
+        problems = validate_validity_response(self.paths, STAGE_06)
+        self.assertTrue(any("points at nothing" in problem for problem in problems), problems)
+
+    def test_answering_a_finding_nobody_raised_is_refused(self) -> None:
+        """Otherwise a stage can look responsive by answering easy invented objections."""
+        self.write_review(self.a_finding("V1"))
+        self.write_response(self.a_response("V1"), self.a_response("V9"))
+        problems = validate_validity_response(self.paths, STAGE_06)
+        self.assertTrue(any("V9" in problem for problem in problems), problems)
+
+    def test_a_review_that_raised_nothing_owes_nothing(self) -> None:
+        self.write_review()
+        self.assertEqual(validate_validity_response(self.paths, STAGE_06), [])
+
+    def test_no_review_at_all_owes_nothing(self) -> None:
+        """A stage must not be blocked because the critique never ran."""
+        self.assertEqual(validate_validity_response(self.paths, STAGE_06), [])
+
+
+class StageGateWiringTest(ValidityTestCase):
+    def test_stage_06_is_blocked_by_an_unanswered_stage_05_finding(self) -> None:
+        self.write_review(self.a_finding())
+        problems = validate_stage_artifacts(STAGE_06, self.paths)
+        self.assertTrue(any("validity_response" in problem for problem in problems), problems)
+
+    def test_stage_05_is_not_blocked_by_its_own_review(self) -> None:
+        self.write_review(self.a_finding())
+        problems = validate_stage_artifacts(STAGE_05, self.paths)
+        self.assertFalse(any("validity_response" in problem for problem in problems), problems)
+
+    def test_stage_07_is_blocked_by_an_unanswered_stage_06_finding(self) -> None:
+        self.write_review(self.a_finding(), stage_slug="06_analysis")
+        problems = validate_stage_artifacts(STAGE_07, self.paths)
+        self.assertTrue(any("validity_response" in problem for problem in problems), problems)
+
+
+class ReviewerTest(ValidityTestCase):
+    def test_the_fake_reviewer_writes_a_real_finding(self) -> None:
+        """Fake mode has to exercise the loop, or the loop is untested end to end."""
+        reviewer = ValidityReviewer(_FakeOperator())
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="# Stage 05")
+
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(validity_review_path(self.paths, STAGE_05.slug).exists())
+        self.assertEqual(load_findings(self.paths, STAGE_05.slug)[0].severity, "critical")
+
+    def test_stages_with_no_result_to_attack_are_skipped(self) -> None:
+        reviewer = ValidityReviewer(_FakeOperator())
+        stage_03 = next(stage for stage in STAGES if stage.number == 3)
+        self.assertEqual(reviewer.review(paths=self.paths, stage=stage_03, stage_markdown="x"), [])
+        self.assertFalse(validity_review_path(self.paths, stage_03.slug).exists())
+
+    def test_a_malformed_finding_is_dropped_rather_than_half_parsed(self) -> None:
+        reviewer = ValidityReviewer(_FakeOperator())
+        parsed = reviewer._parse(  # noqa: SLF001
+            json.dumps({"findings": [{"id": "V1", "finding": ""}, {"id": "V2", "finding": "real"}]})
+        )
+        self.assertEqual([item.identifier for item in parsed], ["V2"])
+
+    def test_an_unknown_category_falls_back_rather_than_being_dropped(self) -> None:
+        """Losing a real objection to a taxonomy mismatch is the worse error."""
+        reviewer = ValidityReviewer(_FakeOperator())
+        parsed = reviewer._parse(  # noqa: SLF001
+            json.dumps({"findings": [{"id": "V1", "category": "vibes", "finding": "something real"}]})
+        )
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0].category, "overclaim")
+
+    def test_findings_wrapped_in_prose_are_still_read(self) -> None:
+        reviewer = ValidityReviewer(_FakeOperator())
+        parsed = reviewer._parse(  # noqa: SLF001
+            'Here is my review:\n```json\n{"findings": [{"id": "V1", "finding": "real"}]}\n```\nDone.'
+        )
+        self.assertEqual(len(parsed), 1)
+
+    def test_an_unparseable_response_yields_nothing_rather_than_crashing(self) -> None:
+        reviewer = ValidityReviewer(_FakeOperator())
+        self.assertEqual(reviewer._parse("no json here"), [])  # noqa: SLF001
+
+
+class PromptRenderingTest(ValidityTestCase):
+    def test_the_next_stage_is_shown_the_findings_and_the_response_format(self) -> None:
+        self.write_review(self.a_finding())
+        rendered = format_findings_for_prompt(self.paths, STAGE_06)
+
+        self.assertIn("V1", rendered)
+        self.assertIn("critical", rendered)
+        self.assertIn("What would settle it", rendered)
+        self.assertIn("validity_response_05_experimentation.json", rendered)
+        self.assertIn("accepted_limitation", rendered)
+
+    def test_a_stage_with_no_findings_gets_no_block(self) -> None:
+        self.assertEqual(format_findings_for_prompt(self.paths, STAGE_06), "")
+
+    def test_the_review_prompt_asks_for_the_mechanism_not_a_verdict(self) -> None:
+        reviewer = ValidityReviewer(_FakeOperator())
+        prompt = reviewer._build_prompt(  # noqa: SLF001
+            paths=self.paths, stage=STAGE_05, stage_markdown="# Stage 05"
+        )
+        self.assertIn("explain why this result is wrong", prompt)
+        self.assertIn("cannot approve, reject, or edit", prompt)
+        self.assertIn("Raising nothing is a legitimate outcome", prompt)
+        # It must not duplicate the completeness reviewer's job.
+        self.assertIn("not assessing completeness", prompt)
+
+    def test_the_review_prompt_carries_the_preregistration_and_protocol(self) -> None:
+        """Without them the reviewer cannot check metric switching or baseline budgets."""
+        write_text(self.paths.preregistration, '{"digest": "abc"}')
+        write_text(self.paths.experimental_protocol, '{"primary_metric": "accuracy"}')
+        reviewer = ValidityReviewer(_FakeOperator())
+        prompt = reviewer._build_prompt(  # noqa: SLF001
+            paths=self.paths, stage=STAGE_05, stage_markdown="# Stage 05"
+        )
+        self.assertIn("Preregistered Hypotheses", prompt)
+        self.assertIn("Experimental Protocol", prompt)
+        self.assertIn("primary_metric", prompt)
+
+
+class ReviewerFailureTest(ValidityTestCase):
+    def test_a_failed_reviewer_is_recorded_as_failed_not_as_clean(self) -> None:
+        """An empty findings list from a crashed critique reads as "nothing wrong"."""
+        reviewer = ValidityReviewer(_FakeOperator())
+        reviewer._write_review(  # noqa: SLF001
+            self.paths, STAGE_05, [], note="exit code 1", failed=True
+        )
+        payload = json.loads(validity_review_path(self.paths, STAGE_05.slug).read_text(encoding="utf-8"))
+        self.assertTrue(payload["reviewer_failed"])
+        self.assertIn("exit code 1", payload["note"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Third in the sequence after #116 (preregistration) and #119 (baseline and replication discipline).

## The gap

AutoR's automated reviewer is a **completeness** gate. Its policy, verbatim, is *"materially complete"*, *"looks toy"*, *"missing concrete files"*. It asks whether the stage did work; it never asks whether the work supports what it says.

Nothing in the pipeline ever asked **why is this result wrong**.

## What this adds

After Stage 05 and Stage 06 are approved, a pass runs with the opposite instruction: assume the result is an artifact and find the mechanism. Ten named failure modes —

`confound` · `weak_baseline` · `insufficient_replication` · `leakage` · `metric_cherry_picking` · `effect_within_noise` · `overclaim` · `unsupported_generalization` · `missing_ablation` · `irreproducible_procedure`

— because an open-ended "find problems" prompt reliably returns prose quality, which is not what is dangerous. It reads the preregistration and the experimental protocol from #116/#119, so it can check whether the reported metric is the declared one and whether each baseline got the budget it was promised.

**It cannot approve, reject, or edit anything.** A reviewer that can block creates a deadlock between two agents. What it produces is *owed an answer*: Stage 06 must answer Stage 05's findings, Stage 07 must answer Stage 06's, and the stage gate refuses one that leaves a finding unanswered.

| status | meaning |
| --- | --- |
| `addressed` | something changed — must name the artifact |
| `rebutted` | the objection does not hold — must give the argument |
| `accepted_limitation` | the objection stands and this run cannot fix it |

There is no `noted`. Dismissing an objection is legitimate and deliberately cheap; what is refused is silence, because a finding nobody responded to is indistinguishable in the run directory from one nobody raised. Answering a finding that was never raised is also refused, or a stage could look responsive by inventing easy objections.

A crashed reviewer records `reviewer_failed: true` rather than an empty finding list, which would read as "nothing wrong". A failed critique never loses the stage — the exception is caught, logged, and the run continues with the stage explicitly unchallenged.

## Composing with the review panel

#118 landed a deliberating review panel while this branch was open, and its Methodologist and Reviewer 2 cover the same ground. Rather than ship a second critic that asks the same questions twice, **when a panel deliberated, its surviving concerns become the findings**. Only the final round counts — a concern withdrawn during deliberation was answered inside the panel, and re-raising it would punish the deliberation for working.

What this adds on top of the panel is the part the panel does not have: the panel decides at *this* stage's gate and its dissent is written down, but nothing requires anyone to engage with it again. The response contract puts the obligation on the **next** stage, in its own artifacts.

## Tests

35 in `tests/test_validity_review.py`, mostly on the response contract. Mutation-checked: disarming the unanswered-finding check, the substantive-explanation check, or the evidence requirement each fails tests.

Verified end to end — a fake run produces findings at 05 and 06 and answers both:

```
workspace/reviews/
├── validity_review_05_experimentation.json    critical · insufficient_replication
├── validity_response_05_experimentation.json  accepted_limitation
├── validity_review_06_analysis.json
└── validity_response_06_analysis.json
```

Fake mode files a *true* objection (the placeholder rests on one run of a two-row split) and accepts it as a limitation, since the stub cannot fix it. A stub that rebutted a true objection would model the failure the reviewer exists to catch.

667 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)