### PR TITLE
Persist the web-search mode like every other run setting

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,12 +108,18 @@ overnight job.
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--web-search {auto,gemini,native}` | `auto` | Which search path the operators use. `gemini` routes searches through the Gemini API's Google Search grounding via `tools/web_search.py`; `native` leaves the backend's own tool in charge; `auto` picks Gemini when it can actually run and falls back to native otherwise. |
+| `--web-search {auto,gemini,native}` | `auto`, or the recorded mode when resuming | Which search path the operators use. `gemini` routes searches through the Gemini API's Google Search grounding via `tools/web_search.py`; `native` leaves the backend's own tool in charge; `auto` picks Gemini when it can actually run and falls back to native otherwise. |
 
 Set `gemini` on deployments where the built-in `WebSearch` tool is disabled —
 notably **Claude Code on Vertex AI** — otherwise Stage 01 has no way to search
 and will either stall or fabricate citations. See
 [ResearchClawBench → Web search](researchclawbench.md#web-search-on-deployments-where-websearch-is-disabled).
+
+The mode is persisted in `run_config.json` and reconciled on resume, like every other
+backend selection. The **mode** is stored, never the resolved backend: `auto` is a
+question about the current environment, and freezing today's answer would make a
+resumed run assert something about the deployment that may no longer be true. A run
+recorded before this field existed reads as `auto`.
 
 #### What "can actually run" means
 

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -83,6 +83,7 @@ The settings the run was started with, so a resume reproduces them.
   "review_operator": "claude",
   "review_model": "sonnet",
   "codex_sandbox": "workspace-write",
+  "web_search": "auto",
   "created_at": "2026-03-30T10:12:22"
 }
 ```
@@ -97,6 +98,7 @@ The settings the run was started with, so a resume reproduces them.
 | `review_operator` | `claude` or `codex`; defaults to `operator`. |
 | `review_model` | Reviewer model; defaults to `sonnet` (Claude) or `default` (Codex). |
 | `codex_sandbox` | `read-only`, `workspace-write`, or `danger-full-access`. |
+| `web_search` | `auto`, `gemini`, or `native`. The mode, not the resolved backend. Absent in runs created before it existed, and read as `auto`. |
 | `created_at` | ISO-8601 to the second. Preserved across rewrites. |
 
 A missing or corrupt file falls back to defaults rather than failing the run.

