### PR TITLE
Read a Files Produced entry as a pattern when it is one

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1628,6 +1628,69 @@ def _extract_path_references(text: str) -> list[str]:
     return paths
 
 
+#: Characters that make a "Files Produced" entry a pattern rather than a literal path.
+PATTERN_CHARS = ("*", "?", "[", "{")
+
+
+def expand_braces(pattern: str) -> list[str]:
+    """Expand ``a{b,c}d`` into ``[abd, acd]``, recursively.
+
+    A stage that produced four files naturally writes
+    ``text/paper_00{0,1,2,3}.txt`` rather than four lines. :mod:`glob` does not
+    understand braces, so without this the entry is treated as one literal
+    filename that cannot exist.
+    """
+    open_at = pattern.find("{")
+    if open_at == -1:
+        return [pattern]
+
+    depth = 0
+    for index in range(open_at, len(pattern)):
+        if pattern[index] == "{":
+            depth += 1
+        elif pattern[index] == "}":
+            depth -= 1
+            if depth == 0:
+                close_at = index
+                break
+    else:
+        return [pattern]  # unbalanced; treat literally rather than guessing
+
+    prefix, body, suffix = pattern[:open_at], pattern[open_at + 1:close_at], pattern[close_at + 1:]
+    options, depth, current = [], 0, ""
+    for char in body:
+        if char == "," and depth == 0:
+            options.append(current)
+            current = ""
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        current += char
+    options.append(current)
+
+    expanded: list[str] = []
+    for option in options:
+        for tail in expand_braces(suffix):
+            expanded.extend(expand_braces(prefix + option + tail))
+    return expanded
+
+
+def _pattern_matches_under(root: Path, pattern: str) -> bool:
+    """True when at least one real file matches *pattern* beneath *root*."""
+    for candidate in expand_braces(pattern):
+        if any(char in candidate for char in ("*", "?", "[")):
+            try:
+                if any(root.glob(candidate)):
+                    return True
+            except (OSError, ValueError, IndexError):
+                continue
+        elif (root / candidate).exists():
+            return True
+    return False
+
+
 def _listed_file_exists(
     run_root: Path,
     listed_path: str,
@@ -1653,25 +1716,37 @@ def _listed_file_exists(
        that complies and then lists ``outputs/metrics.csv`` is describing a
        real file the first two roots cannot see.
 
+    An entry containing ``*``, ``?``, ``[`` or ``{`` is treated as a **pattern**
+    rather than a literal name, and matches when at least one real file matches
+    it. A stage that produced four papers writes
+    ``text/paper_00{0,1,2,3}.txt`` or ``text/paper_00*.txt`` rather than four
+    lines; read literally, those are filenames that cannot exist, and the stage
+    is failed for artifacts it genuinely produced. A pattern matching nothing
+    still fails, so the gate keeps its teeth.
+
     We accept all of them. Absolute paths are honored as-is. Each fallback is
     strictly additive — every path that validated before still validates — so
     existing CLI runs are not affected.
     """
     candidate = Path(listed_path)
+    is_pattern = any(char in listed_path for char in PATTERN_CHARS)
     try:
         if candidate.is_absolute():
-            return candidate.exists()
-        # 1. Run-root-relative (canonical AutoR form)
-        via_root = run_root / candidate
-        if via_root.exists():
-            return True
-        # 2. Workspace-relative fallback
-        via_workspace = run_root / "workspace" / candidate
-        if via_workspace.exists():
-            return True
-        # 3. Extra artifact roots (for example a benchmark workspace)
-        for root in extra_roots or ():
-            if (root / candidate).exists():
+            if not is_pattern:
+                return candidate.exists()
+            anchor = Path(candidate.anchor)
+            return _pattern_matches_under(anchor, str(candidate.relative_to(anchor)))
+
+        roots = [
+            run_root,                    # 1. Run-root-relative (canonical AutoR form)
+            run_root / "workspace",      # 2. Workspace-relative fallback
+            *(extra_roots or ()),        # 3. Extra artifact roots (e.g. a benchmark workspace)
+        ]
+        for root in roots:
+            if is_pattern:
+                if _pattern_matches_under(root, listed_path):
+                    return True
+            elif (root / candidate).exists():
                 return True
     except OSError:
         return False

--- a/tests/test_listed_file_patterns.py
+++ b/tests/test_listed_file_patterns.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_layout,
+    expand_braces,
+    validate_stage_markdown,
+    write_text,
+)
+
+
+class ExpandBracesTest(unittest.TestCase):
+    def test_a_simple_set_expands(self) -> None:
+        self.assertEqual(
+            expand_braces("text/paper_00{0,1,2,3}.txt"),
+            [f"text/paper_00{i}.txt" for i in range(4)],
+        )
+
+    def test_two_sets_produce_the_cross_product(self) -> None:
+        self.assertEqual(sorted(expand_braces("a{b,c}{1,2}.txt")),
+                         ["ab1.txt", "ab2.txt", "ac1.txt", "ac2.txt"])
+
+    def test_nested_sets_expand(self) -> None:
+        self.assertEqual(sorted(expand_braces("x{a,{b,c}}")), ["xa", "xb", "xc"])
+
+    def test_a_plain_path_is_returned_unchanged(self) -> None:
+        self.assertEqual(expand_braces("no-braces.txt"), ["no-braces.txt"])
+
+    def test_unbalanced_braces_are_treated_literally_not_guessed(self) -> None:
+        self.assertEqual(expand_braces("unbalanced{a,b.txt"), ["unbalanced{a,b.txt"])
+
+    def test_expansion_terminates_on_an_empty_option(self) -> None:
+        self.assertEqual(sorted(expand_braces("f{,x}.txt")), ["f.txt", "fx.txt"])
+
+
+class ListedPatternTest(unittest.TestCase):
+    """Real files reported through a pattern must satisfy the gate; nothing else may."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        text_dir = self.paths.literature_dir / "text"
+        text_dir.mkdir(parents=True, exist_ok=True)
+        for index in range(4):
+            write_text(text_dir / f"paper_00{index}.txt", "body\n")
+
+    def _missing(self, listed: str) -> list[str]:
+        markdown = (
+            "# Stage 01: Literature Survey\n\n"
+            "## Objective\no\n\n## Previously Approved Stage Summaries\nn\n\n"
+            "## What I Did\nw\n\n## Key Results\nk\n\n"
+            f"## Files Produced\n- `{listed}`\n\n"
+            "## Decision Ledger\nOpen Questions: -\nLocked Decisions: -\n"
+            "Assumptions: -\nRejected Alternatives: -\n\n"
+            "## Suggestions for Refinement\n1. a\n2. b\n3. c\n\n"
+            "## Your Options\n1. a\n2. b\n3. c\n4. d\n5. e\n6. f\n"
+        )
+        return [
+            p for p in validate_stage_markdown(markdown, stage=STAGES[0], paths=self.paths)
+            if "references missing file" in p
+        ]
+
+    def test_the_brace_form_from_the_real_run_now_validates(self) -> None:
+        self.assertEqual(self._missing("workspace/literature/text/paper_00{0,1,2,3}.txt"), [])
+
+    def test_the_glob_form_from_the_real_run_now_validates(self) -> None:
+        self.assertEqual(self._missing("workspace/literature/text/paper_00*.txt"), [])
+
+    def test_a_literal_path_still_validates(self) -> None:
+        self.assertEqual(self._missing("workspace/literature/text/paper_000.txt"), [])
+
+    def test_a_pattern_matching_nothing_still_fails(self) -> None:
+        """The gate must keep its teeth: patterns are not a way to claim anything."""
+        self.assertEqual(len(self._missing("workspace/literature/text/absent_*.txt")), 1)
+
+    def test_a_brace_set_where_one_member_is_absent_still_passes(self) -> None:
+        # At-least-one semantics, matching how a shell glob reads.
+        self.assertEqual(self._missing("workspace/literature/text/paper_00{0,9}.txt"), [])
+
+    def test_a_missing_literal_path_still_fails(self) -> None:
+        self.assertEqual(len(self._missing("workspace/literature/text/never.txt")), 1)
+
+    def test_a_recursive_glob_is_supported(self) -> None:
+        self.assertEqual(self._missing("workspace/**/paper_001.txt"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**The automated reviewer caught this itself** while approving Stage 01, and was right:

> "the four `text/paper_00N.txt` files the manifest's last_error wrongly flags as missing (a brace-glob artifact in the validator, not a real gap)"

Two forms showed up across the pilot runs, both natural ways to list a set of produced files, both read as one literal filename that cannot exist:

```
workspace/literature/text/paper_00{0,1,2,3}.txt
outputs/lit_survey/ont_models/*.npz
```

The files were there. The stage was failed for artifacts it had genuinely produced, and its retry budget went with it — the same cost as #114 and #117, from a different cause.

## The fix

An entry containing `*`, `?`, `[` or `{` is treated as a **pattern** and matches when at least one real file matches it, against every root the resolver already searches. `glob` does not understand braces, so `expand_braces` handles those first — recursively, and cross-producting multiple sets (`a{b,c}{1,2}.txt` → four names). Unbalanced braces are left literal rather than guessed at.

## The gate keeps its teeth

This is the part worth reviewing. Loosening a validator is how gates quietly stop working, so both directions are pinned:

- A pattern matching **nothing** still fails — patterns are not a way to claim credit for absent work.
- A literal path behaves **exactly** as before.
- Plus the two exact strings from the real runs, so this cannot regress into the same false positive.

674 tests pass, 13 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)