### PR TITLE
Make the review panel falsifiable, and less correlated

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Useful feature | **Artifact indexing across stages** | `artifact_index.json` and related manifests help later stages find data, results, and figures without guessing from filenames. |
 | Useful feature | **Self-improving review policy** | Every correction the reviewer demands becomes a standing rule checked on all later stages, recorded in an auditable `review_policy.json` with the stage and attempt that produced it. |
 | Useful feature | **Resume, redo, and rollback controls** | Long research runs can continue in place, retry a stage, or roll downstream state back without starting over. |
-| Useful feature | **Deliberating review panel** | Instead of one reviewer agent at the approval gate, `--review-panel` seats a PI, domain expert, methodologist, reproducibility engineer and adversarial reviewer who review independently, cross-examine, then converge — and a blocking objection cannot be approved over. |
+| Useful feature | **Deliberating review panel** | Instead of one reviewer agent at the approval gate, `--review-panel` seats a PI, domain expert, methodologist, reproducibility engineer and adversarial reviewer who review independently, cross-examine, then converge — and a blocking objection cannot be approved over. Each run measures the panel against its own single-pass baseline and reports when it did not earn its cost. |
 | Useful feature | **Two output formats** | Stage 07 writes a benchmark-ready markdown report (`report/report.md` + PNG figures) by default, or a venue-aware LaTeX paper package with a compiled PDF via `--output-format latex`. |
 
 In practice, that means AutoR is useful not only because of the high-level framing, but also because it handles real research chores: literature organization, experiment manifests, citation verification, artifact indexing, manuscript packaging, and recoverable long-running workflows.
@@ -291,6 +291,7 @@ AI handles execution load; humans steer the research when direction actually mat
 | Run with the automated reviewer gate | `python main.py --full-auto --goal "Your research goal here"` |
 | Replace the single reviewer with a deliberating panel | `python main.py --review-panel --goal "..."` |
 | Give the panel a researcher persona to stand in for | `python main.py --review-panel --persona docs/persona-example.md --goal "..."` |