--- a/main.py
+++ b/main.py
@@ -22,11 +22,13 @@ from src.utils import (
     DEFAULT_CODEX_SANDBOX,
     DEFAULT_OUTPUT_FORMAT,
     DEFAULT_VENUE,
+    WEB_SEARCH_MODE_CHOICES,
     OUTPUT_FORMAT_CLI_CHOICES,
     MAX_STAGE_ATTEMPTS,
     STAGES,
     build_run_paths,
     load_run_config,
+    normalize_web_search_mode,
     resolve_output_format,
     resolve_stage,
     resolve_venue_key,
@@ -152,8 +154,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--web-search",
-        choices=["auto", "gemini", "native"],
-        default="auto",
+        choices=list(WEB_SEARCH_MODE_CHOICES),
         help=(
             "How operators should search the web. 'gemini' routes searches through the Gemini "
             "API's Google Search grounding via tools/web_search.py, which is required on "
@@ -392,6 +393,24 @@ def _build_resource_entries(paths: list[str]) -> list[ResourceEntry]:
     return entries
 
 
+def resolve_search_context(ui: TerminalUI, *, mode: str, operator: str, codex_sandbox: str) -> str | None:
+    """Decide the search path, announce it, and refuse a request that cannot work.
+
+    Called once per branch rather than once up front, because the answer depends on the
+    operator and sandbox -- and on resume those come from run_config, which is not read
+    until inside the branch.
+    """
+    readiness = assess_search_readiness(operator=operator, codex_sandbox=codex_sandbox)
+    notice, level = web_search_notice(mode, readiness=readiness)
+    ui.show_status(notice, level=level)
+    if mode == "gemini" and readiness.hard_blocker:
+        raise ValueError(
+            f"--web-search gemini cannot work here: {readiness.hard_blocker} "
+            "Fix it, or use --web-search auto to fall back to native search."
+        )
+    return resolve_web_search_context(mode, readiness=readiness)
+
+
 def main() -> int:
     args = parse_args()
     repo_root = Path(__file__).resolve().parent
@@ -400,23 +419,6 @@ def main() -> int:
     persona_text = load_persona(args.persona)
     ui = TerminalUI(interactive=not unattended)
     ui.show_banner()
-
-    # Assessed against the operator this run will actually use, because the sandbox the
-    # search subprocess inherits is part of whether the tool can run at all. Resolved
-    # before the resume branch reads run_config, so a resumed run that switches backends
-    # re-derives it below.
-    readiness = assess_search_readiness(
-        operator=(args.operator or "claude"),
-        codex_sandbox=args.codex_sandbox,
-    )
-    web_search_context = resolve_web_search_context(args.web_search, readiness=readiness)
-    notice, level = web_search_notice(args.web_search, readiness=readiness)
-    ui.show_status(notice, level=level)
-    if args.web_search == "gemini" and readiness.hard_blocker:
-        raise ValueError(
-            f"--web-search gemini cannot work here: {readiness.hard_blocker} "
-            "Fix it, or use --web-search auto to fall back to native search."
-        )
 
     if args.resume_run:
         start_stage = resolve_stage(args.redo_stage)
@@ -463,6 +465,10 @@ def main() -> int:
             ) or default_model_for_operator(review_operator)
         venue = resolve_venue_key(args.venue or existing_config["venue"])
         output_format = resolve_output_format(args.output_format or existing_config.get("output_format"))
+        web_search_mode = normalize_web_search_mode(args.web_search or existing_config.get("web_search"))
+        web_search_context = resolve_search_context(
+            ui, mode=web_search_mode, operator=operator_name, codex_sandbox=codex_sandbox
+        )
         operator = create_operator(
             operator_name,
             model=model,
@@ -497,6 +503,7 @@ def main() -> int:
             max_auto_skips=args.max_auto_skips,
             max_stage_attempts=args.max_attempts,
             web_search_context=web_search_context,
+            web_search_mode=web_search_mode,
         )
         return 0 if manager.resume_run(
             run_root,
@@ -516,6 +523,10 @@ def main() -> int:
     review_model = args.review_model or default_model_for_operator(review_operator)
     venue = resolve_venue_key(args.venue or DEFAULT_VENUE)
     output_format = resolve_output_format(args.output_format or DEFAULT_OUTPUT_FORMAT)
+    web_search_mode = normalize_web_search_mode(args.web_search)
+    web_search_context = resolve_search_context(
+        ui, mode=web_search_mode, operator=operator_name, codex_sandbox=codex_sandbox
+    )
     final_stage = resolve_stage(args.final_stage)
     operator = create_operator(
         operator_name,
@@ -551,6 +562,7 @@ def main() -> int:
         max_auto_skips=args.max_auto_skips,
         max_stage_attempts=args.max_attempts,
         web_search_context=web_search_context,
+        web_search_mode=web_search_mode,
     )
 
     goal = resolve_goal(args, unattended=unattended)

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -348,6 +348,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         max_auto_skips=args.max_auto_skips,
         max_stage_attempts=args.max_attempts,
         web_search_context=resolve_web_search_context(args.web_search, readiness=readiness),
+        web_search_mode=args.web_search,
         # Stages are told to keep code/, outputs/ and report/images/ up to date in the
         # benchmark workspace, so 'Files Produced' must resolve against it too.
         artifact_roots=[workspace],

--- a/src/manager.py
+++ b/src/manager.py
@@ -137,6 +137,7 @@ class ResearchManager:
         max_auto_skips: int = 3,
         max_stage_attempts: int = MAX_STAGE_ATTEMPTS,
         web_search_context: str | None = None,
+        web_search_mode: str | None = None,
         artifact_roots: list[Path] | None = None,
     ) -> None:
         self.project_root = project_root
@@ -164,6 +165,10 @@ class ResearchManager:
         self.max_stage_attempts = max_stage_attempts
         self.auto_skipped_stages: list[str] = []
         self.web_search_context = web_search_context
+        # The *mode* is recorded in run_config so a resume reconciles it the way it does
+        # every other backend selection, instead of silently re-deciding from whatever
+        # credentials happen to be in the environment that day.
+        self.web_search_mode = web_search_mode
         # Extra roots a stage may legitimately write to, beyond the run tree. A benchmark
         # workspace is one: its output contract points stages at paths outside runs/.
         self.artifact_roots = artifact_roots or []
@@ -257,6 +262,7 @@ class ResearchManager:
             review_model=self.review_model,
             codex_sandbox=getattr(self.operator, "codex_sandbox", None),
             output_format=output_format,
+            web_search=self.web_search_mode,
         )
         ensure_run_manifest(paths)
         if not paths.user_input.exists():
