### PR TITLE
Let a different model family veto an approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Useful feature | **Automated experiment manifests** | Machine-readable experiment and result files make runs inspectable, comparable, and reusable downstream. |
 | Useful feature | **Citation verification and writing checks** | Writing expects citation verification, figure-link checks, and self-review artifacts before Stage 07 is considered complete. |
 | Useful feature | **Artifact indexing across stages** | `artifact_index.json` and related manifests help later stages find data, results, and figures without guessing from filenames. |
+| Useful feature | **Cross-model review veto** | When the reviewer approves, a different model family audits that approval and can send the stage back. A veto, never an override, so it can only tighten the gate. |
 | Useful feature | **Self-improving review policy** | Every correction the reviewer demands becomes a standing rule checked on all later stages, recorded in an auditable `review_policy.json` with the stage and attempt that produced it. |
 | Useful feature | **Resume, redo, and rollback controls** | Long research runs can continue in place, retry a stage, or roll downstream state back without starting over. |
 | Useful feature | **Deliberating review panel** | Instead of one reviewer agent at the approval gate, `--review-panel` seats a PI, domain expert, methodologist, reproducibility engineer and adversarial reviewer who review independently, cross-examine, then converge — and a blocking objection cannot be approved over. |
@@ -464,6 +465,27 @@ flowchart TD
 - Stages 01-08 use the standard six-action review menu: `1 / 2 / 3` continue with an AI refinement suggestion, `4` continues with custom feedback, `5` approves, and `6` aborts.
 
 The stage loop is controlled by AutoR, not by Claude.
+
+### Cross-model review
+
+The approval gate runs a coding agent with tools, so it can re-read a paper and re-execute
+an analysis before judging. But it is the same model family as the executor — usually the
+same model. Opus judging opus shares the blind spots that produced the work, which is
+exactly what a review is supposed to catch.
+
+So when the primary reviewer **approves**, a reviewer from a different model family reads
+the same evidence and decides whether that approval is defensible. It is a **veto, never an
+override**:
+
+- It only audits approvals. A refusal already sends the stage back.
+- It cannot approve anything the primary refused, so enabling it can only make the gate
+  stricter — which is why `--cross-review auto` turns it on whenever a Gemini backend is
+  configured.
+- An auditor that errors or returns unparseable output is recorded as *unavailable*, not as
+  agreement. Silence is never laundered into a passed audit.
+
+A cross-model veto is recorded as a standing rule, so a blind spot caught once is checked
+on every stage after it.
 
 ### Self-improving review
 

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from src.operator import ClaudeOperator
 from src.operator_codex import CodexOperator
 from src.operator_protocol import OperatorProtocol
 from src.terminal_ui import TerminalUI
