### PR TITLE
Make Stages 03-06 a research round that can come back with a better question

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ File boundaries:
 - [src/bootstrap.py](src/bootstrap.py) and [src/project_bootstrap.py](src/project_bootstrap.py): `--paper-corpus` and `--project-root` scanning.
 - [src/approval_agent.py](src/approval_agent.py): The strict reviewer agent used by `--full-auto`.
 - [src/backend/](src/backend) and [src/frontend/](src/frontend): AutoR Studio service, HTTP layer, and the browser UI.
+- [src/research_rounds.py](src/research_rounds.py): Stages 03-06 as a repeatable round, so a refuted hypothesis leads to a second round instead of a dead end. Bounded by `--max-rounds`.
 - [src/validity_review.py](src/validity_review.py): The adversarial pass after Stages 05 and 06 — asks why the result is wrong, and requires the next stage to answer every objection.
 - [src/preregistration.py](src/preregistration.py): Freezes the hypotheses before the experiments, adjudicates each one at Stage 06, and traces each manuscript claim back to a supported hypothesis at Stage 07.
 - [src/prompts/](src/prompts): Per-stage prompt templates.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,6 +100,7 @@ to a CLI directly; the operators never decide what stage runs next.
 | [`src/preregistration.py`](../src/preregistration.py) | Freezes the hypothesis set before results exist, adjudicates every frozen hypothesis at Stage 06, and traces every manuscript claim back to a supported one at Stage 07. The one part of the pipeline that gates on whether a claim is warranted rather than on whether a file exists. |
 | [`src/experimental_protocol.py`](../src/experimental_protocol.py) | Declares the primary metric, the seed count and each baseline's tuning budget before the experiments run, and refuses a verdict that rests on one run or on an unstated dispersion measure. |
 | [`src/validity_review.py`](../src/validity_review.py) | The adversarial pass after Stages 05 and 06. Asks why the result is wrong rather than whether the stage is complete, and requires the next stage to answer every finding it raises. Has no authority to approve or reject. |
+| [`src/research_rounds.py`](../src/research_rounds.py) | Stages 03-06 as a repeatable round. Stage 06 decides whether the run converged, needs a better design, needs a new hypothesis, or should be abandoned, and a refuted hypothesis becomes the input to the next round instead of a dead end. |
 | [`src/writing_manifest.py`](../src/writing_manifest.py) | Stage 07 support: writing manifest, figure/result scanning, layout review generation and validation. |
 
 ### Inputs
@@ -291,6 +292,7 @@ Ordered by how much of the system you have to understand first.
 | What counts as a warranted claim | `src/preregistration.py` | small |
 | What counts as adequate evidence | `src/experimental_protocol.py` | small |
 | What a hostile reviewer would object to | `VALIDITY_CATEGORIES` in `src/validity_review.py` | none |
+| How a round may conclude | `DECISIONS` in `src/research_rounds.py` | small |
 | The summary contract | `REQUIRED_STAGE_HEADINGS` + `validate_stage_markdown` | small |
 | The stage list | `STAGES` in `src/utils.py`, plus a new prompt template | moderate |
 | The execution backend | implement `OperatorProtocol`, or subclass `ClaudeOperator` | moderate |

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -450,6 +450,61 @@ as support, and what would count as refutation — stated before any experiment
 runs. A hypothesis with no decision rule cannot come out negative, which makes
 "falsifiable" a word rather than a property, and Stage 05 refuses the run.
 
+### `workspace/notes/research_rounds.json`
+
+Stages 03-06 form a **research round**: design, implement, experiment, analyse.
+Stage 06 closes it with a decision, and the ledger accumulates one entry per
+round.
+
+```json
+{
+  "rounds": [
+    {
+      "round": 1,
+      "decision": "refine_design",
+      "rationale": "The comparison was confounded by tuning on the reporting split.",
+      "what_we_learned": "The gap disappears once tuning and reporting use different splits.",
+      "what_changes_next": "Tune both arms on a held-out development split and re-run.",
+      "negative_result": false,
+      "hypothesis_verdicts": {"H1": "refuted"},
+      "acted_on": true,
+      "budget_note": ""
+    }
+  ]
+}
+```
+
+| decision | what happens |
+| --- | --- |
+| `converged` | continue to Stage 07 |
+| `refine_design` | same hypotheses, next round restarts at Stage 03 |
+| `new_hypothesis` | next round restarts at Stage 02; the preregistration records an amendment |
+| `abandon` | the run stops, and Stage 07 refuses to write up a question the run declared unanswerable |
+
+There is no `continue`: a round that wants another one has to say what would
+change, because repeating a design without changing what it got wrong produces
+the same result at full cost.
+
+**`converged` is refused when no preregistered hypothesis came out supported**,
+unless the round sets `negative_result: true`. A run whose contribution is the
+refutation is a real result and should say so plainly; a run that quietly
+proceeds to write a paper about nothing is the default failure without this
+rule.
+
+`acted_on: false` with a `budget_note` means the round wanted to iterate and
+`--max-rounds` was spent. The run continues to writing, but the record says it
+stopped rather than converged — a distinction the ledger would otherwise lose.
+
+Iteration is off by default (`--max-rounds 1`) because rounds multiply the cost
+of an unattended run. The decision is recorded either way.
+
+Stage 06's pending declaration lives at `workspace/notes/round_decision.json`
+and is consumed when the round closes, so a later round cannot inherit an
+earlier one's conclusion.
+
+Validated by `validate_round_decision` in
+[`src/research_rounds.py`](../src/research_rounds.py).
+
 ### `workspace/notes/preregistration.json`
 
 The hypothesis set, frozen. Written when Stage 04 is approved — design settled,

--- a/main.py
+++ b/main.py
@@ -103,6 +103,19 @@ def parse_args() -> argparse.Namespace:
              "exhausting their retry budget before the run aborts. Defaults to 3.",
     )
     parser.add_argument(
+        "--max-rounds",
+        type=int,
+        default=1,
+        help=(
+            "How many times Stages 03-06 may run. A round ends when Stage 06 declares "
+            "whether the run converged, needs a better design, needs a new hypothesis, or "
+            "should be abandoned. Defaults to 1, which keeps the single-pass behaviour; the "
+            "decision is recorded either way, so a one-round run still says whether it "
+            "converged or merely stopped. Raise it to let a refuted hypothesis lead to a "
+            "second round."
+        ),
+    )
+    parser.add_argument(
         "--review-panel",
         action="store_true",
         help="Replace the single reviewer agent with a deliberating panel of role-differentiated "
@@ -495,6 +508,7 @@ def main() -> int:
             review_model=review_model,
             unattended=unattended,
             max_auto_skips=args.max_auto_skips,
+            max_rounds=args.max_rounds,
             max_stage_attempts=args.max_attempts,
             web_search_context=web_search_context,
         )