@@ -371,6 +377,7 @@ class ResearchManager:
             review_model=self.review_model,
             codex_sandbox=getattr(self.operator, "codex_sandbox", None),
             output_format=output_format,
+            web_search=self.web_search_mode,
         )
         initialize_run_manifest(paths)
         write_artifact_index(paths)

--- a/src/utils.py
+++ b/src/utils.py
@@ -336,6 +336,22 @@ def normalize_codex_sandbox(value: Any) -> str:
     return DEFAULT_CODEX_SANDBOX
 
 
+WEB_SEARCH_MODE_CHOICES = ("auto", "gemini", "native")
+DEFAULT_WEB_SEARCH_MODE = "auto"
+
+
+def normalize_web_search_mode(value: Any) -> str:
+    """Clamp a persisted web-search mode to a known one.
+
+    The *mode* is stored, never the resolved backend: `auto` is a question about the
+    current environment, and freezing today's answer into the run would make a resumed run
+    assert something about the deployment that may no longer be true.
+    """
+    if isinstance(value, str) and value.strip().lower() in WEB_SEARCH_MODE_CHOICES:
+        return value.strip().lower()
+    return DEFAULT_WEB_SEARCH_MODE
+
+
 def default_run_config() -> dict[str, Any]:
     """The configuration a run falls back to when run_config.json is absent or unreadable."""
     return {
@@ -347,6 +363,7 @@ def default_run_config() -> dict[str, Any]:
         "review_operator": "claude",
         "review_model": "sonnet",
         "codex_sandbox": DEFAULT_CODEX_SANDBOX,
+        "web_search": DEFAULT_WEB_SEARCH_MODE,
     }
 
 
@@ -360,6 +377,7 @@ def initialize_run_config(
     review_model: str | None = None,
     codex_sandbox: str | None = None,
     output_format: str | None = None,
+    web_search: str | None = None,
 ) -> dict[str, Any]:
     normalized_operator = operator.strip().lower() if operator.strip() else "claude"
     normalized_review_operator = (
@@ -380,6 +398,7 @@ def initialize_run_config(
             or ("default" if normalized_review_operator == "codex" else "sonnet")
         ),
         "codex_sandbox": normalize_codex_sandbox(codex_sandbox),
+        "web_search": normalize_web_search_mode(web_search),
         "created_at": datetime.now().isoformat(timespec="seconds"),
     }
     write_text(paths.run_config, json.dumps(config, indent=2, ensure_ascii=False))
@@ -424,6 +443,7 @@ def load_run_config(paths: RunPaths) -> dict[str, Any]:
             else ("default" if normalized_review_operator == "codex" else "sonnet")
         ),
         "codex_sandbox": normalize_codex_sandbox(codex_sandbox),
+        "web_search": normalize_web_search_mode(payload.get("web_search")),
     }
     created_at = payload.get("created_at")
     if isinstance(created_at, str) and created_at.strip():
@@ -448,6 +468,7 @@ def save_run_config(paths: RunPaths, config: dict[str, Any]) -> None:
             or ("default" if normalized_review_operator == "codex" else "sonnet")
         ),
         "codex_sandbox": normalize_codex_sandbox(config.get("codex_sandbox")),