+from src.cross_reviewer import resolve_cross_reviewer
 from src.web_search import (
     assess_search_readiness,
     resolve_web_search_context,
@@ -151,6 +152,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--review-model",
         help="Model alias or full model name for the automated reviewer backend. Defaults to the reviewer backend default.",
+    )
+    parser.add_argument(
+        "--cross-review",
+        choices=["auto", "gemini", "off"],
+        default="auto",
+        help=(
+            "Independent second opinion on each approval, from a different model family. "
+            "The primary reviewer shares the executor's blind spots; a Gemini reviewer can "
+            "veto an approval it cannot defend, but can never override a refusal, so it "
+            "only makes the gate stricter. 'auto' enables it when a Gemini backend is "
+            "configured. Only meaningful with an agent approval gate."
+        ),
+    )
+    parser.add_argument(
+        "--cross-review-model",
+        help="Model for the cross-model reviewer. Defaults to gemini-3.1-pro-preview.",
     )
     parser.add_argument(
         "--web-search",

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -59,6 +59,7 @@ from src.utils import (  # noqa: E402
     resolve_stage,
     resolve_venue_key,
 )
+from src.cross_reviewer import resolve_cross_reviewer
 from src.web_search import (  # noqa: E402
     assess_search_readiness,
     resolve_web_search_context,
@@ -196,6 +197,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Run the intake stage. Off by default: the benchmark instructions are already "
              "a complete task specification, so intake only costs wall-clock time.",
+    )
+    parser.add_argument(
+        "--cross-review",
+        choices=["auto", "gemini", "off"],
+        default="auto",
+        help="Independent second opinion on each approval from a different model family. "
+             "Can veto an approval, never override a refusal.",
+    )
+    parser.add_argument(
+        "--cross-review-model",
+        help="Model for the cross-model reviewer. Defaults to gemini-3.1-pro-preview.",
     )
     parser.add_argument(
         "--web-search",
@@ -352,6 +364,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         # Stages are told to keep code/, outputs/ and report/images/ up to date in the
         # benchmark workspace, so 'Files Produced' must resolve against it too.
         artifact_roots=[workspace],
+        cross_reviewer=resolve_cross_reviewer(args.cross_review, args.cross_review_model),
     )
 
     pipeline_completed = False

--- a/src/cross_reviewer.py
+++ b/src/cross_reviewer.py
@@ -1,0 +1,239 @@
+"""An independent second opinion on an approval, from a different model family.
+
+The approval gate in :mod:`src.approval_agent` is strong — it runs a coding agent with
+tools, so it can re-read a paper and re-execute an analysis before judging. But it is the
+same model family as the executor, usually the same model. Opus judging opus shares the
+blind spots that produced the work, and a shared blind spot is exactly what a review is
+supposed to catch.
+
+This adds a **cross-family veto**. When the primary reviewer approves, a Gemini reviewer
+reads the same evidence and answers one question: is this approval defensible? A refusal
+sends the stage back for refinement; an agreement lets it through.
+
+The asymmetry is deliberate, in both directions:
+
+* **It only audits approvals.** A refusal from the primary already sends the stage back,
+  so a second opinion on it would change nothing and cost a call.
+* **It cannot approve anything the primary refused.** It is a veto, never an override, so
+  adding it can only make the gate stricter. That is what makes it safe to enable by
+  default when a Gemini backend is configured.
+
+The Gemini reviewer has no filesystem and cannot re-run an analysis, so it is a
+*documentary* check: it judges the record — the stage summary, the manifests, and the
+primary's stated reasoning — for internal inconsistency, claims the artifacts do not
+support, and approvals whose reasoning does not actually address what was asked. It is
+weaker than the primary at verification and independent of it at judgement, which is the
+combination worth having.
+
+A cross-model refusal is recorded as a standing rule by :mod:`src.review_policy`, so a
+blind spot caught once is checked on every stage afterwards.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from .utils import RunPaths, StageSpec, read_text, truncate_text
+from .web_search import SearchBackend, build_genai_client, resolve_backend
+
+
+#: Deliberately not the default search model: a reviewer should be at least as capable as
+#: the thing it audits, and this one is auditing frontier-model output.
+DEFAULT_CROSS_REVIEW_MODEL = "gemini-3.1-pro-preview"
+
+#: A verdict must justify itself. Below this the refusal is not actionable and is ignored
+#: rather than bouncing a stage on a shrug.
+MIN_REASON_CHARS = 40
+
+
+@dataclass(frozen=True)
+class CrossVerdict:
+    agrees: bool
+    reason: str = ""
+    raw_response: str = ""
+    model: str = ""
+    #: True when the check could not be performed at all, as opposed to performed and
+    #: passed. The two must never be conflated: an unavailable auditor is not agreement.
+    unavailable: bool = False
+
+    @property
+    def vetoes(self) -> bool:
+        return not self.agrees and not self.unavailable
+
+
+class GeminiCrossReviewer:
+    """Second-opinion reviewer backed by Gemini, on Vertex AI or the Developer API."""
+
+    def __init__(self, model: str | None = None, backend: SearchBackend | None = None) -> None:
+        self.requested_model = model or DEFAULT_CROSS_REVIEW_MODEL
+        self._backend = backend
+
+    def backend(self) -> SearchBackend | None:
+        if self._backend is None:
+            self._backend = resolve_backend(self.requested_model)
+        return self._backend
+
+    def available(self) -> bool:
+        return self.backend() is not None
+
+    def audit(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        stage_markdown: str,
+        primary_reason: str,
+        primary_model: str,
+    ) -> CrossVerdict:
+        backend = self.backend()
+        if backend is None:
+            return CrossVerdict(
+                agrees=True,
+                unavailable=True,
+                reason="No Gemini backend configured; cross-model review was skipped.",
+            )
+
+        prompt = self.build_prompt(
+            paths=paths,
+            stage=stage,
+            stage_markdown=stage_markdown,
+            primary_reason=primary_reason,
+            primary_model=primary_model,
+        )
+
+        try:
+            client = build_genai_client(backend)
+            response = client.models.generate_content(model=backend.model, contents=prompt)
+            raw = (getattr(response, "text", "") or "").strip()
+        except Exception as exc:  # noqa: BLE001 - an auditor that errored has not agreed
+            return CrossVerdict(
+                agrees=True,
+                unavailable=True,
+                reason=f"Cross-model review could not run: {exc}",
+                model=backend.model,
+            )
+
+        return self.parse(raw, model=backend.model)
+
+    @staticmethod
+    def parse(raw_response: str, *, model: str = "") -> CrossVerdict:
+        payload = _extract_json_object(raw_response)
+        if payload is None:
+            # An unparseable auditor is an auditor that did not run. Treating it as a veto
+            # would let a formatting failure bounce good work; treating it as agreement
+            # would launder silence into approval, so it is marked unavailable.
+            return CrossVerdict(
+                agrees=True,
+                unavailable=True,
+                reason="Cross-model reviewer did not return valid JSON.",
+                raw_response=raw_response,
+                model=model,
+            )
+
+        verdict = str(payload.get("verdict") or "").strip().lower()
+        reason = " ".join(str(payload.get("reason") or "").split())
+        agrees = verdict not in {"refuse", "reject", "disagree", "block", "veto"}
+
+        if not agrees and len(reason) < MIN_REASON_CHARS:
+            return CrossVerdict(
+                agrees=True,
+                reason=f"Cross-model refusal ignored: no substantive reason given ({reason!r}).",
+                raw_response=raw_response,
+                model=model,
+            )
+
+        return CrossVerdict(agrees=agrees, reason=reason, raw_response=raw_response, model=model)
+
+    def build_prompt(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        stage_markdown: str,
+        primary_reason: str,
+        primary_model: str,
+    ) -> str:
+        return (
+            "# Cross-Model Review Audit\n\n"
+            f"A reviewer running {primary_model or 'another model'} has just APPROVED "
+            f"{stage.stage_title} of an automated research run. You are a reviewer from a "
+            "different model family. Your job is not to redo the review — it is to decide "
+            "whether this approval is defensible on the evidence given.\n\n"
+            "You are the independent check on a system where the author, the executor and "
+            "the first reviewer are all the same model family. Look for what that "
+            "arrangement would miss.\n\n"
+            "## What to look for\n"
+            "- Claims in the stage summary that its own reported artifacts do not support.\n"
+            "- Numbers, citations or results that appear without a stated source or method.\n"
+            "- Internal contradictions between sections.\n"
+            "- An approval whose stated reasoning does not actually address the stage's "
+            "objective, or which praises effort rather than evidence.\n"
+            "- Work that reads as complete but has not established anything checkable.\n\n"
+            "## What not to do\n"
+            "- Do not refuse over style, length, formatting, or wishing for more work.\n"
+            "- Do not refuse because you cannot personally verify a file. You have no "
+            "filesystem; absence of your own verification is not evidence of a problem.\n"
+            "- The sections below are an excerpt, not the run. A section marked as not "
+            "included is a limit of this packet, and says nothing about whether the "
+            "underlying artifact exists. Never treat it as evidence of a missing file, and "
+            "never infer from it that the approving reviewer fabricated anything.\n"
+            "- Do not demand final-paper quality from an early stage.\n"
+            "- Refuse only if approving would let a real defect through.\n\n"
+            "Return JSON only, no prose outside it:\n"
+            '{"verdict":"agree|refuse","reason":"..."}\n\n'
+            "`reason` is required when refusing and must name the specific defect, "
+            "concretely enough that the next attempt can fix it.\n\n"
+            f"## The Approving Reviewer's Stated Reasoning\n\n{truncate_text(primary_reason or '(none given)', max_chars=6000)}\n\n"
+            f"## Stage Summary Under Review\n\n{truncate_text(stage_markdown, max_chars=24000)}\n\n"
+            f"## Original Research Goal\n\n{truncate_text(read_text(paths.user_input), max_chars=4000)}\n\n"
+            f"## Artifact Index\n\n{_excerpt(paths.artifact_index, 6000)}\n\n"
+            f"## Experiment Manifest\n\n{_excerpt(paths.experiment_manifest, 4000)}\n"
+        )
+
+
+#: Shown when a section could not be included. Worded so it cannot be read as evidence
+#: that the underlying artifact is absent — a distinction the auditor got wrong in testing,
+#: vetoing sound work because a section of its own prompt was empty.
+NOT_INCLUDED = "(not included in this audit packet — draw no conclusion from its absence)"
+
+
+def _excerpt(path, max_chars: int) -> str:
+    try:
+        if not path.exists():
+            return NOT_INCLUDED
+    except OSError:
+        return NOT_INCLUDED
+    text = read_text(path).strip()
+    return truncate_text(text, max_chars=max_chars) if text else NOT_INCLUDED
+
+
+def _extract_json_object(raw: str) -> dict[str, Any] | None:
+    candidate = (raw or "").strip()
+    if not candidate:
+        return None
+
+    for text in (
+        candidate,
+        *(m.group(1) for m in re.finditer(r"```(?:json)?\s*(\{.*?\})\s*```", candidate, re.DOTALL)),
+        *(m.group(1) for m in re.finditer(r"(\{.*\})", candidate, re.DOTALL)),
+    ):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def resolve_cross_reviewer(mode: str, model: str | None = None) -> "GeminiCrossReviewer | None":
+    """Build the cross reviewer for a CLI mode, or None to leave the gate single-opinion."""
+    if mode == "off":
+        return None
+    reviewer = GeminiCrossReviewer(model=model)
+    if mode == "auto" and not reviewer.available():
+        return None
+    return reviewer

--- a/src/manager.py
+++ b/src/manager.py
@@ -15,6 +15,7 @@ from .bootstrap import (
     scan_corpus,
 )
 from .approval_agent import AutomatedReviewer, ReviewDecision
+from .cross_reviewer import GeminiCrossReviewer
 from .review_policy import load_policy, policy_summary, record_correction
 from .project_bootstrap import (
     format_project_context_for_prompt,
@@ -140,6 +141,7 @@ class ResearchManager:
         web_search_context: str | None = None,
         web_search_mode: str | None = None,
         artifact_roots: list[Path] | None = None,
+        cross_reviewer: GeminiCrossReviewer | None = None,
     ) -> None:
         self.project_root = project_root
         self.runs_dir = runs_dir
@@ -173,6 +175,9 @@ class ResearchManager:
         # Extra roots a stage may legitimately write to, beyond the run tree. A benchmark
         # workspace is one: its output contract points stages at paths outside runs/.
         self.artifact_roots = artifact_roots or []
+        # A veto-only second opinion from a different model family. Never overrides a
+        # refusal, so enabling it can only make the gate stricter.
+        self.cross_reviewer = cross_reviewer
         # Where a stage's machine-readable output may legitimately land outside the run
         # tree. The benchmark's read-only data/ is excluded on purpose: it is always
         # populated, so counting it would make the stage-03 gate vacuous.
@@ -1870,7 +1875,87 @@ class ResearchManager:
         self._record_review_correction(
             paths=paths, stage=stage, attempt_no=attempt_no, decision=decision, suggestions=suggestions
         )
+
+        cross = self._apply_cross_review(
+            paths=paths, stage=stage, attempt_no=attempt_no, decision=decision,
+            stage_markdown=stage_markdown,
+        )
+        if cross is not None:
+            return cross
+
         return decision.choice, decision.feedback or None
+
+    def _apply_cross_review(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        decision: ReviewDecision,
+        stage_markdown: str,
+    ) -> tuple[str, str | None] | None:
+        """Let an independent model family veto an approval.
+
+        Returns a replacement decision when the audit refuses, or None to leave the
+        primary's decision standing. Only approvals are audited: a refusal already sends
+        the stage back, so a second opinion on it would change nothing.
+        """
+        if self.cross_reviewer is None or decision.choice != "5":
+            return None
+
+        self.ui.show_status("Cross-model reviewer is auditing the approval...", level="info")
+        verdict = self.cross_reviewer.audit(
+            paths=paths,
+            stage=stage,
+            stage_markdown=stage_markdown,
+            primary_reason=decision.reason,
+            primary_model=self.review_model,
+        )
+
+        append_log_entry(
+            paths.logs,
+            f"{stage.slug} attempt {attempt_no} cross_review",
+            "\n".join(
+                [
+                    f"model: {verdict.model or 'unavailable'}",
+                    f"agrees: {verdict.agrees}",
+                    f"unavailable: {verdict.unavailable}",
+                    f"reason: {verdict.reason}",
+                ]
+            ),
+        )
+
+        if verdict.unavailable:
+            # Not agreement — the audit did not happen. Said plainly so a run whose
+            # cross-review silently never ran cannot be mistaken for one that passed it.
+            self.ui.show_status(
+                f"Cross-model review did not run: {verdict.reason}", level="warn"
+            )
+            return None
+
+        if not verdict.vetoes:
+            self.ui.show_status(
+                f"Cross-model reviewer ({verdict.model}) agrees with the approval.", level="success"
+            )
+            return None
+
+        self.ui.show_status(
+            f"Cross-model reviewer ({verdict.model}) vetoed the approval: {verdict.reason}",
+            level="warn",
+        )
+        record_correction(
+            paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            text=f"Cross-model review vetoed an approval of {stage.stage_title}: {verdict.reason}",
+            source="rollback",
+        )
+        feedback = (
+            "An independent reviewer from a different model family rejected the approval of "
+            "this stage. Address this before it can be approved again:\n"
+            f"{verdict.reason}"
+        )
+        return "4", feedback
 
     def _record_review_correction(
         self,

--- a/tests/test_cross_reviewer.py
+++ b/tests/test_cross_reviewer.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.approval_agent import ReviewDecision
+from src.cross_reviewer import (
+    DEFAULT_CROSS_REVIEW_MODEL,
+    MIN_REASON_CHARS,
+    CrossVerdict,
+    GeminiCrossReviewer,
+    resolve_cross_reviewer,
+)
+from src.manager import ResearchManager
+from src.review_policy import load_policy
+from src.terminal_ui import TerminalUI
+from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
+from src.web_search import SearchBackend
+
+
+STAGE_01 = STAGES[0]
+GOOD_REASON = "The summary reports an AUROC of 0.99 with no method or data split stated anywhere."
+
+
+class ParseTest(unittest.TestCase):
+    def test_a_plain_agreement_parses(self) -> None:
+        v = GeminiCrossReviewer.parse('{"verdict":"agree","reason":"consistent"}')
+        self.assertTrue(v.agrees)
+        self.assertFalse(v.vetoes)
+        self.assertFalse(v.unavailable)
+
+    def test_a_substantiated_refusal_vetoes(self) -> None:
+        v = GeminiCrossReviewer.parse('{"verdict":"refuse","reason":"%s"}' % GOOD_REASON)
+        self.assertTrue(v.vetoes)
+        self.assertIn("AUROC", v.reason)
+
+    def test_refusal_synonyms_all_veto(self) -> None:
+        for token in ("refuse", "reject", "disagree", "block", "veto", "REFUSE"):
+            v = GeminiCrossReviewer.parse('{"verdict":"%s","reason":"%s"}' % (token, GOOD_REASON))
+            self.assertTrue(v.vetoes, token)
+
+    def test_a_fenced_response_parses(self) -> None:
+        raw = 'Here is my verdict:\n```json\n{"verdict":"refuse","reason":"%s"}\n```\n' % GOOD_REASON
+        self.assertTrue(GeminiCrossReviewer.parse(raw).vetoes)
+
+    def test_an_unsubstantiated_refusal_is_ignored(self) -> None:
+        """A veto must justify itself, or good work gets bounced on a shrug."""
+        v = GeminiCrossReviewer.parse('{"verdict":"refuse","reason":"bad"}')
+        self.assertFalse(v.vetoes)
+        self.assertIn("no substantive reason", v.reason)
+
+    def test_the_reason_floor_is_exercised_at_the_boundary(self) -> None:
+        under = "x" * (MIN_REASON_CHARS - 1)
+        over = "y" * MIN_REASON_CHARS
+        self.assertFalse(GeminiCrossReviewer.parse('{"verdict":"refuse","reason":"%s"}' % under).vetoes)
+        self.assertTrue(GeminiCrossReviewer.parse('{"verdict":"refuse","reason":"%s"}' % over).vetoes)
+
+    def test_garbage_is_unavailable_not_agreement(self) -> None:
+        """Silence must not be laundered into a passed audit."""
+        v = GeminiCrossReviewer.parse("the model rambled and returned no json")
+        self.assertTrue(v.unavailable)
+        self.assertFalse(v.vetoes)
+
+    def test_an_empty_response_is_unavailable(self) -> None:
+        self.assertTrue(GeminiCrossReviewer.parse("").unavailable)
+
+    def test_an_unknown_verdict_token_is_treated_as_agreement(self) -> None:
+        # Only an explicit refusal blocks; anything else must not silently veto.
+        self.assertFalse(GeminiCrossReviewer.parse('{"verdict":"maybe","reason":"x"}').vetoes)
+
+
+class AvailabilityTest(unittest.TestCase):
+    def _no_backend(self):
+        return patch("src.cross_reviewer.resolve_backend", return_value=None)
+
+    def _backend(self):
+        return patch(
+            "src.cross_reviewer.resolve_backend",
+            return_value=SearchBackend(kind="vertex", model="gemini-x", project="p", location="global"),
+        )
+
+    def test_auto_is_off_without_a_backend(self) -> None:
+        with self._no_backend():
+            self.assertIsNone(resolve_cross_reviewer("auto"))
+
+    def test_auto_is_on_with_a_backend(self) -> None:
+        with self._backend():
+            self.assertIsNotNone(resolve_cross_reviewer("auto"))
+
+    def test_off_is_always_off(self) -> None:
+        with self._backend():
+            self.assertIsNone(resolve_cross_reviewer("off"))
+
+    def test_the_default_model_is_not_the_cheap_search_model(self) -> None:
+        """A reviewer auditing frontier output should not be the flash-tier search model."""
+        from src.web_search import DEFAULT_SEARCH_MODEL, DEFAULT_VERTEX_SEARCH_MODEL
+
+        self.assertNotIn(DEFAULT_CROSS_REVIEW_MODEL, {DEFAULT_SEARCH_MODEL, DEFAULT_VERTEX_SEARCH_MODEL})
+
+    def test_an_unconfigured_audit_reports_unavailable_not_agreement(self) -> None:
+        with self._no_backend():
+            reviewer = GeminiCrossReviewer()
+            with tempfile.TemporaryDirectory() as tmp:
+                paths = build_run_paths(Path(tmp) / "run")
+                ensure_run_layout(paths)
+                verdict = reviewer.audit(
+                    paths=paths, stage=STAGE_01, stage_markdown="# Stage 01: Literature Survey\n",
+                    primary_reason="fine", primary_model="opus",
+                )
+        self.assertTrue(verdict.unavailable)
+        self.assertFalse(verdict.vetoes)
+
+
+class StubOperator:
+    model = "opus"
+    backend_name = "claude"
+
+
+class VetoWiringTest(unittest.TestCase):
+    """The veto must be able to send a stage back, and must never do the opposite."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.memory, "# Memory\n")
+
+    def _manager(self, verdict: CrossVerdict | None) -> ResearchManager:
+        reviewer = None
+        if verdict is not None:
+            reviewer = GeminiCrossReviewer()
+            reviewer.audit = lambda **kwargs: verdict  # type: ignore[assignment]
+        return ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=self.paths.run_root.parent,
+            operator=StubOperator(),
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+            cross_reviewer=reviewer,
+        )
+
+    def _apply(self, verdict, choice="5"):
+        return self._manager(verdict)._apply_cross_review(
+            paths=self.paths, stage=STAGE_01, attempt_no=1,
+            decision=ReviewDecision(choice=choice, decision_token="t", reason="approved"),
+            stage_markdown="# Stage 01: Literature Survey\n",
+        )
+
+    def test_a_veto_turns_an_approval_into_a_refinement(self) -> None:
+        result = self._apply(CrossVerdict(agrees=False, reason=GOOD_REASON, model="gemini-x"))
+        self.assertIsNotNone(result)
+        choice, feedback = result
+        self.assertEqual(choice, "4")
+        self.assertIn(GOOD_REASON, feedback)
+
+    def test_agreement_leaves_the_approval_standing(self) -> None:
+        self.assertIsNone(self._apply(CrossVerdict(agrees=True, model="gemini-x")))
+
+    def test_an_unavailable_audit_leaves_the_approval_standing(self) -> None:
+        self.assertIsNone(self._apply(CrossVerdict(agrees=True, unavailable=True, reason="no backend")))
+
+    def test_a_refusal_is_never_audited(self) -> None:
+        """It is a veto, never an override: it must not be able to rescue a refusal."""
+        for refusal in ("1", "2", "3", "4", "6"):
+            self.assertIsNone(
+                self._apply(CrossVerdict(agrees=False, reason=GOOD_REASON), choice=refusal),
+                refusal,
+            )
+
+    def test_no_cross_reviewer_means_no_change(self) -> None:
+        self.assertIsNone(self._apply(None))
+
+    def test_a_veto_becomes_a_standing_rule(self) -> None:
+        """A blind spot caught once must be checked on every stage afterwards."""
+        self._apply(CrossVerdict(agrees=False, reason=GOOD_REASON, model="gemini-x"))
+        rules = load_policy(self.paths).rules
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0].source, "rollback")
+        self.assertIn(GOOD_REASON, rules[0].text)
+
+    def test_every_outcome_is_written_to_the_run_log(self) -> None:
+        self._apply(CrossVerdict(agrees=True, model="gemini-x"))
+        self.assertIn("cross_review", read_text(self.paths.logs))
+
+    def test_an_unavailable_audit_is_logged_as_unavailable(self) -> None:
+        self._apply(CrossVerdict(agrees=True, unavailable=True, reason="backend down"))
+        log = read_text(self.paths.logs)
+        self.assertIn("unavailable: True", log)
+
+
+class AuditPacketTest(unittest.TestCase):
+    """An absent excerpt is a limit of the packet, never evidence of a missing artifact."""
+
+    def test_an_absent_artifact_renders_as_a_disclaimer_not_as_missing(self) -> None:
+        from src.cross_reviewer import NOT_INCLUDED, _excerpt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rendered = _excerpt(Path(tmp) / "absent.json", 100)
+        self.assertEqual(rendered, NOT_INCLUDED)
+        self.assertNotIn("missing", rendered.split("—")[0].lower())
+
+    def test_an_empty_artifact_renders_the_same_way(self) -> None:
+        from src.cross_reviewer import NOT_INCLUDED, _excerpt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "empty.json"
+            path.write_text("   ", encoding="utf-8")
+            self.assertEqual(_excerpt(path, 100), NOT_INCLUDED)
+
+    def test_present_content_is_included(self) -> None:
+        from src.cross_reviewer import _excerpt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "index.json"
+            path.write_text('{"artifacts": 3}', encoding="utf-8")
+            self.assertIn("artifacts", _excerpt(path, 100))
+
+
+class PromptTest(unittest.TestCase):
+    def test_the_prompt_frames_the_shared_blind_spot_and_forbids_style_vetoes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = build_run_paths(Path(tmp) / "run")
+            ensure_run_layout(paths)
+            write_text(paths.user_input, "study the data")
+            prompt = GeminiCrossReviewer().build_prompt(
+                paths=paths, stage=STAGE_01,
+                stage_markdown="# Stage 01: Literature Survey\n\nclaims here",
+                primary_reason="looks thorough", primary_model="opus",
+            )
+        self.assertIn("different model family", prompt)
+        self.assertIn("looks thorough", prompt)
+        self.assertIn("Do not refuse over style", prompt)
+        # A section absent from the packet must not read as a missing artifact. Testing
+        # showed the auditor veto sound work on exactly this confusion.
+        self.assertIn("not included in this audit packet", prompt)
+        self.assertIn("never infer from it that the approving reviewer fabricated", prompt)
+        # It must not be asked to verify files it cannot reach.
+        self.assertIn("You have no", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The approval gate is strong but **not independent**. It runs a coding agent with tools, so it can re-read a paper and re-execute an analysis before judging — and in the pilot runs it did exactly that. But it is the same model family as the executor, usually the same model. Opus judging opus shares the blind spots that produced the work, which is precisely what a review exists to catch.

When the primary reviewer **approves**, a Gemini reviewer now reads the same evidence and decides whether that approval is defensible.

## Two deliberate asymmetries

- **It only audits approvals.** A refusal already sends the stage back, so a second opinion on one changes nothing and costs a call.
- **It is a veto, never an override.** It cannot approve anything the primary refused, so adding it can only make the gate *stricter*. That is what makes `--cross-review auto` safe to enable whenever a Gemini backend resolves.

## Unavailable ≠ agreement

An auditor that errors, has no backend, or returns unparseable output is recorded as **unavailable**, not as agreement — otherwise a broken audit reads as a passed one, and a run whose cross-review silently never ran looks identical to one that survived it.

Symmetrically, a refusal with **no substantive reason** is ignored: a veto has to be actionable, or it just bounces good work on a shrug.

## Verified live, both directions

Against `gemini-3.1-pro-preview` on Vertex:

```
BAD  → vetoed: "The approval is a generic rubber-stamp that ignores major defects.
        The stage claims to be a 'Literature Survey' but reports novel, unsupported
        experimental results ('Our method achieves 99.4% accuracy')..."
GOOD → agreed
```

**The good-work control failed on the first attempt, and that is the most useful thing in this PR.** The auditor vetoed sound work because the artifact-index section *of its own prompt* was empty, and it read that as proof the approving reviewer had hallucinated the files. An absent excerpt is a limit of the audit packet, not evidence about the run. The packet now says so explicitly and the prompt forbids the inference.

Without that control this would have shipped as a veto that fires on almost everything — a feature that looks rigorous and quietly destroys every run. The regression is pinned by tests.

## Composition

A cross-model veto is recorded as a standing rule by #121, so a blind spot caught once is checked on every stage afterwards. The two features are the same loop at different scopes: one learns within a model family, the other imports judgement from outside it.

752 tests pass, 26 new — including that a refusal is *never* audited (proving the veto cannot rescue one), that unavailable and agreement stay distinct in the log, and that an absent excerpt renders as a disclaimer rather than as "missing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)