@@ -549,6 +563,7 @@ def main() -> int:
         review_model=review_model,
         unattended=unattended,
         max_auto_skips=args.max_auto_skips,
+        max_rounds=args.max_rounds,
         max_stage_attempts=args.max_attempts,
         web_search_context=web_search_context,
     )

--- a/src/experiment_manifest.py
+++ b/src/experiment_manifest.py
@@ -73,6 +73,8 @@ RECORD_ARTIFACTS = frozenset(
         "notes/hypothesis_manifest.json",
         "notes/preregistration.json",
         "notes/experimental_protocol.json",
+        "notes/research_rounds.json",
+        "notes/round_decision.json",
     }
 )
 

--- a/src/manager.py
+++ b/src/manager.py
@@ -43,6 +43,15 @@ from .artifact_index import format_artifact_index_for_prompt, write_artifact_ind
 from .experiment_manifest import format_experiment_manifest_for_prompt, write_experiment_manifest
 from .hypothesis_manifest import write_hypothesis_manifest
 from .validity_review import ValidityReviewer, format_findings_for_prompt
+from .research_rounds import (
+    ROUND_CLOSING_STAGE_NUMBER,
+    read_round_decision,
+    format_round_status,
+    format_rounds_for_prompt,
+    load_rounds,
+    record_round,
+    resume_stage_slug_for,
+)
 from .preregistration import (
     amend_preregistration,
     format_outcomes_for_prompt,
@@ -136,6 +145,7 @@ class ResearchManager:
         review_model: str | None = None,
         unattended: bool = False,
         max_auto_skips: int = 3,
+        max_rounds: int = 1,
         max_stage_attempts: int = MAX_STAGE_ATTEMPTS,
         web_search_context: str | None = None,
         artifact_roots: list[Path] | None = None,
@@ -159,6 +169,10 @@ class ResearchManager:
         self._jump_target_stage: StageSpec | None = None
         self.unattended = unattended
         self.max_auto_skips = max_auto_skips
+        #: How many times Stages 03-06 may run. 1 keeps the historical
+        #: single-pass behaviour; the round decision is recorded either way,
+        #: so a one-round run still says whether it converged or just stopped.
+        self.max_rounds = max(1, int(max_rounds))
         # Retries are the cheapest quality lever there is: each one re-runs the stage with the
         # previous attempt's validation errors attached. The ceiling exists to bound a runaway
         # loop, not to save money, so callers with time to spend should raise it.
@@ -1541,6 +1555,8 @@ class ResearchManager:
                 if stage.slug == "04_implementation":
                     self._freeze_preregistration(paths)
                 self._run_validity_review(paths, stage, stage_markdown)
+                if stage.number == ROUND_CLOSING_STAGE_NUMBER:
+                    self._close_round(paths, stage)
                 if stage.slug == "07_writing":
                     output_format = selected_output_format(paths)
                     if self._research_diagram:
@@ -1753,6 +1769,15 @@ class ResearchManager:
                 + format_preregistration_for_prompt(prereg)
                 + "\n"
             )