+        "web_search": normalize_web_search_mode(config.get("web_search")),
     }
     created_at = config.get("created_at")
     if isinstance(created_at, str) and created_at.strip():
@@ -467,6 +488,7 @@ def ensure_run_config(
     review_model: str | None = None,
     codex_sandbox: str | None = None,
     output_format: str | None = None,
+    web_search: str | None = None,
 ) -> dict[str, Any]:
     current = load_run_config(paths)
     effective_operator = operator or current.get("operator") or "claude"
@@ -482,6 +504,7 @@ def ensure_run_config(
             "default" if effective_review_operator == "codex" else "sonnet"
         ),
         "codex_sandbox": normalize_codex_sandbox(codex_sandbox or current.get("codex_sandbox")),
+        "web_search": normalize_web_search_mode(web_search or current.get("web_search")),
         "created_at": current.get("created_at") or datetime.now().isoformat(timespec="seconds"),
     }
     save_run_config(paths, updated)

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -7,6 +7,7 @@ import io
 import json
 import os
 import tempfile
+import subprocess
 import sys
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -1345,3 +1346,197 @@ class SearchRetryAndTimeoutTest(unittest.TestCase):
         )
         self.assertEqual(captured.get("project"), "p")
         self.assertEqual(captured["http_options"].timeout, web_search_module.SEARCH_TIMEOUT_MS)