+| Seat the panel across different models | `python main.py --review-panel --panel-models pi=opus skeptic=codex:default --goal "..."` |
 | Choose the execution backend | `python main.py --operator claude` or `python main.py --operator codex` |
 | Choose the reviewer backend separately | `python main.py --full-auto --review-operator claude --review-model opus` |
 | Choose a Claude model | `python main.py --operator claude --model sonnet` or `python main.py --operator claude --model opus` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -161,10 +161,14 @@ approval. See [Stage Contract](stage-contract.md#artifact-requirements).
 | `--review-panel` | off | Replace the single reviewer agent with a deliberating panel: independent round, cross-examination on disagreement, then a chair synthesis. Implies `--approval-mode agent`. |
 | `--panel-roles ROLE...` | all five | Seat only these roles, in this order: `pi`, `domain`, `method`, `repro`, `skeptic`. The first seat chairs unless `pi` is present. An unknown name is an error. |
 | `--panel-rounds N` | `2` | Maximum deliberation rounds. Round 1 is always independent; later rounds run only on disagreement. |
+| `--panel-models ROLE=MODEL...` | — | Assign a model per seat, as `role=model` or `role=backend:model` (`pi=opus skeptic=codex:default`). Heterogeneity is the lever with the best evidence behind it. |
 | `--persona PATH` | — | Markdown description of the researcher the panel stands in for, injected into every seat so they hold one consistent bar. |
 
 A blocking objection from any member cannot be approved over — the chair's approval is
-converted to a refinement in code. Full description in [Review Panel](review-panel.md).
+converted to a refinement in code. Each run also writes
+`workspace/reviews/panel/panel_effect.json`, comparing the panel against its own single-pass
+baseline so it can report that it did not earn its cost. Full description, including the
+pre-registered evidence against multi-agent deliberation, in [Review Panel](review-panel.md).
 
 ### Stopping early
 

--- a/docs/review-panel.md
+++ b/docs/review-panel.md
@@ -16,6 +16,41 @@ python rcb_agent.py --review-panel          # benchmark runs
 
 ---
 
+## Does this actually help? Read this first
+
+There is a pre-registered result that argues it may not.
+
+Havranek and Irsova (2026, [arXiv:2607.14713](https://arxiv.org/abs/2607.14713)) had the
+authors of 44 economics meta-analyses rank three identity-masked AI reports on their own
+paper. A plain **single pass beat both multi-agent tools** — mean rank 1.59 against 2.25 and
+2.16, Holm-adjusted p = 0.005 and 0.026 — and the multi-agent tools were the study authors'
+own, pre-registered to win. The most elaborate arm spent about thirty times the tokens and
+ranked 0.57 places worse. The mechanism the authors report is the one that should worry
+anyone building a panel: the reports "tended to raise much the same points."
+
+Two further findings from that paper bear directly on this feature:
+
+- **An AI judge is not a substitute for the intended user.** Author–judge rank correlation was
+  0.14, indistinguishable from zero. Had the external judge ranked the arms instead of the
+  authors, it would have crowned the most expensive tool and *reversed* the finding.
+- **AI judges systematically undervalue human review.** Authors placed their real journal
+  referee report first 71% of the time and never last; the AI judges placed it last on 92–100%
+  of papers. A panel simulating humans is built out of exactly the judges that got this wrong.
+
+So the panel is not offered here as an established improvement. It is offered with an
+instrument attached that can say it did not help — see [Measuring whether it
+helped](#measuring-whether-it-helped).
+
+What the evidence does support is *heterogeneity over deliberation*. Both that paper and
+AgentPanel ([arXiv:2608.03283](https://arxiv.org/abs/2608.03283)) cite Zhang et al. (2025),
+"Stop overvaluing multi-agent debate — we must rethink evaluation and embrace model
+heterogeneity." AgentPanel's own gains over centralized debate are concentrated in
+*feasibility* (5.08 vs 4.08 on LiveIdeaBench; 0.28 vs 0.11 and 0.31 vs 0.04 on IdeaBench),
+not originality, and come from a pool of 20+ heterogeneous model backends with agents free to
+**abstain** and with **deliberately uneven exposure** to each other's output. Those three
+levers — different models, permitted silence, withheld context — are the ones implemented
+here.
+
 ## Why a panel rather than a longer prompt
 
 Asking one reviewer to "consider multiple perspectives" produces one voice listing
@@ -64,6 +99,76 @@ deliberate about, and a second round would only invite the panel to talk itself 
 agreement it already reached.
 
 Raise or lower the ceiling with `--panel-rounds N`.
+
+## Measuring whether it helped
+
+Every panel run contains its own control arm for free: **the chair's round-1 verdict is a
+single pass** — one model, one call, no peer input. Recording it costs nothing and answers the
+only question that matters about this feature.
+
+`workspace/reviews/panel/panel_effect.json` accumulates the comparison across the run:
+
+```json
+{
+  "summary": {
+    "gates_reviewed": 8,
+    "gates_where_the_panel_changed_the_decision": 0,
+    "gates_where_round_1_disagreed": 1,
+    "chair_overrides": 0,
+    "cost_multiple": 5.0,
+    "verdict": "The panel reached the same decision as its own single-pass baseline at all 8 gate(s), at 5.0x the reviewer cost. On this run it did not earn that cost; consider --panel-roles with fewer seats, or dropping the panel."
+  },
+  "gates": [ ... ]
+}
+```
+
+That verdict line is written to be unflattering when that is the truth. A feature that can
+only report its own success is not measured, and the literature above is what happens when
+builders grade their own tools without a baseline.
+
+The same line is appended to the run log at each gate, so a long run surfaces the answer
+without anyone opening a JSON file.
+
+## Abstention
+
+A seat may return `{"decision":"abstain"}` when it has nothing substantive to add. An
+abstention is **not** disagreement — the room can still be unanimous — but it is also not
+agreement, and a panel where every seat abstains reaches the chair rather than passing as
+consensus.
+
+This exists because of the null above. Forcing five seats to produce a verdict on every gate
+is precisely how five reviewers come to raise much the same points. A seat with nothing to say
+is better silent than padding.
+
+## Uneven exposure
+
+Round two does not show every seat the same thing.
+
+- Most seats see the other positions, **anonymised as "Reviewer A/B/C"**. The substance
+  survives; the attribution does not, so a methodologist weighs an objection on its evidence
+  rather than deferring to it because the chair signed it. This is what the cross-model audit
+  tool in the study above does.
+- The **adversarial reviewer sees nothing**. Its entire value is that its read is not
+  downstream of the room's, so it is asked to hold or revise from the artifacts alone.
+
+Per-seat exposure is a `PanelRole` field (`full`, `objections`, `none`). Uniform full exposure
+turns the second round into a convergence machine, which is the failure mode that makes
+deliberation look like agreement.
+
+## Model heterogeneity
+
+`--panel-models pi=opus skeptic=codex:default method=sonnet`
+
+Assign a model, or a backend and model, per seat. Seats left unassigned use the reviewer
+default.
+
+This is the lever with the best evidence behind it. Errors idiosyncratic to one model survive
+when that model checks its own work and correlate less across families than within them — the
+reason the cross-model audit tool in the study above deliberately used two families. Five
+prompts against one model are five correlated reads wearing five hats.
+
+The panel record says so plainly: `homogeneous_panel: true` when every seat shares one
+backend and model, alongside `distinct_backends` and `distinct_models`.
 
 ## The blocking rule
 
@@ -127,7 +232,12 @@ most), or by `--panel-rounds 1` to skip cross-examination.
 ## Limits worth knowing
 
 - **Correlated seats.** Five prompts against one model are less independent than they look.
-  Mixed backends are the real fix; distinct mandates are a partial one.
+  `--panel-models` is the real fix; distinct mandates are a partial one, and the panel record
+  flags a homogeneous roster rather than letting it pass as five opinions.
+- **The null is real and this feature has not refuted it.** The measurement above is an
+  instrument, not a result. If your runs report `changed_decision: 0` across every gate, the
+  honest reading is that the single pass was enough for your work, and the panel should be
+  turned off.
 - **The panel reviews summaries, not the world.** Members are told to open artifacts, and the
   reproducibility seat exists to enforce that, but a determined stage summary can still
   describe a file more favourably than the file reads.

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -741,6 +741,27 @@ Required: non-empty string `overall_status`; booleans `pdf_available` and
 Validated by `validate_layout_review` in
 [`src/writing_manifest.py`](../src/writing_manifest.py).
 
+### `workspace/reviews/panel/`
+
+Written only when `--review-panel` is active. Per gate, `<stage>_attempt_NN.json` and a
+readable `.md` hold every position from every round, including dissent that lost and any
+chair override.
+
+Alongside them, `panel_effect.json` accumulates the panel against its own single-pass
+baseline — the chair's round-1 verdict, which is one model, one call, no peer input:
+
+| Field | Meaning |
+| --- | --- |
+| `gates_reviewed` | Gates the panel has judged this run. |
+| `gates_where_the_panel_changed_the_decision` | How often deliberation reached a different decision than the baseline. **If this stays 0, the panel is not earning its cost.** |
+| `gates_where_round_1_disagreed` | How often the seats were not already unanimous. |
+| `chair_overrides` | Approvals converted to refinements by a blocking objection. |
+| `cost_multiple` | Reviewer calls spent per single-pass call. |
+| `verdict` | One plain sentence, written to be unflattering when that is the truth. |
+
+See [Review Panel](review-panel.md) for the pre-registered evidence this measurement exists
+to answer.
+
 ### `workspace/artifacts/self_review.json`
 
 Required to exist at Stage 07+. Its contents are not schema-validated, so its

--- a/main.py
+++ b/main.py
@@ -5,7 +5,13 @@ import sys
 from pathlib import Path
 
 from src.approval_agent import AutomatedReviewer
-from src.review_panel import DEFAULT_PANEL, ReviewPanel, load_persona, resolve_roles
+from src.review_panel import (
+    DEFAULT_PANEL,
+    ReviewPanel,
+    apply_model_assignments,
+    load_persona,
+    resolve_roles,
+)
 from src.intake import ResourceEntry, classify_resource, collect_resource_paths_from_ui
 from src.manager import ResearchManager
 from src.operator import ClaudeOperator
@@ -120,6 +126,15 @@ def parse_args() -> argparse.Namespace:
         help="Seat only these roles on the panel, in this order: "
              + ", ".join(role.key for role in DEFAULT_PANEL)
              + ". The first seat chairs unless the PI is present. Defaults to all five.",
+    )
+    parser.add_argument(
+        "--panel-models",
+        nargs="+",
+        metavar="ROLE=MODEL",
+        help="Assign a model per panel seat, as role=model or role=backend:model "
+             "(for example: pi=opus skeptic=codex:default). Seats left unassigned use the "
+             "reviewer default. Heterogeneity is the lever with the best evidence behind it: "
+             "five prompts against one model are five correlated reads wearing five hats.",
     )
     parser.add_argument(
         "--panel-rounds",
@@ -275,6 +290,7 @@ def create_reviewer(
     ui: TerminalUI,
     stage_timeout: int,
     panel_roles: list[str] | None = None,
+    panel_models: list[str] | None = None,
     use_panel: bool = False,
     persona_text: str = "",
     deliberation_rounds: int = 2,
@@ -285,7 +301,7 @@ def create_reviewer(
     """
     if use_panel:
         return ReviewPanel(
-            resolve_roles(panel_roles),
+            apply_model_assignments(resolve_roles(panel_roles), panel_models),
             backend_name=backend_name,
             model=model,
             fake_mode=fake_mode,
@@ -487,6 +503,7 @@ def main() -> int:
                 stage_timeout=args.stage_timeout,
                 use_panel=args.review_panel,
                 panel_roles=args.panel_roles,
+                panel_models=args.panel_models,
                 persona_text=persona_text,
                 deliberation_rounds=args.panel_rounds,
             )
@@ -546,6 +563,7 @@ def main() -> int:
             stage_timeout=args.stage_timeout,
             use_panel=args.review_panel,
             panel_roles=args.panel_roles,
+            panel_models=args.panel_models,
             persona_text=persona_text,
             deliberation_rounds=args.panel_rounds,
         )

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -32,7 +32,13 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from src.approval_agent import AutomatedReviewer  # noqa: E402
-from src.review_panel import DEFAULT_PANEL, ReviewPanel, load_persona, resolve_roles  # noqa: E402
+from src.review_panel import (
+    DEFAULT_PANEL,
+    ReviewPanel,
+    apply_model_assignments,
+    load_persona,
+    resolve_roles,
+)  # noqa: E402
 from src.manager import ResearchManager  # noqa: E402
 from src.operator import ClaudeOperator  # noqa: E402
 from src.operator_codex import CodexOperator  # noqa: E402
@@ -164,6 +170,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         nargs="+",
         metavar="ROLE",
         help="Seat only these panel roles, in this order. Defaults to all of them.",
+    )
+    parser.add_argument(
+        "--panel-models",
+        nargs="+",
+        metavar="ROLE=MODEL",
+        help="Assign a model per panel seat, as role=model or role=backend:model "
+             "(for example: pi=opus skeptic=codex:default). Seats left unassigned use the "
+             "reviewer default. Heterogeneity is the lever with the best evidence behind it: "
+             "five prompts against one model are five correlated reads wearing five hats.",
     )
     parser.add_argument(
         "--panel-rounds",
@@ -318,7 +333,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
 
     if args.review_panel:
         reviewer = ReviewPanel(
-            resolve_roles(args.panel_roles),
+            apply_model_assignments(resolve_roles(args.panel_roles), args.panel_models),
             backend_name=review_backend,
             model=review_model,
             fake_mode=args.fake_operator,

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -62,6 +62,11 @@ class PanelRole:
     skill: str | None = None
     backend: str | None = None
     model: str | None = None
+    #: How much of the other seats' round-1 output this member sees when deliberating.
+    #: Uniform full exposure makes the second round a convergence machine; withholding it
+    #: from the seats whose value is independence is what keeps a lone correct objection
+    #: alive long enough to be heard.
+    exposure: str = "full"
     #: A chair breaks ties and writes the final decision. Exactly one role must have it.
     chair: bool = False
 
@@ -143,6 +148,9 @@ DEFAULT_PANEL: tuple[PanelRole, ...] = (
             "Which claim has the thinnest evidence behind it?",
             "What would an unsympathetic reviewer attack first?",
         ),
+        # The seat whose whole job is to not go along with the room is the seat that must
+        # not be shown the room.
+        exposure="none",
     ),
 )
 
@@ -162,10 +170,21 @@ class PanelVerdict:
     feedback: str
     concerns: tuple[str, ...] = ()
     failed: bool = False
+    abstained: bool = False
 
     @property
     def approves(self) -> bool:
         return self.choice == "5" and not self.blocking
+
+    @property
+    def counts(self) -> bool:
+        """Whether this seat contributed a position at all.
+
+        A seat with nothing to say is better silent than padding: forcing every member to
+        produce a verdict on every gate is how five reviewers end up raising much the same
+        points, which is the mechanism behind the null in the multi-agent feedback literature.
+        """
+        return not (self.abstained or self.failed)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -180,6 +199,7 @@ class PanelVerdict:
             "feedback": self.feedback,
             "concerns": list(self.concerns),
             "failed": self.failed,
+            "abstained": self.abstained,
         }
 
 
@@ -191,6 +211,9 @@ class PanelDeliberation:
     decision: ReviewDecision | None = None
     chair_overridden: bool = False
     override_reason: str = ""
+    member_calls: int = 0
+    #: Which seat chairs, so :attr:`solo_baseline` can find its round-1 verdict.
+    chair_key: str = ""
 
     @property
     def final_round(self) -> list[PanelVerdict]:
@@ -199,10 +222,55 @@ class PanelDeliberation:
     def blocking_verdicts(self) -> list[PanelVerdict]:
         return [verdict for verdict in self.final_round if verdict.blocking]
 
-    def to_dict(self) -> dict[str, Any]:
+    @property
+    def solo_baseline(self) -> PanelVerdict | None:
+        """The chair's round-1 verdict: one model, one call, no peer input.
+
+        Every panel run therefore contains its own control arm for free. Recording it is what
+        lets a run answer the only question that matters about this feature — whether the
+        deliberation changed a decision the cheapest possible reviewer would have reached
+        anyway.
+        """
+        if not self.rounds:
+            return None
+        return next((v for v in self.rounds[0] if v.role_key == self.chair_key), None)
+
+    def effect(self) -> dict[str, Any]:
+        """What the panel bought over its own single-pass baseline, at this gate."""
+        solo = self.solo_baseline
+        first = self.rounds[0] if self.rounds else []
+        contributing = [v for v in first if v.counts]
+        final_choice = self.decision.choice if self.decision else None
+        solo_choice = solo.choice if solo is not None else None
         return {
             "stage": self.stage_slug,
             "attempt": self.attempt_no,
+            "solo_choice": solo_choice,
+            "panel_choice": final_choice,
+            "changed_decision": bool(
+                solo_choice is not None and final_choice is not None and solo_choice != final_choice
+            ),
+            "round1_unanimous": len({v.choice for v in contributing}) <= 1,
+            "round1_distinct_positions": len({v.choice for v in contributing}),
+            "abstentions": sum(1 for v in first if v.abstained),
+            "unreachable": sum(1 for v in first if v.failed),
+            "blocking_raised": sum(1 for v in first if v.blocking),
+            "blocking_survived": len(self.blocking_verdicts()),
+            "chair_overridden": self.chair_overridden,
+            "rounds": len(self.rounds),
+            "member_calls": self.member_calls,
+            "solo_calls": 1,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        seats = [(v.backend, v.model) for group in self.rounds for v in group]
+        return {
+            "stage": self.stage_slug,
+            "attempt": self.attempt_no,
+            "distinct_backends": sorted({backend for backend, _ in seats}),
+            "distinct_models": sorted({model for _, model in seats}),
+            # Five prompts against one model are less independent than five seats look.
+            "homogeneous_panel": len({seat for seat in seats}) <= 1,
             "rounds": [[verdict.to_dict() for verdict in group] for group in self.rounds],
             "blocking_after_deliberation": [v.role_key for v in self.blocking_verdicts()],
             "chair_overridden": self.chair_overridden,
@@ -210,7 +278,47 @@ class PanelDeliberation:
             "final_choice": self.decision.choice if self.decision else None,
             "final_reason": self.decision.reason if self.decision else "",
             "final_feedback": self.decision.feedback if self.decision else "",
+            "effect": self.effect(),
         }
+
+
+def apply_model_assignments(roles: tuple[PanelRole, ...], assignments: list[str] | None) -> tuple[PanelRole, ...]:
+    """Assign a backend and model per seat from ``role=[backend:]model`` strings.
+
+    This is the lever with the best evidence behind it. The multi-agent literature's own
+    critics land on model heterogeneity rather than more rounds: errors idiosyncratic to one
+    model survive when that model checks its own work, and correlate less across families than
+    within them. Five prompts against one model are five correlated reads wearing five hats.
+    """
+    if not assignments:
+        return roles
+
+    by_key = {role.key: role for role in roles}
+    updated = dict(by_key)
+    for raw in assignments:
+        if "=" not in raw:
+            raise ValueError(
+                f"Bad panel model assignment: {raw!r}. Expected role=model or role=backend:model."
+            )
+        key, _, spec = raw.partition("=")
+        key = key.strip().lower()
+        if key not in by_key:
+            known = ", ".join(sorted(by_key))
+            raise ValueError(f"Unknown panel role in model assignment: {key}. Seated roles: {known}.")
+        spec = spec.strip()
+        if not spec:
+            raise ValueError(f"Bad panel model assignment: {raw!r}. No model given.")
+        if ":" in spec:
+            backend, _, model = spec.partition(":")
+            backend, model = backend.strip().lower(), model.strip()
+        else:
+            backend, model = None, spec
+        if not model:
+            raise ValueError(f"Bad panel model assignment: {raw!r}. No model given.")
+        current = updated[key]
+        updated[key] = PanelRole(**{**current.__dict__, "backend": backend or current.backend, "model": model})
+
+    return tuple(updated[role.key] for role in roles)
 
 
 def resolve_roles(keys: list[str] | None) -> tuple[PanelRole, ...]:
@@ -279,6 +387,7 @@ class ReviewPanel:
             for role in roles
         }
         self.chair = next(role for role in roles if role.chair)
+        self._calls = 0
 
     # -- the manager-facing contract -----------------------------------------
 
@@ -299,7 +408,10 @@ class ReviewPanel:
                 raw_response='{"decision":"approve","reason":"fake panel"}',
             )
 
-        deliberation = PanelDeliberation(stage_slug=stage.slug, attempt_no=attempt_no)
+        deliberation = PanelDeliberation(
+            stage_slug=stage.slug, attempt_no=attempt_no, chair_key=self.chair.key
+        )
+        self._calls = 0
 
         verdicts = self._round(
             paths=paths,
@@ -338,6 +450,7 @@ class ReviewPanel:
         )
         deliberation.decision = decision
 
+        deliberation.member_calls = self._calls
         decision = self._enforce_blocking_objections(deliberation)
         self._record(paths, deliberation)
         self._render(deliberation)
@@ -380,6 +493,7 @@ class ReviewPanel:
                 prompt=prompt,
                 label=f"panel_{role.key}_r{round_no}",
             )
+            self._calls += 1
             verdicts.append(
                 self._verdict_from_output(
                     role=role,
@@ -415,8 +529,22 @@ class ReviewPanel:
                 failed=True,
             )
 
-        decision = member.parse_decision(stdout_text)
         payload = self._payload(stdout_text)
+        if isinstance(payload, dict) and self._is_abstention(payload):
+            return PanelVerdict(
+                role_key=role.key,
+                role_title=role.title,
+                backend=member.backend_name,
+                model=member.model,
+                choice="",
+                decision_token="abstain",
+                blocking=False,
+                reason=str(payload.get("reason") or "").strip() or "Nothing to add from this seat.",
+                feedback="",
+                abstained=True,
+            )
+
+        decision = member.parse_decision(stdout_text)
         blocking = bool(payload.get("blocking")) if isinstance(payload, dict) else False
         concerns: tuple[str, ...] = ()
         if isinstance(payload, dict) and isinstance(payload.get("concerns"), list):
@@ -437,15 +565,29 @@ class ReviewPanel:
             concerns=concerns,
         )
 
+    @staticmethod
+    def _is_abstention(payload: dict[str, Any]) -> bool:
+        token = str(payload.get("decision") or "").strip().lower()
+        return token in {"abstain", "abstention", "no_comment", "pass"}
+
     def _payload(self, raw_response: str) -> dict[str, Any] | None:
         member = next(iter(self._members.values()))
         return member._extract_json_payload(raw_response)  # noqa: SLF001
 
     @staticmethod
     def _is_unanimous(verdicts: list[PanelVerdict]) -> bool:
+        """Unanimous among the seats that actually spoke.
+
+        An unreachable member is not agreement, so it breaks unanimity. A deliberate
+        abstention is not disagreement either — it is a seat saying it has nothing to add,
+        which is exactly the behaviour that keeps the panel from padding.
+        """
         if any(verdict.failed for verdict in verdicts):
             return False
-        return all(verdict.approves for verdict in verdicts) or len({v.choice for v in verdicts}) == 1
+        speaking = [verdict for verdict in verdicts if verdict.counts]
+        if not speaking:
+            return False
+        return all(v.approves for v in speaking) or len({v.choice for v in speaking}) == 1
 
     # -- synthesis and enforcement -------------------------------------------
 
@@ -469,6 +611,7 @@ class ReviewPanel:
             )
 
         chair = self._members[self.chair.key]
+        self._calls += 1
         self.ui.show_status(f"Panel chair ({self.chair.title}) is synthesizing the decision...", level="info")
         exit_code, stdout_text, stderr_text = chair.run_prompt(
             paths=paths,
@@ -581,22 +724,40 @@ class ReviewPanel:
                 "## Round 1 of the panel: independent review\n\n"
                 "You have not seen the other members' views and you should not speculate about "
                 "them. Form your own judgement from the artifacts. Disagreement between members "
-                "is useful to this run; agreement you did not actually reach is not.\n"
+                "is useful to this run; agreement you did not actually reach is not.\n\n"
+                "If your seat has nothing substantive to add on this stage, return "
+                '`{"decision":"abstain"}` with a one-line reason. An abstention costs the panel '
+                "nothing; a manufactured objection costs it its credibility.\n"
+            )
+        elif role.exposure == "none":
+            round_block = (
+                f"## Round {round_no} of the panel: hold or revise, independently\n\n"
+                "The panel did not agree. You are deliberately **not** being shown what the "
+                "others concluded, because your value to this panel is that your read is not "
+                "downstream of theirs.\n\n"
+                "Re-examine the artifacts and state your position again. Change it only if you "
+                "find something in the work itself, not because a room you cannot see may "
+                "disagree with you.\n"
             )
         else:
+            peers = [verdict for verdict in previous if verdict.role_key != role.key and verdict.counts]
+            if role.exposure == "objections":
+                peers = [verdict for verdict in peers if not verdict.approves]
+            # Peer positions are anonymized: a methodologist should weigh an objection on its
+            # evidence, not defer to it because the chair signed it.
             positions = "\n\n".join(
-                f"**{verdict.role_title}** -> {verdict.decision_token}"
+                f"**Reviewer {chr(ord('A') + index)}** -> {verdict.decision_token}"
                 + (" (BLOCKING)" if verdict.blocking else "")
                 + (f"\nReason: {verdict.reason}" if verdict.reason else "")
                 + (f"\nConcerns: {'; '.join(verdict.concerns)}" if verdict.concerns else "")
-                for verdict in previous
-                if verdict.role_key != role.key
-            )
+                for index, verdict in enumerate(peers)
+            ) or "(no other seat recorded a position)"
             own = next((v for v in previous if v.role_key == role.key), None)
             round_block = (
                 f"## Round {round_no} of the panel: cross-examination\n\n"
-                "The panel did not agree. Below is what every other member concluded. Read them "
-                "as colleagues who looked at the same artifacts and saw something you did not.\n\n"
+                "The panel did not agree. Below is what the other members concluded, with their "
+                "identities withheld so you weigh each objection on its evidence rather than on "
+                "who raised it.\n\n"
                 "Change your position if they found something real. Hold it if they did not — "
                 "converging to be agreeable is the failure mode this round exists to avoid, and "
                 "a lone correct objection is worth more than a comfortable consensus.\n\n"
@@ -767,6 +928,7 @@ class ReviewPanel:
         )
         write_text(panel_dir / f"{stem}.md", self._render_markdown(deliberation))
 
+        effect = record_panel_effect(paths, deliberation)
         summary = "; ".join(
             f"{verdict.role_title}={verdict.decision_token}" + ("(blocking)" if verdict.blocking else "")
             for verdict in deliberation.final_round
@@ -778,7 +940,8 @@ class ReviewPanel:
                 f"rounds: {len(deliberation.rounds)}\n"
                 f"positions: {summary}\n"
                 f"chair_overridden: {deliberation.chair_overridden}\n"
-                f"final_choice: {deliberation.decision.choice if deliberation.decision else '?'}"
+                f"final_choice: {deliberation.decision.choice if deliberation.decision else '?'}\n"
+                f"vs single pass: {effect['summary']['verdict']}"
             ),
         )
 
@@ -826,6 +989,83 @@ class ReviewPanel:
             if deliberation.decision.reason:
                 body.append(f"Reason   : {deliberation.decision.reason}")
         self.ui.panel("Review Panel", body, color=self.ui.FG_MAGENTA)
+
+
+#: Where the run's accumulated panel-versus-single-pass comparison is written.
+PANEL_EFFECT_FILENAME = "panel_effect.json"
+
+
+def record_panel_effect(paths: RunPaths, deliberation: PanelDeliberation) -> dict[str, Any]:
+    """Accumulate what the panel bought over its own single-pass baseline, across the run.
+
+    The multi-agent feedback literature has a pre-registered null at its centre: authors of 44
+    papers ranked a plain single pass *above* two multi-agent tools that spent up to thirty
+    times the tokens, and the tools' own builders had predicted the opposite. The mechanism
+    the authors reported was that the reports "tended to raise much the same points".
+
+    A panel that cannot be shown to change a decision is that null wearing a costume. So this
+    file exists to let a run say, in its own artifacts, that the panel did not earn its cost.
+    It is the least flattering thing the feature writes about itself, which is why it writes it.
+    """
+    path = paths.reviews_dir / "panel" / PANEL_EFFECT_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    history: list[dict[str, Any]] = []
+    if path.exists():
+        try:
+            previous = json.loads(read_text(path))
+            if isinstance(previous, dict) and isinstance(previous.get("gates"), list):
+                history = previous["gates"]
+        except (OSError, json.JSONDecodeError):
+            history = []
+
+    gate = deliberation.effect()
+    # A re-review of the same stage attempt replaces its earlier record rather than
+    # double-counting it into the rate.
+    history = [
+        entry
+        for entry in history
+        if not (entry.get("stage") == gate["stage"] and entry.get("attempt") == gate["attempt"])
+    ]
+    history.append(gate)
+
+    gates = len(history)
+    changed = sum(1 for entry in history if entry.get("changed_decision"))
+    contested = sum(1 for entry in history if not entry.get("round1_unanimous", True))
+    overrides = sum(1 for entry in history if entry.get("chair_overridden"))
+    member_calls = sum(int(entry.get("member_calls") or 0) for entry in history)
+    solo_calls = sum(int(entry.get("solo_calls") or 1) for entry in history)
+
+    summary = {
+        "gates_reviewed": gates,
+        "gates_where_the_panel_changed_the_decision": changed,
+        "gates_where_round_1_disagreed": contested,
+        "chair_overrides": overrides,
+        "panel_calls": member_calls,
+        "single_pass_calls": solo_calls,
+        "cost_multiple": round(member_calls / solo_calls, 2) if solo_calls else None,
+        "verdict": _effect_sentence(gates, changed, member_calls, solo_calls),
+    }
+    payload = {"summary": summary, "gates": history}
+    write_text(path, json.dumps(payload, indent=2, ensure_ascii=False))
+    return payload
+
+
+def _effect_sentence(gates: int, changed: int, member_calls: int, solo_calls: int) -> str:
+    """One line a human can act on, written to be unflattering when that is the truth."""
+    if gates == 0:
+        return "No gates reviewed yet."
+    multiple = (member_calls / solo_calls) if solo_calls else 0
+    if changed == 0:
+        return (
+            f"The panel reached the same decision as its own single-pass baseline at all "
+            f"{gates} gate(s), at {multiple:.1f}x the reviewer cost. On this run it did not "
+            "earn that cost; consider --panel-roles with fewer seats, or dropping the panel."
+        )
+    return (
+        f"The panel changed the decision at {changed} of {gates} gate(s) that a single pass "
+        f"would have settled differently, at {multiple:.1f}x the reviewer cost."
+    )
 
 
 def load_persona(path: Path | str | None) -> str:

--- a/tests/test_review_panel.py
+++ b/tests/test_review_panel.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from src.approval_agent import ReviewDecision
 from src.review_panel import (
     DEFAULT_PANEL,
+    PANEL_EFFECT_FILENAME,
+    apply_model_assignments,
     PanelRole,
     ReviewPanel,
     load_persona,
@@ -228,11 +230,73 @@ class DeliberationTests(unittest.TestCase):
         harness.review()
 
         second_round = [p for p in prompts if "cross-examination" in p]
-        self.assertEqual(len(second_round), len(DEFAULT_PANEL))
+        # Every seat but the adversarial reviewer, which is deliberately kept independent.
+        self.assertEqual(len(second_round), len(DEFAULT_PANEL) - 1)
         self.assertTrue(any("No baseline anywhere." in p for p in second_round))
         # A member is not shown its own verdict as somebody else's position.
         methodologist = next(p for p in second_round if "You are the **Methodologist**" in p)
         self.assertIn("Your own round-1 position", methodologist)
+
+    def test_peer_positions_are_anonymised_in_cross_examination(self) -> None:
+        prompts: list[str] = []
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("custom_feedback", reason="No baseline anywhere."),
+                       _verdict_json("approve")],
+            "repro": [_verdict_json("approve"), _verdict_json("approve")],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [_verdict_json("approve")],
+        }
+        harness = _ScriptedPanel(self, script)
+        original = harness.panel._build_member_prompt
+
+        def capture(**kwargs):
+            prompt = original(**kwargs)
+            prompts.append(prompt)
+            return prompt
+
+        harness.panel._build_member_prompt = capture
+        harness.review()
+
+        peer_views = [p for p in prompts if "cross-examination" in p]
+        for prompt in peer_views:
+            # The substance survives; the attribution does not, so an objection is weighed on
+            # its evidence rather than deferred to because the chair signed it.
+            body = prompt.split("cross-examination", 1)[1].split("## Review Policy", 1)[0]
+            self.assertIn("Reviewer A", body)
+            self.assertNotIn("**Principal Investigator** ->", body)
+        self.assertTrue(any("No baseline anywhere." in p for p in peer_views))
+
+    def test_the_adversarial_seat_is_never_shown_the_room(self) -> None:
+        prompts: list[str] = []
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("custom_feedback", reason="No baseline."),
+                       _verdict_json("approve")],
+            "repro": [_verdict_json("approve"), _verdict_json("approve")],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [_verdict_json("approve")],
+        }
+        harness = _ScriptedPanel(self, script)
+        original = harness.panel._build_member_prompt
+
+        def capture(**kwargs):
+            prompt = original(**kwargs)
+            prompts.append(prompt)
+            return prompt
+
+        harness.panel._build_member_prompt = capture
+        harness.review()
+
+        skeptic_round2 = [
+            p for p in prompts
+            if "You are the **Adversarial Reviewer**" in p and "Round 2" in p
+        ]
+        self.assertEqual(len(skeptic_round2), 1)
+        self.assertIn("deliberately **not** being shown", skeptic_round2[0])
+        self.assertNotIn("No baseline.", skeptic_round2[0])
 
 
 class BlockingObjectionTests(unittest.TestCase):
@@ -483,3 +547,159 @@ class DropInContractTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PanelEffectTests(unittest.TestCase):
+    """The panel must be able to report, in its own artifacts, that it did not help.
+
+    A pre-registered comparison of two multi-agent feedback tools against a plain single pass
+    found the single pass preferred, by the tools' own builders' measurement. A panel that
+    cannot be shown to change a decision is that null wearing a costume, so the run records
+    the comparison whether or not it flatters the feature.
+    """
+
+    def _effect(self, harness) -> dict:
+        path = harness.paths.reviews_dir / "panel" / PANEL_EFFECT_FILENAME
+        return json.loads(read_text(path))
+
+    def test_a_unanimous_panel_reports_that_it_bought_nothing(self) -> None:
+        script = {role.key: [_verdict_json("approve")] for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(self, script)
+        harness.review()
+
+        summary = self._effect(harness)["summary"]
+        self.assertEqual(summary["gates_reviewed"], 1)
+        self.assertEqual(summary["gates_where_the_panel_changed_the_decision"], 0)
+        self.assertEqual(summary["cost_multiple"], 5.0)
+        self.assertIn("did not earn that cost", summary["verdict"])
+
+    def test_a_panel_that_overturns_the_chair_reports_the_change(self) -> None:
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("approve"), _verdict_json("approve")],
+            "repro": [
+                _verdict_json("custom_feedback", blocking=True, reason="metrics.json absent."),
+                _verdict_json("custom_feedback", blocking=True, reason="metrics.json absent."),
+            ],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [_verdict_json("approve")],
+        }
+        harness = _ScriptedPanel(self, script)
+        harness.review()
+
+        summary = self._effect(harness)["summary"]
+        self.assertEqual(summary["gates_where_the_panel_changed_the_decision"], 1)
+        self.assertEqual(summary["gates_where_round_1_disagreed"], 1)
+        self.assertEqual(summary["chair_overrides"], 1)
+        self.assertIn("changed the decision at 1 of 1", summary["verdict"])
+
+    def test_the_baseline_is_the_chairs_own_round_one_verdict(self) -> None:
+        # One model, one call, no peer input: every panel run contains its control arm free.
+        script = {
+            "pi": [_verdict_json("suggestion_2"), _verdict_json("suggestion_2")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [_verdict_json("approve"), _verdict_json("approve")],
+            "repro": [_verdict_json("approve"), _verdict_json("approve")],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [_verdict_json("approve")],
+        }
+        harness = _ScriptedPanel(self, script)
+        harness.review()
+
+        gate = self._effect(harness)["gates"][0]
+        self.assertEqual(gate["solo_choice"], "2")
+        self.assertEqual(gate["panel_choice"], "5")
+        self.assertTrue(gate["changed_decision"])
+
+    def test_gates_accumulate_across_the_run(self) -> None:
+        script = {role.key: [_verdict_json("approve")] * 3 for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(self, script)
+        for stage in STAGES[:3]:
+            harness.panel.review_stage(
+                paths=harness.paths, stage=stage, attempt_no=1,
+                stage_markdown="# S\n\n## Key Results\n\nx\n", suggestions=SUGGESTIONS,
+            )
+        self.assertEqual(self._effect(harness)["summary"]["gates_reviewed"], 3)
+
+    def test_re_reviewing_one_attempt_replaces_rather_than_double_counts(self) -> None:
+        script = {role.key: [_verdict_json("approve")] * 2 for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(self, script)
+        harness.review(attempt_no=1)
+        harness.review(attempt_no=1)
+        self.assertEqual(self._effect(harness)["summary"]["gates_reviewed"], 1)
+
+    def test_a_corrupt_effect_file_does_not_break_the_gate(self) -> None:
+        script = {role.key: [_verdict_json("approve")] for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(self, script)
+        path = harness.paths.reviews_dir / "panel" / PANEL_EFFECT_FILENAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_text(path, "{ not json")
+        self.assertEqual(harness.review().choice, "5")
+        self.assertEqual(self._effect(harness)["summary"]["gates_reviewed"], 1)
+
+
+class AbstentionTests(unittest.TestCase):
+    def test_a_seat_with_nothing_to_add_may_abstain(self) -> None:
+        script = {role.key: [_verdict_json("approve")] for role in DEFAULT_PANEL}
+        script["domain"] = ['{"decision":"abstain","reason":"no field claim in this stage"}']
+        harness = _ScriptedPanel(self, script)
+
+        decision = harness.review()
+
+        # An abstention is not disagreement, so the room is still unanimous and approves.
+        self.assertEqual(decision.choice, "5")
+        self.assertEqual(harness.rounds_for("__chair__"), 0)
+        record = harness.record()
+        self.assertTrue(record["rounds"][0][1]["abstained"])
+        self.assertEqual(record["effect"]["abstentions"], 1)
+
+    def test_an_all_abstaining_panel_is_not_treated_as_approval(self) -> None:
+        script = {role.key: ['{"decision":"abstain","reason":"nothing"}'] * 2 for role in DEFAULT_PANEL}
+        script["__chair__"] = [_verdict_json("custom_feedback", feedback="Nobody reviewed this.")]
+        harness = _ScriptedPanel(self, script)
+
+        decision = harness.review()
+
+        # Silence from every seat must reach the chair rather than pass as consensus.
+        self.assertGreater(harness.rounds_for("__chair__"), 0)
+        self.assertEqual(decision.choice, "4")
+
+
+class HeterogeneityTests(unittest.TestCase):
+    def test_assignments_set_backend_and_model_per_seat(self) -> None:
+        roles = apply_model_assignments(DEFAULT_PANEL, ["pi=opus", "skeptic=codex:default"])
+        by_key = {role.key: role for role in roles}
+        self.assertEqual((by_key["pi"].backend, by_key["pi"].model), (None, "opus"))
+        self.assertEqual((by_key["skeptic"].backend, by_key["skeptic"].model), ("codex", "default"))
+        self.assertIsNone(by_key["method"].model)
+
+    def test_no_assignments_leaves_the_roster_untouched(self) -> None:
+        self.assertEqual(apply_model_assignments(DEFAULT_PANEL, None), DEFAULT_PANEL)
+        self.assertEqual(apply_model_assignments(DEFAULT_PANEL, []), DEFAULT_PANEL)
+
+    def test_a_malformed_or_unknown_assignment_is_refused(self) -> None:
+        for bad in ("pi", "pi=", "nobody=opus"):
+            with self.assertRaises(ValueError, msg=bad):
+                apply_model_assignments(DEFAULT_PANEL, [bad])
+
+    def test_the_record_says_when_every_seat_shares_one_model(self) -> None:
+        script = {role.key: [_verdict_json("approve")] for role in DEFAULT_PANEL}
+        harness = _ScriptedPanel(self, script)
+        harness.review()
+        record = harness.record()
+        # Five prompts against one model are five correlated reads; the record admits it.
+        self.assertTrue(record["homogeneous_panel"])
+        self.assertEqual(record["distinct_models"], ["sonnet"])
+
+    def test_a_mixed_panel_is_recorded_as_heterogeneous(self) -> None:
+        roles = apply_model_assignments(resolve_roles(["pi", "skeptic"]), ["skeptic=opus"])
+        harness = _ScriptedPanel(
+            self,
+            {"pi": [_verdict_json("approve")], "skeptic": [_verdict_json("approve")]},
+            roles=roles,
+        )
+        harness.review()
+        record = harness.record()
+        self.assertFalse(record["homogeneous_panel"])
+        self.assertEqual(record["distinct_models"], ["opus", "sonnet"])


### PR DESCRIPTION
Two papers bear directly on the panel landed in #120. **The first is evidence against it**, and this PR responds to that rather than around it.

## The result

Havranek & Irsova, [*Does Multi-Agent Debate Improve AI Feedback on Research Papers?*](https://arxiv.org/abs/2607.14713) — pre-registered, identity-masked, within-paper. The authors of 44 economics meta-analyses ranked three AI reports on their own paper:

| Arm | Mean rank | Tokens/paper |
|:---|:---|:---|
| **Single pass** | **1.59** | 27k |
| mad-research | 2.25 | 238k |
| paper-workshop | 2.16 | 800k |

Holm p = 0.005 and 0.026. The multi-agent tools were **the study authors' own**, pre-registered to win. ~30x the tokens, 0.57 rank points worse. The reported mechanism is the one that should worry anyone building a panel: the reports *"tended to raise much the same points."*

Two further findings land on this feature specifically:

- **An AI judge is not a substitute for the intended user.** Author–judge rank correlation 0.14. Had the external judge ranked the arms, it would have crowned the most expensive tool and *reversed* the finding.
- **AI judges systematically undervalue human review.** Authors placed their real referee report first 71% of the time and never last; AI judges placed it last on 92–100% of papers. A panel simulating humans is built from exactly the judges that got that wrong.

## The response: an instrument, not more agents

**Every panel run already contains its own control arm.** The chair's round-1 verdict *is* a single pass — one model, one call, no peer input. Recording it costs nothing.

`workspace/reviews/panel/panel_effect.json` accumulates panel-vs-baseline across the run and writes one plain sentence, deliberately unflattering when that is the truth:

> The panel reached the same decision as its own single-pass baseline at all 8 gate(s), at 5.0x the reviewer cost. On this run it did not earn that cost; consider `--panel-roles` with fewer seats, or dropping the panel.

A feature that can only report its own success is not measured. That is what the paper is about.

## The three levers the evidence actually supports

Both papers cite Zhang et al. (2025), *"Stop overvaluing multi-agent debate — embrace model heterogeneity."* [AgentPanel](https://arxiv.org/abs/2608.03283)'s gains over centralized debate are concentrated in **feasibility** (5.08 vs 4.08; 0.28 vs 0.11) and come from heterogeneous backends, permitted abstention, and uneven exposure — not more rounds.

- **`--panel-models pi=opus skeptic=codex:default`.** Errors idiosyncratic to one model survive when that model checks its own work. The record now says `homogeneous_panel: true` rather than letting five prompts against one model pass as five opinions.
- **Abstention.** `{"decision":"abstain"}` is not disagreement (unanimity survives) and not agreement (an all-abstaining panel reaches the chair). Forcing five seats to speak on every gate is precisely how five reviewers raise much the same points.
- **Uneven exposure.** Peer positions in round two are **anonymised** as "Reviewer A/B/C" — substance survives, attribution does not, so an objection is weighed on evidence rather than deferred to because the chair signed it. The **adversarial seat sees nothing**: its value is that its read is not downstream of the room's.

## Verification

741 tests. Mutation-verified rather than assumed:

| Mutant | Tests killed |
|:---|:---|
| change-detection always reports `False` | 2 |
| abstention counts as a real position | 1 |
| adversarial seat is shown the room | 2 |

Control run passes. Also exercised end to end: a unanimous panel reports `changed_decision: 0` at 5.0x cost with the "did not earn that cost" verdict; a panel with a surviving blocking objection reports 3 of 3 changed at 11.0x.

## What this does not claim

It does not refute the null. The measurement is an instrument, not a result — [docs/review-panel.md](docs/review-panel.md) now opens with the evidence against the feature, and says plainly that a run reporting `changed_decision: 0` across every gate should turn the panel off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)