+        rounds_context = format_rounds_for_prompt(paths)
+        if rounds_context and stage.number >= 2:
+            stage_template = (
+                stage_template.rstrip()
+                + "\n\n# Earlier Research Rounds\n\n"
+                + rounds_context
+                + "\n"
+            )
+
         findings_context = format_findings_for_prompt(paths, stage)
         if findings_context:
             stage_template = (
@@ -2325,6 +2350,76 @@ class ResearchManager:
         if manifest is None:
             raise RuntimeError(f"Could not load run manifest from {paths.run_manifest}")
         return format_manifest_status(manifest)
+
+    def _close_round(self, paths: RunPaths, stage: StageSpec) -> None:
+        """End the round and, if it asked for another and the budget allows, start one.
+
+        The decision is recorded whatever the budget is. A run that wanted
+        another round and could not have one should say so — the alternative is
+        a record indistinguishable from a run that converged.
+        """
+        rounds_so_far = len(load_rounds(paths))
+        pending = read_round_decision(paths)
+        decision = str((pending or {}).get("decision") or "").strip()
+        resume_slug = resume_stage_slug_for(decision)
+        budget_left = rounds_so_far + 1 < self.max_rounds
+        act = bool(resume_slug) and budget_left
+
+        entry = record_round(
+            paths,
+            acted_on=act or not resume_slug,
+            budget_note=(
+                ""
+                if act or not resume_slug
+                else f"round budget spent ({rounds_so_far + 1}/{self.max_rounds})"
+            ),
+        )
+        if entry is None:
+            return
+
+        append_log_entry(
+            paths.logs,
+            f"{stage.slug} round_closed",
+            (
+                f"Round {entry.number} decision: {entry.decision}"
+                + (" (negative result)" if entry.negative_result else "")
+                + f"\nVerdicts: {entry.hypothesis_verdicts or 'none recorded'}"
+                f"\nRationale: {entry.rationale}"
+                + (f"\nNot acted on: {entry.budget_note}" if entry.budget_note else "")
+            ),
+        )
+
+        if not resume_slug:
+            self.ui.show_status(
+                f"Round {entry.number} closed: {entry.decision}"
+                + (" (negative result)" if entry.negative_result else ""),
+                level="info" if entry.decision == "converged" else "warn",
+            )
+            return
+
+        if not budget_left:
+            self.ui.show_status(
+                f"Round {entry.number} wanted to {entry.decision}, but the round budget "
+                f"({self.max_rounds}) is spent. Continuing to writing with that on the record. "
+                "Raise --max-rounds to let the run iterate.",
+                level="warn",
+            )
+            return
+
+        target = next(item for item in STAGES if item.slug == resume_slug)
+        self.ui.show_status(
+            f"Round {entry.number} chose {entry.decision}. Starting round {entry.number + 1} "
+            f"from {target.stage_title}.",
+            level="warn",
+        )
+        self._rollback_and_jump(
+            paths=paths,
+            current_stage=stage,
+            target_stage=target,
+            reason=(
+                f"Round {entry.number} concluded {entry.decision}: {entry.rationale}"
+            ),
+        )
 
     def _run_validity_review(self, paths: RunPaths, stage: StageSpec, stage_markdown: str) -> None:
         """Attack the result once the stage that produced it is approved.

--- a/src/operator.py
+++ b/src/operator.py
@@ -821,6 +821,30 @@ Original stderr:
                     },
                 )
 
+            # Stage 06+: close the round. The fake hypothesis came out refuted,
+            # so the only honest way to converge is to declare the refutation
+            # the result. A stub that claimed convergence on a supported
+            # hypothesis it never had would model the failure this gate exists
+            # to catch.
+            _write_json(
+                paths.round_decision,
+                {
+                    "decision": "converged",
+                    "rationale": (
+                        "fake-operator mode measures nothing, so no further round would "
+                        "produce a different outcome. Closing the round rather than "
+                        "spending budget on a stub."
+                    ),
+                    "what_we_learned": (
+                        "Nothing about the research question. The run exercised the workflow "
+                        "end to end and the preregistered hypothesis was not supported by the "
+                        "placeholder result."
+                    ),
+                    "what_changes_next": "",
+                    "negative_result": True,
+                },
+            )
+
             # Stage 06+: answer whatever the adversarial reviewer raised against
             # the previous stage. The fake response is `accepted_limitation`,
             # because the fake finding (a single run of a two-row split) is

--- a/src/prompts/06_analysis.md
+++ b/src/prompts/06_analysis.md
@@ -31,6 +31,38 @@ Interpret the available evidence rigorously and determine what claims the curren
 - Make uncertainty explicit.
 - Translate raw outputs into defensible takeaways.
 
+## Round Decision (required)
+
+Stages 03-06 form a research round. This stage closes it. Write
+`{{WORKSPACE_NOTES_DIR}}/round_decision.json`:
+
+```json
+{
+  "decision": "converged | refine_design | new_hypothesis | abandon",
+  "rationale": "why this is the right call given what the evidence showed",
+  "what_we_learned": "what this round established, including when the answer is that a prediction was wrong",
+  "what_changes_next": "what a further round would do differently (required unless converged or abandoned)",
+  "negative_result": false
+}
+```
+
+- `converged` — the run has what it needs; go and write it up.
+- `refine_design` — the hypotheses stand but the design could not test them properly.
+  The next round restarts at Stage 03.
+- `new_hypothesis` — the hypotheses were wrong in an informative way. The next round
+  restarts at Stage 02, and the preregistration records the change as an amendment.
+- `abandon` — the question cannot be answered with the resources available. Say so.
+
+A round that wants another one must say what would change. Repeating a design without
+changing what it got wrong produces the same result at full cost.
+
+**You may not declare `converged` when no preregistered hypothesis came out supported,
+unless you set `negative_result: true`.** A run whose contribution is the refutation is
+a real result and should say so plainly. What is not available is proceeding to write a
+paper as though something had been shown. If the round budget is already spent the run
+will continue regardless — but the record will say the round wanted to iterate, which is
+the honest version.
+
 ## Stage Output Requirements
 
 The markdown at `{{STAGE_OUTPUT_PATH}}` must follow the required output structure exactly.

--- a/src/research_rounds.py
+++ b/src/research_rounds.py
@@ -1,0 +1,320 @@
+"""Turn the one-way march into a loop that can come back with a better question.
+
+AutoR's stages run 01 through 08 and stop. Rollback exists, but it is a *repair*
+mechanism: something went wrong, invalidate the downstream work, do it again.
+There was no way to express the ordinary shape of research — we predicted X, we
+measured, X was wrong, here is what that tells us and here is round two.
+
+The consequence was structural, not cosmetic. A refuted hypothesis had nowhere
+to go. Stage 06 adjudicates it (see :mod:`src.preregistration`), Stage 07 then
+has to write a manuscript, and the only paths available were to write up a
+result the run does not have or to roll back and pretend the first attempt never
+happened. Neither is what a researcher does.
+
+A **round** covers Stages 03-06: design, implement, experiment, analyse. It ends
+with a decision recorded in ``workspace/notes/research_rounds.json``:
+
+- ``converged`` — go and write it up.
+- ``refine_design`` — same hypotheses, the design could not test them properly.
+  Back to Stage 03.
+- ``new_hypothesis`` — the hypotheses were wrong in an informative way. Back to
+  Stage 02, where the preregistration amendment machinery records the change.
+- ``abandon`` — the question cannot be answered with the resources available.
+  The run stops and says so.
+
+**What stops every round declaring victory.** An agent asked "are we done?" says
+yes. So ``converged`` is refused when no hypothesis came out supported, unless
+the round explicitly declares a negative result — a run whose contribution *is*
+the refutation. Both are legitimate; quietly proceeding to write a paper about
+nothing is not, and it is the default failure without this rule.
+
+Iteration is bounded by ``--max-rounds`` and off by default, because rounds
+multiply the cost of an unattended run. The decision is recorded either way, so
+a single-round run still says whether it converged or merely stopped.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+
+from .utils import RunPaths, StageSpec
+
+
+#: What a round may conclude. There is no "continue" — a round that wants
+#: another one has to say what it would change.
+DECISIONS = ("converged", "refine_design", "new_hypothesis", "abandon")
+
+#: Which stage each decision resumes from. ``converged`` and ``abandon`` do not
+#: resume.
+DECISION_ENTRY_STAGE = {
+    "refine_design": "03_study_design",
+    "new_hypothesis": "02_hypothesis_generation",
+}
+
+#: The round ends when this stage is approved.
+ROUND_CLOSING_STAGE_NUMBER = 6
+
+#: The first stage inside a round. Stages before it are per-run, not per-round.
+ROUND_FIRST_STAGE_NUMBER = 3
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _load_json(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+@dataclass(frozen=True)
+class Round:
+    number: int
+    decision: str
+    rationale: str
+    what_we_learned: str
+    what_changes_next: str
+    negative_result: bool
+    hypothesis_verdicts: dict[str, str]
+    recorded_at: str
+    acted_on: bool = True
+    budget_note: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "round": self.number,
+            "decision": self.decision,
+            "rationale": self.rationale,
+            "what_we_learned": self.what_we_learned,
+            "what_changes_next": self.what_changes_next,
+            "negative_result": self.negative_result,
+            "hypothesis_verdicts": dict(self.hypothesis_verdicts),
+            "recorded_at": self.recorded_at,
+            "acted_on": self.acted_on,
+            "budget_note": self.budget_note,
+        }
+
+
+def load_rounds(paths: RunPaths) -> list[Round]:
+    payload = _load_json(paths.research_rounds)
+    if not isinstance(payload, dict):
+        return []
+    rounds: list[Round] = []
+    for entry in payload.get("rounds", []):
+        if not isinstance(entry, dict):
+            continue
+        verdicts = entry.get("hypothesis_verdicts")
+        rounds.append(
+            Round(
+                number=int(entry.get("round") or 0),
+                decision=str(entry.get("decision") or "").strip(),
+                rationale=str(entry.get("rationale") or "").strip(),
+                what_we_learned=str(entry.get("what_we_learned") or "").strip(),
+                what_changes_next=str(entry.get("what_changes_next") or "").strip(),
+                negative_result=bool(entry.get("negative_result", False)),
+                hypothesis_verdicts={
+                    str(key): str(value) for key, value in verdicts.items()
+                }
+                if isinstance(verdicts, dict)
+                else {},
+                recorded_at=str(entry.get("recorded_at") or ""),
+                acted_on=bool(entry.get("acted_on", True)),
+                budget_note=str(entry.get("budget_note") or ""),
+            )
+        )
+    return rounds
+
+
+def current_round_number(paths: RunPaths) -> int:
+    """1-based. The round in progress is one past the last one recorded."""
+    return len(load_rounds(paths)) + 1
+
+
+def latest_round(paths: RunPaths) -> Round | None:
+    rounds = load_rounds(paths)
+    return rounds[-1] if rounds else None
+
+
+def _write_rounds(paths: RunPaths, rounds: list[Round]) -> None:
+    paths.research_rounds.parent.mkdir(parents=True, exist_ok=True)
+    paths.research_rounds.write_text(
+        json.dumps(
+            {"updated_at": _now(), "rounds": [item.to_dict() for item in rounds]},
+            indent=2,
+            ensure_ascii=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_round_decision(paths: RunPaths) -> dict | None:
+    """Stage 06's declaration, before the round budget is applied to it."""
+    payload = _load_json(paths.round_decision)
+    return payload if isinstance(payload, dict) else None
+
+
+def validate_round_decision(paths: RunPaths, stage: StageSpec) -> list[str]:
+    """Stage 06 must say what the round concluded, and may not claim more than it has.
+
+    The rule that carries the weight: ``converged`` with no supported hypothesis
+    and no declared negative result is refused. Without it, a run that refuted
+    everything it predicted proceeds to write a paper, and nothing in the
+    pipeline objects.
+    """
+    if stage.number < ROUND_CLOSING_STAGE_NUMBER:
+        return []
+
+    if stage.number > ROUND_CLOSING_STAGE_NUMBER:
+        # The declaration is consumed when the round closes, so from Stage 07 on
+        # the question is what the closed round concluded, not what is pending.
+        final = latest_round(paths)
+        if final is None:
+            return [
+                "requires at least one closed research round. Stage 06 records the round's "
+                "conclusion in workspace/notes/research_rounds.json when it is approved."
+            ]
+        if final.decision == "abandon":
+            return [
+                f"cannot run: round {final.number} concluded `abandon` — {final.rationale}. "
+                "Writing up a run that decided the question could not be answered would "
+                "contradict its own record."
+            ]
+        return []
+
+    payload = read_round_decision(paths)
+    if payload is None:
+        return [
+            "requires workspace/notes/round_decision.json saying what this round concluded: "
+            f"one of {', '.join(DECISIONS)}, with the reasoning and what would change next."
+        ]
+
+    problems: list[str] = []
+    decision = str(payload.get("decision") or "").strip()
+    if decision not in DECISIONS:
+        problems.append(
+            f"round_decision.json decision is {decision!r}; expected one of {', '.join(DECISIONS)}."
+        )
+        return problems
+
+    if len(str(payload.get("rationale") or "").strip()) < 40:
+        problems.append("round_decision.json needs a substantive rationale for the decision.")
+    if len(str(payload.get("what_we_learned") or "").strip()) < 40:
+        problems.append(
+            "round_decision.json must say what this round established, including when the "
+            "answer is that a prediction was wrong."
+        )
+    if decision in DECISION_ENTRY_STAGE and len(str(payload.get("what_changes_next") or "").strip()) < 40:
+        problems.append(
+            f"round_decision.json chooses {decision} but does not say what would change. "
+            "Repeating a round without changing anything produces the same result."
+        )
+
+    from .preregistration import load_hypothesis_outcomes, load_preregistration
+
+    prereg = load_preregistration(paths)
+    if prereg is not None and decision == "converged":
+        outcomes = load_hypothesis_outcomes(paths)
+        supported = [item.identifier for item in outcomes if item.verdict == "supported"]
+        if not supported and not bool(payload.get("negative_result", False)):
+            refuted = [item.identifier for item in outcomes if item.verdict == "refuted"]
+            problems.append(
+                "round_decision.json declares the run converged, but no preregistered "
+                f"hypothesis came out supported ({len(refuted)} refuted). Either run another "
+                "round, or set `negative_result: true` and make the refutation the "
+                "contribution — a paper reporting what does not work is a real paper, and a "
+                "paper that quietly drops its own refuted prediction is not."
+            )
+    return problems
+
+
+def record_round(
+    paths: RunPaths,
+    *,
+    acted_on: bool,
+    budget_note: str = "",
+) -> Round | None:
+    """Close the round from Stage 06's declaration and the adjudicated verdicts."""
+    payload = read_round_decision(paths)
+    if payload is None:
+        return None
+
+    from .preregistration import load_hypothesis_outcomes
+
+    verdicts = {item.identifier: item.verdict for item in load_hypothesis_outcomes(paths)}
+    rounds = load_rounds(paths)
+    entry = Round(
+        number=len(rounds) + 1,
+        decision=str(payload.get("decision") or "").strip(),
+        rationale=str(payload.get("rationale") or "").strip(),
+        what_we_learned=str(payload.get("what_we_learned") or "").strip(),
+        what_changes_next=str(payload.get("what_changes_next") or "").strip(),
+        negative_result=bool(payload.get("negative_result", False)),
+        hypothesis_verdicts=verdicts,
+        recorded_at=_now(),
+        acted_on=acted_on,
+        budget_note=budget_note,
+    )
+    rounds.append(entry)
+    _write_rounds(paths, rounds)
+    # The declaration belongs to one round. Leaving it in place would let the
+    # next round inherit the previous round's conclusion.
+    paths.round_decision.unlink(missing_ok=True)
+    return entry
+
+
+def resume_stage_slug_for(decision: str) -> str | None:
+    return DECISION_ENTRY_STAGE.get(decision)
+
+
+def format_rounds_for_prompt(paths: RunPaths) -> str:
+    """What earlier rounds established. Injected into every stage inside a round.
+
+    Without this a second round repeats the first: same design, same blind spot,
+    same result, at full cost.
+    """
+    rounds = load_rounds(paths)
+    if not rounds:
+        return ""
+    lines = [
+        f"This is round {len(rounds) + 1}. Earlier rounds of this run:",
+        "",
+    ]
+    for entry in rounds:
+        lines.append(f"### Round {entry.number} — {entry.decision}")
+        if entry.hypothesis_verdicts:
+            verdicts = ", ".join(
+                f"{key}: {value}" for key, value in sorted(entry.hypothesis_verdicts.items())
+            )
+            lines.append(f"- Verdicts: {verdicts}")
+        if entry.what_we_learned:
+            lines.append(f"- What it established: {entry.what_we_learned}")
+        if entry.what_changes_next:
+            lines.append(f"- What this round should change: {entry.what_changes_next}")
+        if entry.rationale:
+            lines.append(f"- Why: {entry.rationale}")
+        lines.append("")
+    lines.append(
+        "Do not repeat an earlier round's design without changing what it got wrong. A "
+        "refuted hypothesis from an earlier round is a finding this run owns; carry it "
+        "forward rather than quietly dropping it."
+    )
+    return "\n".join(lines)
+
+
+def format_round_status(paths: RunPaths, max_rounds: int) -> str:
+    rounds = load_rounds(paths)
+    if not rounds:
+        return ""
+    final = rounds[-1]
+    if final.decision == "converged":
+        shape = "converged" + (" on a negative result" if final.negative_result else "")
+    elif not final.acted_on:
+        shape = f"stopped with the round budget spent ({len(rounds)}/{max_rounds}), wanting {final.decision}"
+    else:
+        shape = final.decision
+    return f"{len(rounds)} round(s); {shape}"

--- a/src/utils.py
+++ b/src/utils.py
@@ -74,6 +74,8 @@ class RunPaths:
     hypothesis_manifest: Path
     preregistration: Path
     experimental_protocol: Path
+    research_rounds: Path
+    round_decision: Path
     hypothesis_outcomes: Path
     claim_provenance: Path
     writing_dir: Path
@@ -248,6 +250,8 @@ def build_run_paths(run_root: Path) -> RunPaths:
         hypothesis_manifest=workspace_root / "notes" / "hypothesis_manifest.json",
         preregistration=workspace_root / "notes" / "preregistration.json",
         experimental_protocol=workspace_root / "notes" / "experimental_protocol.json",
+        research_rounds=workspace_root / "notes" / "research_rounds.json",
+        round_decision=workspace_root / "notes" / "round_decision.json",
         hypothesis_outcomes=workspace_root / "results" / "hypothesis_outcomes.json",
         claim_provenance=workspace_root / "artifacts" / "claim_provenance.json",
         writing_dir=workspace_root / "writing",
@@ -1146,9 +1150,12 @@ def validate_stage_artifacts(
 
     # Answering the previous stage's adversarial review. Self-selecting: only
     # Stage 06 (answering 05) and Stage 07 (answering 06) owe anything.
+    from .research_rounds import validate_round_decision
     from .validity_review import validate_validity_response
 
     for problem in validate_validity_response(paths, stage):
+        problems.append(f"{stage.stage_title} {problem}")
+    for problem in validate_round_decision(paths, stage):
         problems.append(f"{stage.stage_title} {problem}")
 
     if stage.number >= 3:

--- a/tests/prereg_support.py
+++ b/tests/prereg_support.py
@@ -75,7 +75,32 @@ def write_experimental_protocol(paths: RunPaths, *, planned_seeds: int = 5) -> N
     )
 
 
-def write_validity_chain(paths: RunPaths, *, evidence: str = "results/metrics.json") -> None:
+def write_round_decision(paths: RunPaths, *, decision: str = "converged", **overrides) -> None:
+    payload = {
+        "decision": decision,
+        "rationale": "The evidence settles the preregistered question for this round.",
+        "what_we_learned": "The treatment clears the decision rule the round declared in advance.",
+        "what_changes_next": "",
+        "negative_result": False,
+    }
+    payload.update(overrides)
+    write_text(paths.round_decision, json.dumps(payload))
+
+
+def close_round(paths: RunPaths, **kwargs) -> None:
+    """Declare and close a round, as Stage 06 approval would."""
+    from src.research_rounds import record_round
+
+    write_round_decision(paths, **kwargs)
+    record_round(paths, acted_on=True)
+
+
+def write_validity_chain(
+    paths: RunPaths,
+    *,
+    evidence: str = "results/metrics.json",
+    close_first_round: bool = True,
+) -> None:
     """Freeze hypotheses, adjudicate them, and trace one claim to the verdict.
 
     ``evidence`` is a workspace-relative path. It is created if the caller has
@@ -133,6 +158,10 @@ def write_validity_chain(paths: RunPaths, *, evidence: str = "results/metrics.js
             }
         ),
     )
+    # A run that reaches Stage 07 has closed at least one round. Tests that
+    # drive rounds themselves opt out.
+    if close_first_round:
+        close_round(paths)
 
 
 def reload_preregistration(paths: RunPaths):

--- a/tests/test_experimental_protocol.py
+++ b/tests/test_experimental_protocol.py
@@ -21,7 +21,11 @@ from src.experimental_protocol import (
     validate_outcome_statistics,
 )
 from src.utils import STAGES, build_run_paths, ensure_run_layout, validate_stage_artifacts, write_text
-from tests.prereg_support import write_experimental_protocol, write_validity_chain
+from tests.prereg_support import (
+    write_experimental_protocol,
+    write_round_decision,
+    write_validity_chain,
+)
 
 
 STAGE_04 = next(stage for stage in STAGES if stage.number == 4)
@@ -214,6 +218,7 @@ class StageGateWiringTest(ProtocolTestCase):
         write_text(self.paths.results_dir / "metrics.json", '{"acc": 0.9}')
         write_experimental_protocol(self.paths)
         write_validity_chain(self.paths)
+        write_round_decision(self.paths)
         problems = [
             p
             for p in validate_stage_artifacts(STAGE_06, self.paths)

--- a/tests/test_manager_smoke.py
+++ b/tests/test_manager_smoke.py
@@ -289,6 +289,21 @@ class ScriptedSmokeOperator:
             produced.append(relative_to_run(result_path, paths.run_root))
 
         if stage.number >= 6:
+            write_text(
+                paths.round_decision,
+                json.dumps(
+                    {
+                        "decision": "converged",
+                        "rationale": "The smoke comparison clears the decision rule the round declared.",
+                        "what_we_learned": "Retrieval exceeded the retrieval-off baseline by the declared margin.",
+                        "what_changes_next": "",
+                        "negative_result": False,
+                    }
+                ),
+            )
+            produced.append(relative_to_run(paths.round_decision, paths.run_root))
+
+        if stage.number >= 6:
             from src.preregistration import load_preregistration
 
             prereg = load_preregistration(paths)

--- a/tests/test_rcb_scoring.py
+++ b/tests/test_rcb_scoring.py
@@ -96,6 +96,7 @@ class FigureBudgetTests(unittest.TestCase):
                 "hypothesis_outcomes.json",
                 "metrics.json",
                 "preregistration.json",
+                "research_rounds.json",
             ],
         )
         # outputs/ is swept before report/, so an image there would take a judge slot.

--- a/tests/test_research_rounds.py
+++ b/tests/test_research_rounds.py
@@ -1,0 +1,337 @@
+"""Research rounds: the loop that lets a refuted hypothesis lead somewhere.
+
+Before this, Stages 01-08 ran once. Rollback existed but is a repair mechanism —
+something went wrong, redo it — and there was no way to say *we predicted X, X
+was wrong, here is round two*. A refuted hypothesis had nowhere to go, so the
+only paths from Stage 06 were to write up a result the run did not have or to
+roll back and pretend the attempt never happened.
+
+The tests that carry the most weight are the ones about `converged`. An agent
+asked "are we done?" says yes, and a run that refuted everything it predicted
+will otherwise proceed to write a paper with nothing objecting.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.manager import ResearchManager
+from src.research_rounds import (
+    DECISIONS,
+    current_round_number,
+    format_round_status,
+    format_rounds_for_prompt,
+    latest_round,
+    load_rounds,
+    read_round_decision,
+    record_round,
+    resume_stage_slug_for,
+    validate_round_decision,
+)
+from src.utils import STAGES, build_run_paths, ensure_run_layout, validate_stage_artifacts, write_text
+from tests.prereg_support import write_round_decision, write_validity_chain
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STAGE_05 = next(stage for stage in STAGES if stage.number == 5)
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+STAGE_07 = next(stage for stage in STAGES if stage.number == 7)
+
+
+class RoundTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.results_dir / "metrics.json", '{"acc": 0.9}')
+
+    def refute_everything(self) -> None:
+        outcomes = json.loads(self.paths.hypothesis_outcomes.read_text(encoding="utf-8"))
+        for entry in outcomes["outcomes"]:
+            entry["verdict"] = "refuted"
+            entry["rationale"] = "the measured gap fell short of the preregistered rule"
+        write_text(self.paths.hypothesis_outcomes, json.dumps(outcomes))
+
+
+class DecisionContractTest(RoundTestCase):
+    def test_stage_06_must_declare_a_decision(self) -> None:
+        problems = validate_round_decision(self.paths, STAGE_06)
+        self.assertTrue(any("round_decision.json" in problem for problem in problems), problems)
+
+    def test_an_unknown_decision_word_is_refused(self) -> None:
+        write_round_decision(self.paths, decision="keep_going")
+        problems = validate_round_decision(self.paths, STAGE_06)
+        self.assertTrue(any("expected one of" in problem for problem in problems), problems)
+
+    def test_the_vocabulary_has_no_bare_continue(self) -> None:
+        """A round that wants another one has to say what it would change."""
+        self.assertNotIn("continue", DECISIONS)
+
+    def test_iterating_without_saying_what_changes_is_refused(self) -> None:
+        write_round_decision(self.paths, decision="refine_design", what_changes_next="")
+        problems = validate_round_decision(self.paths, STAGE_06)
+        self.assertTrue(any("does not say what would change" in p for p in problems), problems)
+
+    def test_converging_needs_no_change_plan(self) -> None:
+        write_validity_chain(self.paths, close_first_round=False)
+        write_round_decision(self.paths)
+        self.assertEqual(validate_round_decision(self.paths, STAGE_06), [])
+
+    def test_a_thin_rationale_is_refused(self) -> None:
+        write_round_decision(self.paths, rationale="done")
+        problems = validate_round_decision(self.paths, STAGE_06)
+        self.assertTrue(any("substantive rationale" in problem for problem in problems), problems)
+
+    def test_stages_before_06_owe_no_decision(self) -> None:
+        self.assertEqual(validate_round_decision(self.paths, STAGE_05), [])
+
+
+class ConvergenceHonestyTest(RoundTestCase):
+    """The rule that stops every round declaring victory."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        write_validity_chain(self.paths, close_first_round=False)
+        self.refute_everything()
+
+    def test_converging_with_nothing_supported_is_refused(self) -> None:
+        write_round_decision(self.paths)
+        problems = validate_round_decision(self.paths, STAGE_06)
+        self.assertTrue(any("no preregistered" in problem for problem in problems), problems)
+
+    def test_the_same_round_may_converge_on_a_declared_negative_result(self) -> None:
+        """Reporting what does not work is a real contribution. Hiding it is not."""
+        write_round_decision(self.paths, negative_result=True)
+        self.assertEqual(validate_round_decision(self.paths, STAGE_06), [])
+
+    def test_the_same_round_may_choose_to_iterate_instead(self) -> None:
+        write_round_decision(
+            self.paths,
+            decision="new_hypothesis",
+            what_changes_next="Replace H1 with a mechanism-level hypothesis the data can separate.",
+        )
+        self.assertEqual(validate_round_decision(self.paths, STAGE_06), [])
+
+    def test_a_supported_hypothesis_makes_convergence_unremarkable(self) -> None:
+        outcomes = json.loads(self.paths.hypothesis_outcomes.read_text(encoding="utf-8"))
+        outcomes["outcomes"][0]["verdict"] = "supported"
+        write_text(self.paths.hypothesis_outcomes, json.dumps(outcomes))
+        write_round_decision(self.paths)
+        self.assertEqual(validate_round_decision(self.paths, STAGE_06), [])
+
+
+class LedgerTest(RoundTestCase):
+    def test_closing_a_round_captures_the_verdicts_alongside_the_decision(self) -> None:
+        write_validity_chain(self.paths, close_first_round=False)
+        self.refute_everything()
+        write_round_decision(self.paths, negative_result=True)
+
+        entry = record_round(self.paths, acted_on=True)
+
+        assert entry is not None
+        self.assertEqual(entry.number, 1)
+        self.assertEqual(entry.hypothesis_verdicts, {"H1": "refuted"})
+        self.assertTrue(entry.negative_result)
+
+    def test_the_declaration_is_consumed_so_the_next_round_cannot_inherit_it(self) -> None:
+        write_validity_chain(self.paths, close_first_round=False)
+        write_round_decision(self.paths)
+        record_round(self.paths, acted_on=True)
+        self.assertIsNone(read_round_decision(self.paths))
+
+    def test_rounds_accumulate(self) -> None:
+        write_validity_chain(self.paths, close_first_round=False)
+        for _ in range(3):
+            write_round_decision(self.paths)
+            record_round(self.paths, acted_on=True)
+        self.assertEqual([item.number for item in load_rounds(self.paths)], [1, 2, 3])
+        self.assertEqual(current_round_number(self.paths), 4)
+
+    def test_a_decision_the_budget_blocked_is_recorded_as_not_acted_on(self) -> None:
+        """Otherwise the record cannot distinguish converging from merely stopping."""
+        write_validity_chain(self.paths, close_first_round=False)
+        write_round_decision(
+            self.paths, decision="refine_design", what_changes_next="Use a held-out split for tuning."
+        )
+        entry = record_round(self.paths, acted_on=False, budget_note="round budget spent (1/1)")
+
+        assert entry is not None
+        self.assertFalse(entry.acted_on)
+        self.assertIn("budget spent", entry.budget_note)
+        self.assertIn("wanting refine_design", format_round_status(self.paths, 1))
+
+    def test_the_status_line_distinguishes_a_negative_convergence(self) -> None:
+        write_validity_chain(self.paths, close_first_round=False)
+        self.refute_everything()
+        write_round_decision(self.paths, negative_result=True)
+        record_round(self.paths, acted_on=True)
+        self.assertIn("negative result", format_round_status(self.paths, 3))
+
+
+class ResumeRoutingTest(RoundTestCase):
+    def test_refine_design_restarts_at_the_design_stage(self) -> None:
+        self.assertEqual(resume_stage_slug_for("refine_design"), "03_study_design")
+
+    def test_new_hypothesis_restarts_at_the_hypothesis_stage(self) -> None:
+        self.assertEqual(resume_stage_slug_for("new_hypothesis"), "02_hypothesis_generation")
+
+    def test_converged_and_abandon_do_not_resume(self) -> None:
+        self.assertIsNone(resume_stage_slug_for("converged"))
+        self.assertIsNone(resume_stage_slug_for("abandon"))
+
+
+class Stage07GateTest(RoundTestCase):
+    def test_writing_requires_a_closed_round(self) -> None:
+        problems = validate_round_decision(self.paths, STAGE_07)
+        self.assertTrue(any("closed research round" in problem for problem in problems), problems)
+
+    def test_writing_is_refused_after_an_abandoned_round(self) -> None:
+        """Writing up a run that decided the question is unanswerable contradicts its record."""
+        write_validity_chain(self.paths, close_first_round=False)
+        write_round_decision(
+            self.paths,
+            decision="abandon",
+            what_changes_next="Nothing available would settle this within the compute budget.",
+        )
+        record_round(self.paths, acted_on=True)
+
+        problems = validate_round_decision(self.paths, STAGE_07)
+        self.assertTrue(any("concluded `abandon`" in problem for problem in problems), problems)
+
+    def test_writing_proceeds_after_a_converged_round(self) -> None:
+        write_validity_chain(self.paths)
+        self.assertEqual(validate_round_decision(self.paths, STAGE_07), [])
+
+    def test_writing_proceeds_when_the_budget_stopped_an_iteration(self) -> None:
+        write_validity_chain(self.paths, close_first_round=False)
+        write_round_decision(
+            self.paths, decision="refine_design", what_changes_next="Tune on a development split."
+        )
+        record_round(self.paths, acted_on=False, budget_note="budget spent")
+        self.assertEqual(validate_round_decision(self.paths, STAGE_07), [])
+
+    def test_the_stage_gate_calls_this(self) -> None:
+        problems = validate_stage_artifacts(STAGE_07, self.paths)
+        self.assertTrue(any("closed research round" in problem for problem in problems), problems)
+
+
+class PromptCarryForwardTest(RoundTestCase):
+    def test_a_later_round_is_told_what_the_earlier_ones_established(self) -> None:
+        """Without this a second round repeats the first at full cost."""
+        write_validity_chain(self.paths, close_first_round=False)
+        self.refute_everything()
+        write_round_decision(
+            self.paths,
+            decision="refine_design",
+            what_changes_next="Tune both arms on a development split instead of the reporting split.",
+            what_we_learned="The gap disappears once tuning and reporting use different splits.",
+        )
+        record_round(self.paths, acted_on=True)
+
+        rendered = format_rounds_for_prompt(self.paths)
+
+        self.assertIn("This is round 2", rendered)
+        self.assertIn("H1: refuted", rendered)
+        self.assertIn("development split", rendered)
+        self.assertIn("Do not repeat an earlier round's design", rendered)
+
+    def test_the_first_round_gets_no_block(self) -> None:
+        self.assertEqual(format_rounds_for_prompt(self.paths), "")
+
+
+class ManagerLoopTest(unittest.TestCase):
+    """The loop itself: does a decision to iterate actually re-run the stages?"""
+
+    def _manager(self, tmp_dir: str, max_rounds: int):
+        from tests.test_manager_smoke import ScriptedSmokeOperator
+
+        operator = ScriptedSmokeOperator()
+        manager = ResearchManager(
+            project_root=REPO_ROOT,
+            runs_dir=Path(tmp_dir) / "runs",
+            operator=operator,
+            output_stream=io.StringIO(),
+            max_rounds=max_rounds,
+        )
+        return operator, manager
+
+    def _iterate_once_then_converge(self, manager, paths):
+        """Patch the scripted operator so round 1 asks for a second one."""
+        original = manager.operator.run_stage
+
+        def run_stage(stage, prompt, run_paths, attempt_no, continue_session=False):
+            result = original(stage, prompt, run_paths, attempt_no, continue_session)
+            if stage.number == 6 and not load_rounds(run_paths):
+                write_text(
+                    run_paths.round_decision,
+                    json.dumps(
+                        {
+                            "decision": "refine_design",
+                            "rationale": "The first design could not separate the effect from tuning noise.",
+                            "what_we_learned": "The comparison was confounded by tuning on the reporting split.",
+                            "what_changes_next": "Tune both arms on a held-out development split and re-run.",
+                            "negative_result": False,
+                        }
+                    ),
+                )
+            return result
+
+        manager.operator.run_stage = run_stage
+
+    def test_a_round_that_asks_to_iterate_reruns_the_design_stage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operator, manager = self._manager(tmp_dir, max_rounds=2)
+            paths = manager._create_run("Round loop test.", venue="neurips_2025")
+            self._iterate_once_then_converge(manager, paths)
+
+            with patch.object(manager, "_ask_choice", return_value="5"):
+                completed = manager._run_from_paths(paths)
+
+            self.assertTrue(completed)
+            rounds = load_rounds(paths)
+            self.assertEqual([item.decision for item in rounds], ["refine_design", "converged"])
+            # Stage 03 ran twice: once per round.
+            self.assertEqual(operator.invocations["03_study_design"], 2)
+
+    def test_the_round_budget_stops_the_loop_and_says_so(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operator, manager = self._manager(tmp_dir, max_rounds=1)
+            paths = manager._create_run("Round budget test.", venue="neurips_2025")
+            self._iterate_once_then_converge(manager, paths)
+
+            with patch.object(manager, "_ask_choice", return_value="5"):
+                completed = manager._run_from_paths(paths)
+
+            self.assertTrue(completed)
+            rounds = load_rounds(paths)
+            self.assertEqual(len(rounds), 1)
+            self.assertEqual(rounds[0].decision, "refine_design")
+            self.assertFalse(rounds[0].acted_on)
+            self.assertIn("budget spent", rounds[0].budget_note)
+            # The run still finished rather than stalling.
+            self.assertEqual(operator.invocations["03_study_design"], 1)
+            self.assertIn("07_writing", operator.invocations)
+
+    def test_a_single_round_run_still_records_that_it_converged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _operator, manager = self._manager(tmp_dir, max_rounds=1)
+            paths = manager._create_run("Single round test.", venue="neurips_2025")
+
+            with patch.object(manager, "_ask_choice", return_value="5"):
+                manager._run_from_paths(paths)
+
+            final = latest_round(paths)
+            assert final is not None
+            self.assertEqual(final.decision, "converged")
+            self.assertTrue(final.acted_on)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Last of the four. After #116 (preregistration), #119 (baseline and replication discipline) and #122 (adversarial review).

## The gap

AutoR ran 01 through 08 and stopped. Rollback exists, but it is a *repair* mechanism — something went wrong, invalidate the downstream work, do it again. There was no way to express the ordinary shape of research: **we predicted X, we measured, X was wrong, here is what that tells us and here is round two.**

That became structural once #116 landed. Stage 06 now adjudicates every preregistered hypothesis, so a run can come out of analysis with everything refuted — and the only paths onward were to write up a result the run does not have, or to roll back and pretend the first attempt never happened. Neither is what a researcher does.

## Rounds

Stages 03–06 are a round: design, implement, experiment, analyse. Stage 06 closes it.

| decision | what happens |
| --- | --- |
| `converged` | continue to Stage 07 |
| `refine_design` | hypotheses stand, design could not test them — next round restarts at Stage 03 |
| `new_hypothesis` | hypotheses were wrong informatively — next round restarts at Stage 02, and #116's amendment machinery records the change |
| `abandon` | the run stops; Stage 07 refuses to write up a question the run declared unanswerable |

There is deliberately no `continue`. A round that wants another one has to say what would change, because repeating a design without changing what it got wrong produces the same result at full cost. Each round's verdicts, what it established, and what it would change are injected into the next round's prompts — so round two is not round one again.

## What stops every round declaring victory

An agent asked "are we done?" says yes.

**`converged` is refused when no preregistered hypothesis came out supported**, unless the round sets `negative_result: true`. A run whose contribution *is* the refutation is a real result and should say so plainly. Both are available; quietly proceeding to write a paper about nothing is not, and it is the default failure without this rule.

## Budget

`--max-rounds`, default 1, because rounds multiply the cost of an unattended run. The decision is recorded either way — a round that wanted to iterate and could not is written with `acted_on: false` and a budget note, so the ledger distinguishes converging from merely stopping. Previously a run that stopped and a run that finished looked identical.

## Tests

29 in `tests/test_research_rounds.py`, including manager-level tests that a `refine_design` decision actually re-runs Stage 03 (`invocations["03_study_design"] == 2`) and that the budget stops the loop without stalling the run. Mutation-checked: disarming the convergence-honesty rule, the abandon gate, or the consumption of the pending declaration each fails tests.

755 tests green, including against the merge with `origin/main`.

## The four together

```
Stage 02  hypotheses + decision rules
Stage 03  primary metric, seed count, baselines with tuning budgets     #119
Stage 04  ── freeze ──▶ preregistration.json (hashed)                   #116
Stage 05  experiments ──▶ adversarial review ──▶ findings               #122
Stage 06  verdict per hypothesis + statistics ──▶ round decision        #116 #119 (this)
          answers the findings                                          #122
Stage 07  claims trace to supported hypotheses, or say exploratory      #116
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)