+
+
+class WebSearchModePersistenceTest(unittest.TestCase):
+    """`--web-search` was the only backend selection not recorded in run_config.json.
+
+    operator, model, venue, codex_sandbox, approval_mode, review_operator, review_model
+    and output_format are all persisted and reconciled on resume. This one was re-derived
+    from the ambient environment every time, so a resumed run could silently change what
+    it told the operator about the deployment -- and with Vertex ADC in the mix, the input
+    to that decision is an expiring credential.
+    """
+
+    def _paths(self, tmp):
+        from src.utils import build_run_paths, ensure_run_layout
+
+        paths = build_run_paths(Path(tmp) / "run")
+        ensure_run_layout(paths)
+        return paths
+
+    def test_the_mode_round_trips_through_the_config(self) -> None:
+        from src.utils import load_run_config, save_run_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            for mode in ("auto", "gemini", "native"):
+                with self.subTest(mode=mode):
+                    save_run_config(paths, {"web_search": mode})
+                    self.assertEqual(load_run_config(paths)["web_search"], mode)
+
+    def test_a_legacy_config_without_the_key_reads_as_auto(self) -> None:
+        """Runs created before this existed must keep working."""
+        from src.utils import load_run_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            paths.run_config.write_text(json.dumps({"model": "sonnet", "operator": "claude"}))
+            self.assertEqual(load_run_config(paths)["web_search"], "auto")
+
+    def test_a_bogus_persisted_mode_is_clamped(self) -> None:
+        from src.utils import load_run_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            paths.run_config.write_text(json.dumps({"web_search": "sideways"}))
+            self.assertEqual(load_run_config(paths)["web_search"], "auto")
+
+    def test_the_default_config_carries_the_key(self) -> None:
+        from src.utils import default_run_config
+
+        self.assertEqual(default_run_config()["web_search"], "auto")
+
+    def test_ensure_preserves_the_recorded_mode_when_no_flag_is_given(self) -> None:
+        from src.utils import ensure_run_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            ensure_run_config(paths, model="sonnet", web_search="gemini")
+            self.assertEqual(ensure_run_config(paths, model="sonnet")["web_search"], "gemini")
+
+    def test_an_explicit_flag_overrides_the_recorded_mode(self) -> None:
+        from src.utils import ensure_run_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            ensure_run_config(paths, model="sonnet", web_search="gemini")
+            self.assertEqual(
+                ensure_run_config(paths, model="sonnet", web_search="native")["web_search"],
+                "native",
+            )
+
+    def test_it_is_persisted_beside_every_other_selection(self) -> None:
+        """A field the writer drops is a field the resume cannot reconcile."""
+        from src.utils import default_run_config, load_run_config, save_run_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp)
+            save_run_config(paths, default_run_config())
+            written = json.loads(paths.run_config.read_text())
+        for key in ("operator", "model", "venue", "codex_sandbox", "approval_mode", "web_search"):
+            self.assertIn(key, written)
+        self.assertEqual(set(load_run_config(paths)) - {"created_at"}, set(written) - {"created_at"})
+
+
+class NormalizeWebSearchModeTest(unittest.TestCase):
+    def test_known_modes_survive(self) -> None:
+        from src.utils import normalize_web_search_mode
+
+        for mode in ("auto", "gemini", "native"):
+            self.assertEqual(normalize_web_search_mode(mode), mode)
+
+    def test_case_and_padding_are_tolerated(self) -> None:
+        from src.utils import normalize_web_search_mode
+
+        self.assertEqual(normalize_web_search_mode("  GEMINI "), "gemini")
+
+    def test_anything_else_falls_back_to_auto(self) -> None:
+        from src.utils import normalize_web_search_mode
+
+        for value in (None, "", "sideways", 7, [], {"a": 1}):
+            with self.subTest(value=value):
+                self.assertEqual(normalize_web_search_mode(value), "auto")
+
+    def test_the_cli_accepts_exactly_the_modes_the_config_can_store(self) -> None:
+        """A flag value the config cannot store would be silently downgraded on resume."""
+        from src.utils import WEB_SEARCH_MODE_CHOICES, normalize_web_search_mode
+
+        for mode in WEB_SEARCH_MODE_CHOICES:
+            with self.subTest(mode=mode):
+                with patch.object(sys, "argv", ["main.py", "--web-search", mode, "--goal", "g"]):
+                    args = autor_main.parse_args()
+                self.assertEqual(args.web_search, mode)
+                self.assertEqual(normalize_web_search_mode(args.web_search), mode)
+
+    def test_the_cli_rejects_a_mode_the_config_would_clamp(self) -> None:
+        with patch.object(sys, "argv", ["main.py", "--web-search", "sideways", "--goal", "g"]):
+            with redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit):
+                    autor_main.parse_args()
+
+    def test_omitting_the_flag_is_distinguishable_from_passing_auto(self) -> None:
+        """Without this, a resume could not tell "keep what the run recorded" from
+        "the user asked for auto", and the recorded mode would be overwritten every time."""
+        with patch.object(sys, "argv", ["main.py", "--goal", "g"]):
+            self.assertIsNone(autor_main.parse_args().web_search)
+        with patch.object(sys, "argv", ["main.py", "--goal", "g", "--web-search", "auto"]):
+            self.assertEqual(autor_main.parse_args().web_search, "auto")
+
+
+class WebSearchModeReachesTheRunTest(unittest.TestCase):
+    """End to end through the real CLI: the mode has to survive to run_config.json.
+
+    The unit tests above prove `src/utils.py` can round-trip the field. These prove the
+    manager actually hands it over and that the resume branch reconciles it -- the two
+    seams where dropping it is invisible, because the run still works and just searches
+    differently than it was told to.
+    """
+
+    REPO_ROOT = Path(__file__).resolve().parent.parent
+
+    def _run_cli(self, runs_dir: Path, *extra: str, stdin: str = "6\n"):
+        return subprocess.run(
+            [sys.executable, "main.py", "--fake-operator", "--runs-dir", str(runs_dir), *extra],
+            cwd=self.REPO_ROOT,
+            input=stdin,
+            text=True,
+            capture_output=True,
+        )
+
+    @staticmethod
+    def _recorded(runs_dir: Path) -> dict:
+        run_root = sorted(p for p in runs_dir.iterdir() if p.is_dir())[-1]
+        return json.loads((run_root / "run_config.json").read_text()), run_root
+
+    def test_a_new_run_records_the_mode_it_was_started_with(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runs_dir = Path(tmp) / "runs"
+            result = self._run_cli(runs_dir, "--goal", "record the mode", "--web-search", "native")
+            self.assertEqual(result.returncode, 1, msg=result.stderr)
+            config, _ = self._recorded(runs_dir)
+        self.assertEqual(config["web_search"], "native")
+
+    def test_a_new_run_without_the_flag_records_the_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runs_dir = Path(tmp) / "runs"
+            result = self._run_cli(runs_dir, "--goal", "default mode")
+            self.assertEqual(result.returncode, 1, msg=result.stderr)
+            config, _ = self._recorded(runs_dir)
+        self.assertEqual(config["web_search"], "auto")
+
+    def test_a_resume_without_the_flag_keeps_the_recorded_mode(self) -> None:
+        """This is the defect: the mode used to be re-derived from the environment on
+        every resume, so a run started with --web-search native could quietly start
+        telling operators that WebSearch is disabled halfway through."""
+        with tempfile.TemporaryDirectory() as tmp:
+            runs_dir = Path(tmp) / "runs"
+            self._run_cli(runs_dir, "--goal", "resume keeps mode", "--web-search", "native")
+            config, run_root = self._recorded(runs_dir)
+            self.assertEqual(config["web_search"], "native")
+
+            result = self._run_cli(runs_dir, "--resume-run", run_root.name)
+            self.assertEqual(result.returncode, 1, msg=result.stderr)
+            config, _ = self._recorded(runs_dir)
+        self.assertEqual(config["web_search"], "native")
+
+    def test_a_resume_with_the_flag_overrides_the_recorded_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runs_dir = Path(tmp) / "runs"
+            self._run_cli(runs_dir, "--goal", "resume overrides", "--web-search", "native")
+            _, run_root = self._recorded(runs_dir)
+
+            result = self._run_cli(runs_dir, "--resume-run", run_root.name, "--web-search", "auto")
+            self.assertEqual(result.returncode, 1, msg=result.stderr)
+            config, _ = self._recorded(runs_dir)
+        self.assertEqual(config["web_search"], "auto")


### PR DESCRIPTION
Fourth of the verified web-search findings.

## The defect

`--web-search` was the **only** backend selection not recorded in `run_config.json`. `operator`, `model`, `venue`, `codex_sandbox`, `approval_mode`, `review_operator`, `review_model` and `output_format` are all persisted and reconciled on resume. This one was re-derived from the ambient environment every time.

So a run started with `--web-search native` could quietly start telling operators that `WebSearch` is disabled halfway through — and with Vertex ADC now in the mix, the input to that decision is an **expiring credential**.

## The fix

`web_search` joins the run_config key set across `default_run_config`, `initialize_run_config`, `load_run_config`, `save_run_config` and `ensure_run_config`, with a `normalize_web_search_mode` helper beside `normalize_codex_sandbox`. A config written before this existed has no such key and reads as `auto`, so old runs keep working.

**The mode is stored, never the resolved backend.** `auto` is a question about the current environment; freezing today's answer into the run would make a resumed run assert something about the deployment that may no longer be true.

`--web-search` loses its argparse default, so *"not passed"* is distinguishable from *"passed auto"* — the same shape `--operator`, `--venue` and `--codex-sandbox` already have. Without that, a resume could not tell "keep what the run recorded" from "the user asked for auto", and would overwrite it every time.

## Restructured while I was there

The resolution ran **once, before the resume branch**, from the flag and `args.operator` alone. That meant a resumed run assessed readiness against the *wrong operator* — the recorded one lives in `run_config`, which is not read until inside the branch. `resolve_search_context` is now called once per branch with that branch's effective operator and sandbox.

## Verification

- **678 tests green** (+23), `py_compile` clean.
- Unit tests prove `src/utils.py` round-trips the field. **Four more drive the real CLI end to end**, because the manager handing it over and the resume branch reconciling it are the two seams where dropping it is invisible — the run still works, it just searches differently than it was told to.
- **Mutation swept with a control run: 13 mutants, all killed.** The first pass left exactly two survivors, both at those seams; the end-to-end tests are what closed them.
- Verified under both environments: dependencies installed, and `google`/`pyyaml` blocked the way CI has them.

## Remaining

One finding left — the test-quality cluster, headed by **zero coverage of the SDK call path**, where 24 mutants survive the green suite including deleting the Google Search grounding tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)