### PR TITLE
Make the stages a graph the run navigates, and the drafts something it can improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Execution model | A coding agent as the execution layer, AutoR as the research control loop |
 | Control model | Human approval by default, with an optional strict reviewer-agent gate for unattended runs |
 | Research unit | A reproducible run under `runs/<run_id>/` |
-| Workflow shape | 9-stage workflow: optional intake plus eight formal research stages |
+| Workflow shape | Nine stages as a **directed graph** the run navigates; the linear sequence is one path through it |
+| Improvement | Drafts are measured and ratcheted, so a stage can only get better — and the score is blind to what the run concluded |
 | Quality bar | Artifact-backed outputs, not markdown-only summaries |
 | Recovery | Resume, redo-stage, rollback-stage, stage-local continuation |
 
@@ -90,6 +91,10 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Layer | Highlight | What AutoR actually does |
 | --- | --- | --- |
 | Big idea | **Human-centered research execution** | AutoR is not an autonomous scientist. AI handles execution; humans retain approval and direction at every stage boundary. |
+| Big idea | **The stages are a graph, not a list** | Analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it. AutoR computes which moves are open by checking artifacts on disk; the agent chooses among those and says why. [Details](docs/self-improvement.md) |
+| Big idea | **Improvement that is measured, not hoped for** | A refinement round is scored against a rigour rubric read off disk. The best-scoring draft is what gets promoted; a round that scores worse is reverted. A stage can only improve. |
+| Big idea | **Self-improvement that cannot p-hack** | The fitness function is blind to what the run concluded — a refuted hypothesis with clean evidence outscores a supported one resting on an assertion — and any round that moves a hypothesis verdict is rejected outright. |
+| Big idea | **The harness learns across runs** | An optional archive compares each graph edge against runs that reached the same node and did not take it, and reorders which move is preferred. It can never open a guarded edge. |
 | Big idea | **Research loop over agent loop** | The system manages stage progression, validation, repair, recovery, and human checkpoints above the lower-level agent execution loop. |
 | Big idea | **Every run is a reproducible research artifact** | Each run leaves behind prompts, logs, approved summaries, code, data, figures, writing sources, and packaged outputs under `runs/<run_id>/`. |
 | Big idea | **Verifiable outputs, not paper-shaped theater** | The workflow is judged by inspectable artifacts and human approval, not by whether a generated document merely looks polished. |
@@ -133,6 +138,7 @@ It is:
 
 Latest mainline updates:
 
+- **2026-08-06**: Added recursive self-improvement. The nine stages are now a **directed graph** the run navigates (`--stage-graph adaptive`), with the agent choosing the move out of each node among the ones AutoR's guards leave open (`--routing auto`). Stage drafts are scored against a rigour rubric read off disk and iterated under a champion ratchet, so a stage can only improve (`--evolve`); a round that scores worse is reverted, and a round that changes a hypothesis verdict is rejected outright. An optional cross-run archive learns which moves pay (`--archive`). All of it is off by default: a run that passes none of these flags walks 01 through 08 exactly as before, through the same engine. See [Recursive Self-Improvement](docs/self-improvement.md).
 - **2026-06-02**: Added a configurable Codex sandbox mode. Codex-backed runs still default to `workspace-write`, but users who intentionally need remote GPU or SSH execution can now opt into `--codex-sandbox danger-full-access`; the setting is persisted in `run_config.json` and preserved on resume.
 - **2026-05-10**: Refined the terminal-first run experience. Stage 00 now uses a dedicated clarification flow: the first intake pass asks the user questions one by one with selectable options, custom answers, and skip; the revised intake brief then uses a compact refine / approve / abort menu instead of showing the normal suggestion template. The terminal UI also keeps colored frames on wrapped body rows, handles long lines and wide characters more reliably, and the Codex backend now uses the current `--sandbox workspace-write` execution flag instead of the deprecated Codex CLI `--full-auto` flag.
 - **2026-04-20**: Added an optional `--full-auto` approval mode. The execution loop is unchanged, but the manual approval gate can now be replaced by a strict simulated reviewer agent backed by Claude or Codex, with reviewer settings persisted in `run_config.json`.
@@ -318,6 +324,21 @@ For Codex-backed runs, AutoR defaults to `--codex-sandbox workspace-write`. If a
 
 Valid stage identifiers include `03`, `3`, and `03_study_design`.
 
+```bash
+# Let the run navigate its own topology: backward moves enabled, agent routing.
+python main.py --goal "..." --stage-graph adaptive --routing auto
+
+# Measured self-improvement rounds inside each stage.
+python main.py --goal "..." --evolve --evolve-rounds 3
+
+# Everything, plus a cross-run archive that learns which moves pay.
+python main.py --goal "..." --stage-graph adaptive --routing auto \
+               --evolve --archive ~/.autor/archive
+
+# What the archive has learned so far.
+python main.py --archive ~/.autor/archive --archive-report
+```
+
 ### Studio (browser UI)
 
 AutoR Studio is a local web UI that drives the same real Claude-backed pipeline through a browser instead of a terminal. Human-in-the-loop approval, feedback, stage re-runs, live session traces, and the compiled paper all live in one page.
@@ -432,6 +453,64 @@ flowchart TD
     H8 -- Approve --> Z[Run complete]
     H8 -- Abort --> X
 ```
+
+### The Stage Graph
+
+The nine stages are nodes in a directed graph. The default topology has one edge
+out of each node, which is the sequence above. `--stage-graph adaptive` adds the
+backward moves, and the run chooses.
+
+```mermaid
+flowchart LR
+    S1[01 Literature] --> S2[02 Hypotheses]
+    S2 --> S3[03 Design]
+    S3 --> S4[04 Implementation]
+    S4 --> S5[05 Experiments]
+    S5 --> S6[06 Analysis]
+    S6 -->|guard: every hypothesis adjudicated| S7[07 Writing]
+    S7 --> S8[08 Dissemination]
+    S8 --> Z([finish])
+
+    S4 -.->|not executable as specified| S3
+    S5 -.->|comparison cannot distinguish| S3
+    S5 -.->|implementation is at fault| S4
+    S6 -.->|results insufficient to decide| S5
+    S6 -.->|confound the results cannot repair| S3
+    S6 -.->|evidence refutes, and points somewhere| S2
+    S7 -.->|claim has no analysis behind it| S6
+    S7 -.->|needs a result never produced| S5
+    S8 -.->|deliverable is not what a reader needs| S7
+```
+
+Solid edges advance, dotted edges go back. The move into Stage 07 is guarded: the
+hypotheses have to be frozen and every one of them adjudicated before anything can
+be written up. That check is over artifacts on disk, so it is not something an
+agent can argue its way past — a gated edge is simply not on the menu it chooses
+from.
+
+A refusal or a routing failure falls back to the forward edge, so the worst case
+is the linear pipeline rather than a stall. Two budgets bound the walk:
+`--graph-max-visits` per stage and `--graph-max-steps` overall.
+
+### Self-Improvement Rounds
+
+With `--evolve`, a stage that produces a valid draft is measured against a rigour
+rubric read off disk — do the paths it names resolve, do the numbers it reports
+appear in a results file, did it produce artifacts during *this* execution, is the
+decision ledger four different things. AutoR then spends further rounds targeting
+the criteria that lost points.
+
+The best-scoring draft is what gets promoted. A round that scores worse is
+reverted, so a stage can only improve. A round that changes a hypothesis verdict
+is rejected outright, whatever it scored — the rubric is blind to what the run
+concluded, which removes the incentive, and the drift check removes the
+possibility.
+
+A revision a *human* asked for always stands. The ratchet governs AutoR's own
+rounds, not the direction it is given.
+
+Full mechanism, and the reasoning behind each refusal, in
+[docs/self-improvement.md](docs/self-improvement.md).
 
 ### Stage Attempt Loop
 
@@ -754,6 +833,11 @@ A run with only markdown notes does not pass validation.
 
 - optional intake stage and resource ingestion
 - 9-stage workflow: optional intake plus eight formal research stages
+- the stages as a navigable directed graph, with guarded backward moves
+- agent-chosen routing constrained to the moves the guards leave open
+- measured self-improvement rounds under a champion ratchet
+- an outcome-blind rigour rubric, and verdict-drift rejection
+- an optional cross-run archive of topology variants and edge payoffs
 - mandatory human approval after every stage
 - Claude Code or Codex as the execution layer
 - Stage 00 clarification Q&A plus a compact intake approval flow
@@ -796,6 +880,7 @@ The [docs/](docs/) directory is the reference documentation. This README is the 
 | [Run Artifacts](docs/run-artifacts.md) | The run directory, file by file, and the schema of every machine-readable artifact. |
 | [Stage Contract](docs/stage-contract.md) | Exactly what a stage must produce to be accepted, as the code enforces it. |
 | [Studio Guide & API](docs/studio.md) | The browser workspace and its complete HTTP API. |
+| [Recursive Self-Improvement](docs/self-improvement.md) | The stage graph, routing, the rigour rubric and the champion ratchet, the cross-run archive — and the constraint that keeps a scored loop from becoming an automated p-hacker. |
 | [ResearchClawBench](docs/researchclawbench.md) | Running with no human in the loop: unattended execution, the benchmark adapter and its output contract, and Gemini-backed web search. |
 | [ResearchClawBench Landscape](docs/researchclawbench-landscape.md) | How EvoScientist, ARIS Codex and MIRA actually score on the benchmark, which reported numbers reproduce, and the baseline any result must be quoted against. |
 
@@ -830,6 +915,7 @@ The most valuable next steps are the ones that make AutoR more like a real resea
 
 Implemented milestone:
 
+- ~~Recursive self-improvement.~~ The stages are a directed graph the run navigates, stage drafts are measured and ratcheted so a stage can only improve, and an optional archive learns which moves pay across runs. Implemented in `src/stage_graph.py`, `src/router.py`, `src/rubric.py`, `src/evolution.py`, `src/pareto.py` and `src/archive.py`; see [docs/self-improvement.md](docs/self-improvement.md).
 - ~~Stage-local continuation sessions.~~ Keep one Claude conversation per stage, reuse it for `1/2/3/4` refinement, and fall back to a fresh session only when resume fails. This is now implemented in the operator and manager flow.
 - ~~Artifact-level validation for non-toy outputs.~~ Enforce machine-readable data, result files, figures, LaTeX sources, PDF output, and review artifacts at the right stages. This is now part of the workflow validation path.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -190,6 +190,23 @@ Neither flag does anything without `--resume-run`.
 | `--project-root PATH` | — | Scan an existing project repository, infer how far it has already progressed, and recommend a re-entry stage. Use this instead of starting from zero on work you already have. |
 | `--paper-corpus PATH` | — | Scan a directory of your own prior papers (PDF, LaTeX, BibTeX, notes) to build a researcher profile — topics, citation neighborhood, and writing style — that seeds downstream stages. |
 
+### Stage graph and self-improvement
+
+All of these are off by default. See [Recursive Self-Improvement](self-improvement.md)
+for the mechanism and the reasoning behind each refusal.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--stage-graph {linear,adaptive}` | `linear` | How the run moves between stages. `linear` is one edge out of each node, which is the sequence AutoR has always run. `adaptive` adds ten backward moves, so an analysis that exposes a design flaw can send the run to Stage 03 instead of writing up around it. The move into Stage 07 is guarded on every hypothesis having a verdict. Preserved on resume. |
+| `--routing {off,auto,agent}` | `off` | Who chooses the move out of a completed stage. `off` always takes the graph's default edge. `auto` asks the backend wherever more than one move is live — on a linear graph that is never, so it costs nothing there. `agent` asks at every node. AutoR decides which moves are available by evaluating guards against artifacts on disk; the backend only chooses among those, and a choice outside the menu falls back to the forward edge. Preserved on resume. |
+| `--graph-max-steps N` | `20` | Stage executions allowed in one walk. Only bites in adaptive mode; a linear walk cannot exceed eight. |
+| `--graph-max-visits N` | `3` | Times one stage may be entered. A revisit is a productive move; the fourth entry into the same stage is a loop. |
+| `--evolve` | off | Score each valid stage draft against a rigour rubric read off disk, then spend further rounds targeting the criteria that lost points. The best-scoring draft is promoted; a round that scores worse is reverted. A round that changes a hypothesis verdict is rejected outright. A revision a human asked for always stands. |
+| `--evolve-rounds N` | `3` with `--evolve` | Self-improvement rounds per stage. Implies `--evolve` when above zero. Budgeted separately from `--max-attempts`, which bounds a stage that is *failing* rather than one being improved. Rounds also stop after two consecutive rounds with no gain. Preserved on resume. |
+| `--evolve-stages STAGE [STAGE ...]` | all | Restrict self-improvement to these stage slugs or numbers, e.g. `06_analysis` or `5 6 7`. |
+| `--archive PATH` | — | Directory holding the cross-run topology archive. AutoR records this run's route and measured fitness there, compares each edge against runs that reached the same node and did not take it, and samples the topology it runs from what the archive has learned. Requires `--evolve`, which is what produces the fitness. A learned prior only reorders which move is preferred; it can never open a guarded edge. |
+| `--archive-report` | off | Print what the archive at `--archive` has learned, and exit. |
+
 ### Optional enhancements
 
 | Flag | Default | Description |

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -17,7 +17,7 @@ runs/<run_id>/
 ├── .claude/skills/             # agent skills, installed from src/skills/ (this is the operator's cwd)
 ├── user_input.txt              # the original research goal, verbatim
 ├── memory.md                   # approved cross-stage memory (the only shared context)
-├── run_config.json             # backend, model, venue, approval mode, sandbox
+├── run_config.json             # backend, model, venue, approval mode, sandbox, stage graph
 ├── run_manifest.json           # stage lifecycle state — the machine-readable source of truth
 ├── artifact_index.json         # index over workspace/{data,results,figures}
 ├── intake_context.json         # Stage 00 Q&A, ingested resources, refined goal
@@ -26,6 +26,7 @@ runs/<run_id>/
 ├── prompt_cache/               # the exact prompt sent for every attempt
 ├── operator_state/             # per-stage session IDs, attempt state, start markers
 ├── handoff/                    # compressed per-stage handoff summaries
+├── evolution/                  # stage graph route, rubric scores, champions, candidates (--evolve / --stage-graph)
 ├── stages/                     # stage summaries: <slug>.tmp.md draft, <slug>.md approved
 ├── notebook/                   # Studio Notebook session and transcript (Studio runs only)
 ├── sessions/                   # Studio trace events per stage (Studio runs only)
@@ -83,6 +84,9 @@ The settings the run was started with, so a resume reproduces them.
   "review_operator": "claude",
   "review_model": "sonnet",
   "codex_sandbox": "workspace-write",
+  "stage_graph": "linear",
+  "routing_mode": "off",
+  "evolve_rounds": 0,
   "created_at": "2026-03-30T10:12:22"
 }
 ```
@@ -97,6 +101,9 @@ The settings the run was started with, so a resume reproduces them.
 | `review_operator` | `claude` or `codex`; defaults to `operator`. |
 | `review_model` | Reviewer model; defaults to `sonnet` (Claude) or `default` (Codex). |
 | `codex_sandbox` | `read-only`, `workspace-write`, or `danger-full-access`. |
+| `stage_graph` | `linear` (default) or `adaptive`. See [Recursive Self-Improvement](self-improvement.md). |
+| `routing_mode` | `off` (default), `auto`, or `agent`. Who chooses the move out of a completed stage. |
+| `evolve_rounds` | Self-improvement rounds per stage; `0` is off. |
 | `created_at` | ISO-8601 to the second. Preserved across rewrites. |
 
 A missing or corrupt file falls back to defaults rather than failing the run.
@@ -332,6 +339,25 @@ At most the four most recent handoffs before the current stage are injected
 into a prompt, and the `Decision Ledger` section is stripped from that
 injection — the ledger is kept on disk for audit, not spent on context. This
 is what keeps long runs from growing their prompts without bound.
+
+### `evolution/`
+
+Written only when `--evolve` or a non-linear `--stage-graph` is in use. Outside
+`workspace/` on purpose: this records *how* the run reached its answer, not part of
+the answer, and a benchmark export that swept it up would ship the losing drafts
+alongside the report.
+
+| Path | Contents |
+| --- | --- |
+| `stage_graph.json` | Every visit: the stage, when it was entered and left, the move chosen out of it, its kind, the stated reason, what AutoR would have chosen, whether the agent chose it, and the rubric total at the time. |
+| `improvement_ledger.jsonl` | One row per measured round: stage, attempt, per-criterion scores, delta against the champion, the verdict (`first`, `promoted`, `frontier`, `regressed`, `directed`, `verdict_drift`), whether the draft was reverted, and the verdict digest. |
+| `routing_refusals.jsonl` | Every agent routing choice AutoR refused, why, and which edge it fell back to. |
+| `summary.json` | The settled champion score per stage. This is what the cross-run archive reads. |
+| `<stage_slug>/champion.md` · `champion.json` | The best-scoring draft of that stage and its score. |
+| `<stage_slug>/frontier.json` | Non-dominated candidates, kept for merge rounds. |
+| `<stage_slug>/candidates/attempt_NN.md` · `.json` | Every candidate measured, **including the ones that lost**. A discarded draft is the only evidence that the ratchet discarded anything. |
+
+See [Recursive Self-Improvement](self-improvement.md).
 
 ### `workspace/`
 

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -1,0 +1,357 @@
+# Recursive self-improvement
+
+AutoR's stages are a directed graph the run navigates, its drafts are measured
+and ratcheted so a stage can only get better, and what it learns about its own
+topology accumulates across runs.
+
+This page is the whole mechanism: what each part does, what it refuses to do, and
+why the refusals are the load-bearing half.
+
+Everything here is off by default. A run that passes none of these flags walks 01
+through 08 exactly as it always did — through the same engine, which is what keeps
+the default path exercised by every test of the new one.
+
+```bash
+# The stages as a graph, with the agent choosing the move out of each node.
+python main.py --goal "..." --stage-graph adaptive --routing auto
+
+# Measured improvement rounds inside each stage.
+python main.py --goal "..." --evolve --evolve-rounds 3
+
+# Both, plus a cross-run archive that learns which moves pay.
+python main.py --goal "..." --stage-graph adaptive --routing auto \
+               --evolve --archive ~/.autor/archive
+
+# What the archive has learned so far.
+python main.py --archive ~/.autor/archive --archive-report
+```
+
+---
+
+## 1. The stage graph
+
+`src/stage_graph.py`
+
+Research is not a pipeline. Analysis finds that the experiment answered a
+different question than the one that was asked. Writing finds that a claim has no
+result behind it. Each of those is a *backward* move, and a linear stage list has
+no way to express one — so AutoR's response to "Stage 06 shows the design was
+wrong" was to write up the wrong design more carefully.
+
+Nodes are stages. Edges are the moves allowed between them.
+
+| Topology | Edges | Behaviour |
+| --- | --- | --- |
+| `linear` (default) | one advance edge out of each node | identical to the sequence AutoR has always run |
+| `adaptive` | the advance edges plus ten backward moves | the run can return to an earlier stage when a later one shows it has to |
+
+The backward edges exist for named research conditions, not as an error path:
+
+| Move | Taken when |
+| --- | --- |
+| `06 → 05` | the results are real but insufficient to decide a hypothesis |
+| `06 → 03` | the analysis exposed a confound the results cannot repair |
+| `06 → 02` | the evidence refutes the hypotheses and points somewhere specific |
+| `07 → 06` | a claim has no analysis behind it, or a figure does not show what the text says |
+| `07 → 05` | the write-up needs a result that was never produced |
+| `05 → 03` | running it showed the comparison cannot distinguish the hypotheses |
+| `04 → 03` | the design is not executable as specified |
+
+Full list in `REVISIT_EDGES`.
+
+### Guards
+
+Each edge carries a guard evaluated against artifacts on disk. The one that
+matters is on the edge into `07_writing`: **the hypotheses must be frozen and
+every one of them adjudicated.** Writing up before adjudication is how a
+manuscript ends up claiming a result the run never established, and an agent asked
+where to go next reaches for the deliverable.
+
+Guards apply in the adaptive topology only. On a linear graph there is one edge
+out of each node, so a guard could only halt the run, and the condition it would
+halt on is already a stage validation error with a better message. Two gates over
+one condition is one gate too many, and the one that fires second is the one
+nobody maintains.
+
+---
+
+## 2. Routing
+
+`src/router.py`
+
+`--routing auto` asks the backend to choose wherever more than one move is live.
+On a linear graph that is never, so `auto` costs nothing there. `--routing agent`
+asks at every node.
+
+The division of labour is the point:
+
+- **AutoR decides what is possible.** Guards are evaluated against disk. A gated
+  edge is not on the menu, however the agent argues for it.
+- **The agent decides what is sensible.** It has just done the work and is the only
+  party that knows whether the results decided anything.
+- **AutoR decides what happens when they disagree.** A choice outside the menu is
+  refused, recorded, and replaced by the default edge — which at every node is the
+  forward one, so a refusal degrades to the old pipeline rather than to a stall.
+
+Blocked moves are shown to the agent *with the reason they are blocked*. Hiding
+them is the more obvious design and it is the wrong one: an agent that can see
+"`07_writing` is closed because H2 has no verdict" routes to the analysis stage
+that would fix it. An agent shown only the open moves picks the best of them and
+never learns what it missed.
+
+Four refusals, each falling forward:
+
+| Refusal | Why |
+| --- | --- |
+| the move is blocked | a guard failed; the reason is attached |
+| the move does not exist | not an edge out of this node |
+| no reason given | "continue the workflow" is not a routing decision |
+| **the same reason twice** | the run has already gone back there on those grounds and it did not resolve; that is a loop, not an iteration |
+
+The last one is checked against the *recorded reason*, not a counter, so going
+back for a genuinely different reason is never penalised for the earlier trip.
+
+Two budgets bound the walk: `--graph-max-visits` (default 3) per stage, and
+`--graph-max-steps` (default 20) over the whole run.
+
+---
+
+## 3. Measured improvement rounds
+
+`src/rubric.py`, `src/evolution.py`, `src/pareto.py`
+
+AutoR already iterated: a reviewer asks for changes, the stage runs again, the new
+draft replaces the old one. Nothing compared the two. A refinement that dropped a
+resolving file reference or replaced a measured number with a hedge was promoted
+on exactly the same terms as one that fixed something. "Refine" was a hope.
+
+`--evolve` supplies the missing ordering.
+
+### The rubric
+
+Eight criteria, all read off disk rather than off the prose, so the score moves
+when the work moves and not when the wording does.
+
+| Criterion | Weight | Measures | From |
+| --- | --- | --- | --- |
+| `contract` | 2.0 | stage markdown contract errors | all stages |
+| `grounding` | 3.0 | every path the draft names resolves, and how much of the narrative is anchored in one | all stages |
+| `artifact_breadth` | 2.0 | artifact kinds written *during this stage's execution* | 03 |
+| `quantification` | 2.0 | findings in Key Results carrying numbers | 04 |
+| `numeric_fidelity` | 3.0 | **every reported number appears in a results artifact** | 05 |
+| `traceability` | 1.5 | the four decision-ledger buckets, filled and distinct | all stages |
+| `commitment` | 1.5 | reports completed work rather than intentions | all stages |
+| `reproducibility` | 3.0 | the machine-readable validity chain for this stage | all stages |
+
+`numeric_fidelity` is the deep-review check. It extracts every measurement the
+draft reports and looks for it in `workspace/results` and `workspace/data`,
+matching a percentage against its fraction (`74.1%` is satisfied by `0.741`) with
+a tolerance of half the last reported decimal. It catches the failure mode
+independent evaluations of automated science keep finding — a fluent write-up
+quoting metrics that exist nowhere in the run. Every other gate passes such a
+draft: the sections are present, the files it names exist, the prose is
+quantified. The number is simply invented.
+
+### The ratchet
+
+| Round outcome | What happens |
+| --- | --- |
+| `first` | the first measured draft becomes the champion |
+| `promoted` | beat the champion by at least `min_gain`; becomes the champion |
+| `frontier` | lost on the total but is the only draft holding some criterion; kept for a merge round, draft reverted |
+| `regressed` | no better; **the champion's markdown is written back over the draft** |
+| `verdict_drift` | the round changed what the run concluded; rejected outright |
+| `directed` | a human or the reviewer asked for this one; it stands whatever it measures |
+
+The champion is what gets promoted at approval — not the last draft. The reviewer
+and the human see the best candidate the run produced.
+
+`directed` matters as much as the rest. The ratchet governs AutoR's own polish
+rounds; it does not govern a person asking for a change. AutoR silently reverting
+a requested edit because a rubric preferred the previous wording would be the
+opposite of the arrangement this project is built on. The delta is still measured
+and written to the ledger, so the human keeps the decision and gets the number.
+
+### The directive
+
+A polish round is not told "make it better". It is told which criteria lost
+points, what was measured, and what would raise each one — and told to leave alone
+anything already at full marks, because a round aimed at a saturated criterion
+produces churn.
+
+When the Pareto frontier holds two drafts with complementary strengths and merging
+them has more headroom than fixing the champion's weakest criterion, the round
+becomes a **merge** instead: both candidates are on disk, the directive names what
+each one uniquely holds, and asks for the draft that keeps both.
+
+Every directive ends with the same prohibitions, because the ways a scored loop
+cheats are predictable: pad the prose, restate an unverified number more
+confidently, delete a weak section to raise an average, or move the finding.
+
+### Budgets
+
+Polish rounds are counted separately from `--max-attempts`, which bounds a stage
+that is *failing*. Charging improvement rounds to the repair budget would make a
+stage being made better look like one that was thrashing, and would leave nothing
+if a later round broke something.
+
+Rounds stop at `--evolve-rounds`, or after two consecutive rounds with no gain.
+Most stages are done after one targeted fix.
+
+---
+
+## 4. The cross-run archive
+
+`src/archive.py`
+
+A run that navigates its own topology produces something a linear pipeline never
+could: evidence about the topology. One run means nothing. Forty mean the backward
+edge out of Stage 06 is worth taking, and that is a fact about the harness.
+
+For each edge, the archive compares runs that took it against runs that **reached
+the same node and did not**. Comparing against the whole archive would credit the
+edge with the difference between runs that got as far as Stage 06 and runs that
+never did.
+
+```
+| Edge                            | Took | Mean  | Skipped | Mean  | Delta  | Believable |
+| 06_analysis->05_experimentation | 7    | 0.842 | 9       | 0.671 | +0.171 | yes        |
+| 07_writing->01_literature_survey| 1    | 0.910 | 15      | 0.706 | +0.204 | no         |
+```
+
+A believable payoff produces a child variant of the incumbent topology with **one
+edge's priority moved by one step** — enough to be attributable, which a variant
+that reshuffled five edges would not be. The child explains itself in the archive:
+the numbers that justified it are in its note.
+
+Three refusals hold this together:
+
+- **Below `min_observations` on each side, nothing is acted on.** A variant that
+  beat the incumbent once beat it once.
+- **Scores from different rubric versions are never compared.** A reweight would
+  otherwise read as every archived run having improved overnight.
+- **A learned prior can only reorder preferences.** It cannot open a guarded edge,
+  add an edge that was not declared, or remove one. The guards are the correctness
+  argument for letting an agent route at all, and the component that learns from
+  outcomes is exactly the one that must not be able to weaken them — the cheapest
+  way to raise mean fitness across an archive would be to stop checking whether
+  hypotheses were adjudicated before writing up.
+
+Parents are sampled by fitness with a novelty bonus for under-observed variants.
+Pure fitness-proportional sampling locks onto whatever won first and stops
+generating the observations that would overturn it.
+
+---
+
+## The constraint the whole design is built around
+
+A fitness function plus a loop is an optimiser. Point an optimiser at a research
+pipeline and the cheapest way to raise the score is to change the finding.
+
+`src/preregistration.py` already stops a human-driven version of that. A scored
+improvement loop would reintroduce it with a budget. So:
+
+**No criterion reads a verdict value.** Adjudication records are routed through
+`_verdict_blind_outcomes`, which strips the verdict before any scoring code can
+see it. Stage 06 is scored on whether every preregistered hypothesis carries a
+verdict backed by an artifact that exists — a hypothesis *refuted* cleanly with the
+evidence on disk scores higher than one supported on an assertion.
+
+**A round that moves a verdict is rejected.** Blindness removes the gradient; it
+does not remove the possibility. `verdict_digest` fingerprints the verdict set, and
+a polish round that changed it is reverted with a `verdict_drift` row in the
+ledger — regardless of what it scored. Since the rubric is blind, a rewritten
+conclusion scores the same, which is exactly why this check cannot be a score
+comparison.
+
+**The rubric is mechanical.** An LLM judge scoring drafts written by the same model
+family is a fitness function the optimiser can talk to, and the point of a ratchet
+is that it cannot be argued with. Qualitative judgement stays where it already is:
+the human, or the reviewer agent at the stage boundary, which now sees the best
+candidate instead of the most recent one.
+
+Both properties are tested end to end rather than argued for. `tests/test_rubric.py`
+flips every verdict on disk and asserts the total does not move; the neighbouring
+test asserts the digest does.
+
+---
+
+## What is on disk afterwards
+
+```
+runs/<run_id>/evolution/
+├── stage_graph.json              # every visit, the move out of it, who chose, the score
+├── improvement_ledger.jsonl      # one row per round: criteria, delta, verdict, note
+├── routing_refusals.jsonl        # every refused agent choice and what it fell back to
+├── summary.json                  # settled champion score per stage
+└── <stage_slug>/
+    ├── champion.md / champion.json
+    ├── frontier.json
+    └── candidates/attempt_NN.md  # including the ones that lost
+```
+
+The losing candidates are kept deliberately. A discarded draft is the only
+evidence that the ratchet discarded anything; without it, a run says "the champion
+scored 0.84" and there is no way to tell that from a run that only ever produced
+one draft.
+
+`evolution/` sits outside `workspace/` because it records how the run reached its
+answer, not part of the answer. A benchmark export that swept it up would ship the
+losing drafts alongside the report.
+
+---
+
+## Relation to prior work
+
+Four systems this builds on, and where the research-harness setting required
+something different.
+
+**Darwin Gödel Machine** (Zhang et al., [arXiv:2505.22954](https://arxiv.org/abs/2505.22954))
+— an archive of self-modified agents, empirical validation instead of proof,
+parents sampled from the archive rather than only the incumbent. AutoR keeps the
+arrangement and changes the unit of variation from agent source code to
+**topology**. A research harness people run on their own machines should not
+rewrite its own Python between runs; a topology is data, it diffs, it reverts, and
+it can be validated before it is used. Promotion is also stricter: a rigour score
+on a research run is noisier than a SWE-bench pass rate, so an improvement has to
+replay before it is believed.
+
+**GEPA** (Agrawal et al., [arXiv:2507.19457](https://arxiv.org/abs/2507.19457)) —
+natural-language reflection over execution traces in place of scalar reward, and a
+Pareto frontier so a specialist is not evicted by an average. AutoR's frontier is
+over **rigour criteria** rather than tasks, which fits a research stage better:
+there is one task, and the interesting variation is which dimension of it a draft
+got right. The reflective mutation is grounded in the criterion that lost points
+and the evidence for it, rather than in a free-form trace reading.
+
+**The AI Scientist v2 / v3** (Sakana AI) — tree search over candidates, and a deep
+reviewer that checks manuscript claims against raw numerical output. The candidate
+tree is here as the champion-plus-frontier, with losers kept. The deep reviewer is
+here as `numeric_fidelity`, made mechanical: a check that reads the results files
+cannot be talked out of a discrepancy.
+
+**ADAS / Meta Agent Search** (Hu et al., [arXiv:2408.08435](https://arxiv.org/abs/2408.08435))
+— a meta agent that writes new agent workflows in code, with an archive of
+successful designs. AutoR does the topology part online and typed: instead of a
+meta agent inventing a workflow offline, the graph is navigated at runtime with
+mechanically-checked guards, and the archive learns edge statistics from measured
+outcomes.
+
+The thing none of the four had to solve is the one this page keeps returning to.
+Each of them optimises against an external ground truth — a benchmark pass rate, a
+task score. Research has none, which is the whole problem. Substituting a rigour
+measurement for a quality judgement is what makes the loop safe to run, and making
+that measurement blind to the finding is what stops it becoming an automated
+p-hacker.
+
+---
+
+## Deliberate non-goals
+
+- **AutoR does not edit its own shipped Python.** The self-edit surface is the
+  topology. Prompt-template and skill overlays are the natural next surface and are
+  not implemented.
+- **No LLM judge in the fitness function.** See above.
+- **The archive does not tune prompts.** It learns about moves.
+- **A learned prior never touches a guard.** Stated three times on this page
+  because it is the property that would be most tempting to relax.

--- a/main.py
+++ b/main.py
@@ -16,6 +16,9 @@ from src.web_search import (
     resolve_web_search_context,
     web_search_notice,
 )
+from src.archive import Archive, resolve_graph
+from src.evolution import DEFAULT_ROUNDS, EvolutionConfig
+from src.stage_graph import DEFAULT_MAX_STEPS, DEFAULT_MAX_VISITS
 from src.utils import (
     CODEX_SANDBOX_CHOICES,
     DEFAULT_CODEX_SANDBOX,
@@ -23,6 +26,9 @@ from src.utils import (
     DEFAULT_VENUE,
     OUTPUT_FORMAT_CLI_CHOICES,
     MAX_STAGE_ATTEMPTS,
+    normalize_walk_settings,
+    ROUTING_MODE_CHOICES,
+    STAGE_GRAPH_CHOICES,
     STAGES,
     build_run_paths,
     load_run_config,
@@ -202,12 +208,133 @@ def parse_args() -> argparse.Namespace:
              "AutoR will analyze them to build a researcher profile that seeds downstream stages.",
     )
     parser.add_argument(
+        "--stage-graph",
+        choices=list(STAGE_GRAPH_CHOICES),
+        help=(
+            "How the run moves between stages. 'linear' (the default) runs 01 through 08 in "
+            "order, which is one edge out of every node. 'adaptive' adds the backward moves: "
+            "an analysis that exposes a design flaw can send the run back to Stage 03 instead "
+            "of writing up around it. Preserved when resuming."
+        ),
+    )
+    parser.add_argument(
+        "--routing",
+        choices=list(ROUTING_MODE_CHOICES),
+        help=(
+            "Who chooses the move out of a completed stage. 'off' (the default) always takes "
+            "the graph's default edge. 'auto' asks the backend wherever more than one move is "
+            "available, which on a linear graph is never. 'agent' asks at every node. AutoR "
+            "decides which moves are available by evaluating each edge's guard against the "
+            "artifacts on disk; the backend only chooses among those. Preserved when resuming."
+        ),
+    )
+    parser.add_argument(
+        "--graph-max-steps",
+        type=int,
+        help=(
+            f"Stage executions allowed in one graph walk before the run stops. Defaults to "
+            f"{DEFAULT_MAX_STEPS}. Only bites in adaptive mode; a linear walk cannot exceed "
+            "eight."
+        ),
+    )
+    parser.add_argument(
+        "--graph-max-visits",
+        type=int,
+        help=(
+            f"Times one stage may be entered. Defaults to {DEFAULT_MAX_VISITS}. A revisit is a "
+            "productive move; the fourth entry into the same stage is a loop."
+        ),
+    )
+    parser.add_argument(
+        "--evolve",
+        action="store_true",
+        help=(
+            "Turn on self-improvement rounds. After a stage produces a valid draft, AutoR scores "
+            "it against a rigour rubric read off disk, then spends up to --evolve-rounds further "
+            "rounds targeting the criteria that lost points. The best-scoring draft is what gets "
+            "promoted, and a round that scores worse is reverted, so a stage can only improve. "
+            "The score is blind to what the run concluded, and a round that changes a hypothesis "
+            "verdict is rejected outright."
+        ),
+    )
+    parser.add_argument(
+        "--evolve-rounds",
+        type=int,
+        help=(
+            f"Self-improvement rounds per stage. Implies --evolve when above zero. Defaults to "
+            f"{DEFAULT_ROUNDS} with --evolve. These rounds are budgeted separately from "
+            "--max-attempts, which bounds a stage that is failing rather than one being improved."
+        ),
+    )
+    parser.add_argument(
+        "--evolve-stages",
+        nargs="+",
+        metavar="STAGE",
+        help=(
+            "Restrict self-improvement to these stage slugs or numbers (for example '06_analysis' "
+            "or '5 6 7'). Defaults to every stage."
+        ),
+    )
+    parser.add_argument(
+        "--archive",
+        metavar="PATH",
+        help=(
+            "Directory holding the cross-run topology archive. When set, AutoR records this "
+            "run's route and measured fitness there, compares each graph edge against runs that "
+            "reached the same node and did not take it, and samples the topology it runs from "
+            "what the archive has learned. Requires --evolve, which is what produces the "
+            "fitness. A learned prior only reorders which move is preferred; it can never open "
+            "a guarded edge."
+        ),
+    )
+    parser.add_argument(
+        "--archive-report",
+        action="store_true",
+        help="Print what the archive at --archive has learned so far, and exit.",
+    )
+    parser.add_argument(
         "--stage-timeout",
         type=int,
         default=14400,
         help="Maximum seconds per stage attempt before timeout. Defaults to 14400 (4 hours).",
     )
     return parser.parse_args()
+
+
+def resolve_walk_settings(args: argparse.Namespace, existing: dict | None = None) -> dict:
+    """CLI flags over the resumed run's settings over the defaults.
+
+    A flag that was not passed must not overwrite what the run was started with,
+    which is why every one of these is checked for presence rather than read for
+    its value: `--stage-graph` defaults to None here, not to "linear", so resuming
+    an adaptive run without repeating the flag keeps it adaptive.
+    """
+    current = dict(existing or {})
+    if args.stage_graph:
+        current["stage_graph"] = args.stage_graph
+    if args.routing:
+        current["routing_mode"] = args.routing
+    if args.evolve_rounds is not None:
+        current["evolve_rounds"] = max(0, args.evolve_rounds)
+    elif args.evolve and not current.get("evolve_rounds"):
+        current["evolve_rounds"] = DEFAULT_ROUNDS
+    return normalize_walk_settings(current)
+
+
+def build_evolution_config(walk: dict, args: argparse.Namespace) -> EvolutionConfig:
+    rounds = int(walk["evolve_rounds"])
+    stages: tuple[str, ...] = ()
+    if args.evolve_stages:
+        resolved = [resolve_stage(value) for value in args.evolve_stages]
+        unknown = [
+            value for value, stage in zip(args.evolve_stages, resolved) if stage is None
+        ]
+        if unknown:
+            raise ValueError(
+                "--evolve-stages does not recognise: " + ", ".join(unknown)
+            )
+        stages = tuple(stage.slug for stage in resolved if stage is not None)
+    return EvolutionConfig(enabled=rounds > 0, rounds=rounds or DEFAULT_ROUNDS, stages=stages)
 
 
 def default_model_for_operator(operator_name: str) -> str:
@@ -336,12 +463,61 @@ def _build_resource_entries(paths: list[str]) -> list[ResourceEntry]:
     return entries
 
 
+def open_archive(args: argparse.Namespace) -> Archive | None:
+    return Archive(Path(args.archive).expanduser().resolve()) if args.archive else None
+
+
+def record_into_archive(
+    archive: Archive | None,
+    manager: ResearchManager,
+    variant_id: str,
+    ui: TerminalUI,
+) -> None:
+    """Fold a finished run into the archive, and let it propose and promote.
+
+    Recording is best-effort on purpose. An archive is a research aid; a failure to
+    write one must not turn a completed run into a failed command, because the run
+    already produced everything the operator asked for.
+    """
+    if archive is None or manager.last_run_paths is None:
+        return
+    try:
+        record = archive.record_run(manager.last_run_paths, variant_id=variant_id)
+        if record is None:
+            ui.show_status(
+                "Nothing was recorded in the archive: this run has no measured stages. "
+                "Pass --evolve so stages are scored.",
+                level="warn",
+            )
+            return
+        ui.show_status(
+            f"Archived {record.run_id} under variant `{variant_id}` "
+            f"(mean fitness {record.mean_fitness:.3f}, route: {record.route or 'n/a'}).",
+            level="info",
+        )
+        if archive.promote(variant_id):
+            ui.show_status(f"Variant `{variant_id}` has replayed its improvement and is promoted.", level="success")
+        proposal = archive.propose_variant()
+        if proposal is not None:
+            ui.show_status(f"Archive proposed `{proposal.variant_id}`: {proposal.note}", level="info")
+    except OSError as exc:
+        ui.show_status(f"Could not update the archive: {exc}", level="warn")
+
+
 def main() -> int:
     args = parse_args()
     repo_root = Path(__file__).resolve().parent
     runs_dir = repo_root / args.runs_dir
     unattended = resolve_unattended(args)
     ui = TerminalUI(interactive=not unattended)
+
+    if args.archive_report:
+        archive = open_archive(args)
+        if archive is None:
+            raise ValueError("--archive-report needs --archive PATH to say which archive to read.")
+        print(archive.report())
+        return 0
+
     ui.show_banner()
 
     # Assessed against the operator this run will actually use, because the sandbox the
@@ -402,6 +578,9 @@ def main() -> int:
             ) or default_model_for_operator(review_operator)
         venue = resolve_venue_key(args.venue or existing_config["venue"])
         output_format = resolve_output_format(args.output_format or existing_config.get("output_format"))
+        walk = resolve_walk_settings(args, existing_config)
+        archive = open_archive(args)
+        graph, variant_id = resolve_graph(archive, walk["stage_graph"])
         operator = create_operator(
             operator_name,
             model=model,
@@ -432,8 +611,13 @@ def main() -> int:
             max_auto_skips=args.max_auto_skips,
             max_stage_attempts=args.max_attempts,
             web_search_context=web_search_context,
+            stage_graph=graph,
+            routing_mode=walk["routing_mode"],
+            evolution=build_evolution_config(walk, args),
+            graph_max_steps=args.graph_max_steps,
+            graph_max_visits=args.graph_max_visits,
         )
-        return 0 if manager.resume_run(
+        completed = manager.resume_run(
             run_root,
             start_stage=start_stage or rollback_stage,
             venue=venue,
@@ -441,7 +625,9 @@ def main() -> int:
             research_diagram=args.research_diagram,
             output_format=output_format,
             final_stage=final_stage,
-        ) else 1
+        )
+        record_into_archive(archive, manager, variant_id, ui)
+        return 0 if completed else 1
 
     operator_name = (args.operator or "claude").strip().lower()
     model = args.model or default_model_for_operator(operator_name)
@@ -452,6 +638,9 @@ def main() -> int:
     venue = resolve_venue_key(args.venue or DEFAULT_VENUE)
     output_format = resolve_output_format(args.output_format or DEFAULT_OUTPUT_FORMAT)
     final_stage = resolve_stage(args.final_stage)
+    walk = resolve_walk_settings(args)
+    archive = open_archive(args)
+    graph, variant_id = resolve_graph(archive, walk["stage_graph"])
     operator = create_operator(
         operator_name,
         model=model,
@@ -482,6 +671,11 @@ def main() -> int:
         max_auto_skips=args.max_auto_skips,
         max_stage_attempts=args.max_attempts,
         web_search_context=web_search_context,
+        stage_graph=graph,
+        routing_mode=walk["routing_mode"],
+        evolution=build_evolution_config(walk, args),
+        graph_max_steps=args.graph_max_steps,
+        graph_max_visits=args.graph_max_visits,
     )
 
     goal = resolve_goal(args, unattended=unattended)
@@ -499,7 +693,7 @@ def main() -> int:
     project_root_arg = Path(args.project_root).expanduser().resolve() if args.project_root else None
     paper_corpus = Path(args.paper_corpus).expanduser().resolve() if args.paper_corpus else None
 
-    return 0 if manager.run(
+    completed = manager.run(
         goal,
         venue=venue,
         resources=resources or None,
@@ -509,7 +703,9 @@ def main() -> int:
         paper_corpus=paper_corpus,
         output_format=output_format,
         final_stage=final_stage,
-    ) else 1
+    )
+    record_into_archive(archive, manager, variant_id, ui)
+    return 0 if completed else 1
 
 
 if __name__ == "__main__":

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -42,6 +42,51 @@ DECISION_TO_CHOICE = {
 }
 
 
+def _try_load_json(text: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def extract_json_payload(raw_response: str) -> dict[str, Any] | None:
+    """Recover a JSON object from whatever a backend actually printed.
+
+    Shared with :mod:`src.router`, which asks a backend for a decision on the same
+    terms. Two copies of this would drift on the day one backend starts wrapping
+    its output differently, and the copy that was not updated would silently fall
+    back to its refusal path instead of reading a decision that was right there.
+    """
+    candidate = raw_response.strip()
+    if not candidate:
+        return None
+
+    direct = _try_load_json(candidate)
+    if direct is not None:
+        return direct
+
+    fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", candidate, flags=re.DOTALL)
+    if fence_match:
+        fenced = _try_load_json(fence_match.group(1))
+        if fenced is not None:
+            return fenced
+
+    brace_match = re.search(r"(\{.*\})", candidate, flags=re.DOTALL)
+    if brace_match:
+        extracted = _try_load_json(brace_match.group(1))
+        if extracted is not None:
+            return extracted
+
+    fragments = extract_stream_text_fragments(candidate)
+    for fragment in reversed(fragments):
+        extracted = _try_load_json(fragment)
+        if extracted is not None:
+            return extracted
+
+    return None
+
+
 @dataclass(frozen=True)
 class ReviewDecision:
     choice: str
@@ -264,40 +309,10 @@ class AutomatedReviewer:
         )
 
     def _extract_json_payload(self, raw_response: str) -> dict[str, Any] | None:
-        candidate = raw_response.strip()
-        if not candidate:
-            return None
-
-        direct = self._try_load_json(candidate)
-        if direct is not None:
-            return direct
-
-        fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", candidate, flags=re.DOTALL)
-        if fence_match:
-            fenced = self._try_load_json(fence_match.group(1))
-            if fenced is not None:
-                return fenced
-
-        brace_match = re.search(r"(\{.*\})", candidate, flags=re.DOTALL)
-        if brace_match:
-            extracted = self._try_load_json(brace_match.group(1))
-            if extracted is not None:
-                return extracted
-
-        fragments = extract_stream_text_fragments(candidate)
-        for fragment in reversed(fragments):
-            extracted = self._try_load_json(fragment)
-            if extracted is not None:
-                return extracted
-
-        return None
+        return extract_json_payload(raw_response)
 
     def _try_load_json(self, text: str) -> dict[str, Any] | None:
-        try:
-            payload = json.loads(text)
-        except json.JSONDecodeError:
-            return None
-        return payload if isinstance(payload, dict) else None
+        return _try_load_json(text)
 
     def _normalize_decision_token(self, value: Any) -> str:
         if not isinstance(value, str):

--- a/src/archive.py
+++ b/src/archive.py
@@ -1,0 +1,596 @@
+"""Learn which moves through the graph actually pay, across runs.
+
+A run that navigates its own topology produces something a linear pipeline never
+could: evidence about the topology. Run 12 went back from Stage 06 to Stage 05
+because one seed was not enough, and finished at 0.81. Run 13 wrote up the single
+seed and finished at 0.62. Neither number means much alone. Forty of them mean the
+backward edge out of Stage 06 is worth taking, and that is a fact about the
+harness rather than about either run.
+
+This is the Darwin Gödel Machine's arrangement (Zhang et al., arXiv 2505.22954) —
+an archive of self-modified variants, empirical validation in place of proof,
+parents sampled from the archive rather than only from the incumbent — with the
+unit of variation changed. DGM's variants are agent source code. Here they are
+**topologies**: an edge set and the order the edges are preferred in. That
+substitution is deliberate on three counts.
+
+* A research harness people run on their own machines should not rewrite its own
+  Python between runs. A topology is data, it diffs, and it reverts.
+* The topology is where the leverage is. Whether the run goes back to Stage 05
+  when the analysis is thin matters more than any wording in the prompt.
+* A topology can be validated before it is used. An edge priority is a number; a
+  rewritten agent is only validated by running it.
+
+**What a learned prior is not allowed to do.** It reorders preferences. It never
+opens a guarded edge, never adds an edge that was not declared, and never removes
+one. The guards are the correctness argument for letting an agent route at all
+(:mod:`src.stage_graph`), and a component that learns from outcomes is exactly the
+component that must not be able to weaken them — the cheapest way to raise mean
+fitness across an archive would be to stop checking whether hypotheses were
+adjudicated before writing up.
+
+**Promotion needs the improvement to replay.** DGM promotes on a benchmark delta.
+A rigour score on a research run is noisier than a SWE-bench pass rate, so a
+variant here stays unpromoted until it has been observed ``min_observations``
+times and still beats the incumbent. Scores from different rubric versions are
+never compared at all: a reweighting would otherwise read as every archived run
+having improved overnight.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from .evolution import load_run_fitness
+from .router import routing_summary
+from .rubric import RUBRIC_VERSION
+from .stage_graph import Edge, StageGraph
+from .utils import RunPaths, append_jsonl, read_text, write_text
+
+
+ARCHIVE_VERSION = "1"
+
+#: Runs on each side of a comparison before an edge payoff is believed. Research
+#: runs vary for reasons that have nothing to do with the route — the goal, the
+#: data, the day. Three is not enough to be sure and is enough to stop acting on
+#: a single lucky run, which is the failure that matters here.
+DEFAULT_MIN_OBSERVATIONS = 3
+
+#: Mean fitness a challenger must beat the incumbent by. Roughly the size of one
+#: criterion moving a quarter of its range on a seven-criterion rubric; below that
+#: the archive would promote noise.
+DEFAULT_MIN_GAIN = 0.02
+
+#: Weight on an unproven variant when sampling a parent. Pure fitness-proportional
+#: sampling converges on whatever won first and never revisits the decision, which
+#: is the local minimum DGM's archive exists to escape.
+NOVELTY_WEIGHT = 0.35
+
+
+# ----------------------------------------------------------------------------
+# Records
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    run_id: str
+    variant_id: str
+    rubric_version: str
+    #: ``source->target`` counted once per traversal. A run that took an edge twice
+    #: is two observations of it, which is what the payoff arithmetic wants.
+    edges: dict[str, int]
+    stage_fitness: dict[str, float]
+    route: str
+    steps: int
+    revisits: int
+    agent_directed: int
+    recorded_at: str
+
+    @property
+    def mean_fitness(self) -> float:
+        """Mean champion score across the stages this run actually measured.
+
+        Averaged over measured stages rather than over all eight: a run stopped at
+        Stage 07 by ``--final-stage`` did not fail Stage 08, and counting an absent
+        stage as a zero would make every partial run look like a bad topology.
+        """
+        if not self.stage_fitness:
+            return 0.0
+        return sum(self.stage_fitness.values()) / len(self.stage_fitness)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "variant_id": self.variant_id,
+            "rubric_version": self.rubric_version,
+            "edges": dict(self.edges),
+            "stage_fitness": dict(self.stage_fitness),
+            "mean_fitness": round(self.mean_fitness, 4),
+            "route": self.route,
+            "steps": self.steps,
+            "revisits": self.revisits,
+            "agent_directed": self.agent_directed,
+            "recorded_at": self.recorded_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "RunRecord":
+        return cls(
+            run_id=str(payload.get("run_id") or ""),
+            variant_id=str(payload.get("variant_id") or ""),
+            rubric_version=str(payload.get("rubric_version") or ""),
+            edges={str(k): int(v) for k, v in (payload.get("edges") or {}).items()},
+            stage_fitness={
+                str(k): float(v)
+                for k, v in (payload.get("stage_fitness") or {}).items()
+                if isinstance(v, (int, float))
+            },
+            route=str(payload.get("route") or ""),
+            steps=int(payload.get("steps") or 0),
+            revisits=int(payload.get("revisits") or 0),
+            agent_directed=int(payload.get("agent_directed") or 0),
+            recorded_at=str(payload.get("recorded_at") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class Variant:
+    """A topology in the archive: which edges, and in what order they are preferred."""
+
+    variant_id: str
+    #: The built-in topology this variant is a modification of.
+    topology: str
+    #: ``source->target`` to priority. Absent edges keep the built-in priority.
+    edge_priority: dict[str, int] = field(default_factory=dict)
+    parent_id: str = ""
+    generation: int = 0
+    #: Why this variant was proposed, in one sentence, from the payoff that
+    #: suggested it. An archive of unexplained numbers is not something anyone will
+    #: act on, and a promotion nobody can justify is one nobody can withdraw.
+    note: str = ""
+    promoted: bool = False
+    created_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "variant_id": self.variant_id,
+            "topology": self.topology,
+            "edge_priority": dict(self.edge_priority),
+            "parent_id": self.parent_id,
+            "generation": self.generation,
+            "note": self.note,
+            "promoted": self.promoted,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "Variant":
+        return cls(
+            variant_id=str(payload.get("variant_id") or ""),
+            topology=str(payload.get("topology") or "adaptive"),
+            edge_priority={
+                str(k): int(v) for k, v in (payload.get("edge_priority") or {}).items()
+            },
+            parent_id=str(payload.get("parent_id") or ""),
+            generation=int(payload.get("generation") or 0),
+            note=str(payload.get("note") or ""),
+            promoted=bool(payload.get("promoted")),
+            created_at=str(payload.get("created_at") or ""),
+        )
+
+    def apply_to(self, graph: StageGraph) -> StageGraph:
+        """A copy of ``graph`` with this variant's priorities substituted in.
+
+        Only the priority changes. Edges the variant does not mention keep theirs,
+        edges it mentions that the graph does not have are ignored, and no guard is
+        touched — a variant cannot open a door, only prefer one that is already open.
+        """
+        rebuilt: list[Edge] = []
+        for edge in graph.edges:
+            key = f"{edge.source}->{edge.target}"
+            priority = self.edge_priority.get(key, edge.priority)
+            rebuilt.append(
+                Edge(
+                    source=edge.source,
+                    target=edge.target,
+                    kind=edge.kind,
+                    rationale=edge.rationale,
+                    guard=edge.guard,
+                    priority=priority,
+                )
+            )
+        return StageGraph(rebuilt, name=graph.name)
+
+
+BASELINE_VARIANT = Variant(
+    variant_id="baseline",
+    topology="adaptive",
+    note="The declared topology with its hand-set priorities.",
+    promoted=True,
+)
+
+
+# ----------------------------------------------------------------------------
+# Payoff
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EdgePayoff:
+    edge: str
+    taken_runs: int
+    skipped_runs: int
+    taken_mean: float
+    skipped_mean: float
+
+    @property
+    def delta(self) -> float:
+        return self.taken_mean - self.skipped_mean
+
+    def believable(self, min_observations: int) -> bool:
+        return self.taken_runs >= min_observations and self.skipped_runs >= min_observations
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "edge": self.edge,
+            "taken_runs": self.taken_runs,
+            "skipped_runs": self.skipped_runs,
+            "taken_mean": round(self.taken_mean, 4),
+            "skipped_mean": round(self.skipped_mean, 4),
+            "delta": round(self.delta, 4),
+        }
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def edge_payoffs(records: Iterable[RunRecord]) -> dict[str, EdgePayoff]:
+    """For each edge, runs that took it against runs that were at the same node and did not.
+
+    The comparison is against *runs that reached the source*, not against every run
+    in the archive. Comparing "took 06→05" against the whole archive would credit
+    the edge with the difference between runs that got as far as Stage 06 and runs
+    that did not, which has nothing to do with the edge.
+    """
+    usable = [record for record in records if record.rubric_version == RUBRIC_VERSION]
+    payoffs: dict[str, EdgePayoff] = {}
+
+    edges = {edge for record in usable for edge in record.edges}
+    for edge in sorted(edges):
+        source = edge.split("->", 1)[0]
+        reached = [
+            record
+            for record in usable
+            if any(key.split("->", 1)[0] == source for key in record.edges)
+        ]
+        taken = [record.mean_fitness for record in reached if edge in record.edges]
+        skipped = [record.mean_fitness for record in reached if edge not in record.edges]
+        payoffs[edge] = EdgePayoff(edge, len(taken), len(skipped), _mean(taken), _mean(skipped))
+    return payoffs
+
+
+# ----------------------------------------------------------------------------
+# The archive
+# ----------------------------------------------------------------------------
+
+
+class Archive:
+    """Runs, variants, and the arithmetic that turns the first into the second."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        min_observations: int = DEFAULT_MIN_OBSERVATIONS,
+        min_gain: float = DEFAULT_MIN_GAIN,
+    ) -> None:
+        self.root = Path(root)
+        self.min_observations = min_observations
+        self.min_gain = min_gain
+
+    # -- storage -------------------------------------------------------------
+
+    @property
+    def runs_file(self) -> Path:
+        return self.root / "runs.jsonl"
+
+    @property
+    def variants_file(self) -> Path:
+        return self.root / "variants.json"
+
+    def runs(self) -> list[RunRecord]:
+        if not self.runs_file.exists():
+            return []
+        records: list[RunRecord] = []
+        for line in read_text(self.runs_file).splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                # One malformed line is not a reason to lose the archive. It is a
+                # reason not to pretend the archive is complete, which is why the
+                # count is what every believability test is against.
+                continue
+            if isinstance(payload, dict):
+                records.append(RunRecord.from_dict(payload))
+        return records
+
+    def variants(self) -> list[Variant]:
+        if not self.variants_file.exists():
+            return [BASELINE_VARIANT]
+        try:
+            payload = json.loads(read_text(self.variants_file))
+        except json.JSONDecodeError:
+            return [BASELINE_VARIANT]
+        stored = [
+            Variant.from_dict(item)
+            for item in (payload if isinstance(payload, list) else [])
+            if isinstance(item, Mapping)
+        ]
+        if not any(item.variant_id == BASELINE_VARIANT.variant_id for item in stored):
+            stored.insert(0, BASELINE_VARIANT)
+        return stored
+
+    def variant(self, variant_id: str) -> Variant | None:
+        return next((item for item in self.variants() if item.variant_id == variant_id), None)
+
+    def _save_variants(self, variants: Sequence[Variant]) -> None:
+        write_text(
+            self.variants_file,
+            json.dumps([item.to_dict() for item in variants], indent=2, ensure_ascii=False),
+        )
+
+    # -- recording -----------------------------------------------------------
+
+    def record_run(self, paths: RunPaths, *, variant_id: str = "baseline") -> RunRecord | None:
+        """Append a finished run's route and fitness. Returns ``None`` if unmeasured.
+
+        A run with no evolution summary contributes nothing: without per-stage
+        scores there is no fitness, and a record carrying a route but no outcome
+        would be counted in the denominator of every payoff it appears in while
+        adding no information to the numerator.
+        """
+        fitness = load_run_fitness(paths)
+        if not fitness:
+            return None
+        summary = routing_summary(paths)
+        record = RunRecord(
+            run_id=paths.run_root.name,
+            variant_id=variant_id,
+            rubric_version=RUBRIC_VERSION,
+            edges={str(k): int(v) for k, v in (summary.get("edges") or {}).items()},
+            stage_fitness=fitness,
+            route=str(summary.get("route") or ""),
+            steps=int(summary.get("steps") or 0),
+            revisits=int(summary.get("revisits") or 0),
+            agent_directed=int(summary.get("agent_directed") or 0),
+            recorded_at=_now(),
+        )
+        append_jsonl(self.runs_file, record.to_dict())
+        return record
+
+    # -- selection -----------------------------------------------------------
+
+    def variant_fitness(self) -> dict[str, tuple[int, float]]:
+        """Observation count and mean fitness per variant, current rubric only."""
+        buckets: dict[str, list[float]] = {}
+        for record in self.runs():
+            if record.rubric_version != RUBRIC_VERSION:
+                continue
+            buckets.setdefault(record.variant_id, []).append(record.mean_fitness)
+        return {key: (len(values), _mean(values)) for key, values in buckets.items()}
+
+    def incumbent(self) -> Variant:
+        """The promoted variant with the best measured mean, or the baseline."""
+        fitness = self.variant_fitness()
+        promoted = [item for item in self.variants() if item.promoted]
+        if not promoted:
+            return BASELINE_VARIANT
+        return max(
+            promoted,
+            key=lambda item: fitness.get(item.variant_id, (0, 0.0))[1],
+        )
+
+    def sample_parent(self, *, seed: int | None = None) -> Variant:
+        """Pick a variant to run next: mostly the good ones, sometimes an unproven one.
+
+        Fitness-proportional alone would lock the archive onto whichever variant
+        won early, and stop generating the observations that would show a different
+        one is better. The novelty term is what keeps under-sampled variants in the
+        draw. Seeded from the archive size so the choice is reproducible from the
+        archive itself rather than from the wall clock.
+        """
+        variants = self.variants()
+        if len(variants) == 1:
+            return variants[0]
+        fitness = self.variant_fitness()
+        weights: list[float] = []
+        for item in variants:
+            observations, mean = fitness.get(item.variant_id, (0, 0.0))
+            novelty = NOVELTY_WEIGHT / (1.0 + observations)
+            weights.append(max(mean, 0.0) + novelty)
+        rng = random.Random(len(self.runs()) if seed is None else seed)
+        return rng.choices(variants, weights=weights, k=1)[0]
+
+    # -- variation -----------------------------------------------------------
+
+    def propose_variant(self, *, graph: StageGraph | None = None) -> Variant | None:
+        """Derive a child of the incumbent from an edge payoff that is believable.
+
+        Returns ``None`` when nothing in the archive supports a change, which is the
+        common answer and the right one. A proposer that always proposes converts an
+        archive into a random walk.
+        """
+        payoffs = [
+            payoff
+            for payoff in edge_payoffs(self.runs()).values()
+            if payoff.believable(self.min_observations) and abs(payoff.delta) >= self.min_gain
+        ]
+        if not payoffs:
+            return None
+
+        parent = self.incumbent()
+        best = max(payoffs, key=lambda item: abs(item.delta))
+        base_graph = graph or StageGraph.named(parent.topology)
+        source, target = best.edge.split("->", 1)
+        current = next(
+            (
+                edge.priority
+                for edge in base_graph.edges
+                if edge.source == source and edge.target == target
+            ),
+            None,
+        )
+        if current is None:
+            return None
+
+        # Preferred one step more, or one step less. A single step keeps the change
+        # attributable: a variant that reshuffles five edges at once cannot be told
+        # apart from a variant that got lucky on one of them.
+        adjusted = max(0, current - 1) if best.delta > 0 else current + 1
+        if adjusted == current:
+            return None
+
+        priorities = dict(parent.edge_priority)
+        priorities[best.edge] = adjusted
+        if priorities == parent.edge_priority:
+            return None
+
+        direction = "preferred" if best.delta > 0 else "deprioritised"
+        variant = Variant(
+            variant_id=_variant_id(parent, best.edge, adjusted),
+            topology=parent.topology,
+            edge_priority=priorities,
+            parent_id=parent.variant_id,
+            generation=parent.generation + 1,
+            note=(
+                f"`{best.edge}` {direction}: runs that took it averaged "
+                f"{best.taken_mean:.3f} over {best.taken_runs} run(s) against "
+                f"{best.skipped_mean:.3f} over {best.skipped_runs} that reached the same node "
+                f"and did not ({best.delta:+.3f})."
+            ),
+            promoted=False,
+            created_at=_now(),
+        )
+        existing = self.variants()
+        if any(item.variant_id == variant.variant_id for item in existing):
+            return None
+        self._save_variants([*existing, variant])
+        return variant
+
+    def promote(self, variant_id: str) -> bool:
+        """Mark a variant promoted, if the evidence for it has replayed.
+
+        Two independent conditions, and the observation count is the one that does
+        the work: a challenger that beat the incumbent once beat it once.
+        """
+        fitness = self.variant_fitness()
+        challenger = self.variant(variant_id)
+        if challenger is None or challenger.promoted:
+            return False
+        observations, mean = fitness.get(variant_id, (0, 0.0))
+        if observations < self.min_observations:
+            return False
+        incumbent = self.incumbent()
+        _, incumbent_mean = fitness.get(incumbent.variant_id, (0, 0.0))
+        if mean - incumbent_mean < self.min_gain:
+            return False
+
+        updated = [
+            Variant(
+                variant_id=item.variant_id,
+                topology=item.topology,
+                edge_priority=item.edge_priority,
+                parent_id=item.parent_id,
+                generation=item.generation,
+                note=item.note,
+                promoted=True if item.variant_id == variant_id else item.promoted,
+                created_at=item.created_at,
+            )
+            for item in self.variants()
+        ]
+        self._save_variants(updated)
+        return True
+
+    # -- reporting -----------------------------------------------------------
+
+    def report(self) -> str:
+        records = self.runs()
+        usable = [item for item in records if item.rubric_version == RUBRIC_VERSION]
+        lines = [
+            f"# AutoR topology archive ({self.root})",
+            "",
+            f"- archive format: v{ARCHIVE_VERSION}",
+            f"- rubric: v{RUBRIC_VERSION}",
+            f"- runs recorded: {len(records)} ({len(usable)} on the current rubric)",
+            f"- variants: {len(self.variants())}",
+            "",
+        ]
+        fitness = self.variant_fitness()
+        if fitness:
+            lines += ["## Variants", "", "| Variant | Runs | Mean fitness | Promoted |", "| --- | --- | --- | --- |"]
+            for item in self.variants():
+                observations, mean = fitness.get(item.variant_id, (0, 0.0))
+                lines.append(
+                    f"| `{item.variant_id}` | {observations} | "
+                    f"{mean:.3f} | {'yes' if item.promoted else 'no'} |"
+                )
+            lines.append("")
+
+        payoffs = edge_payoffs(usable)
+        if payoffs:
+            lines += [
+                "## Edge payoff",
+                "",
+                "Runs that took the edge against runs that reached the same node and did not.",
+                "",
+                "| Edge | Took | Mean | Skipped | Mean | Delta | Believable |",
+                "| --- | --- | --- | --- | --- | --- | --- |",
+            ]
+            for payoff in sorted(payoffs.values(), key=lambda item: abs(item.delta), reverse=True):
+                lines.append(
+                    f"| `{payoff.edge}` | {payoff.taken_runs} | {payoff.taken_mean:.3f} | "
+                    f"{payoff.skipped_runs} | {payoff.skipped_mean:.3f} | {payoff.delta:+.3f} | "
+                    f"{'yes' if payoff.believable(self.min_observations) else 'no'} |"
+                )
+            lines.append("")
+            lines.append(
+                f"An edge is believable at {self.min_observations} runs on each side. Below that "
+                "the delta is printed and not acted on."
+            )
+        return "\n".join(lines)
+
+
+def _variant_id(parent: Variant, edge: str, priority: int) -> str:
+    slug = edge.replace("->", "_to_").replace("0", "")
+    return f"g{parent.generation + 1}-{slug}-p{priority}"
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def resolve_graph(archive: Archive | None, topology: str) -> tuple[StageGraph, str]:
+    """The graph to run, and the id of the variant it came from.
+
+    With no archive, or an archive with nothing promoted, this is the declared
+    topology unchanged — so an operator who has never enabled the archive gets the
+    same graph they always did.
+    """
+    base = StageGraph.named(topology)
+    if archive is None:
+        return base, "baseline"
+    variant = archive.sample_parent()
+    if variant.variant_id == BASELINE_VARIANT.variant_id or variant.topology != topology:
+        return base, BASELINE_VARIANT.variant_id
+    return variant.apply_to(base), variant.variant_id
+

--- a/src/evolution.py
+++ b/src/evolution.py
@@ -1,0 +1,624 @@
+"""Make a refinement round prove it helped before it is allowed to stand.
+
+AutoR's stage loop already iterates. What it never had was an ordering: attempt
+three replaced attempt two because it happened later, and a round that dropped a
+resolving reference or replaced a measured number with a hedge was promoted on
+exactly the same terms as one that fixed something. "Refine" was a hope.
+
+This module turns the loop into a ratchet.
+
+* Every candidate is measured by :mod:`src.rubric`, which reads the run off disk.
+* The champion is the draft that gets promoted at approval — not the last one.
+* A round that scores worse is **reverted**: the champion's markdown is written
+  back over the draft, so the reviewer and the human see the best candidate the
+  run produced rather than the most recent.
+* Candidates that lose on the total but win on some criterion stay on a Pareto
+  frontier (:mod:`src.pareto`), and a later round is spent merging them.
+* The improvement directive names the criteria that lost points and the evidence,
+  and says nothing about the ones already at full marks — a round told "make it
+  better" produces churn, a round told "these four referenced paths do not exist"
+  produces a fix.
+
+**The round that must not be allowed to win.**
+
+A scored loop is an optimiser, and in a research pipeline the cheapest way to
+raise a score is to change the finding. :mod:`src.rubric` is built so no criterion
+can see a verdict, which removes the gradient. This module closes the remaining
+route: a polish round that rewrites `hypothesis_outcomes.json` — even to a set
+that scores identically — is rejected outright and the champion is restored, with
+a ``verdict_drift`` row in the ledger. Improving the evidence is the point;
+improving the answer is the failure the whole scientific-validity chain exists to
+prevent, and a self-improvement loop is the most efficient way to reintroduce it.
+
+Everything is on disk under ``runs/<id>/evolution/``: every candidate, every
+score, every directive, every reverted round. A ratchet that cannot be inspected
+is a claim about a ratchet.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .pareto import Complement, complementary_pair, format_frontier_for_prompt, insert
+from .rubric import (
+    RUBRIC_VERSION,
+    StageScore,
+    format_score_for_prompt,
+    format_score_line,
+    score_stage,
+)
+from .utils import RunPaths, StageSpec, append_jsonl, append_log_entry, read_text, write_text
+
+
+#: Below this, a round did not improve anything — it moved the number. The rubric
+#: is built from counts and ratios, so a real fix moves the total by far more than
+#: this; anything smaller is a reworded sentence crossing a length threshold.
+DEFAULT_MIN_GAIN = 0.005
+
+#: Consecutive rounds without a gain before the stage is declared polished. One is
+#: too eager: a merge round often costs a point somewhere before paying for itself,
+#: and stopping on the first flat round would never reach the merge.
+DEFAULT_PATIENCE = 2
+
+#: Rounds per stage when evolution is on and no budget is given. Chosen so a
+#: default run pays for a first draft, one targeted fix, and a merge.
+DEFAULT_ROUNDS = 3
+
+
+@dataclass(frozen=True)
+class EvolutionConfig:
+    enabled: bool = False
+    #: Polish rounds allowed per stage, beyond the first draft. These do not consume
+    #: the stage's repair budget: a stage that is being improved is not a stage that
+    #: is failing, and charging improvement rounds against `--max-attempts` would
+    #: make a well-behaved stage look like it was thrashing.
+    rounds: int = DEFAULT_ROUNDS
+    min_gain: float = DEFAULT_MIN_GAIN
+    patience: int = DEFAULT_PATIENCE
+    #: Stages to evolve. Empty means all of them.
+    stages: tuple[str, ...] = ()
+
+    def applies_to(self, stage: StageSpec) -> bool:
+        if not self.enabled:
+            return False
+        return not self.stages or stage.slug in self.stages
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "rounds": self.rounds,
+            "min_gain": self.min_gain,
+            "patience": self.patience,
+            "stages": list(self.stages),
+            "rubric_version": RUBRIC_VERSION,
+        }
+
+
+@dataclass
+class StageEvolutionState:
+    stage_slug: str
+    champion: StageScore | None = None
+    frontier: list[StageScore] = field(default_factory=list)
+    rounds_spent: int = 0
+    flat_rounds: int = 0
+    #: Verdict fingerprint of the champion, carried so drift is measured against
+    #: the draft that is standing rather than against the previous attempt — two
+    #: rejected rounds in a row must not be able to walk the verdicts anywhere.
+    verdict_digest: str = ""
+    history: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RoundOutcome:
+    #: ``first`` | ``promoted`` | ``frontier`` | ``regressed`` | ``verdict_drift``
+    #: | ``directed`` (a human or the reviewer asked for this one; it stands).
+    verdict: str
+    score: StageScore
+    champion: StageScore | None
+    delta: float
+    #: True when the draft on disk was replaced by the champion's markdown.
+    reverted: bool
+    note: str
+
+    @property
+    def improved(self) -> bool:
+        return self.verdict in {"first", "promoted"}
+
+
+class EvolutionController:
+    """Per-run owner of the champion ratchet, the frontier, and the ledger."""
+
+    def __init__(
+        self,
+        config: EvolutionConfig,
+        *,
+        artifact_dirs: Mapping[str, Sequence[Path]] | None = None,
+        artifact_roots: Sequence[Path] | None = None,
+    ) -> None:
+        self.config = config
+        self.artifact_dirs = artifact_dirs
+        self.artifact_roots = artifact_roots
+        self._states: dict[str, StageEvolutionState] = {}
+
+    # -- paths ---------------------------------------------------------------
+
+    def stage_dir(self, paths: RunPaths, stage: StageSpec) -> Path:
+        return paths.evolution_dir / stage.slug
+
+    def champion_file(self, paths: RunPaths, stage: StageSpec) -> Path:
+        return self.stage_dir(paths, stage) / "champion.md"
+
+    def _champion_score_file(self, paths: RunPaths, stage: StageSpec) -> Path:
+        return self.stage_dir(paths, stage) / "champion.json"
+
+    def _frontier_file(self, paths: RunPaths, stage: StageSpec) -> Path:
+        return self.stage_dir(paths, stage) / "frontier.json"
+
+    def _candidate_file(self, paths: RunPaths, stage: StageSpec, attempt_no: int) -> Path:
+        return self.stage_dir(paths, stage) / "candidates" / f"attempt_{attempt_no:02d}.md"
+
+    def ledger_file(self, paths: RunPaths) -> Path:
+        return paths.evolution_dir / "improvement_ledger.jsonl"
+
+    def summary_file(self, paths: RunPaths) -> Path:
+        return paths.evolution_dir / "summary.json"
+
+    # -- state ---------------------------------------------------------------
+
+    def state(self, paths: RunPaths, stage: StageSpec) -> StageEvolutionState:
+        """Load or rehydrate this stage's state.
+
+        Rehydrated from disk on first touch so a resumed run keeps its champion.
+        Without that, `--resume-run` would restart the ratchet from nothing and
+        the next draft would win by default, silently discarding the best work the
+        earlier session produced.
+        """
+        cached = self._states.get(stage.slug)
+        if cached is not None:
+            return cached
+
+        state = StageEvolutionState(stage_slug=stage.slug)
+        stored = _read_json(self._champion_score_file(paths, stage))
+        if isinstance(stored, Mapping):
+            champion = StageScore.from_dict(stored)
+            if champion.rubric_version == RUBRIC_VERSION:
+                state.champion = champion
+                state.verdict_digest = champion.verdict_digest
+            else:
+                # Scores from another rubric version are not comparable, so the
+                # champion is dropped rather than defended. Recorded, because a
+                # champion vanishing between sessions with no explanation is the
+                # kind of thing that gets debugged for an hour.
+                append_log_entry(
+                    paths.logs,
+                    f"{stage.slug} evolution_champion_discarded",
+                    f"Stored champion was measured under rubric v{champion.rubric_version}; "
+                    f"this build is v{RUBRIC_VERSION}. Starting the ratchet over.",
+                )
+        stored_frontier = _read_json(self._frontier_file(paths, stage))
+        if isinstance(stored_frontier, list):
+            state.frontier = [
+                score
+                for score in (
+                    StageScore.from_dict(item) for item in stored_frontier if isinstance(item, Mapping)
+                )
+                if score.rubric_version == RUBRIC_VERSION
+            ]
+        self._states[stage.slug] = state
+        return state
+
+    # -- the ratchet ---------------------------------------------------------
+
+    def consider(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        draft_path: Path,
+        is_polish_round: bool = False,
+    ) -> RoundOutcome:
+        """Measure the draft at ``draft_path`` and decide whether it may stand.
+
+        Reverts the draft file to the champion when it may not. The manager keeps
+        working with the same path either way, which is what makes the ratchet
+        invisible to every other part of the loop.
+        """
+        state = self.state(paths, stage)
+        markdown = read_text(draft_path)
+        score = score_stage(
+            paths=paths,
+            stage=stage,
+            markdown=markdown,
+            attempt_no=attempt_no,
+            artifact_dirs=self.artifact_dirs,
+            artifact_roots=self.artifact_roots,
+        )
+        self._archive_candidate(paths, stage, attempt_no, markdown, score)
+
+        champion = state.champion
+        delta = score.total - champion.total if champion is not None else score.total
+
+        # 0. Was this round asked for by a person?
+        #
+        # The ratchet governs AutoR's own polish rounds. It does not govern a
+        # reviewer or a human who asked for a change: that is direction, and a
+        # measurement is not entitled to overrule it. AutoR would otherwise
+        # silently revert a requested edit because a rubric preferred the previous
+        # wording, which is the opposite of the arrangement this project is built
+        # on. The delta is still measured and recorded, so the ledger shows whether
+        # the requested change helped — the human keeps the decision and gets the
+        # number.
+        if not is_polish_round and champion is not None:
+            update = insert(state.frontier, score)
+            state.frontier = list(update.members) if update.verdict != "incomparable" else [score]
+            state.champion = score
+            state.verdict_digest = score.verdict_digest
+            state.flat_rounds = 0
+            self._persist(paths, stage, state, markdown)
+            outcome = RoundOutcome(
+                "directed",
+                score,
+                score,
+                delta,
+                False,
+                f"Directed revision; it stands regardless of measurement ({delta:+.3f}).",
+            )
+            self._record(paths, stage, attempt_no, outcome, state, is_polish_round)
+            return outcome
+
+        # 1. Did this round move what the run concludes?
+        drifted = (
+            is_polish_round
+            and bool(state.verdict_digest)
+            and bool(score.verdict_digest)
+            and score.verdict_digest != state.verdict_digest
+        )
+        if drifted:
+            outcome = RoundOutcome(
+                verdict="verdict_drift",
+                score=score,
+                champion=champion,
+                delta=delta,
+                reverted=self._revert(paths, stage, draft_path),
+                note=(
+                    "This round changed a hypothesis verdict. An improvement round may "
+                    "strengthen the evidence for a finding; it may not change the finding. "
+                    "The previous draft was restored."
+                ),
+            )
+            state.flat_rounds += 1
+            self._record(paths, stage, attempt_no, outcome, state, is_polish_round)
+            return outcome
+
+        # 2. Is it the first thing we have measured?
+        if champion is None:
+            state.champion = score
+            state.verdict_digest = score.verdict_digest
+            state.frontier = [score]
+            self._persist(paths, stage, state, markdown)
+            outcome = RoundOutcome("first", score, score, delta, False, "First measured draft.")
+            self._record(paths, stage, attempt_no, outcome, state, is_polish_round)
+            return outcome
+
+        # 3. Did it beat the champion by enough to be a fix rather than noise?
+        if delta >= self.config.min_gain:
+            update = insert(state.frontier, score)
+            state.frontier = list(update.members) if update.verdict != "incomparable" else [score]
+            state.champion = score
+            state.verdict_digest = score.verdict_digest
+            state.flat_rounds = 0
+            self._persist(paths, stage, state, markdown)
+            outcome = RoundOutcome(
+                "promoted", score, score, delta, False, f"New champion (+{delta:.3f})."
+            )
+            self._record(paths, stage, attempt_no, outcome, state, is_polish_round)
+            return outcome
+
+        # 4. It lost on the total. Is it the only draft good at something?
+        update = insert(state.frontier, score)
+        state.flat_rounds += 1
+        if update.accepted:
+            state.frontier = list(update.members)
+            self._persist(paths, stage, state, None)
+            outcome = RoundOutcome(
+                "frontier",
+                score,
+                champion,
+                delta,
+                self._revert(paths, stage, draft_path),
+                "Lost on the total but is the only draft holding some criterion; kept on the "
+                "frontier for a merge round.",
+            )
+            self._record(paths, stage, attempt_no, outcome, state, is_polish_round)
+            return outcome
+
+        outcome = RoundOutcome(
+            "regressed",
+            score,
+            champion,
+            delta,
+            self._revert(paths, stage, draft_path),
+            f"No better than the standing draft ({delta:+.3f}); the champion was restored.",
+        )
+        self._record(paths, stage, attempt_no, outcome, state, is_polish_round)
+        return outcome
+
+    def _revert(self, paths: RunPaths, stage: StageSpec, draft_path: Path) -> bool:
+        champion_markdown = self.champion_file(paths, stage)
+        if not champion_markdown.exists():
+            return False
+        shutil.copyfile(champion_markdown, draft_path)
+        return True
+
+    # -- round scheduling ----------------------------------------------------
+
+    def should_continue(self, paths: RunPaths, stage: StageSpec) -> bool:
+        """Whether another polish round is worth paying for.
+
+        Two independent stops. The budget bounds the spend; the patience counter
+        stops a stage that has stopped responding, which is the common case — most
+        stages are done after one targeted fix, and the remaining rounds would be
+        spent rewording a draft that is already at the ceiling of what the rubric
+        can see.
+        """
+        if not self.config.applies_to(stage):
+            return False
+        state = self.state(paths, stage)
+        if state.rounds_spent >= self.config.rounds:
+            return False
+        if state.flat_rounds >= self.config.patience:
+            return False
+        if state.champion is not None and state.champion.total >= 1.0 - 1e-9:
+            return False
+        return True
+
+    def begin_round(self, paths: RunPaths, stage: StageSpec) -> None:
+        self.state(paths, stage).rounds_spent += 1
+
+    def next_directive(self, paths: RunPaths, stage: StageSpec) -> str:
+        """The instruction for the next polish round.
+
+        Two shapes. A merge, when the frontier holds drafts with complementary
+        strengths and combining them has more headroom than fixing the champion's
+        weakest criterion. Otherwise a targeted repair naming the criteria that
+        lost points, with what was measured and what would raise it.
+
+        Both end with the same prohibitions, because the ways a scored loop cheats
+        are predictable: pad the prose, restate a number more confidently, or quietly
+        move the finding.
+        """
+        state = self.state(paths, stage)
+        champion = state.champion
+        if champion is None:
+            return ""
+
+        complement = complementary_pair(state.frontier)
+        weakest = champion.weakest(limit=3)
+        merge_headroom = complement.headroom if complement is not None else 0.0
+        repair_headroom = sum((1.0 - item.score) * item.weight for item in weakest) / (
+            sum(item.weight for item in champion.criteria) or 1.0
+        )
+
+        if complement is not None and merge_headroom > repair_headroom and merge_headroom > self.config.min_gain:
+            body = self._merge_directive(paths, stage, complement)
+        else:
+            body = self._repair_directive(champion, weakest)
+
+        return body + "\n\n" + self._prohibitions(stage, champion)
+
+    def _repair_directive(self, champion: StageScore, weakest: Sequence[Any]) -> str:
+        lines = [
+            "## Targeted improvement round",
+            "",
+            "The current draft has been measured against AutoR's rigour rubric. This round "
+            "exists to raise the criteria below and nothing else.",
+            "",
+            format_score_for_prompt(champion),
+            "",
+            "Work through them in order. For each one, change the *run* — write the missing "
+            "artifact, record the missing measurement, resolve the broken reference — and then "
+            "update the stage summary to match. A criterion already at 1.00 is finished: do not "
+            "touch that part of the draft.",
+        ]
+        if not weakest:
+            lines.append("")
+            lines.append(
+                "No criterion has a named shortfall. If nothing here can be raised by real work, "
+                "say so in Suggestions for Refinement and leave the draft as it is."
+            )
+        return "\n".join(lines)
+
+    def _merge_directive(self, paths: RunPaths, stage: StageSpec, complement: Complement) -> str:
+        left, right = complement.left, complement.right
+        return "\n".join(
+            [
+                "## Merge round",
+                "",
+                "Two earlier drafts of this stage are each the only one that got something right. "
+                "Neither dominates the other, so the best available draft is one that has not been "
+                "written yet: the one that keeps both sets of strengths.",
+                "",
+                format_frontier_for_prompt([left, right]),
+                "",
+                f"- Attempt {left.attempt_no} is the only one holding: "
+                + ", ".join(f"`{key}`" for key in complement.left_wins),
+                f"- Attempt {right.attempt_no} is the only one holding: "
+                + ", ".join(f"`{key}`" for key in complement.right_wins),
+                "",
+                f"Both are on disk under `{self.stage_dir(paths, stage).name}/candidates/`. Read them, "
+                "then produce a draft that keeps what each one got right. Combining the measured "
+                f"best of both would reach {complement.merged_ceiling:.3f}, against "
+                f"{max(left.total, right.total):.3f} for the better of the two.",
+                "",
+                "This is a merge, not a rewrite. Anything neither draft got wrong stays as it is.",
+            ]
+        )
+
+    def _prohibitions(self, stage: StageSpec, champion: StageScore) -> str:
+        lines = [
+            "### What does not count as improvement",
+            "",
+            "- Do not lengthen a section to raise a score. Every criterion here is a ratio or a "
+            "count over artifacts on disk; prose cannot move any of them.",
+            "- Do not restate an unverified number more confidently. If a value is not in a file "
+            "under `workspace/results`, either measure it and write it there or remove the claim.",
+            "- Do not delete a weak part of the draft to raise an average. A dropped file "
+            "reference lowers `grounding`, and the previous draft is kept and compared.",
+        ]
+        if champion.verdict_digest:
+            lines.append(
+                "- **Do not change any hypothesis verdict.** The hypotheses were frozen before "
+                "results existed and every verdict is already recorded. Strengthen the evidence "
+                "behind a finding as much as you can; do not touch the finding. A round that "
+                "moves a verdict is rejected automatically and this draft is restored."
+            )
+        if stage.number >= 5:
+            lines.append(
+                "- Do not re-run an experiment in order to obtain a different outcome. Re-running "
+                "for more repeats is welcome; record every run, including the ones that disagree."
+            )
+        return "\n".join(lines)
+
+    # -- promotion -----------------------------------------------------------
+
+    def champion_markdown(self, paths: RunPaths, stage: StageSpec) -> str | None:
+        path = self.champion_file(paths, stage)
+        return read_text(path) if path.exists() else None
+
+    def finalize_stage(self, paths: RunPaths, stage: StageSpec) -> StageScore | None:
+        """Record this stage's settled champion into the run-level summary.
+
+        The summary is what :mod:`src.archive` reads when the run is over, so a
+        stage that was never evolved has to be absent from it rather than present
+        with a zero — an unmeasured stage averaged in as a failure would drag a
+        scaffold variant's fitness down for work it never did.
+        """
+        state = self.state(paths, stage)
+        if state.champion is None:
+            return None
+        summary = _read_json(self.summary_file(paths))
+        payload: dict[str, Any] = dict(summary) if isinstance(summary, Mapping) else {}
+        payload.setdefault("rubric_version", RUBRIC_VERSION)
+        payload.setdefault("stages", {})
+        payload["stages"][stage.slug] = {
+            **state.champion.to_dict(),
+            "rounds_spent": state.rounds_spent,
+            "candidates_measured": len(state.history),
+            "frontier_size": len(state.frontier),
+        }
+        payload["updated_at"] = _now()
+        write_text(self.summary_file(paths), json.dumps(payload, indent=2, ensure_ascii=False))
+        return state.champion
+
+    # -- persistence ---------------------------------------------------------
+
+    def _archive_candidate(
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        markdown: str,
+        score: StageScore,
+    ) -> None:
+        """Keep every candidate, including the ones that lost.
+
+        A discarded candidate is the only evidence that the ratchet discarded
+        anything. Without it the run says "the champion scored 0.84" and there is
+        no way to tell that from a run that only ever produced one draft.
+        """
+        candidate_path = self._candidate_file(paths, stage, attempt_no)
+        write_text(candidate_path, markdown)
+        write_text(
+            candidate_path.with_suffix(".json"),
+            json.dumps(score.to_dict(), indent=2, ensure_ascii=False),
+        )
+
+    def _persist(
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        state: StageEvolutionState,
+        champion_markdown: str | None,
+    ) -> None:
+        if state.champion is not None:
+            write_text(
+                self._champion_score_file(paths, stage),
+                json.dumps(state.champion.to_dict(), indent=2, ensure_ascii=False),
+            )
+        if champion_markdown is not None:
+            write_text(self.champion_file(paths, stage), champion_markdown)
+        write_text(
+            self._frontier_file(paths, stage),
+            json.dumps([item.to_dict() for item in state.frontier], indent=2, ensure_ascii=False),
+        )
+
+    def _record(
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        outcome: RoundOutcome,
+        state: StageEvolutionState,
+        is_polish_round: bool,
+    ) -> None:
+        row = {
+            "recorded_at": _now(),
+            "stage": stage.slug,
+            "attempt": attempt_no,
+            "round_kind": "polish" if is_polish_round else "stage_attempt",
+            "rounds_spent": state.rounds_spent,
+            "verdict": outcome.verdict,
+            "total": round(outcome.score.total, 4),
+            "delta": round(outcome.delta, 4),
+            "reverted": outcome.reverted,
+            "champion_total": round(outcome.champion.total, 4) if outcome.champion else None,
+            "frontier_size": len(state.frontier),
+            "criteria": {item.key: round(item.score, 4) for item in outcome.score.criteria},
+            "verdict_digest": outcome.score.verdict_digest,
+            "note": outcome.note,
+        }
+        state.history.append(row)
+        append_jsonl(self.ledger_file(paths), row)
+        append_log_entry(
+            paths.logs,
+            f"{stage.slug} attempt {attempt_no} evolution_{outcome.verdict}",
+            f"{format_score_line(outcome.score)}\ndelta: {outcome.delta:+.4f}\n{outcome.note}",
+        )
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+
+
+def load_run_fitness(paths: RunPaths) -> dict[str, float]:
+    """Per-stage champion totals for a finished run, for the cross-run archive.
+
+    Absent stages stay absent. :mod:`src.archive` averages over what a variant was
+    actually measured on, and a stage that never ran must not read as one it failed.
+    """
+    payload = _read_json(paths.evolution_dir / "summary.json")
+    if not isinstance(payload, Mapping):
+        return {}
+    if str(payload.get("rubric_version") or "") != RUBRIC_VERSION:
+        return {}
+    stages = payload.get("stages")
+    if not isinstance(stages, Mapping):
+        return {}
+    fitness: dict[str, float] = {}
+    for slug, entry in stages.items():
+        if isinstance(entry, Mapping) and isinstance(entry.get("total"), (int, float)):
+            fitness[str(slug)] = float(entry["total"])
+    return fitness

--- a/src/manager.py
+++ b/src/manager.py
@@ -65,6 +65,19 @@ from .manifest import (
     update_manifest_run_status,
 )
 from .operator_protocol import OperatorProtocol
+from .evolution import EvolutionConfig, EvolutionController
+from .router import StageRouter, format_decision
+from .stage_graph import (
+    FINISH as GRAPH_FINISH,
+    GraphState,
+    StageGraph,
+    enter as graph_enter,
+    format_route,
+    leave as graph_leave,
+    load_graph_state,
+    save_graph_state,
+    stage_for_slug,
+)
 from .diagram_gen import post_writing_diagram_hook
 from .terminal_ui import TerminalUI
 from .platform.foundry import generate_paper_package, generate_release_package
@@ -137,6 +150,11 @@ class ResearchManager:
         max_stage_attempts: int = MAX_STAGE_ATTEMPTS,
         web_search_context: str | None = None,
         artifact_roots: list[Path] | None = None,
+        stage_graph: StageGraph | None = None,
+        routing_mode: str = "off",
+        evolution: EvolutionConfig | None = None,
+        graph_max_steps: int | None = None,
+        graph_max_visits: int | None = None,
     ) -> None:
         self.project_root = project_root
         self.runs_dir = runs_dir
@@ -151,6 +169,7 @@ class ResearchManager:
             self.approval_mode = "manual"
         self.review_operator = review_operator or getattr(reviewer, "backend_name", getattr(operator, "backend_name", "claude"))
         self.review_model = review_model or getattr(reviewer, "model", getattr(operator, "model", "unknown"))
+        self.last_run_paths: RunPaths | None = None
         self._redo_start_stage: StageSpec | None = None
         self._research_diagram: bool = False
         self._final_stage: StageSpec | None = None
@@ -173,6 +192,37 @@ class ResearchManager:
             "data": [root / "outputs" for root in self.artifact_roots],
             "results": [root / "outputs" for root in self.artifact_roots],
             "figures": [root / "report" / "images" for root in self.artifact_roots],
+        }
+        # The stages are a graph. The default topology has exactly one edge out of
+        # each node, so a caller that asks for nothing gets the sequence AutoR has
+        # always run — through the same walk that the adaptive topology uses, so
+        # the default path keeps being exercised by every test of either.
+        self.stage_graph = stage_graph or StageGraph.linear()
+        self.graph_max_steps = graph_max_steps
+        self.graph_max_visits = graph_max_visits
+        self.router = StageRouter(
+            operator=operator,
+            mode=routing_mode,
+            fake_mode=bool(getattr(operator, "fake_mode", False)),
+        )
+        evolution_config = evolution or EvolutionConfig()
+        self.evolution = (
+            EvolutionController(
+                evolution_config,
+                artifact_dirs=self.artifact_dirs,
+                artifact_roots=self.artifact_roots,
+            )
+            if evolution_config.enabled
+            else None
+        )
+        # What gets written into run_config.json, so `--resume-run` continues the
+        # same walk. Derived from the manager's own settings rather than re-read
+        # from the CLI: the two would otherwise disagree whenever a caller built a
+        # manager directly, and the run would resume as something it never was.
+        self._walk_settings = {
+            "stage_graph": self.stage_graph.name,
+            "routing_mode": self.router.mode,
+            "evolve_rounds": evolution_config.rounds if evolution_config.enabled else 0,
         }
 
     def run(
@@ -256,6 +306,7 @@ class ResearchManager:
             review_model=self.review_model,
             codex_sandbox=getattr(self.operator, "codex_sandbox", None),
             output_format=output_format,
+            walk=self._walk_settings,
         )
         ensure_run_manifest(paths)
         if not paths.user_input.exists():
@@ -289,18 +340,58 @@ class ResearchManager:
         return self._run_from_paths(paths, start_stage=start_stage)
 
     def _run_from_paths(self, paths: RunPaths, start_stage: StageSpec | None = None) -> bool:
-        stages_to_run = self._select_stages_for_run(paths, start_stage)
-        stage_index = 0
+        """Walk the stage graph until it reaches ``finish`` or nothing is open.
 
-        while stage_index < len(stages_to_run):
-            stage = stages_to_run[stage_index]
+        The default topology has one edge out of every node, so this reproduces the
+        old sequential walk exactly; ``--stage-graph adaptive`` adds the backward
+        moves. Both go through this loop rather than through a linear path and a
+        graph path, because a second walk implementation is a second place for the
+        approval, abort and resume semantics to be subtly different.
+        """
+        # Exposed so a caller that owns an archive can find the run it just drove
+        # without re-deriving the run id from the runs directory, which would pick
+        # the wrong one whenever two runs start in the same second.
+        self.last_run_paths = paths
+        entry = self._graph_entry_stage(paths, start_stage)
+        if entry is None:
+            return self._complete_run(paths)
+
+        state = load_graph_state(
+            paths, max_steps=self.graph_max_steps, max_visits=self.graph_max_visits
+        )
+        stage: StageSpec | None = entry
+
+        while stage is not None:
+            if state.steps >= state.max_steps:
+                state.halted_because = (
+                    f"the run reached the {state.max_steps}-step limit for this graph"
+                )
+                save_graph_state(paths, state)
+                self.ui.show_status(state.halted_because, level="warn")
+                break
+
+            graph_enter(paths, state, stage)
             self._jump_target_stage = None
             approved = self._run_stage(paths, stage)
+
+            # `/back <stage>` and retry-exhaustion rollback are operator overrides.
+            # They outrank the router: a person redirecting the run is not a move
+            # the graph gets a vote on.
             if self._jump_target_stage is not None:
                 target = self._jump_target_stage
-                stages_to_run = self._select_stages_for_run(paths, target)
-                stage_index = 0
+                graph_leave(
+                    paths,
+                    state,
+                    chose=target.slug,
+                    kind="revisit",
+                    reason="Operator redirected the run.",
+                    default_choice="",
+                    agent_directed=False,
+                    score_total=None,
+                )
+                stage = target
                 continue
+
             if not approved:
                 append_log_entry(
                     paths.logs,
@@ -313,11 +404,22 @@ class ResearchManager:
                     last_event="run.cancelled",
                     current_stage_slug=stage.slug,
                 )
+                save_graph_state(paths, state)
                 self._print("Run aborted.")
                 return False
-            stage_index += 1
 
-        append_log_entry(paths.logs, "run_complete", "All stages approved.")
+            stage = self._advance_from(paths, state, stage)
+
+        save_graph_state(paths, state)
+        return self._complete_run(paths, state=state)
+
+    def _complete_run(self, paths: RunPaths, state: "GraphState | None" = None) -> bool:
+        route = format_route(state) if state is not None else ""
+        append_log_entry(
+            paths.logs,
+            "run_complete",
+            "All stages approved." + (f"\nRoute: {route}" if route else ""),
+        )
         update_manifest_run_status(
             paths,
             run_status="completed",
@@ -325,8 +427,98 @@ class ResearchManager:
             current_stage_slug=None,
             completed_at=datetime.now().isoformat(timespec="seconds"),
         )
+        if route and self.stage_graph.name != "linear":
+            self.ui.show_status(f"Route taken: {route}", level="info")
         self._print("All stages approved. Run complete.")
         return True
+
+    def _graph_entry_stage(self, paths: RunPaths, start_stage: StageSpec | None) -> StageSpec | None:
+        """Where the walk starts: the requested stage, or the first unsettled one."""
+        pending = self._select_stages_for_run(paths, start_stage)
+        return pending[0] if pending else None
+
+    def _advance_from(
+        self,
+        paths: RunPaths,
+        state: "GraphState",
+        stage: StageSpec,
+    ) -> StageSpec | None:
+        """Choose and take the edge out of an approved stage."""
+        score = None
+        if self.evolution is not None:
+            score = self.evolution.finalize_stage(paths, stage)
+
+        decision = self.router.choose(
+            paths=paths,
+            stage=stage,
+            graph=self.stage_graph,
+            state=state,
+            score=score,
+            final_stage=self._final_stage,
+        )
+        graph_leave(
+            paths,
+            state,
+            chose=decision.target,
+            kind=decision.kind,
+            reason=decision.reason,
+            default_choice=decision.default_target,
+            agent_directed=decision.agent_directed,
+            score_total=score.total if score is not None else None,
+        )
+        if decision.agent_directed or decision.refusal:
+            self.ui.show_status(format_decision(decision), level="info")
+
+        if decision.finished:
+            return None
+
+        target = stage_for_slug(decision.target)
+        if target is None:
+            return None
+
+        if decision.kind == "revisit":
+            # Re-entering a stage invalidates everything downstream of it. The
+            # manifest already knows how to say so; skipping this would leave a
+            # later stage's approved summary in memory describing work that the
+            # revisit is about to replace.
+            self._print(self._format_rollback_preview(paths, target))
+            rollback_to_stage(
+                paths,
+                target,
+                reason=f"Graph revisit from {stage.slug}: {decision.reason}",
+            )
+            return target
+
+        return self._skip_settled(paths, state, target)
+
+    def _skip_settled(
+        self,
+        paths: RunPaths,
+        state: "GraphState",
+        target: StageSpec,
+    ) -> StageSpec | None:
+        """Follow advance edges past stages a resumed run already settled.
+
+        `--resume-run` used to get this from `_select_stages_for_run` filtering the
+        list up front. A graph walk decides one move at a time, so the same rule has
+        to be applied at the move: an advance edge into an already-approved stage
+        moves through it rather than running it again.
+        """
+        seen: set[str] = set()
+        current: StageSpec | None = target
+        while current is not None and current.slug not in seen:
+            seen.add(current.slug)
+            manifest = ensure_run_manifest(paths)
+            entry = next((item for item in manifest.stages if item.slug == current.slug), None)
+            if entry is None or not entry.settled:
+                return current
+            move = self.stage_graph.default_move(
+                paths, current.slug, state, final_stage=self._final_stage
+            )
+            if move is None or move.target == GRAPH_FINISH:
+                return None
+            current = stage_for_slug(move.target)
+        return current
 
     def _generate_writing_review(self, paths: RunPaths) -> dict[str, object]:
         """Produce the Stage 07 triage artifact that matches this run's output format.
@@ -370,6 +562,7 @@ class ResearchManager:
             review_model=self.review_model,
             codex_sandbox=getattr(self.operator, "codex_sandbox", None),
             output_format=output_format,
+            walk=self._walk_settings,
         )
         initialize_run_manifest(paths)
         write_artifact_index(paths)
@@ -382,6 +575,8 @@ class ResearchManager:
                 f"Model: {config['model']}\n"
                 f"Venue: {config['venue']}\n"
                 f"Output format: {config['output_format']}\n"
+                f"Stage graph: {config['stage_graph']} (routing: {config['routing_mode']}, "
+                f"evolve rounds: {config['evolve_rounds']})\n"
                 f"Approval mode: {config['approval_mode']}\n"
                 f"Review backend: {config['review_operator']}\n"
                 f"Review model: {config['review_model']}\n"
@@ -1178,6 +1373,13 @@ class ResearchManager:
     def _run_stage(self, paths: RunPaths, stage: StageSpec) -> bool:
         attempt_no = read_attempt_count(paths, stage) + 1
         loop_attempts = 0
+        # Polish rounds are AutoR improving work that already passed validation, so
+        # they are counted separately from `--max-attempts`, which bounds a stage
+        # that is *failing*. Charging them to the same budget would make a stage
+        # that is being made better look like one that is thrashing, and would
+        # leave nothing for the repair path if a later round did break something.
+        polish_rounds = 0
+        is_polish_round = False
         revision_feedback: str | None = None
         continue_session = False
         last_validation_errors: list[str] = []
@@ -1216,7 +1418,7 @@ class ResearchManager:
                 pass
 
         while True:
-            if loop_attempts >= self.max_stage_attempts:
+            if loop_attempts - polish_rounds >= self.max_stage_attempts:
                 error = (
                     f"Exceeded {self.max_stage_attempts} attempts in the current stage run. "
                     f"Last validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
@@ -1449,6 +1651,40 @@ class ResearchManager:
                 result = repair_result
 
             stage_markdown = read_text(result.stage_file_path)
+
+            # The draft is valid. Measure it, and decide whether it may stand.
+            if self.evolution is not None and self.evolution.config.applies_to(stage):
+                outcome = self.evolution.consider(
+                    paths=paths,
+                    stage=stage,
+                    attempt_no=attempt_no,
+                    draft_path=result.stage_file_path,
+                    is_polish_round=is_polish_round,
+                )
+                if outcome.reverted:
+                    # `consider` wrote the champion back over the draft; everything
+                    # downstream — review, promotion, handoff — has to read the
+                    # draft that is now on disk rather than the one that lost.
+                    stage_markdown = read_text(result.stage_file_path)
+                self.ui.show_status(
+                    f"{stage.stage_title} attempt {attempt_no}: {outcome.note} "
+                    f"[{outcome.score.total:.3f}]",
+                    level="success" if outcome.improved else "info",
+                )
+                if self.evolution.should_continue(paths, stage):
+                    directive = self.evolution.next_directive(paths, stage)
+                    if directive:
+                        self.evolution.begin_round(paths, stage)
+                        polish_rounds += 1
+                        is_polish_round = True
+                        revision_feedback = directive
+                        continue_session = True
+                        attempt_no += 1
+                        continue
+
+            # Anything from here is a human or reviewer decision, so the next
+            # attempt it produces is directed rather than self-initiated.
+            is_polish_round = False
             mark_stage_human_review_manifest(
                 paths,
                 stage,

--- a/src/pareto.py
+++ b/src/pareto.py
@@ -1,0 +1,212 @@
+"""Keep the drafts that are best at *something*, not only the one best on average.
+
+A single scalar picks one winner and throws the rest away. That is the right move
+when the candidates differ by quality; it is the wrong move when they differ by
+*shape*, which is what actually happens across refinement rounds. One draft has
+every file reference resolving and no numbers in it. The next has the numbers and
+broke two references. Averaged, they are indistinguishable and the loop keeps
+whichever came second. Neither is the draft that should exist, and the ingredients
+for that draft are sitting in the two of them.
+
+GEPA (Agrawal et al., arXiv 2507.19457) makes this point about *tasks*: a prompt
+that wins on one task and loses on another should stay in the pool, because a
+scalar average would evict a specialist that is the only source of some capability.
+The frontier here is over rigour criteria rather than tasks, which fits a research
+stage better — there is only one task, and the interesting variation is which
+dimension of it a draft got right.
+
+The consequence used downstream is the merge. When the frontier holds two drafts
+with complementary strengths, :func:`complementary_pair` names them and says which
+criteria each one owns, and :mod:`src.evolution` spends a round asking for the
+draft that keeps both — a targeted request, not "try again".
+
+Nothing here reads a total. Domination is over the criterion vector, so a draft
+cannot enter the frontier by being slightly better at the one criterion that
+happens to carry the most weight.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from .rubric import StageScore
+
+
+#: Criterion scores are floats derived from counts and ratios, so two drafts that
+#: differ only by floating-point noise are the same draft. Without this, a rerun
+#: that changed nothing would read as a strict improvement and enter the frontier.
+EPSILON = 1e-6
+
+
+def _vector(score: StageScore) -> dict[str, float]:
+    return {item.key: item.score for item in score.criteria}
+
+
+def comparable(left: StageScore, right: StageScore) -> bool:
+    """Two scores may only be ranked when they measure the same thing.
+
+    A rubric version bump changes what the numbers mean. Ranking across one would
+    show every draft measured under the old version suddenly rising or falling,
+    with nothing in the run having changed — the reason every consumer here
+    refuses rather than coercing.
+    """
+    if not left.comparable_to(right):
+        return False
+    return set(_vector(left)) == set(_vector(right))
+
+
+def dominates(left: StageScore, right: StageScore) -> bool:
+    """``left`` is at least as good on every criterion and strictly better on one."""
+    if not comparable(left, right):
+        return False
+    left_vector, right_vector = _vector(left), _vector(right)
+    strictly_better = False
+    for key, value in left_vector.items():
+        other = right_vector[key]
+        if value < other - EPSILON:
+            return False
+        if value > other + EPSILON:
+            strictly_better = True
+    return strictly_better
+
+
+def frontier(scores: Iterable[StageScore]) -> list[StageScore]:
+    """The non-dominated subset, in descending total order.
+
+    Ordering by total is presentation only: the frontier is a set, and the order
+    exists so a human reading the ledger sees the strongest candidate first.
+    """
+    pool = list(scores)
+    kept: list[StageScore] = []
+    for candidate in pool:
+        if any(dominates(other, candidate) for other in pool if other is not candidate):
+            continue
+        # Two candidates with identical vectors dominate neither. Keep the earlier
+        # one: a later attempt that measured the same is not an improvement, and
+        # letting it in would grow the frontier without adding anything.
+        if any(_vector(other) == _vector(candidate) for other in kept):
+            continue
+        kept.append(candidate)
+    kept.sort(key=lambda item: item.total, reverse=True)
+    return kept
+
+
+@dataclass(frozen=True)
+class FrontierUpdate:
+    """What happened when a candidate was offered to the frontier."""
+
+    #: ``entered`` — the candidate is non-dominated and is now on the frontier.
+    #: ``dominated`` — an existing candidate is at least as good everywhere.
+    #: ``duplicate`` — an existing candidate has the identical criterion vector.
+    #: ``incomparable`` — a rubric version or criterion-set mismatch; refused.
+    verdict: str
+    members: tuple[StageScore, ...]
+    #: Members the candidate pushed off the frontier, if any.
+    evicted: tuple[StageScore, ...] = ()
+
+    @property
+    def accepted(self) -> bool:
+        return self.verdict == "entered"
+
+
+def insert(members: Sequence[StageScore], candidate: StageScore) -> FrontierUpdate:
+    """Offer a candidate to the frontier and say what became of it."""
+    usable = [item for item in members if comparable(item, candidate)]
+    if len(usable) != len(members):
+        # A mismatch means the stored frontier was measured under a different
+        # rubric. Refusing is the honest outcome: silently dropping the stale
+        # members would erase the record of what the earlier drafts scored.
+        return FrontierUpdate("incomparable", tuple(members))
+
+    for existing in usable:
+        if _vector(existing) == _vector(candidate):
+            return FrontierUpdate("duplicate", tuple(members))
+    if any(dominates(existing, candidate) for existing in usable):
+        return FrontierUpdate("dominated", tuple(members))
+
+    evicted = tuple(existing for existing in usable if dominates(candidate, existing))
+    survivors = [existing for existing in usable if existing not in evicted]
+    survivors.append(candidate)
+    survivors.sort(key=lambda item: item.total, reverse=True)
+    return FrontierUpdate("entered", tuple(survivors), evicted)
+
+
+@dataclass(frozen=True)
+class Complement:
+    """Two frontier members that are each the only source of some strength."""
+
+    left: StageScore
+    right: StageScore
+    #: Criteria on which ``left`` beats ``right``, worst gap first.
+    left_wins: tuple[str, ...]
+    right_wins: tuple[str, ...]
+    #: Total weighted score a draft would reach by taking the better of the two on
+    #: every criterion. The headroom a merge round is chasing.
+    merged_ceiling: float
+
+    @property
+    def headroom(self) -> float:
+        return self.merged_ceiling - max(self.left.total, self.right.total)
+
+
+def complementary_pair(members: Sequence[StageScore]) -> Complement | None:
+    """The frontier pair whose merge would gain the most, or ``None``.
+
+    Returns ``None`` when the frontier holds fewer than two comparable members, or
+    when no pair is genuinely complementary — one draft beating another everywhere
+    it differs is not a merge opportunity, it is a champion.
+    """
+    best: Complement | None = None
+    for index, left in enumerate(members):
+        for right in members[index + 1:]:
+            if not comparable(left, right):
+                continue
+            left_vector, right_vector = _vector(left), _vector(right)
+            weights = {item.key: item.weight for item in left.criteria}
+
+            left_wins = tuple(
+                key
+                for key in sorted(
+                    left_vector,
+                    key=lambda k: (left_vector[k] - right_vector[k]) * weights.get(k, 1.0),
+                    reverse=True,
+                )
+                if left_vector[key] > right_vector[key] + EPSILON
+            )
+            right_wins = tuple(
+                key
+                for key in sorted(
+                    right_vector,
+                    key=lambda k: (right_vector[k] - left_vector[k]) * weights.get(k, 1.0),
+                    reverse=True,
+                )
+                if right_vector[key] > left_vector[key] + EPSILON
+            )
+            if not left_wins or not right_wins:
+                continue
+
+            total_weight = sum(weights.values()) or 1.0
+            ceiling = (
+                sum(
+                    max(left_vector[key], right_vector[key]) * weights.get(key, 1.0)
+                    for key in left_vector
+                )
+                / total_weight
+            )
+            candidate = Complement(left, right, left_wins, right_wins, ceiling)
+            if best is None or candidate.headroom > best.headroom:
+                best = candidate
+    return best
+
+
+def format_frontier_for_prompt(members: Sequence[StageScore]) -> str:
+    if not members:
+        return "(empty)"
+    lines = ["| Attempt | Total | Strong on | Weak on |", "| --- | --- | --- | --- |"]
+    for score in members:
+        ordered = sorted(score.criteria, key=lambda item: item.score, reverse=True)
+        strong = ", ".join(item.key for item in ordered if item.score >= 0.999) or "—"
+        weak = ", ".join(item.key for item in reversed(ordered) if item.score < 0.999) or "—"
+        lines.append(f"| {score.attempt_no} | {score.total:.3f} | {strong} | {weak} |")
+    return "\n".join(lines)

--- a/src/router.py
+++ b/src/router.py
@@ -1,0 +1,367 @@
+"""Ask the agent which stage comes next, and hold it to the moves that are open.
+
+The graph in :mod:`src.stage_graph` says which moves exist and which are live.
+This module is where one gets chosen. The division matters more than it looks:
+
+* **AutoR decides what is possible.** Guards are evaluated against artifacts on
+  disk. An edge whose guard fails is not selectable, no matter how the agent
+  argues for it.
+* **The agent decides what is sensible.** Among the live moves it picks one and
+  says why, having just done the work and being the only party that knows whether
+  the results actually decided anything.
+* **AutoR decides what happens when those disagree.** A choice outside the menu is
+  refused, recorded with the reason it was refused, and replaced by the default
+  edge — which at every node is the forward one, so a refusal degrades to the old
+  linear pipeline rather than to a stall.
+
+Blocked moves are shown to the agent along with why they are blocked. Hiding them
+would be the more obvious design and it is the wrong one: an agent that can see
+"`07_writing` is closed because H2 has no verdict" routes to the analysis stage
+that would fix it, while an agent shown only the open moves picks the best of them
+without ever learning what it was missing.
+
+**The refusal that carries the weight.** A revisit whose justification repeats one
+already on the path is refused. Returning to Stage 05 a third time because "more
+repeats are needed" is not iteration; the run has been there twice with that exact
+reason and did not resolve it. The check is on the recorded reason rather than on
+a count, so a run that goes back for a *different* reason is never penalised for
+the earlier trip.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .approval_agent import extract_json_payload
+from .rubric import StageScore, format_score_for_prompt
+from .stage_graph import FINISH, GraphState, Move, StageGraph
+from .utils import (
+    RunPaths,
+    StageSpec,
+    append_jsonl,
+    append_log_entry,
+    read_text,
+    truncate_text,
+    write_text,
+)
+
+
+#: ``off`` keeps the deterministic default edge — the historical behaviour, and what
+#: a linear graph collapses to anyway. ``agent`` asks the backend at every node.
+#: ``auto`` asks only where the answer can differ, which is any node with more than
+#: one live move; on a linear graph that is never, so ``auto`` costs nothing there.
+ROUTING_MODES = ("off", "auto", "agent")
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    target: str
+    kind: str
+    reason: str
+    #: What the graph would have taken with nobody asked. Recorded even when it
+    #: equals ``target``: an agreement is evidence about the topology too, and the
+    #: archive cannot tell "the agent confirmed the default" from "the agent was
+    #: never consulted" unless both are on the record.
+    default_target: str
+    agent_directed: bool
+    #: Why the agent's choice was not used, when it was not. Empty otherwise.
+    refusal: str = ""
+
+    @property
+    def finished(self) -> bool:
+        return self.target == FINISH
+
+
+class StageRouter:
+    """Chooses the edge out of a completed stage."""
+
+    def __init__(
+        self,
+        operator: Any | None = None,
+        *,
+        mode: str = "auto",
+        fake_mode: bool = False,
+    ) -> None:
+        if mode not in ROUTING_MODES:
+            raise ValueError(f"Unknown routing mode: {mode!r}. Expected one of {', '.join(ROUTING_MODES)}.")
+        self.mode = mode
+        self.operator = operator
+        self.fake_mode = fake_mode
+
+    def choose(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        graph: StageGraph,
+        state: GraphState,
+        score: StageScore | None = None,
+        final_stage: StageSpec | None = None,
+    ) -> RoutingDecision:
+        moves = graph.moves(paths, stage.slug, state, final_stage=final_stage)
+        live = [move for move in moves if move.admissible]
+        default = graph.default_move(paths, stage.slug, state, final_stage=final_stage)
+        default_target = default.target if default is not None else FINISH
+
+        if default is None:
+            # Nothing is open. That is a real answer at Stage 08 and a halt anywhere
+            # else; either way the walk stops, and the state records which it was.
+            state.halted_because = (
+                ""
+                if stage.slug == "08_dissemination"
+                else f"no move out of {stage.slug} is available: "
+                + "; ".join(move.blocked_because for move in moves) or "the graph has no edge here"
+            )
+            return RoutingDecision(FINISH, "finish", "No further move is available.", FINISH, False)
+
+        should_ask = self.mode == "agent" or (self.mode == "auto" and len(live) > 1)
+        if not should_ask or self.operator is None or self.fake_mode:
+            return RoutingDecision(
+                default.target,
+                default.edge.kind,
+                default.edge.rationale,
+                default_target,
+                agent_directed=False,
+            )
+
+        proposal = self._ask(paths=paths, stage=stage, moves=moves, state=state, score=score)
+        if proposal is None:
+            return self._refuse(
+                paths, stage, default, default_target,
+                "the router produced no readable decision",
+            )
+
+        target = str(proposal.get("target") or "").strip()
+        reason = str(proposal.get("reason") or "").strip()
+
+        chosen = next((move for move in live if move.edge.target == target), None)
+        if chosen is None:
+            blocked = next((move for move in moves if move.edge.target == target), None)
+            detail = (
+                f"`{target}` is not available: {blocked.blocked_because}"
+                if blocked is not None
+                else f"`{target}` is not a move out of {stage.slug}"
+            )
+            return self._refuse(paths, stage, default, default_target, detail)
+
+        if not reason:
+            return self._refuse(
+                paths, stage, default, default_target,
+                f"`{target}` was chosen with no stated reason",
+            )
+
+        if chosen.edge.kind == "revisit" and graph.repeats_a_previous_reason(state, target, reason):
+            return self._refuse(
+                paths, stage, default, default_target,
+                f"the run has already gone back to `{target}` for this same reason and it was not "
+                "resolved; going again on the same grounds is a loop, not an iteration",
+            )
+
+        append_log_entry(
+            paths.logs,
+            f"{stage.slug} route_chosen",
+            f"target: {target}\nkind: {chosen.edge.kind}\ndefault: {default_target}\nreason: {reason}",
+        )
+        return RoutingDecision(target, chosen.edge.kind, reason, default_target, agent_directed=True)
+
+    # -- refusal -------------------------------------------------------------
+
+    def _refuse(
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        default: Move,
+        default_target: str,
+        detail: str,
+    ) -> RoutingDecision:
+        append_log_entry(
+            paths.logs,
+            f"{stage.slug} route_refused",
+            f"{detail}\nFalling back to the graph's default move: {default.target}",
+        )
+        append_jsonl(
+            paths.evolution_dir / "routing_refusals.jsonl",
+            {"stage": stage.slug, "detail": detail, "fell_back_to": default.target},
+        )
+        return RoutingDecision(
+            default.target,
+            default.edge.kind,
+            f"Router fell back to the default move: {detail}.",
+            default_target,
+            agent_directed=False,
+            refusal=detail,
+        )
+
+    # -- the ask -------------------------------------------------------------
+
+    def _ask(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        moves: list[Move],
+        state: GraphState,
+        score: StageScore | None,
+    ) -> dict[str, Any] | None:
+        prompt_path = paths.prompt_cache_dir / f"{stage.slug}_route.prompt.md"
+        write_text(prompt_path, self.build_prompt(paths=paths, stage=stage, moves=moves, state=state, score=score))
+
+        session_id = str(uuid.uuid4())
+        try:
+            command, cwd, stdin_text = self.operator._prepare_invocation(  # noqa: SLF001
+                prompt_path, session_id, paths=paths, resume=False
+            )
+            exit_code, stdout_text, _stderr, _observed, _meta = self.operator._run_streaming_command(  # noqa: SLF001
+                command=command,
+                cwd=cwd,
+                stage=stage,
+                attempt_no=0,
+                paths=paths,
+                mode="route",
+                stdin_text=stdin_text,
+            )
+        except Exception as exc:  # noqa: BLE001 - a routing failure must not end the run
+            append_log_entry(paths.logs, f"{stage.slug} route_error", str(exc))
+            return None
+
+        if exit_code != 0:
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} route_error",
+                f"Routing backend exited {exit_code}.",
+            )
+            return None
+        return extract_json_payload(stdout_text)
+
+    def build_prompt(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        moves: list[Move],
+        state: GraphState,
+        score: StageScore | None,
+    ) -> str:
+        graph = StageGraph(tuple(move.edge for move in moves))
+        route = " → ".join(f"{visit.stage}" for visit in state.path) or "(this is the first stage)"
+        revisits = [
+            f"- went back to `{visit.chose}` after `{visit.stage}`: {visit.reason}"
+            for visit in state.path
+            if visit.kind == "revisit" and visit.reason
+        ]
+
+        sections = [
+            "# AutoR Routing Decision",
+            "",
+            f"You have just completed **{stage.stage_title}** and it has been approved. "
+            "AutoR's stages are a directed graph, not a fixed sequence. Choose the move out of "
+            "this node.",
+            "",
+            "You are choosing where the *research* should go, not where the workflow usually "
+            "goes. Going backwards is a first-class move and is often the right one: an analysis "
+            "that exposes a design flaw is a finding, and writing up around it is not.",
+            "",
+            "## Moves out of this node",
+            "",
+            graph.describe_for_prompt(moves),
+            "",
+            "A move marked unavailable cannot be chosen. The reason it is unavailable is usually "
+            "actionable — if the writing stage is closed because a hypothesis has no verdict, the "
+            "move that opens it is the one to take.",
+            "",
+            "## Route so far",
+            "",
+            route,
+        ]
+        if revisits:
+            sections += ["", "Backward moves already taken:", *revisits, "",
+                         "Do not go back to the same stage for the same reason twice. If the "
+                         "reason is genuinely unchanged, the earlier trip did not work and "
+                         "repeating it will not either."]
+        if score is not None:
+            sections += ["", "## Measured standing of the stage you just finished", "",
+                         format_score_for_prompt(score)]
+
+        sections += [
+            "",
+            "## Original goal",
+            "",
+            truncate_text(_read(paths.user_input), max_chars=2500),
+            "",
+            "## Stage summary you just produced",
+            "",
+            truncate_text(_read(paths.stage_file(stage)) or _read(paths.stage_tmp_file(stage)), max_chars=12000),
+            "",
+            "## Answer",
+            "",
+            "Return JSON only, with no prose outside the object:",
+            "",
+            '{"target":"<stage slug or finish>","reason":"<one or two sentences>"}',
+            "",
+            "- `target` must be one of the available moves above, spelled exactly as shown.",
+            "- `reason` must say what in *this stage's results* makes that the right move. "
+            "\"Continue the workflow\" is not a reason; \"H2 is inconclusive because only one "
+            "seed was run\" is.",
+            "- Choose `finish` only if the run has produced what it set out to produce.",
+        ]
+        return "\n".join(sections)
+
+
+def _read(path: Path) -> str:
+    try:
+        return read_text(path)
+    except OSError:
+        return ""
+
+
+def format_decision(decision: RoutingDecision) -> str:
+    """One line for the terminal."""
+    if decision.refusal:
+        return f"→ {decision.target} (default; agent choice refused: {decision.refusal})"
+    who = "agent" if decision.agent_directed else "default"
+    marker = " ↩" if decision.kind == "revisit" else ""
+    return f"→ {decision.target}{marker} ({who}): {decision.reason}"
+
+
+def routing_summary(paths: RunPaths) -> dict[str, Any]:
+    """Aggregate this run's routing for the archive.
+
+    Reported per edge rather than per stage because the thing worth learning across
+    runs is whether *a move* pays, and the same target reached from two different
+    sources is two different decisions.
+    """
+    payload = _load_json(paths.evolution_dir / "stage_graph.json")
+    if not isinstance(payload, dict):
+        return {}
+    edges: dict[str, int] = {}
+    agent_directed = 0
+    revisits = 0
+    for visit in payload.get("path", []):
+        if not isinstance(visit, dict):
+            continue
+        source, target = str(visit.get("stage") or ""), str(visit.get("chose") or "")
+        if not source or not target:
+            continue
+        edges[f"{source}->{target}"] = edges.get(f"{source}->{target}", 0) + 1
+        if visit.get("agent_directed"):
+            agent_directed += 1
+        if visit.get("kind") == "revisit":
+            revisits += 1
+    return {
+        "edges": edges,
+        "steps": len(payload.get("path", [])),
+        "agent_directed": agent_directed,
+        "revisits": revisits,
+        "route": payload.get("route", ""),
+    }
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None

--- a/src/rubric.py
+++ b/src/rubric.py
@@ -1,0 +1,917 @@
+"""Measure a stage draft, so a refinement round can be told whether it helped.
+
+AutoR already refines: a reviewer asks for changes, the stage runs again, the new
+draft replaces the old one. Nothing anywhere compares the two. A refinement that
+made the stage *worse* — dropped a resolving file reference, replaced a measured
+number with a hedge, collapsed the decision ledger into one repeated sentence —
+is promoted exactly like one that helped, because "later" was the only ordering
+the loop had.
+
+This module supplies the missing ordering. It scores a draft against criteria
+that are read off disk rather than off the prose, so the score moves when the
+work moves and not when the wording does.
+
+**The score is deliberately blind to what the run concluded.**
+
+That constraint is the whole design, not a caveat. A fitness function plus a loop
+is an optimiser, and an optimiser pointed at "how good does this result look"
+is an automated p-hacker: it will find that the cheapest way to raise the number
+is to change the answer. :mod:`src.preregistration` exists to stop a human-driven
+version of that. A scored improvement loop would reintroduce it with a budget.
+
+So no criterion here reads a verdict *value*. Stage 06 is scored on whether every
+preregistered hypothesis carries a verdict backed by an artifact that exists — a
+run whose hypothesis was refuted, cleanly, with the evidence on disk, scores
+higher than one whose hypothesis was supported on an assertion. The verdicts are
+routed through :func:`_verdict_blind_outcomes`, which strips the value before any
+scoring code can see it, and :func:`verdict_digest` hashes the verdict set so
+:mod:`src.evolution` can reject a polish round that moved one.
+
+The rubric is mechanical on purpose. An LLM judge scoring drafts written by the
+same model family is a fitness function the optimiser can talk to, and the point
+of a ratchet is that it cannot be argued with. Qualitative judgement stays where
+it already is: the human, or the reviewer agent at the stage boundary, which now
+sees the best candidate instead of the last one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .utils import (
+    FIGURE_SUFFIXES,
+    MACHINE_DATA_SUFFIXES,
+    RESULT_SUFFIXES,
+    RunPaths,
+    StageSpec,
+    _existing_files,
+    _extract_path_references,
+    _listed_file_exists,
+    extract_markdown_section,
+    stage_execution_started_at,
+    validate_stage_markdown,
+)
+
+
+#: Bump when a criterion is added, removed, reweighted, or has its measurement
+#: changed. Scores carrying different versions are not comparable, and every
+#: consumer that ranks two scores has to refuse to rank across a version change:
+#: a reweight would otherwise read as a run that got better or worse overnight.
+RUBRIC_VERSION = "1"
+
+#: The keys the rubric refuses to read out of an adjudication artifact.
+#:
+#: Enforced by construction in :func:`_verdict_blind_outcomes` rather than by
+#: review, and checked end-to-end by a test that flips every verdict on disk and
+#: asserts the total is unchanged.
+OUTCOME_BLIND_FIELDS = ("verdict", "status", "conclusion", "result")
+
+#: A file smaller than this is not evidence that a stage produced anything. Zero
+#: byte placeholders are the cheapest way to satisfy a criterion that counts.
+MIN_ARTIFACT_BYTES = 32
+
+#: Written in the future or the conditional. A stage summary is a report on work
+#: that happened; a draft that mostly describes intentions is the characteristic
+#: failure of an automated pipeline, and it is invisible to every other gate
+#: because the prose is fluent and every required section is present.
+_HEDGE_PATTERNS = (
+    r"\bwe (?:will|plan to|intend to|aim to|would|expect to)\b",
+    r"\b(?:is|are) (?:designed|intended|expected|planned) to\b",
+    r"\bshould (?:improve|increase|reduce|show|demonstrate|help)\b",
+    r"\b(?:could|might|may) (?:improve|increase|reduce|show|demonstrate|help)\b",
+    r"\bto be (?:run|executed|measured|evaluated|determined|added)\b",
+    r"\bnext (?:step|steps) (?:is|are|will)\b",
+    r"\bnot yet (?:run|measured|evaluated|implemented)\b",
+    r"\bin a future (?:stage|iteration|round)\b",
+)
+
+#: A number carrying a unit or a comparison. "improved accuracy" is a sentence;
+#: "62.4% vs 58.1% (+4.3 points, n=5)" is a result.
+_QUANTITY_PATTERN = re.compile(
+    r"(?<![\w.])"
+    r"[-+]?\d+(?:[.,]\d+)?"
+    r"\s*"
+    r"(?:%|pp|points?|×|x\b|ms\b|s\b|GB\b|MB\b|k\b|M\b|B\b|σ|±|/\d)",
+    flags=re.IGNORECASE,
+)
+#: A bare number attached to a named quantity: `accuracy 0.741`, `n = 5`, `p<0.01`.
+_NAMED_QUANTITY_PATTERN = re.compile(
+    r"\b[A-Za-z][\w@.-]{2,}\s*[:=]?\s*[<>≤≥]?\s*[-+]?\d+(?:\.\d+)?\b"
+)
+
+_DECISION_LEDGER_BUCKETS = (
+    "Open Questions",
+    "Locked Decisions",
+    "Assumptions",
+    "Rejected Alternatives",
+)
+
+@dataclass(frozen=True)
+class Criterion:
+    """One measurable dimension of a stage draft.
+
+    ``min_stage`` exists because a criterion that cannot apply must not be scored
+    zero: Stage 01 has no experiment manifest to produce, and grading it as if it
+    failed to produce one would make every early stage look worse than every late
+    one, which would make the champion ratchet prefer late stages' drafts for no
+    reason connected to their quality.
+    """
+
+    key: str
+    title: str
+    weight: float
+    min_stage: int = 1
+    max_stage: int = 8
+
+    def applies_to(self, stage: StageSpec) -> bool:
+        return self.min_stage <= stage.number <= self.max_stage
+
+
+CRITERIA: tuple[Criterion, ...] = (
+    Criterion("contract", "Contract compliance", weight=2.0),
+    Criterion("grounding", "References that resolve", weight=3.0),
+    Criterion("artifact_breadth", "Artifacts produced this stage", weight=2.0, min_stage=3),
+    Criterion("quantification", "Findings carrying numbers", weight=2.0, min_stage=4),
+    Criterion("numeric_fidelity", "Reported numbers trace to results", weight=3.0, min_stage=5),
+    Criterion("traceability", "Decision ledger", weight=1.5),
+    Criterion("commitment", "Reports work, not intentions", weight=1.5),
+    Criterion("reproducibility", "Machine-readable validity chain", weight=3.0),
+)
+
+CRITERIA_BY_KEY: dict[str, Criterion] = {item.key: item for item in CRITERIA}
+
+
+@dataclass(frozen=True)
+class CriterionScore:
+    key: str
+    title: str
+    weight: float
+    #: 0.0 to 1.0.
+    score: float
+    #: What was measured, in one line, so the ledger says why and not just how much.
+    observed: str
+    #: What would raise it. Empty at full marks — an improvement directive built
+    #: from a saturated criterion asks for churn, not improvement.
+    shortfall: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "title": self.title,
+            "weight": self.weight,
+            "score": round(self.score, 4),
+            "observed": self.observed,
+            "shortfall": self.shortfall,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CriterionScore":
+        return cls(
+            key=str(payload.get("key") or ""),
+            title=str(payload.get("title") or ""),
+            weight=float(payload.get("weight") or 0.0),
+            score=float(payload.get("score") or 0.0),
+            observed=str(payload.get("observed") or ""),
+            shortfall=str(payload.get("shortfall") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class StageScore:
+    """A draft's measured standing, and the fingerprint of what it concluded.
+
+    ``verdict_digest`` is not scored. It is carried so that a caller comparing two
+    scores can tell the difference between a draft that got better and a draft
+    that changed its mind — which is the one comparison a fitness-driven loop must
+    never get wrong.
+    """
+
+    stage_slug: str
+    attempt_no: int
+    rubric_version: str
+    criteria: tuple[CriterionScore, ...]
+    total: float
+    verdict_digest: str = ""
+
+    @property
+    def by_key(self) -> dict[str, CriterionScore]:
+        return {item.key: item for item in self.criteria}
+
+    def weakest(self, limit: int = 3) -> list[CriterionScore]:
+        """Unsaturated criteria, worst first, weighted by how much they are worth.
+
+        Sorting on the raw score would send a polish round after a 0.4 criterion
+        worth 1.5 ahead of a 0.6 criterion worth 3.0, when the second is where the
+        points are.
+        """
+        candidates = [item for item in self.criteria if item.score < 1.0 and item.shortfall]
+        candidates.sort(key=lambda item: ((1.0 - item.score) * item.weight, item.weight), reverse=True)
+        return candidates[:limit]
+
+    def comparable_to(self, other: "StageScore") -> bool:
+        return (
+            self.rubric_version == other.rubric_version
+            and self.stage_slug == other.stage_slug
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage_slug,
+            "attempt": self.attempt_no,
+            "rubric_version": self.rubric_version,
+            "total": round(self.total, 4),
+            "verdict_digest": self.verdict_digest,
+            "criteria": [item.to_dict() for item in self.criteria],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "StageScore":
+        return cls(
+            stage_slug=str(payload.get("stage") or ""),
+            attempt_no=int(payload.get("attempt") or 0),
+            rubric_version=str(payload.get("rubric_version") or ""),
+            criteria=tuple(
+                CriterionScore.from_dict(item)
+                for item in payload.get("criteria", [])
+                if isinstance(item, Mapping)
+            ),
+            total=float(payload.get("total") or 0.0),
+            verdict_digest=str(payload.get("verdict_digest") or ""),
+        )
+
+
+# ----------------------------------------------------------------------------
+# Outcome blindness
+# ----------------------------------------------------------------------------
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+
+
+def _verdict_blind_outcomes(paths: RunPaths) -> list[dict[str, Any]]:
+    """Adjudication records with every outcome-bearing field removed.
+
+    The scoring code below reads only this. It cannot prefer `supported` over
+    `refuted` because by the time it runs, the distinction is gone: what survives
+    is whether a verdict was recorded at all, and what it points at.
+    """
+    payload = _load_json(paths.hypothesis_outcomes)
+    if not isinstance(payload, dict):
+        return []
+    blinded: list[dict[str, Any]] = []
+    for entry in payload.get("outcomes", []):
+        if not isinstance(entry, dict):
+            continue
+        # Every outcome-bearing field collapses to a boolean here. Building the
+        # blinded record by listing what survives, rather than by deleting what
+        # does not, is what makes a criterion added later unable to reach a verdict
+        # by accident: there is nothing in the returned dict to reach.
+        recorded = any(str(entry.get(field) or "").strip() for field in OUTCOME_BLIND_FIELDS)
+        blinded.append(
+            {
+                "id": str(entry.get("id") or "").strip(),
+                "has_verdict": recorded,
+                "rationale_chars": len(str(entry.get("rationale") or "").strip()),
+                "evidence": [
+                    str(item).strip()
+                    for item in entry.get("evidence", [])
+                    if str(item).strip()
+                ],
+            }
+        )
+    return blinded
+
+
+def verdict_digest(paths: RunPaths) -> str:
+    """Fingerprint what the run currently concludes, for drift detection only.
+
+    Deliberately *not* an input to any score. :mod:`src.evolution` compares this
+    across a polish round and rejects the round if it moved, which is how a loop
+    that is allowed to improve the evidence is stopped from improving the answer.
+    """
+    payload = _load_json(paths.hypothesis_outcomes)
+    if not isinstance(payload, dict):
+        return ""
+    verdicts = sorted(
+        (str(entry.get("id") or "").strip(), str(entry.get("verdict") or "").strip())
+        for entry in payload.get("outcomes", [])
+        if isinstance(entry, dict)
+    )
+    if not verdicts:
+        return ""
+    canonical = json.dumps(verdicts, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ----------------------------------------------------------------------------
+# Individual criteria
+# ----------------------------------------------------------------------------
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _score_contract(
+    markdown: str,
+    stage: StageSpec,
+    paths: RunPaths,
+    artifact_roots: Sequence[Path] | None,
+) -> CriterionScore:
+    """The stage's markdown contract, expressed as a number instead of a pass/fail.
+
+    Inside the stage loop this is normally saturated, because a draft only reaches
+    the ratchet after validation cleared. It is not dead weight: the archive
+    replays cold drafts through the same rubric, and a repair pass that fixed four
+    of five errors should read as progress rather than as another failure.
+
+    **Deliberately not** :func:`validate_stage_artifacts`. That gate is right and
+    it is not outcome-blind: :func:`validate_hypothesis_outcomes` demands an
+    evidence pointer for a hypothesis recorded as supported or refuted and not for
+    one recorded as inconclusive, which is correct for a gate and would be a
+    gradient here — the cheapest way to a clean contract score would be to call
+    every outcome inconclusive. The artifact side is covered instead by
+    ``artifact_breadth`` and ``reproducibility``, which apply the same requirement
+    to every verdict. Splitting them this way also stops one condition being
+    weighted twice.
+    """
+    problems = validate_stage_markdown(
+        markdown, stage=stage, paths=paths, artifact_roots=artifact_roots
+    )
+    count = len(problems)
+    score = _clamp(1.0 - 0.2 * count)
+    if count == 0:
+        return CriterionScore(
+            "contract", CRITERIA_BY_KEY["contract"].title, 2.0, 1.0, "no stage-contract errors"
+        )
+    return CriterionScore(
+        "contract",
+        CRITERIA_BY_KEY["contract"].title,
+        2.0,
+        score,
+        f"{count} stage-contract error(s)",
+        "Clear the outstanding validation errors: " + "; ".join(problems[:3]),
+    )
+
+
+def _score_grounding(
+    markdown: str,
+    paths: RunPaths,
+    artifact_roots: Sequence[Path] | None,
+) -> CriterionScore:
+    """Every path the draft names, across the whole draft, has to resolve.
+
+    The shipped gate checks `Files Produced` only. A stage that cites
+    `workspace/results/ablation.json` in Key Results and never wrote it passes
+    that gate and reads as if the artifact exists, which is the failure mode this
+    criterion is for.
+    """
+    weight = CRITERIA_BY_KEY["grounding"].weight
+    referenced = _extract_path_references(markdown)
+    if not referenced:
+        return CriterionScore(
+            "grounding",
+            CRITERIA_BY_KEY["grounding"].title,
+            weight,
+            0.0,
+            "no file references",
+            "Cite the concrete files this stage produced, as backticked paths, in "
+            "What I Did and Key Results as well as Files Produced.",
+        )
+
+    resolving = [ref for ref in referenced if _listed_file_exists(paths.run_root, ref, artifact_roots)]
+    missing = [ref for ref in referenced if ref not in resolving]
+    resolution = len(resolving) / len(referenced)
+
+    # Resolution alone saturates at one reference. Breadth is what separates a
+    # summary anchored in the run from one that names its single output file.
+    breadth = _clamp(len(resolving) / 6.0)
+    score = _clamp(0.7 * resolution + 0.3 * breadth)
+
+    observed = f"{len(resolving)}/{len(referenced)} referenced paths resolve"
+    if missing:
+        shortfall = (
+            "These referenced paths do not exist: "
+            + ", ".join(f"`{item}`" for item in missing[:4])
+            + ". Produce the file or stop citing it."
+        )
+    elif breadth < 1.0:
+        shortfall = (
+            "Anchor more of the narrative in artifacts: cite the specific file "
+            "behind each claim in Key Results, not only the headline output."
+        )
+    else:
+        shortfall = ""
+    return CriterionScore("grounding", CRITERIA_BY_KEY["grounding"].title, weight, score, observed, shortfall)
+
+
+def _fresh_artifact_kinds(
+    paths: RunPaths,
+    stage: StageSpec,
+    artifact_dirs: Mapping[str, Sequence[Path]] | None,
+) -> tuple[set[str], set[str]]:
+    """Which artifact kinds exist, and which were written during this stage.
+
+    Freshness matters because the run tree accumulates. Without a cutoff, Stage 07
+    would score full marks on figures Stage 06 produced, and a stage that did
+    nothing at all would be indistinguishable from one that did.
+    """
+    cutoff = stage_execution_started_at(paths, stage)
+    kinds: dict[str, tuple[Path, ...]] = {
+        "data": (paths.data_dir, *(artifact_dirs or {}).get("data", ())),
+        "results": (paths.results_dir, *(artifact_dirs or {}).get("results", ())),
+        "figures": (paths.figures_dir, *(artifact_dirs or {}).get("figures", ())),
+        "code": (paths.code_dir,),
+        "writing": (paths.writing_dir, paths.report_dir),
+    }
+    suffixes = {
+        "data": MACHINE_DATA_SUFFIXES,
+        "results": RESULT_SUFFIXES,
+        "figures": FIGURE_SUFFIXES,
+        "code": {".py", ".sh", ".r", ".jl", ".ipynb", ".cpp", ".rs", ".go", ".ts", ".js"},
+        "writing": {".md", ".tex", ".bib"},
+    }
+
+    present: set[str] = set()
+    fresh: set[str] = set()
+    for kind, directories in kinds.items():
+        allowed = suffixes[kind]
+        for directory in directories:
+            for path in _existing_files(directory):
+                if path.suffix.lower() not in allowed:
+                    continue
+                try:
+                    stat = path.stat()
+                except OSError:
+                    continue
+                # A zero-byte file is the cheapest possible way to satisfy a gate
+                # that counts, so it does not count.
+                if stat.st_size < MIN_ARTIFACT_BYTES:
+                    continue
+                present.add(kind)
+                if cutoff is None or stat.st_mtime >= cutoff:
+                    fresh.add(kind)
+    return present, fresh
+
+
+def _score_artifact_breadth(
+    paths: RunPaths,
+    stage: StageSpec,
+    artifact_dirs: Mapping[str, Sequence[Path]] | None,
+) -> CriterionScore:
+    weight = CRITERIA_BY_KEY["artifact_breadth"].weight
+    present, fresh = _fresh_artifact_kinds(paths, stage, artifact_dirs)
+    # What a stage is reasonably expected to touch. Scored against an expectation
+    # rather than a raw count so a stage cannot climb by emitting more of the one
+    # kind it already had.
+    expected = 2 if stage.number < 5 else 3
+    score = _clamp(len(fresh) / expected)
+    observed = (
+        f"{len(fresh)} artifact kind(s) written during this stage "
+        f"({', '.join(sorted(fresh)) or 'none'}); {len(present)} present overall"
+    )
+    if score >= 1.0:
+        shortfall = ""
+    elif not fresh and present:
+        shortfall = (
+            "Every artifact in the run predates this stage's execution. Produce or "
+            "update the files this stage is responsible for."
+        )
+    else:
+        shortfall = (
+            f"Only {len(fresh)} of an expected {expected} artifact kinds were written here. "
+            "Add the missing machine-readable outputs (data, results, figures, code) rather "
+            "than describing them in prose."
+        )
+    return CriterionScore(
+        "artifact_breadth", CRITERIA_BY_KEY["artifact_breadth"].title, weight, score, observed, shortfall
+    )
+
+
+def _score_quantification(markdown: str) -> CriterionScore:
+    """Key Results has to contain results, in the sense of numbers.
+
+    Scored on Key Results alone. Counting quantities across the whole document
+    would let a Study Design section full of budget figures stand in for having
+    measured anything.
+    """
+    weight = CRITERIA_BY_KEY["quantification"].weight
+    section = extract_markdown_section(markdown, "Key Results") or ""
+    united = len(_QUANTITY_PATTERN.findall(section))
+    named = len(_NAMED_QUANTITY_PATTERN.findall(section))
+    quantities = united + named
+    score = _clamp(quantities / 6.0)
+    observed = f"{quantities} quantified statement(s) in Key Results"
+    if score >= 1.0:
+        shortfall = ""
+    elif quantities == 0:
+        shortfall = (
+            "Key Results states no measured quantity. Report the numbers: the metric, "
+            "the value, the comparison, and how many runs it is over."
+        )
+    else:
+        shortfall = (
+            "Key Results is mostly narrative. Give each finding its number, its baseline "
+            "comparison, and its spread across repeats."
+        )
+    return CriterionScore(
+        "quantification", CRITERIA_BY_KEY["quantification"].title, weight, score, observed, shortfall
+    )
+
+
+def _artifact_numbers(paths: RunPaths) -> set[float]:
+    """Every number recorded in a machine-readable result artifact.
+
+    Read from the files themselves rather than from anything the stage wrote in
+    prose, because the point is to have a source of truth the draft did not author.
+    """
+    values: set[float] = set()
+
+    def absorb(node: Any) -> None:
+        if isinstance(node, bool):
+            return
+        if isinstance(node, (int, float)):
+            values.add(float(node))
+        elif isinstance(node, Mapping):
+            for item in node.values():
+                absorb(item)
+        elif isinstance(node, (list, tuple)):
+            for item in node:
+                absorb(item)
+        elif isinstance(node, str):
+            for token in re.findall(r"[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?", node):
+                try:
+                    values.add(float(token))
+                except ValueError:
+                    continue
+
+    for directory in (paths.results_dir, paths.data_dir):
+        for path in _existing_files(directory):
+            suffix = path.suffix.lower()
+            if suffix not in {".json", ".jsonl", ".csv", ".tsv", ".yaml", ".yml", ".txt"}:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            if suffix == ".json":
+                parsed = _load_json(path)
+                if parsed is not None:
+                    absorb(parsed)
+                    continue
+            absorb(text)
+    return values
+
+
+#: Reported values that are almost never measurements: seed counts, epoch counts,
+#: years, section numbers. Penalising a draft for saying "5 seeds" when no artifact
+#: happens to contain a bare 5 would make the criterion noise.
+def _is_measurement_like(raw: str, value: float) -> bool:
+    if "." in raw:
+        return True
+    return abs(value) >= 1000
+
+
+def _score_numeric_fidelity(markdown: str, paths: RunPaths) -> CriterionScore:
+    """Every number the draft reports has to appear in an artifact it did not write.
+
+    This is the check that catches the failure mode independent evaluations keep
+    finding in automated science: a fluent write-up quoting metrics that exist
+    nowhere in the run. Every other gate here passes such a draft — the sections
+    are present, the files it names exist, the prose is quantified. The number
+    itself is simply invented, and only a comparison against the raw outputs sees
+    it.
+
+    Tolerance is one half of the last reported decimal place, and a percentage is
+    matched against its fraction too, so `74.1%` is satisfied by `0.741` in a
+    results file. Anything looser would accept a number that merely resembles one
+    that was measured.
+    """
+    weight = CRITERIA_BY_KEY["numeric_fidelity"].weight
+    section = "\n".join(
+        extract_markdown_section(markdown, heading) or ""
+        for heading in ("Key Results", "What I Did")
+    )
+    # Strip backticked spans: a path like `results/run_05.json` and a command line
+    # are not claims about a measured value.
+    section = re.sub(r"`[^`\n]*`", " ", section)
+
+    reported: list[tuple[str, float, bool]] = []
+    for match in re.finditer(r"(?<![\w.])([-+]?\d+(?:\.\d+)?)\s*(%?)", section):
+        raw, percent = match.group(1), bool(match.group(2))
+        try:
+            value = float(raw)
+        except ValueError:
+            continue
+        if not _is_measurement_like(raw, value):
+            continue
+        reported.append((raw, value, percent))
+
+    if not reported:
+        return CriterionScore(
+            "numeric_fidelity",
+            CRITERIA_BY_KEY["numeric_fidelity"].title,
+            weight,
+            0.0,
+            "no measured value reported",
+            "Report the measured values in Key Results, and make sure each one also appears "
+            "in a file under workspace/results so a reader can check it.",
+        )
+
+    known = _artifact_numbers(paths)
+    if not known:
+        return CriterionScore(
+            "numeric_fidelity",
+            CRITERIA_BY_KEY["numeric_fidelity"].title,
+            weight,
+            0.0,
+            f"{len(reported)} reported value(s), no machine-readable results to check them against",
+            "Write the raw measurements to workspace/results as JSON or CSV. A number that "
+            "appears only in the summary cannot be verified by anyone, including the next stage.",
+        )
+
+    def matches(value: float, raw: str, percent: bool) -> bool:
+        decimals = len(raw.split(".")[1]) if "." in raw else 0
+        tolerance = max(0.5 * (10 ** -decimals), abs(value) * 1e-9)
+        for candidate in (value, value / 100.0) if percent else (value,):
+            scale = max(0.5 * (10 ** -decimals) / 100.0, tolerance) if candidate != value else tolerance
+            if any(abs(candidate - known_value) <= scale for known_value in known):
+                return True
+        return False
+
+    unmatched = [raw for raw, value, percent in reported if not matches(value, raw, percent)]
+    score = _clamp((len(reported) - len(unmatched)) / len(reported))
+    observed = f"{len(reported) - len(unmatched)}/{len(reported)} reported values found in results artifacts"
+    shortfall = (
+        ""
+        if not unmatched
+        else (
+            "These reported values appear in no results artifact: "
+            + ", ".join(unmatched[:6])
+            + ". Either write the raw measurement to workspace/results, or correct the number. "
+            "Do not restate it more confidently."
+        )
+    )
+    return CriterionScore(
+        "numeric_fidelity", CRITERIA_BY_KEY["numeric_fidelity"].title, weight, score, observed, shortfall
+    )
+
+
+def _score_traceability(markdown: str) -> CriterionScore:
+    """The four decision-ledger buckets, filled and saying different things.
+
+    The shipped gate checks the four headings are present. The failure it cannot
+    see is a ledger whose four buckets contain the same sentence, or three of
+    which say "None" — which is what an agent writes when it is satisfying a
+    heading rather than recording a decision.
+    """
+    weight = CRITERIA_BY_KEY["traceability"].weight
+    section = extract_markdown_section(markdown, "Decision Ledger") or ""
+    filled: list[str] = []
+    empty: list[str] = []
+    for bucket in _DECISION_LEDGER_BUCKETS:
+        pattern = re.compile(
+            rf"{re.escape(bucket)}\s*:?\s*\**\s*\n?(.*?)(?=(?:{'|'.join(re.escape(other) for other in _DECISION_LEDGER_BUCKETS)})|\Z)",
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        match = pattern.search(section)
+        body = (match.group(1) if match else "").strip(" \n\t-*:")
+        normalized = re.sub(r"\s+", " ", body.lower()).strip(" .-")
+        if len(normalized) < 12 or normalized in {"none", "n/a", "na", "nothing", "none yet", "tbd"}:
+            empty.append(bucket)
+        else:
+            filled.append(normalized)
+
+    distinct = len({item[:120] for item in filled})
+    score = _clamp(distinct / len(_DECISION_LEDGER_BUCKETS))
+    observed = f"{distinct}/{len(_DECISION_LEDGER_BUCKETS)} decision-ledger buckets carry distinct content"
+    if score >= 1.0:
+        shortfall = ""
+    elif empty:
+        shortfall = (
+            "These decision-ledger buckets are empty or say nothing: "
+            + ", ".join(empty)
+            + ". Record the decision that was actually taken, or state that none was and why."
+        )
+    else:
+        shortfall = (
+            "The decision-ledger buckets repeat each other. An assumption, a locked "
+            "decision, and a rejected alternative are three different things."
+        )
+    return CriterionScore(
+        "traceability", CRITERIA_BY_KEY["traceability"].title, weight, score, observed, shortfall
+    )
+
+
+def _score_commitment(markdown: str) -> CriterionScore:
+    """Density of intention over report, in the sections describing work done."""
+    weight = CRITERIA_BY_KEY["commitment"].weight
+    body = "\n".join(
+        extract_markdown_section(markdown, heading) or ""
+        for heading in ("What I Did", "Key Results")
+    )
+    words = max(len(body.split()), 1)
+    hedges = sum(len(re.findall(pattern, body, flags=re.IGNORECASE)) for pattern in _HEDGE_PATTERNS)
+    # One hedge per 200 words is ordinary scientific caution. Six is a plan.
+    allowance = max(words / 200.0, 1.0)
+    score = _clamp(1.0 - (hedges / (allowance * 5.0)))
+    observed = f"{hedges} forward-looking phrase(s) across {words} words of What I Did / Key Results"
+    shortfall = (
+        ""
+        if score >= 1.0
+        else (
+            "What I Did and Key Results describe intentions rather than completed work. "
+            "State what was run and what came out; move anything not yet done into "
+            "Suggestions for Refinement."
+        )
+    )
+    return CriterionScore(
+        "commitment", CRITERIA_BY_KEY["commitment"].title, weight, score, observed, shortfall
+    )
+
+
+def _score_reproducibility(paths: RunPaths, stage: StageSpec) -> CriterionScore:
+    """The machine-readable validity chain that applies at this stage.
+
+    Each check is a boolean over an artifact that either exists and parses or does
+    not. Nothing here reads a verdict value; Stage 06's check is that every
+    adjudication points at a file, not that it points at a favourable one.
+    """
+    weight = CRITERIA_BY_KEY["reproducibility"].weight
+    checks: list[tuple[str, bool, str]] = []
+
+    if stage.number >= 1:
+        ledger = paths.literature_dir / "evidence_ledger.json"
+        checks.append(
+            (
+                "literature evidence ledger",
+                isinstance(_load_json(ledger), (dict, list)),
+                "Write workspace/literature/evidence_ledger.json so each cited claim points at a source.",
+            )
+        )
+    if stage.number >= 3:
+        protocol = _load_json(paths.experimental_protocol)
+        checks.append(
+            (
+                "experimental protocol",
+                isinstance(protocol, dict) and bool(protocol.get("baselines")),
+                "Declare workspace/notes/experimental_protocol.json with a competent baseline and "
+                "a tuning budget for each comparison.",
+            )
+        )
+    if stage.number >= 4:
+        prereg = _load_json(paths.preregistration)
+        checks.append(
+            (
+                "frozen preregistration",
+                isinstance(prereg, dict) and bool(prereg.get("hypotheses")),
+                "Fix the hypothesis set before results exist; it is written when Stage 04 is approved.",
+            )
+        )
+    if stage.number >= 5:
+        manifest = _load_json(paths.experiment_manifest)
+        checks.append(
+            (
+                "experiment manifest",
+                isinstance(manifest, dict) and bool(manifest.get("experiments")),
+                "Record every experiment in workspace/results/experiment_manifest.json with its "
+                "command, config and seeds.",
+            )
+        )
+    if stage.number >= 6:
+        outcomes = _verdict_blind_outcomes(paths)
+        adjudicated = [item for item in outcomes if item["has_verdict"]]
+        evidenced = [
+            item
+            for item in adjudicated
+            if item["evidence"] and all(_evidence_resolves(paths, ref) for ref in item["evidence"])
+        ]
+        checks.append(
+            (
+                "adjudicated hypotheses",
+                bool(adjudicated) and len(evidenced) == len(adjudicated),
+                "Give every preregistered hypothesis a verdict in "
+                "workspace/results/hypothesis_outcomes.json, each pointing at a result file that "
+                "exists. A refuted hypothesis with clean evidence is a complete outcome; an "
+                "unevidenced one is not.",
+            )
+        )
+    if stage.number >= 7:
+        provenance = _load_json(paths.claim_provenance)
+        claims = provenance.get("claims") if isinstance(provenance, dict) else None
+        checks.append(
+            (
+                "claim provenance",
+                isinstance(claims, list) and bool(claims),
+                "Map every claim the write-up makes to a preregistered hypothesis or label it "
+                "exploratory, in workspace/artifacts/claim_provenance.json.",
+            )
+        )
+
+    if not checks:
+        return CriterionScore(
+            "reproducibility", CRITERIA_BY_KEY["reproducibility"].title, weight, 1.0, "no chain links apply yet"
+        )
+
+    passing = [name for name, ok, _ in checks if ok]
+    failing = [(name, hint) for name, ok, hint in checks if not ok]
+    score = len(passing) / len(checks)
+    observed = f"{len(passing)}/{len(checks)} validity-chain artifacts in place"
+    shortfall = (
+        ""
+        if not failing
+        else "Missing: " + " ".join(f"[{name}] {hint}" for name, hint in failing[:3])
+    )
+    return CriterionScore(
+        "reproducibility", CRITERIA_BY_KEY["reproducibility"].title, weight, score, observed, shortfall
+    )
+
+
+def _evidence_resolves(paths: RunPaths, reference: str) -> bool:
+    candidate = reference.lstrip("./")
+    return any((base / candidate).is_file() for base in (paths.workspace_root, paths.run_root))
+
+
+# ----------------------------------------------------------------------------
+# Entry point
+# ----------------------------------------------------------------------------
+
+
+def score_stage(
+    *,
+    paths: RunPaths,
+    stage: StageSpec,
+    markdown: str,
+    attempt_no: int = 1,
+    artifact_dirs: Mapping[str, Sequence[Path]] | None = None,
+    artifact_roots: Sequence[Path] | None = None,
+) -> StageScore:
+    """Measure one stage draft. Pure read: nothing on disk is modified."""
+    scores: list[CriterionScore] = []
+    for criterion in CRITERIA:
+        if not criterion.applies_to(stage):
+            continue
+        if criterion.key == "contract":
+            scores.append(_score_contract(markdown, stage, paths, artifact_roots))
+        elif criterion.key == "grounding":
+            scores.append(_score_grounding(markdown, paths, artifact_roots))
+        elif criterion.key == "artifact_breadth":
+            scores.append(_score_artifact_breadth(paths, stage, artifact_dirs))
+        elif criterion.key == "quantification":
+            scores.append(_score_quantification(markdown))
+        elif criterion.key == "numeric_fidelity":
+            scores.append(_score_numeric_fidelity(markdown, paths))
+        elif criterion.key == "traceability":
+            scores.append(_score_traceability(markdown))
+        elif criterion.key == "commitment":
+            scores.append(_score_commitment(markdown))
+        elif criterion.key == "reproducibility":
+            scores.append(_score_reproducibility(paths, stage))
+
+    total_weight = sum(item.weight for item in scores) or 1.0
+    total = sum(item.score * item.weight for item in scores) / total_weight
+
+    return StageScore(
+        stage_slug=stage.slug,
+        attempt_no=attempt_no,
+        rubric_version=RUBRIC_VERSION,
+        criteria=tuple(scores),
+        total=total,
+        verdict_digest=verdict_digest(paths),
+    )
+
+
+def format_score_for_prompt(score: StageScore, *, limit: int = 4) -> str:
+    """Render a score as the operator sees it: worst criteria first, with the ask."""
+    lines = [
+        f"Measured standing of the current draft: **{score.total:.3f}** "
+        f"(rubric v{score.rubric_version}, 0.0-1.0).",
+        "",
+        "| Criterion | Score | Observed |",
+        "| --- | --- | --- |",
+    ]
+    for item in sorted(score.criteria, key=lambda entry: entry.score):
+        lines.append(f"| {item.title} | {item.score:.2f} | {item.observed} |")
+
+    weakest = score.weakest(limit=limit)
+    if weakest:
+        lines.append("")
+        lines.append("Where the points are:")
+        for item in weakest:
+            lines.append(f"- **{item.title}** ({item.score:.2f}): {item.shortfall}")
+    return "\n".join(lines)
+
+
+def format_score_line(score: StageScore) -> str:
+    """One line, for a terminal status or a log heading."""
+    parts = ", ".join(f"{item.key}={item.score:.2f}" for item in score.criteria)
+    return f"{score.total:.3f} [{parts}]"

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -1,0 +1,646 @@
+"""The eight stages as a directed graph the run navigates, instead of a list it walks.
+
+Real research is not a pipeline. Analysis finds that the experiment answered a
+different question than the one that was asked; writing finds that a claim has no
+result behind it; a result nobody expected is worth more than the one that was
+planned. Every one of those is a *backward* move, and a linear stage list has no
+way to express one. AutoR's loop could only refine the current stage or abort, so
+the system's response to "Stage 06 shows the design was wrong" was to write up the
+wrong design more carefully.
+
+This module makes the topology explicit. Nodes are stages; edges are the moves
+that are allowed between them; after each approved stage the run chooses an edge.
+The default topology is exactly the old sequence — 01→02→…→08, one edge out of
+each node — so a run that does not ask for anything else behaves as it always did.
+The linear pipeline is not replaced, it is one path through the graph.
+
+**Why the agent does not simply decide.**
+
+An agent choosing its own next step chooses the short path to the deliverable.
+The terminal node is where the reward is, and every autonomous research system
+that has been evaluated drifts toward writing up early. So the choice here is a
+two-part thing, and the parts are not both the agent's:
+
+1. AutoR computes which moves are *admissible*, by evaluating each edge's guard
+   against artifacts on disk. An edge into ``07_writing`` requires a frozen
+   preregistration and a verdict on every hypothesis. The agent cannot route
+   around a gate, because a gated edge is not on the menu.
+2. The agent chooses among the admissible moves and says why. Its reason is
+   recorded next to the measurement that made the move admissible.
+
+The backward edges are the reason the graph exists, so they are cheap to take and
+expensive to take *twice for the same reason*: a node carries a visit budget, and
+:func:`admissible_moves` withdraws a revisit whose justification has not changed
+since the last time it was taken. A loop that keeps returning to Stage 05 with the
+same complaint is not iterating, it is stuck, and the difference is measurable.
+
+The path is recorded in ``evolution/stage_graph.json`` — every visit, the move out
+of it, whether the agent's choice matched what AutoR would have picked, and the
+rubric total at the time. :mod:`src.archive` reads those across runs to learn
+which edges actually pay, which is what lets the topology improve rather than just
+exist.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from .utils import (
+    FIGURE_SUFFIXES,
+    MACHINE_DATA_SUFFIXES,
+    RESULT_SUFFIXES,
+    RunPaths,
+    StageSpec,
+    STAGES,
+    _count_files_with_suffixes,
+    read_text,
+    write_text,
+)
+
+
+#: Terminal target. Not a stage — a node the run can move to and stop.
+FINISH = "finish"
+
+#: How many stage executions a graph run may make before it is stopped, regardless
+#: of visit budgets. A cap on the whole walk, not on any node: three stages each
+#: revisited twice is a productive run, and the same total spent bouncing between
+#: two nodes is not, but only the global number bounds the cost of either.
+DEFAULT_MAX_STEPS = 20
+
+#: Times a single stage may be entered. Two revisits of Stage 05 is a run that
+#: took its own analysis seriously; a fourth is a loop.
+DEFAULT_MAX_VISITS = 3
+
+
+# ----------------------------------------------------------------------------
+# Guards
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GuardResult:
+    ok: bool
+    #: Why the edge is or is not available, in the words the router will show the
+    #: agent. A guard that fails without saying what would satisfy it turns a
+    #: routing decision into a guess.
+    reason: str
+
+
+GuardFn = Callable[[RunPaths, "GraphState"], GuardResult]
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return None
+
+
+def _guard_always(paths: RunPaths, state: "GraphState") -> GuardResult:
+    return GuardResult(True, "no precondition")
+
+
+def _guard_design_artifacts(paths: RunPaths, state: "GraphState") -> GuardResult:
+    count = _count_files_with_suffixes(paths.data_dir, MACHINE_DATA_SUFFIXES)
+    protocol = _load_json(paths.experimental_protocol)
+    has_protocol = isinstance(protocol, dict) and bool(protocol.get("baselines"))
+    if count and has_protocol:
+        return GuardResult(True, f"{count} machine-readable design artifact(s) and a declared protocol")
+    missing = []
+    if not count:
+        missing.append("machine-readable artifacts under workspace/data")
+    if not has_protocol:
+        missing.append("workspace/notes/experimental_protocol.json declaring the baselines")
+    return GuardResult(False, "the study design has produced no " + " and no ".join(missing))
+
+
+def _guard_runnable_code(paths: RunPaths, state: "GraphState") -> GuardResult:
+    count = _count_files_with_suffixes(
+        paths.code_dir, {".py", ".sh", ".r", ".jl", ".ipynb", ".cpp", ".rs", ".go"}
+    )
+    if count:
+        return GuardResult(True, f"{count} executable file(s) under workspace/code")
+    return GuardResult(False, "there is nothing to run: workspace/code holds no executable file")
+
+
+def _guard_results_exist(paths: RunPaths, state: "GraphState") -> GuardResult:
+    count = _count_files_with_suffixes(paths.results_dir, RESULT_SUFFIXES)
+    manifest = _load_json(paths.experiment_manifest)
+    has_manifest = isinstance(manifest, dict) and bool(manifest.get("experiments"))
+    if count and has_manifest:
+        return GuardResult(True, f"{count} result artifact(s) and a populated experiment manifest")
+    return GuardResult(
+        False,
+        "no experiment has produced a machine-readable result under workspace/results "
+        "with a matching entry in experiment_manifest.json",
+    )
+
+
+def _guard_validity_chain(paths: RunPaths, state: "GraphState") -> GuardResult:
+    """The one gate a self-routing agent must not be able to talk its way past.
+
+    Writing before the hypotheses are adjudicated is how a manuscript ends up
+    claiming a result the run never established. The check is over artifacts, not
+    over the agent's assessment of its own readiness.
+    """
+    prereg = _load_json(paths.preregistration)
+    hypotheses = prereg.get("hypotheses") if isinstance(prereg, dict) else None
+    if not hypotheses:
+        return GuardResult(False, "the hypotheses were never frozen; there is nothing to write up against")
+
+    expected = {
+        str(item.get("id") or "").strip()
+        for item in hypotheses
+        if isinstance(item, dict) and str(item.get("type") or "") == "empirical"
+    }
+    outcomes = _load_json(paths.hypothesis_outcomes)
+    recorded = {
+        str(item.get("id") or "").strip()
+        for item in (outcomes.get("outcomes", []) if isinstance(outcomes, dict) else [])
+        if isinstance(item, dict) and str(item.get("verdict") or "").strip()
+    }
+    unadjudicated = sorted(expected - recorded)
+    if unadjudicated:
+        return GuardResult(
+            False,
+            "these preregistered hypotheses have no verdict yet: " + ", ".join(unadjudicated),
+        )
+    figures = _count_files_with_suffixes(paths.figures_dir, FIGURE_SUFFIXES)
+    if not figures:
+        return GuardResult(False, "the analysis produced no figure under workspace/figures")
+    return GuardResult(True, f"every hypothesis is adjudicated and {figures} figure(s) exist")
+
+
+def _guard_report_exists(paths: RunPaths, state: "GraphState") -> GuardResult:
+    if paths.report_file.exists() or _count_files_with_suffixes(paths.writing_dir, {".tex", ".md"}):
+        return GuardResult(True, "a written deliverable exists")
+    return GuardResult(False, "no report or manuscript source has been written")
+
+
+def _guard_has_hypotheses(paths: RunPaths, state: "GraphState") -> GuardResult:
+    manifest = _load_json(paths.hypothesis_manifest)
+    if isinstance(manifest, dict) and manifest.get("empirical_hypotheses"):
+        return GuardResult(True, "typed hypotheses are on record")
+    return GuardResult(False, "no empirical hypothesis has been stated yet")
+
+
+GUARDS: dict[str, GuardFn] = {
+    "always": _guard_always,
+    "design_artifacts": _guard_design_artifacts,
+    "runnable_code": _guard_runnable_code,
+    "results_exist": _guard_results_exist,
+    "validity_chain": _guard_validity_chain,
+    "report_exists": _guard_report_exists,
+    "has_hypotheses": _guard_has_hypotheses,
+}
+
+
+# ----------------------------------------------------------------------------
+# Edges
+# ----------------------------------------------------------------------------
+
+
+#: ``advance`` moves forward, ``revisit`` goes back to redo work in the light of
+#: something later, ``finish`` ends the run. The kind is not decoration: a revisit
+#: is budgeted and justified differently from an advance, and the archive learns
+#: their payoffs separately — so an edge declared with a kind nothing handles is
+#: refused at construction rather than silently treated as an advance.
+EDGE_KINDS = ("advance", "revisit", "finish")
+
+
+@dataclass(frozen=True)
+class Edge:
+    source: str
+    target: str
+    kind: str
+    #: Shown to the router. Says what condition in the *research* makes this the
+    #: right move — not what the target stage does, which the agent already knows.
+    rationale: str
+    guard: str = "always"
+    #: Deterministic tie-break, low first. Also the fallback order when routing is
+    #: off or the agent's choice is refused, which is why the advance edge out of
+    #: every node is priority 0: the fallback through the graph is the old pipeline.
+    priority: int = 0
+
+    def __post_init__(self) -> None:
+        if self.kind not in EDGE_KINDS:
+            raise ValueError(
+                f"Edge {self.source}->{self.target} has kind {self.kind!r}; "
+                f"expected one of {', '.join(EDGE_KINDS)}."
+            )
+        if self.guard not in GUARDS:
+            raise ValueError(
+                f"Edge {self.source}->{self.target} names guard {self.guard!r}, which is not "
+                f"registered. A guard that does not resolve would silently pass."
+            )
+
+    def guard_fn(self) -> GuardFn:
+        return GUARDS[self.guard]
+
+
+#: Preconditions on the forward moves. They apply in the adaptive topology, where
+#: the run is choosing between edges and a guard is what stops it choosing the one
+#: that skips the work. They deliberately do **not** apply to the linear topology:
+#: there is one edge out of each node there, so a guard could only ever halt the
+#: run, and the condition it would halt on is already a stage validation error with
+#: a better message. Two gates over one condition is one gate too many, and the one
+#: that fires second is the one nobody maintains.
+_ADVANCE_GUARDS = {
+    "03_study_design": "has_hypotheses",
+    "04_implementation": "design_artifacts",
+    "05_experimentation": "runnable_code",
+    "06_analysis": "results_exist",
+    "07_writing": "validity_chain",
+    "08_dissemination": "report_exists",
+}
+
+
+def _advance_edges(*, guarded: bool) -> list[Edge]:
+    edges: list[Edge] = []
+    guards = _ADVANCE_GUARDS if guarded else {}
+    for index, stage in enumerate(STAGES):
+        target = STAGES[index + 1].slug if index + 1 < len(STAGES) else FINISH
+        edges.append(
+            Edge(
+                source=stage.slug,
+                target=target,
+                kind="advance" if target != FINISH else "finish",
+                rationale=(
+                    "This stage is complete and the next one is the natural continuation."
+                    if target != FINISH
+                    else "The run has produced everything it set out to produce."
+                ),
+                guard=guards.get(target, "always"),
+                priority=0,
+            )
+        )
+    return edges
+
+
+#: The moves a linear list cannot express. Each one exists because a specific
+#: discovery at the source stage invalidates work at the target — which is the
+#: normal way research goes, not an error path.
+REVISIT_EDGES: tuple[Edge, ...] = (
+    Edge(
+        "04_implementation", "03_study_design", "revisit",
+        "Building it showed the design is not executable as specified — the metric cannot be "
+        "computed, the dataset does not contain what the plan assumed, or the budget is off by "
+        "an order of magnitude.",
+        guard="always", priority=2,
+    ),
+    Edge(
+        "05_experimentation", "04_implementation", "revisit",
+        "The experiment could not run, or ran and produced something the implementation is "
+        "clearly responsible for.",
+        guard="always", priority=2,
+    ),
+    Edge(
+        "05_experimentation", "03_study_design", "revisit",
+        "Running it showed the comparison does not answer the question — the baseline is not "
+        "competent, or the measurement cannot distinguish the hypotheses.",
+        guard="always", priority=3,
+    ),
+    Edge(
+        "06_analysis", "05_experimentation", "revisit",
+        "The results are real but insufficient to decide a hypothesis: too few repeats, a "
+        "missing ablation, a condition that was never run.",
+        guard="runnable_code", priority=1,
+    ),
+    Edge(
+        "06_analysis", "03_study_design", "revisit",
+        "The analysis exposed a design flaw the results cannot repair — a confound, a leak, or "
+        "a comparison that was never fair.",
+        guard="always", priority=3,
+    ),
+    Edge(
+        "06_analysis", "02_hypothesis_generation", "revisit",
+        "The evidence refutes the hypotheses and points somewhere specific. Recording the "
+        "refutation and stating the new hypothesis is a result; quietly rewriting the old one "
+        "is not, and the amendment is logged either way.",
+        guard="always", priority=4,
+    ),
+    Edge(
+        "07_writing", "06_analysis", "revisit",
+        "Writing it up showed a claim has no analysis behind it, or a figure does not show what "
+        "the text says it shows.",
+        guard="results_exist", priority=1,
+    ),
+    Edge(
+        "07_writing", "05_experimentation", "revisit",
+        "Writing it up showed the paper needs a result that was never produced.",
+        guard="runnable_code", priority=3,
+    ),
+    Edge(
+        "07_writing", "01_literature_survey", "revisit",
+        "The finding turns out to relate to work the survey missed, and the contribution cannot "
+        "be stated honestly without it.",
+        guard="always", priority=4,
+    ),
+    Edge(
+        "08_dissemination", "07_writing", "revisit",
+        "Packaging it showed the deliverable is not what a reader would need.",
+        guard="always", priority=2,
+    ),
+)
+
+
+# ----------------------------------------------------------------------------
+# State
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class Visit:
+    stage: str
+    entered_at: str
+    #: Filled in when the run leaves. An unfinished visit is the record of where a
+    #: run was interrupted, which is what a resume needs.
+    left_at: str = ""
+    chose: str = ""
+    kind: str = ""
+    reason: str = ""
+    #: What AutoR would have chosen with no agent involved. Kept beside the actual
+    #: choice so a disagreement is visible: the archive learns from the cases where
+    #: the router departed from the pipeline and it paid off, and from where it did
+    #: not, and neither is recoverable if only the taken edge is stored.
+    default_choice: str = ""
+    agent_directed: bool = False
+    score_total: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stage": self.stage,
+            "entered_at": self.entered_at,
+            "left_at": self.left_at,
+            "chose": self.chose,
+            "kind": self.kind,
+            "reason": self.reason,
+            "default_choice": self.default_choice,
+            "agent_directed": self.agent_directed,
+            "score_total": self.score_total,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "Visit":
+        total = payload.get("score_total")
+        return cls(
+            stage=str(payload.get("stage") or ""),
+            entered_at=str(payload.get("entered_at") or ""),
+            left_at=str(payload.get("left_at") or ""),
+            chose=str(payload.get("chose") or ""),
+            kind=str(payload.get("kind") or ""),
+            reason=str(payload.get("reason") or ""),
+            default_choice=str(payload.get("default_choice") or ""),
+            agent_directed=bool(payload.get("agent_directed")),
+            score_total=float(total) if isinstance(total, (int, float)) else None,
+        )
+
+
+@dataclass
+class GraphState:
+    path: list[Visit] = field(default_factory=list)
+    max_steps: int = DEFAULT_MAX_STEPS
+    max_visits: int = DEFAULT_MAX_VISITS
+    #: Set when the walk stopped for a reason other than reaching ``finish``.
+    halted_because: str = ""
+
+    @property
+    def steps(self) -> int:
+        return len(self.path)
+
+    def visits(self, slug: str) -> int:
+        return sum(1 for visit in self.path if visit.stage == slug)
+
+    def revisit_reasons(self, slug: str) -> list[str]:
+        """Why the run entered ``slug`` before, normalised for comparison."""
+        return [
+            " ".join(visit.reason.lower().split())
+            for visit in self.path
+            if visit.chose == slug and visit.reason
+        ]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": [visit.to_dict() for visit in self.path],
+            "max_steps": self.max_steps,
+            "max_visits": self.max_visits,
+            "halted_because": self.halted_because,
+            "route": " -> ".join(visit.stage for visit in self.path),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "GraphState":
+        return cls(
+            path=[Visit.from_dict(item) for item in payload.get("path", []) if isinstance(item, Mapping)],
+            max_steps=int(payload.get("max_steps") or DEFAULT_MAX_STEPS),
+            max_visits=int(payload.get("max_visits") or DEFAULT_MAX_VISITS),
+            halted_because=str(payload.get("halted_because") or ""),
+        )
+
+
+def state_file(paths: RunPaths) -> Path:
+    return paths.evolution_dir / "stage_graph.json"
+
+
+def load_graph_state(paths: RunPaths, *, max_steps: int | None = None, max_visits: int | None = None) -> GraphState:
+    payload = _load_json(state_file(paths))
+    state = GraphState.from_dict(payload) if isinstance(payload, Mapping) else GraphState()
+    if max_steps is not None:
+        state.max_steps = max_steps
+    if max_visits is not None:
+        state.max_visits = max_visits
+    return state
+
+
+def save_graph_state(paths: RunPaths, state: GraphState) -> None:
+    write_text(state_file(paths), json.dumps(state.to_dict(), indent=2, ensure_ascii=False))
+
+
+# ----------------------------------------------------------------------------
+# The graph
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Move:
+    """An edge the run is allowed to take right now, and why."""
+
+    edge: Edge
+    guard: GuardResult
+    #: Set when the edge exists but may not be taken. The edge is still shown to
+    #: the router with this attached: an agent that can see *why* Stage 07 is
+    #: closed will route to what opens it, whereas an agent shown a shorter menu
+    #: will pick the wrong item off it and never know what it missed.
+    blocked_because: str = ""
+
+    @property
+    def admissible(self) -> bool:
+        return not self.blocked_because
+
+    @property
+    def target(self) -> str:
+        return self.edge.target
+
+
+class StageGraph:
+    """Nodes, edges, and the rule for which edges are live given what is on disk."""
+
+    def __init__(self, edges: Sequence[Edge], *, name: str = "linear") -> None:
+        self.name = name
+        self.edges = tuple(edges)
+        self._by_source: dict[str, list[Edge]] = {}
+        for edge in self.edges:
+            self._by_source.setdefault(edge.source, []).append(edge)
+        for group in self._by_source.values():
+            group.sort(key=lambda item: (item.priority, item.target))
+
+    # -- construction --------------------------------------------------------
+
+    @classmethod
+    def linear(cls) -> "StageGraph":
+        """The topology AutoR has always had: one edge out of each stage.
+
+        Kept as a real graph rather than a special case, so the default run and the
+        adaptive run go through the same engine. A bug in the walk shows up in both,
+        which is the only way the default path stays trustworthy once it stops being
+        the only path.
+        """
+        return cls(_advance_edges(guarded=False), name="linear")
+
+    @classmethod
+    def adaptive(cls) -> "StageGraph":
+        """The advance edges plus every backward move that has a research meaning."""
+        return cls([*_advance_edges(guarded=True), *REVISIT_EDGES], name="adaptive")
+
+    @classmethod
+    def named(cls, name: str) -> "StageGraph":
+        if name == "adaptive":
+            return cls.adaptive()
+        if name == "linear":
+            return cls.linear()
+        raise ValueError(f"Unknown stage graph topology: {name!r}. Expected 'linear' or 'adaptive'.")
+
+    # -- navigation ----------------------------------------------------------
+
+    def out_edges(self, slug: str) -> list[Edge]:
+        return list(self._by_source.get(slug, []))
+
+    def moves(self, paths: RunPaths, slug: str, state: GraphState, *, final_stage: StageSpec | None = None) -> list[Move]:
+        """Every edge out of ``slug``, each labelled admissible or blocked.
+
+        Blocked edges are returned rather than filtered out. The router needs them:
+        the useful thing to tell an agent is not "you may go to 06" but "07 is
+        closed because H2 has no verdict", which is a reason to go to 06.
+        """
+        results: list[Move] = []
+        for edge in self.out_edges(slug):
+            if final_stage is not None and edge.target != FINISH:
+                target_stage = stage_for_slug(edge.target)
+                if target_stage is not None and target_stage.number > final_stage.number:
+                    continue
+
+            guard = edge.guard_fn()(paths, state)
+            blocked = ""
+            if not guard.ok:
+                blocked = guard.reason
+            elif edge.target != FINISH and state.visits(edge.target) >= state.max_visits:
+                blocked = (
+                    f"{edge.target} has already been entered {state.visits(edge.target)} times, "
+                    f"which is the per-stage limit"
+                )
+            elif state.steps >= state.max_steps:
+                blocked = f"the run has taken {state.steps} steps, which is the limit for this graph"
+            results.append(Move(edge, guard, blocked))
+        return results
+
+    def admissible_moves(self, paths: RunPaths, slug: str, state: GraphState, **kwargs: Any) -> list[Move]:
+        return [move for move in self.moves(paths, slug, state, **kwargs) if move.admissible]
+
+    def default_move(self, paths: RunPaths, slug: str, state: GraphState, **kwargs: Any) -> Move | None:
+        """What AutoR takes when nothing chooses: the lowest-priority live edge.
+
+        Priority 0 is the advance edge at every node, so with all guards passing
+        this reproduces the old sequence exactly.
+        """
+        moves = self.admissible_moves(paths, slug, state, **kwargs)
+        if not moves:
+            return None
+        return min(moves, key=lambda move: (move.edge.priority, move.edge.target))
+
+    def repeats_a_previous_reason(self, state: GraphState, target: str, reason: str) -> bool:
+        """Whether this exact justification has already sent the run to ``target``.
+
+        A revisit is worth taking when something has been learned. Returning to
+        Stage 05 for the third time because "more repeats are needed" is the same
+        move, and the graph is not going to reach a different place by making it
+        again.
+        """
+        normalized = " ".join(reason.lower().split())
+        if not normalized:
+            return False
+        return normalized in state.revisit_reasons(target)
+
+    def describe_for_prompt(self, moves: Sequence[Move]) -> str:
+        lines = ["| Move | Target | Kind | Available | Why this move exists |", "| --- | --- | --- | --- | --- |"]
+        for index, move in enumerate(moves, start=1):
+            availability = "yes" if move.admissible else f"**no** — {move.blocked_because}"
+            lines.append(
+                f"| {index} | `{move.edge.target}` | {move.edge.kind} | {availability} | "
+                f"{move.edge.rationale} |"
+            )
+        return "\n".join(lines)
+
+
+def stage_for_slug(slug: str) -> StageSpec | None:
+    return next((stage for stage in STAGES if stage.slug == slug), None)
+
+
+def enter(paths: RunPaths, state: GraphState, stage: StageSpec) -> Visit:
+    visit = Visit(stage=stage.slug, entered_at=_now())
+    state.path.append(visit)
+    save_graph_state(paths, state)
+    return visit
+
+
+def leave(
+    paths: RunPaths,
+    state: GraphState,
+    *,
+    chose: str,
+    kind: str,
+    reason: str,
+    default_choice: str,
+    agent_directed: bool,
+    score_total: float | None,
+) -> None:
+    if not state.path:
+        return
+    visit = state.path[-1]
+    visit.left_at = _now()
+    visit.chose = chose
+    visit.kind = kind
+    visit.reason = reason
+    visit.default_choice = default_choice
+    visit.agent_directed = agent_directed
+    visit.score_total = score_total
+    save_graph_state(paths, state)
+
+
+def format_route(state: GraphState) -> str:
+    """The path as a human reads it, with the backward moves marked."""
+    if not state.path:
+        return "(no stages run)"
+    parts: list[str] = []
+    for visit in state.path:
+        marker = " ↩" if visit.kind == "revisit" else ""
+        parts.append(f"{visit.stage}{marker}")
+    tail = " → finish" if state.path[-1].chose == FINISH else ""
+    return " → ".join(parts) + tail
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")

--- a/src/utils.py
+++ b/src/utils.py
@@ -87,6 +87,11 @@ class RunPaths:
     bootstrap_dir: Path
     profile_dir: Path
     intake_context: Path
+    #: Every candidate draft, its measured score, the champion, the Pareto frontier
+    #: and the improvement ledger. Outside ``workspace/`` on purpose: it is a record
+    #: of how the run reached its answer, not part of the answer, and a benchmark
+    #: export that swept it up would ship the losing drafts alongside the report.
+    evolution_dir: Path
     #: Where the operator's agent CLI looks for project skills. The operator is
     #: invoked with ``cwd=run_root``, so this is the run's own ``.claude/skills``
     #: and not the AutoR checkout's.
@@ -261,6 +266,7 @@ def build_run_paths(run_root: Path) -> RunPaths:
         bootstrap_dir=workspace_root / "bootstrap",
         profile_dir=workspace_root / "profile",
         intake_context=run_root / "intake_context.json",
+        evolution_dir=run_root / "evolution",
     )
 
 
@@ -336,6 +342,46 @@ def normalize_codex_sandbox(value: Any) -> str:
     return DEFAULT_CODEX_SANDBOX
 
 
+#: How the run moves between stages. ``linear`` is the historical sequence, one
+#: edge out of each node. ``adaptive`` adds the backward moves and lets the run
+#: return to an earlier stage when a later one shows it has to.
+DEFAULT_STAGE_GRAPH = "linear"
+STAGE_GRAPH_CHOICES = ("linear", "adaptive")
+
+#: Who picks the edge. ``off`` always takes the graph's default, which on a linear
+#: topology is the only one. ``auto`` asks the backend wherever more than one move
+#: is live; ``agent`` asks at every node.
+DEFAULT_ROUTING_MODE = "off"
+ROUTING_MODE_CHOICES = ("off", "auto", "agent")
+
+#: Self-improvement rounds per stage. Zero is off, which is the default: the loop
+#: costs a backend call per round, and a caller who has not asked for it should not
+#: be paying for it.
+DEFAULT_EVOLVE_ROUNDS = 0
+
+
+def normalize_walk_settings(source: "Mapping[str, Any]") -> dict[str, Any]:
+    """Normalise the three settings that describe how a run walks its stages.
+
+    One definition, called from every run-config reader and writer. The config
+    functions each restate the whole field list, so a fourth setting added by hand
+    in five places is a setting that will eventually be preserved on resume by four
+    of them.
+    """
+    graph = str(source.get("stage_graph") or "").strip().lower()
+    routing = str(source.get("routing_mode") or "").strip().lower()
+    rounds = source.get("evolve_rounds")
+    try:
+        rounds_value = max(0, int(rounds))
+    except (TypeError, ValueError):
+        rounds_value = DEFAULT_EVOLVE_ROUNDS
+    return {
+        "stage_graph": graph if graph in STAGE_GRAPH_CHOICES else DEFAULT_STAGE_GRAPH,
+        "routing_mode": routing if routing in ROUTING_MODE_CHOICES else DEFAULT_ROUTING_MODE,
+        "evolve_rounds": rounds_value,
+    }
+
+
 def default_run_config() -> dict[str, Any]:
     """The configuration a run falls back to when run_config.json is absent or unreadable."""
     return {
@@ -347,6 +393,7 @@ def default_run_config() -> dict[str, Any]:
         "review_operator": "claude",
         "review_model": "sonnet",
         "codex_sandbox": DEFAULT_CODEX_SANDBOX,
+        **normalize_walk_settings({}),
     }
 
 
@@ -360,6 +407,7 @@ def initialize_run_config(
     review_model: str | None = None,
     codex_sandbox: str | None = None,
     output_format: str | None = None,
+    walk: "Mapping[str, Any] | None" = None,
 ) -> dict[str, Any]:
     normalized_operator = operator.strip().lower() if operator.strip() else "claude"
     normalized_review_operator = (
@@ -380,6 +428,7 @@ def initialize_run_config(
             or ("default" if normalized_review_operator == "codex" else "sonnet")
         ),
         "codex_sandbox": normalize_codex_sandbox(codex_sandbox),
+        **normalize_walk_settings(walk or {}),
         "created_at": datetime.now().isoformat(timespec="seconds"),
     }
     write_text(paths.run_config, json.dumps(config, indent=2, ensure_ascii=False))
@@ -424,6 +473,7 @@ def load_run_config(paths: RunPaths) -> dict[str, Any]:
             else ("default" if normalized_review_operator == "codex" else "sonnet")
         ),
         "codex_sandbox": normalize_codex_sandbox(codex_sandbox),
+        **normalize_walk_settings(payload),
     }
     created_at = payload.get("created_at")
     if isinstance(created_at, str) and created_at.strip():
@@ -448,6 +498,7 @@ def save_run_config(paths: RunPaths, config: dict[str, Any]) -> None:
             or ("default" if normalized_review_operator == "codex" else "sonnet")
         ),
         "codex_sandbox": normalize_codex_sandbox(config.get("codex_sandbox")),
+        **normalize_walk_settings(config),
     }
     created_at = config.get("created_at")
     if isinstance(created_at, str) and created_at.strip():
@@ -467,6 +518,7 @@ def ensure_run_config(
     review_model: str | None = None,
     codex_sandbox: str | None = None,
     output_format: str | None = None,
+    walk: "Mapping[str, Any] | None" = None,
 ) -> dict[str, Any]:
     current = load_run_config(paths)
     effective_operator = operator or current.get("operator") or "claude"
@@ -482,6 +534,10 @@ def ensure_run_config(
             "default" if effective_review_operator == "codex" else "sonnet"
         ),
         "codex_sandbox": normalize_codex_sandbox(codex_sandbox or current.get("codex_sandbox")),
+        # An explicit setting wins; otherwise the run keeps what it was started
+        # with, which is what makes `--resume-run` continue the same walk rather
+        # than silently reverting an adaptive run to the linear default.
+        **normalize_walk_settings({**current, **(walk or {})}),
         "created_at": current.get("created_at") or datetime.now().isoformat(timespec="seconds"),
     }
     save_run_config(paths, updated)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,264 @@
+"""The cross-run archive: what it learns, and what it is not allowed to conclude.
+
+An archive that acts on one run is a superstition generator. Most of these tests
+are the refusals — too few observations, a rubric version change, a variant that
+beat the incumbent once — and one is the invariant that matters more than any of
+them: a learned prior reorders preferences and can never open a guarded edge.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.archive import (
+    Archive,
+    BASELINE_VARIANT,
+    RunRecord,
+    Variant,
+    edge_payoffs,
+    resolve_graph,
+)
+from src.rubric import RUBRIC_VERSION
+from src.stage_graph import StageGraph
+from src.utils import append_jsonl
+
+
+def record(
+    run_id: str,
+    *,
+    edges: dict[str, int],
+    fitness: float,
+    variant_id: str = "baseline",
+    rubric_version: str | None = None,
+) -> RunRecord:
+    return RunRecord(
+        run_id=run_id,
+        variant_id=variant_id,
+        rubric_version=rubric_version or RUBRIC_VERSION,
+        edges=edges,
+        stage_fitness={"05_experimentation": fitness, "06_analysis": fitness},
+        route="",
+        steps=len(edges),
+        revisits=0,
+        agent_directed=0,
+        recorded_at="2026-08-06T00:00:00",
+    )
+
+
+BACK = "06_analysis->05_experimentation"
+FORWARD = "06_analysis->07_writing"
+
+
+class ArchiveTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.archive = Archive(Path(self._tmp.name) / "archive")
+
+    def seed(self, records) -> None:
+        for item in records:
+            append_jsonl(self.archive.runs_file, item.to_dict())
+
+    def seed_a_believable_payoff(self, *, taken: float = 0.85, skipped: float = 0.60) -> None:
+        self.seed(
+            [record(f"back{i}", edges={BACK: 1}, fitness=taken) for i in range(3)]
+            + [record(f"fwd{i}", edges={FORWARD: 1}, fitness=skipped) for i in range(3)]
+        )
+
+    # -- payoff arithmetic ---------------------------------------------------
+
+    def test_an_edge_is_compared_against_runs_that_reached_the_same_node(self) -> None:
+        """Comparing against the whole archive would credit the edge with the
+        difference between runs that got to Stage 06 and runs that never did."""
+        self.seed(
+            [
+                record("a", edges={BACK: 1}, fitness=0.9),
+                record("b", edges={FORWARD: 1}, fitness=0.6),
+                record("c", edges={"01_literature_survey->02_hypothesis_generation": 1}, fitness=0.1),
+            ]
+        )
+        payoff = edge_payoffs(self.archive.runs())[BACK]
+        self.assertEqual((payoff.taken_runs, payoff.skipped_runs), (1, 1))
+        self.assertAlmostEqual(payoff.delta, 0.3, places=6)
+
+    def test_one_lucky_run_is_not_believable(self) -> None:
+        self.seed([record("a", edges={BACK: 1}, fitness=0.95), record("b", edges={FORWARD: 1}, fitness=0.2)])
+        self.assertFalse(edge_payoffs(self.archive.runs())[BACK].believable(3))
+
+    def test_runs_measured_under_another_rubric_are_not_mixed_in(self) -> None:
+        """A reweight would otherwise read as every archived run having moved."""
+        self.seed(
+            [record(f"old{i}", edges={BACK: 1}, fitness=0.99, rubric_version="0") for i in range(5)]
+            + [record("new", edges={BACK: 1}, fitness=0.4)]
+        )
+        payoff = edge_payoffs(self.archive.runs())[BACK]
+        self.assertEqual(payoff.taken_runs, 1)
+        self.assertAlmostEqual(payoff.taken_mean, 0.4, places=6)
+
+    def test_a_partial_run_is_averaged_over_what_it_measured(self) -> None:
+        """A run stopped at Stage 07 by `--final-stage` did not fail Stage 08."""
+        partial = RunRecord(
+            run_id="p",
+            variant_id="baseline",
+            rubric_version=RUBRIC_VERSION,
+            edges={},
+            stage_fitness={"01_literature_survey": 0.8},
+            route="",
+            steps=1,
+            revisits=0,
+            agent_directed=0,
+            recorded_at="t",
+        )
+        self.assertAlmostEqual(partial.mean_fitness, 0.8)
+
+    def test_a_malformed_line_does_not_lose_the_archive(self) -> None:
+        self.seed([record("a", edges={BACK: 1}, fitness=0.7)])
+        with self.archive.runs_file.open("a", encoding="utf-8") as handle:
+            handle.write("{not json at all\n")
+        self.seed([record("b", edges={BACK: 1}, fitness=0.8)])
+        self.assertEqual([item.run_id for item in self.archive.runs()], ["a", "b"])
+
+    # -- variation -----------------------------------------------------------
+
+    def test_nothing_is_proposed_from_an_empty_archive(self) -> None:
+        """A proposer that always proposes turns an archive into a random walk."""
+        self.assertIsNone(self.archive.propose_variant())
+
+    def test_a_believable_payoff_produces_a_child_that_explains_itself(self) -> None:
+        self.seed_a_believable_payoff()
+        variant = self.archive.propose_variant()
+        self.assertIsNotNone(variant)
+        self.assertEqual(variant.parent_id, BASELINE_VARIANT.variant_id)
+        self.assertEqual(variant.generation, 1)
+        self.assertFalse(variant.promoted)
+        self.assertIn(BACK, variant.note)
+        self.assertIn("0.85", variant.note)
+
+    def test_a_child_changes_one_edge_at_a_time(self) -> None:
+        """A variant that reshuffles five edges cannot be told apart from one that
+        got lucky on one of them."""
+        self.seed_a_believable_payoff()
+        variant = self.archive.propose_variant()
+        self.assertEqual(len(variant.edge_priority), 1)
+
+    def test_the_same_child_is_not_proposed_twice(self) -> None:
+        self.seed_a_believable_payoff()
+        self.assertIsNotNone(self.archive.propose_variant())
+        self.assertIsNone(self.archive.propose_variant())
+
+    def test_a_losing_edge_is_deprioritised_rather_than_removed(self) -> None:
+        self.seed_a_believable_payoff(taken=0.55, skipped=0.85)
+        variant = self.archive.propose_variant()
+        graph = variant.apply_to(StageGraph.adaptive())
+        edge = next(e for e in graph.edges if f"{e.source}->{e.target}" == BACK)
+        original = next(e for e in StageGraph.adaptive().edges if f"{e.source}->{e.target}" == BACK)
+        self.assertGreater(edge.priority, original.priority)
+        self.assertIn(BACK, {f"{e.source}->{e.target}" for e in graph.edges})
+
+    # -- the invariant -------------------------------------------------------
+
+    def test_a_variant_cannot_open_a_guarded_edge(self) -> None:
+        """The guards are the correctness argument for letting an agent route at
+        all, and the component that learns from outcomes is exactly the one that
+        must not be able to weaken them: the cheapest way to raise mean fitness
+        would be to stop checking that hypotheses were adjudicated."""
+        base = StageGraph.adaptive()
+        hostile = Variant(
+            variant_id="hostile",
+            topology="adaptive",
+            edge_priority={FORWARD: -99, "06_analysis->99_nonexistent": 0},
+        )
+        rebuilt = hostile.apply_to(base)
+
+        self.assertEqual(
+            {(e.source, e.target, e.guard) for e in rebuilt.edges},
+            {(e.source, e.target, e.guard) for e in base.edges},
+        )
+        self.assertNotIn("99_nonexistent", {e.target for e in rebuilt.edges})
+
+    def test_an_untouched_edge_keeps_its_priority(self) -> None:
+        base = StageGraph.adaptive()
+        rebuilt = Variant("v", "adaptive", edge_priority={BACK: 0}).apply_to(base)
+        for edge in base.edges:
+            key = f"{edge.source}->{edge.target}"
+            if key == BACK:
+                continue
+            match = next(e for e in rebuilt.edges if e.source == edge.source and e.target == edge.target)
+            self.assertEqual(match.priority, edge.priority)
+
+    # -- promotion -----------------------------------------------------------
+
+    def test_beating_the_incumbent_once_does_not_promote(self) -> None:
+        self.archive._save_variants([BASELINE_VARIANT, Variant("challenger", "adaptive", parent_id="baseline")])
+        self.seed(
+            [record("b1", edges={}, fitness=0.5), record("c1", edges={}, fitness=0.9, variant_id="challenger")]
+        )
+        self.assertFalse(self.archive.promote("challenger"))
+
+    def test_an_improvement_that_replays_is_promoted(self) -> None:
+        self.archive._save_variants([BASELINE_VARIANT, Variant("challenger", "adaptive", parent_id="baseline")])
+        self.seed(
+            [record(f"b{i}", edges={}, fitness=0.50) for i in range(3)]
+            + [record(f"c{i}", edges={}, fitness=0.80, variant_id="challenger") for i in range(3)]
+        )
+        self.assertTrue(self.archive.promote("challenger"))
+        self.assertTrue(self.archive.variant("challenger").promoted)
+
+    def test_a_challenger_that_only_ties_is_not_promoted(self) -> None:
+        self.archive._save_variants([BASELINE_VARIANT, Variant("challenger", "adaptive")])
+        self.seed(
+            [record(f"b{i}", edges={}, fitness=0.70) for i in range(4)]
+            + [record(f"c{i}", edges={}, fitness=0.705, variant_id="challenger") for i in range(4)]
+        )
+        self.assertFalse(self.archive.promote("challenger"))
+
+    # -- sampling ------------------------------------------------------------
+
+    def test_sampling_is_reproducible_from_the_archive(self) -> None:
+        self.archive._save_variants([BASELINE_VARIANT, Variant("challenger", "adaptive")])
+        self.seed([record("b1", edges={}, fitness=0.6)])
+        self.assertEqual(
+            self.archive.sample_parent().variant_id, self.archive.sample_parent().variant_id
+        )
+
+    def test_an_unproven_variant_stays_in_the_draw(self) -> None:
+        """Fitness-proportional sampling alone locks the archive onto whatever won
+        first and stops generating the observations that would overturn it."""
+        self.archive._save_variants([BASELINE_VARIANT, Variant("unproven", "adaptive")])
+        self.seed([record(f"b{i}", edges={}, fitness=0.9) for i in range(8)])
+        picks = {self.archive.sample_parent(seed=seed).variant_id for seed in range(40)}
+        self.assertIn("unproven", picks)
+        self.assertIn(BASELINE_VARIANT.variant_id, picks)
+
+    # -- resolution ----------------------------------------------------------
+
+    def test_no_archive_means_the_declared_topology_unchanged(self) -> None:
+        graph, variant_id = resolve_graph(None, "adaptive")
+        self.assertEqual(variant_id, "baseline")
+        self.assertEqual(
+            {(e.source, e.target, e.priority) for e in graph.edges},
+            {(e.source, e.target, e.priority) for e in StageGraph.adaptive().edges},
+        )
+
+    def test_a_variant_for_another_topology_is_not_applied(self) -> None:
+        self.archive._save_variants(
+            [BASELINE_VARIANT, Variant("adaptive-child", "adaptive", edge_priority={BACK: 0})]
+        )
+        graph, variant_id = resolve_graph(self.archive, "linear")
+        self.assertEqual(variant_id, "baseline")
+        self.assertEqual(graph.name, "linear")
+
+    def test_the_report_marks_which_payoffs_are_believable(self) -> None:
+        self.seed_a_believable_payoff()
+        self.seed([record("lonely", edges={"07_writing->06_analysis": 1}, fitness=0.99)])
+        report = self.archive.report()
+        self.assertIn(f"rubric: v{RUBRIC_VERSION}", report)
+        self.assertIn(BACK, report)
+        self.assertIn("| no |", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -1,0 +1,296 @@
+"""The ratchet: what may stand, what is reverted, and what is never allowed to win.
+
+The three properties worth having are all negative. A round that scores worse does
+not survive. A round that changed the run's conclusion does not survive whatever it
+scores. And a round a *person* asked for survives whatever it scores, because the
+measurement is not entitled to overrule the human whose project this is.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.evolution import EvolutionConfig, EvolutionController, load_run_fitness
+from src.pareto import complementary_pair, dominates, frontier, insert
+from src.rubric import RUBRIC_VERSION, CriterionScore, StageScore
+from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
+from tests import prereg_support
+from tests.test_rubric import stage_markdown
+
+
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+
+
+class RatchetTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        self.controller = EvolutionController(EvolutionConfig(enabled=True, rounds=3))
+        self.build_run()
+
+    def build_run(self) -> None:
+        prereg_support.write_hypothesis_manifest(self.paths)
+        prereg_support.write_experimental_protocol(self.paths)
+        write_text(self.paths.code_dir / "run_sweep.py", "print('x')\n" * 4)
+        write_text(
+            self.paths.results_dir / "metrics.json",
+            json.dumps({"baseline": 0.582, "treatment": 0.741, "seeds": 5}),
+        )
+        write_text(self.paths.data_dir / "splits.json", json.dumps({"test": [1, 2, 3]}))
+        write_text(self.paths.figures_dir / "effect.png", "x" * 128)
+        write_text(
+            self.paths.literature_dir / "evidence_ledger.json", json.dumps({"entries": [{"claim": "c"}]})
+        )
+        write_text(
+            self.paths.experiment_manifest,
+            json.dumps({"experiments": [{"id": "e1", "command": "python run_sweep.py"}]}),
+        )
+        prereg_support.freeze_preregistration(self.paths)
+        self.write_outcomes("supported")
+
+    def write_outcomes(self, verdict: str) -> None:
+        prereg = json.loads(self.paths.preregistration.read_text(encoding="utf-8"))
+        write_text(
+            self.paths.hypothesis_outcomes,
+            json.dumps(
+                {
+                    "preregistration_digest": prereg["digest"],
+                    "outcomes": [
+                        {
+                            "id": prereg_support.HYPOTHESIS_ID,
+                            "verdict": verdict,
+                            "rationale": "The gap sits either side of the decision rule.",
+                            "evidence": ["results/metrics.json"],
+                        }
+                    ],
+                }
+            ),
+        )
+
+    def offer(self, markdown: str, attempt_no: int, *, polish: bool = True):
+        draft = self.paths.stage_tmp_file(STAGE_06)
+        write_text(draft, markdown)
+        return self.controller.consider(
+            paths=self.paths,
+            stage=STAGE_06,
+            attempt_no=attempt_no,
+            draft_path=draft,
+            is_polish_round=polish,
+        )
+
+    # -- the ratchet ---------------------------------------------------------
+
+    def test_a_worse_polish_round_is_reverted_to_the_champion(self) -> None:
+        strong = stage_markdown(STAGE_06)
+        self.offer(strong, 1, polish=False)
+
+        weak = stage_markdown(
+            STAGE_06,
+            key_results="Things improved.",
+            what_i_did="We will run the sweep and should improve the baseline.",
+        )
+        outcome = self.offer(weak, 2)
+
+        self.assertEqual(outcome.verdict, "regressed")
+        self.assertTrue(outcome.reverted)
+        self.assertEqual(read_text(self.paths.stage_tmp_file(STAGE_06)).strip(), strong.strip())
+
+    def test_a_better_polish_round_becomes_the_champion(self) -> None:
+        self.offer(
+            stage_markdown(STAGE_06, key_results="Things improved.", files="- `workspace/results/metrics.json`"),
+            1,
+            polish=False,
+        )
+        outcome = self.offer(stage_markdown(STAGE_06), 2)
+        self.assertEqual(outcome.verdict, "promoted")
+        self.assertGreater(outcome.delta, 0)
+        self.assertFalse(outcome.reverted)
+
+    def test_a_polish_round_that_moves_a_verdict_is_rejected_whatever_it_scores(self) -> None:
+        """The failure a scored loop introduces and nothing else in AutoR would see.
+
+        The rubric is blind to verdicts, so a rewritten conclusion scores the same;
+        that is exactly why the drift check cannot be a score comparison.
+        """
+        self.offer(stage_markdown(STAGE_06), 1, polish=False)
+        self.write_outcomes("refuted")
+        outcome = self.offer(stage_markdown(STAGE_06), 2)
+
+        self.assertEqual(outcome.verdict, "verdict_drift")
+        self.assertTrue(outcome.reverted)
+        rows = [
+            json.loads(line)
+            for line in read_text(self.controller.ledger_file(self.paths)).splitlines()
+            if line.strip()
+        ]
+        self.assertEqual(rows[-1]["verdict"], "verdict_drift")
+
+    def test_a_directed_revision_stands_even_when_it_measures_worse(self) -> None:
+        """A human asking for a change is direction, not an optimisation step.
+
+        AutoR silently reverting a requested edit because a rubric preferred the
+        previous wording is the opposite of the arrangement this project is built
+        on. The delta is still recorded, so the ledger says whether it helped.
+        """
+        self.offer(stage_markdown(STAGE_06), 1, polish=False)
+        weak = stage_markdown(STAGE_06, key_results="Things improved.")
+        outcome = self.offer(weak, 2, polish=False)
+
+        self.assertEqual(outcome.verdict, "directed")
+        self.assertFalse(outcome.reverted)
+        self.assertLess(outcome.delta, 0)
+        self.assertEqual(read_text(self.paths.stage_tmp_file(STAGE_06)).strip(), weak.strip())
+
+    def test_every_candidate_is_kept_including_the_ones_that_lost(self) -> None:
+        """A discarded candidate is the only evidence that anything was discarded."""
+        self.offer(stage_markdown(STAGE_06), 1, polish=False)
+        self.offer(stage_markdown(STAGE_06, key_results="Things improved."), 2)
+        candidates = sorted(
+            (self.controller.stage_dir(self.paths, STAGE_06) / "candidates").glob("attempt_*.md")
+        )
+        self.assertEqual(len(candidates), 2)
+
+    # -- round scheduling ----------------------------------------------------
+
+    def test_the_round_budget_is_respected(self) -> None:
+        controller = EvolutionController(EvolutionConfig(enabled=True, rounds=2))
+        self.controller = controller
+        self.offer(stage_markdown(STAGE_06, key_results="Things improved."), 1, polish=False)
+        spent = 0
+        while controller.should_continue(self.paths, STAGE_06):
+            controller.begin_round(self.paths, STAGE_06)
+            spent += 1
+            self.assertLess(spent, 10, msg="should_continue never went false")
+        self.assertEqual(spent, 2)
+
+    def test_a_stage_that_stops_responding_stops_being_polished(self) -> None:
+        """Most stages are done after one targeted fix. Spending the rest of the
+        budget rewording a draft at the ceiling is the common waste."""
+        controller = EvolutionController(EvolutionConfig(enabled=True, rounds=8, patience=2))
+        self.controller = controller
+        self.offer(stage_markdown(STAGE_06), 1, polish=False)
+        flat = stage_markdown(STAGE_06, key_results="Things improved.")
+        controller.begin_round(self.paths, STAGE_06)
+        self.offer(flat, 2)
+        controller.begin_round(self.paths, STAGE_06)
+        self.offer(flat, 3)
+        self.assertFalse(controller.should_continue(self.paths, STAGE_06))
+
+    def test_the_directive_names_the_failing_criterion_and_not_the_saturated_ones(self) -> None:
+        self.offer(stage_markdown(STAGE_06, key_results="Accuracy reached 91.7%."), 1, polish=False)
+        directive = self.controller.next_directive(self.paths, STAGE_06)
+        self.assertIn("91.7", directive)
+        self.assertIn("Do not change any hypothesis verdict", directive)
+        self.assertIn("Do not lengthen a section", directive)
+
+    def test_a_config_that_excludes_a_stage_does_not_polish_it(self) -> None:
+        controller = EvolutionController(
+            EvolutionConfig(enabled=True, rounds=3, stages=("05_experimentation",))
+        )
+        self.assertFalse(controller.should_continue(self.paths, STAGE_06))
+
+    # -- persistence ---------------------------------------------------------
+
+    def test_a_resumed_run_keeps_its_champion(self) -> None:
+        """Without this the next draft wins by default and the best work the
+        earlier session produced is discarded with nothing recording it."""
+        strong = stage_markdown(STAGE_06)
+        self.offer(strong, 1, polish=False)
+
+        resumed = EvolutionController(EvolutionConfig(enabled=True, rounds=3))
+        state = resumed.state(self.paths, STAGE_06)
+        self.assertIsNotNone(state.champion)
+
+        draft = self.paths.stage_tmp_file(STAGE_06)
+        write_text(draft, stage_markdown(STAGE_06, key_results="Things improved."))
+        outcome = resumed.consider(
+            paths=self.paths, stage=STAGE_06, attempt_no=2, draft_path=draft, is_polish_round=True
+        )
+        self.assertEqual(outcome.verdict, "regressed")
+        self.assertEqual(read_text(draft).strip(), strong.strip())
+
+    def test_a_champion_from_another_rubric_version_is_discarded_not_defended(self) -> None:
+        stale = StageScore(
+            stage_slug=STAGE_06.slug,
+            attempt_no=1,
+            rubric_version="rubric-from-last-year",
+            criteria=(),
+            total=0.99,
+        )
+        write_text(
+            self.controller.stage_dir(self.paths, STAGE_06) / "champion.json",
+            json.dumps(stale.to_dict()),
+        )
+        fresh = EvolutionController(EvolutionConfig(enabled=True, rounds=1))
+        self.assertIsNone(fresh.state(self.paths, STAGE_06).champion)
+
+    def test_the_run_summary_omits_stages_that_were_never_measured(self) -> None:
+        """An absent stage averaged in as a failure would drag a topology variant's
+        fitness down for work it never did."""
+        self.offer(stage_markdown(STAGE_06), 1, polish=False)
+        self.controller.finalize_stage(self.paths, STAGE_06)
+        fitness = load_run_fitness(self.paths)
+        self.assertEqual(set(fitness), {STAGE_06.slug})
+
+
+def _score(attempt: int, **criteria: float) -> StageScore:
+    items = tuple(
+        CriterionScore(key, key, weight=1.0, score=value, observed="", shortfall="more")
+        for key, value in criteria.items()
+    )
+    return StageScore(
+        stage_slug="06_analysis",
+        attempt_no=attempt,
+        rubric_version=RUBRIC_VERSION,
+        criteria=items,
+        total=sum(criteria.values()) / len(criteria),
+    )
+
+
+class FrontierTests(unittest.TestCase):
+    """A scalar picks one winner. Two drafts can differ by shape instead of quality."""
+
+    def test_a_draft_better_everywhere_dominates(self) -> None:
+        self.assertTrue(dominates(_score(2, a=0.9, b=0.9), _score(1, a=0.5, b=0.5)))
+        self.assertFalse(dominates(_score(1, a=0.9, b=0.2), _score(2, a=0.2, b=0.9)))
+
+    def test_an_identical_rerun_does_not_dominate_and_does_not_enter(self) -> None:
+        """Floating-point noise on a rerun that changed nothing must not read as a
+        strict improvement."""
+        first = _score(1, a=0.6, b=0.4)
+        self.assertFalse(dominates(_score(2, a=0.6, b=0.4), first))
+        self.assertEqual(insert([first], _score(2, a=0.6, b=0.4)).verdict, "duplicate")
+
+    def test_a_specialist_survives_a_lower_total(self) -> None:
+        allrounder = _score(1, a=0.7, b=0.7)
+        specialist = _score(2, a=1.0, b=0.2)
+        kept = frontier([allrounder, specialist])
+        self.assertEqual(len(kept), 2)
+        self.assertEqual(insert([allrounder], specialist).verdict, "entered")
+
+    def test_scores_from_different_rubric_versions_are_refused_not_coerced(self) -> None:
+        """A reweight would otherwise read as every archived draft having moved."""
+        current = _score(1, a=0.6, b=0.6)
+        other = StageScore("06_analysis", 2, "9", current.criteria, 0.9)
+        self.assertFalse(dominates(other, current))
+        self.assertEqual(insert([current], other).verdict, "incomparable")
+
+    def test_a_complementary_pair_names_what_each_draft_owns(self) -> None:
+        pair = complementary_pair([_score(1, a=1.0, b=0.2), _score(2, a=0.2, b=1.0)])
+        self.assertIsNotNone(pair)
+        self.assertEqual(pair.left_wins, ("a",))
+        self.assertEqual(pair.right_wins, ("b",))
+        self.assertGreater(pair.headroom, 0)
+
+    def test_no_complement_when_one_draft_simply_wins(self) -> None:
+        self.assertIsNone(complementary_pair([_score(1, a=0.9, b=0.9), _score(2, a=0.5, b=0.5)]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -1,0 +1,248 @@
+"""End to end: the run navigating its own topology, through the real manager loop.
+
+The unit tests around the graph prove the topology is right. This proves the walk
+is wired to it — that a router decision actually redirects the manager, that a
+backward move invalidates the downstream stages it should, and, first of all, that
+a run which asked for none of this still runs 01 through 08 exactly as it did
+before the graph existed.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest.mock import patch
+
+from src.evolution import EvolutionConfig
+from src.manager import ResearchManager
+from src.manifest import load_run_manifest
+from src.router import RoutingDecision
+from src.stage_graph import FINISH, StageGraph, load_graph_state
+from src.utils import STAGES, build_run_paths, load_run_config, read_text
+from tests.test_manager_smoke import REPO_ROOT, ScriptedSmokeOperator
+
+
+STAGE_05 = next(stage for stage in STAGES if stage.slug == "05_experimentation")
+STAGE_06 = next(stage for stage in STAGES if stage.slug == "06_analysis")
+STAGE_07 = next(stage for stage in STAGES if stage.slug == "07_writing")
+
+
+def _advance(stage) -> RoutingDecision:
+    """The forward move, scripted. Keeps a walk test deterministic.
+
+    Delegating the non-forced decisions to the real router would make the route
+    depend on which guards the smoke operator's artifacts happen to satisfy, so
+    the test would be asserting the fake operator's output rather than the walk.
+    """
+    index = next(i for i, item in enumerate(STAGES) if item.slug == stage.slug)
+    target = STAGES[index + 1].slug if index + 1 < len(STAGES) else FINISH
+    return RoutingDecision(target, "advance" if target != FINISH else "finish", "continue", target, False)
+
+
+class GraphWalkTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.runs_dir = Path(self._tmp.name) / "runs"
+
+    def build(self, **kwargs) -> tuple[ScriptedSmokeOperator, ResearchManager]:
+        operator = ScriptedSmokeOperator()
+        manager = ResearchManager(
+            project_root=REPO_ROOT,
+            runs_dir=self.runs_dir,
+            operator=operator,
+            output_stream=io.StringIO(),
+            **kwargs,
+        )
+        return operator, manager
+
+    def drive(self, manager: ResearchManager, goal: str = "Walk the stage graph.") -> bool:
+        stack = ExitStack()
+        stack.enter_context(patch.object(manager.ui, "choose_intake_clarification_answer", return_value=None))
+        stack.enter_context(patch.object(manager.ui, "read_optional_multiline_feedback", return_value=None))
+        stack.enter_context(patch.object(manager.ui, "choose_intake_final_action", return_value="5"))
+        stack.enter_context(patch.object(manager, "_ask_choice", return_value="5"))
+        with stack:
+            return manager.run(goal, venue="neurips_2025")
+
+    def only_run(self):
+        roots = sorted(path for path in self.runs_dir.iterdir() if path.is_dir())
+        self.assertEqual(len(roots), 1)
+        return build_run_paths(roots[0])
+
+    # -- the default has to be what it always was ----------------------------
+
+    def test_a_default_run_still_walks_01_through_08(self) -> None:
+        """The regression that would matter most. A run that asked for nothing new
+        must produce the same route it always did, through the new engine."""
+        _operator, manager = self.build()
+        self.assertTrue(self.drive(manager))
+
+        paths = self.only_run()
+        state = load_graph_state(paths)
+        self.assertEqual([visit.stage for visit in state.path], [stage.slug for stage in STAGES])
+        self.assertEqual(state.path[-1].chose, FINISH)
+        self.assertFalse(any(visit.agent_directed for visit in state.path))
+        self.assertEqual(load_run_config(paths)["stage_graph"], "linear")
+
+    def test_a_default_run_never_calls_the_router(self) -> None:
+        """`routing off` is the default, and a default that quietly spent a backend
+        call per stage boundary would be a cost nobody asked for."""
+        _operator, manager = self.build()
+        with patch.object(manager.router, "_ask", side_effect=AssertionError("router was asked")):
+            self.assertTrue(self.drive(manager))
+
+    # -- the walk follows the router -----------------------------------------
+
+    def test_a_backward_decision_sends_the_run_back(self) -> None:
+        """The move a linear list cannot express, taken through the real loop."""
+        _operator, manager = self.build(stage_graph=StageGraph.adaptive(), routing_mode="agent")
+        sent_back = {"done": False}
+
+        def choose(*, paths, stage, graph, state, score=None, final_stage=None):
+            if stage.slug == STAGE_06.slug and not sent_back["done"]:
+                sent_back["done"] = True
+                return RoutingDecision(
+                    STAGE_05.slug,
+                    "revisit",
+                    "H1 rests on a single seed, so the verdict cannot be decided.",
+                    STAGE_07.slug,
+                    agent_directed=True,
+                )
+            return _advance(stage)
+
+        with patch.object(manager.router, "choose", side_effect=choose):
+            self.assertTrue(self.drive(manager))
+
+        route = [visit.stage for visit in load_graph_state(self.only_run()).path]
+        self.assertEqual(
+            route,
+            [
+                "01_literature_survey",
+                "02_hypothesis_generation",
+                "03_study_design",
+                "04_implementation",
+                "05_experimentation",
+                "06_analysis",
+                "05_experimentation",
+                "06_analysis",
+                "07_writing",
+                "08_dissemination",
+            ],
+        )
+
+    def test_a_backward_move_marks_the_downstream_stages_stale(self) -> None:
+        """Re-entering a stage invalidates what came after it. Skipping this would
+        leave a later stage's approved summary in memory describing work the
+        revisit is about to replace."""
+        _operator, manager = self.build(stage_graph=StageGraph.adaptive(), routing_mode="agent")
+        seen: list[str] = []
+
+        def choose(*, paths, stage, graph, state, score=None, final_stage=None):
+            if stage.slug == STAGE_06.slug and STAGE_06.slug not in seen:
+                seen.append(STAGE_06.slug)
+                manifest_before = load_run_manifest(paths.run_manifest)
+                approved = {
+                    entry.slug for entry in manifest_before.stages if entry.status == "approved"
+                }
+                self.assertIn(STAGE_05.slug, approved)
+                return RoutingDecision(
+                    STAGE_05.slug, "revisit", "The ablation was never run.", STAGE_07.slug, True
+                )
+            return _advance(stage)
+
+        with patch.object(manager.router, "choose", side_effect=choose):
+            self.assertTrue(self.drive(manager))
+
+        paths = self.only_run()
+        reasons = [
+            visit.reason for visit in load_graph_state(paths).path if visit.kind == "revisit"
+        ]
+        self.assertIn("The ablation was never run.", reasons)
+
+    def test_the_step_limit_stops_a_run_that_will_not_converge(self) -> None:
+        """A router that always goes back is the failure mode a budget exists for."""
+        _operator, manager = self.build(
+            stage_graph=StageGraph.adaptive(),
+            routing_mode="agent",
+            graph_max_steps=6,
+            graph_max_visits=99,
+        )
+
+        def choose(*, paths, stage, graph, state, score=None, final_stage=None):
+            if stage.slug == STAGE_05.slug:
+                return RoutingDecision(STAGE_06.slug, "advance", "on", STAGE_06.slug, True)
+            if stage.slug == STAGE_06.slug:
+                return RoutingDecision(
+                    STAGE_05.slug, "revisit", f"again {state.steps}", STAGE_07.slug, True
+                )
+            return _advance(stage)
+
+        with patch.object(manager.router, "choose", side_effect=choose):
+            self.drive(manager)
+
+        state = load_graph_state(self.only_run())
+        self.assertLessEqual(state.steps, 6)
+        self.assertIn("step limit", state.halted_because)
+
+    # -- settings survive a resume -------------------------------------------
+
+    def test_the_walk_settings_are_preserved_on_resume(self) -> None:
+        """Resuming an adaptive run without repeating the flag must not silently
+        revert it to the linear default."""
+        _operator, manager = self.build(
+            stage_graph=StageGraph.adaptive(),
+            routing_mode="auto",
+            evolution=EvolutionConfig(enabled=True, rounds=2),
+        )
+        self.drive(manager)
+        paths = self.only_run()
+        config = load_run_config(paths)
+        self.assertEqual(config["stage_graph"], "adaptive")
+        self.assertEqual(config["routing_mode"], "auto")
+        self.assertEqual(config["evolve_rounds"], 2)
+
+    # -- evolution through the real loop -------------------------------------
+
+    def test_evolution_promotes_the_champion_and_writes_a_ledger(self) -> None:
+        _operator, manager = self.build(evolution=EvolutionConfig(enabled=True, rounds=2))
+        self.assertTrue(self.drive(manager))
+
+        paths = self.only_run()
+        ledger = paths.evolution_dir / "improvement_ledger.jsonl"
+        self.assertTrue(ledger.exists())
+        rows = [json.loads(line) for line in read_text(ledger).splitlines() if line.strip()]
+        self.assertTrue(rows)
+        for row in rows:
+            self.assertIn(row["stage"], {stage.slug for stage in STAGES})
+            self.assertIn(
+                row["verdict"],
+                {"first", "promoted", "frontier", "regressed", "directed", "verdict_drift"},
+            )
+
+        summary = json.loads(read_text(paths.evolution_dir / "summary.json"))
+        self.assertTrue(summary["stages"])
+        for slug, entry in summary["stages"].items():
+            self.assertGreaterEqual(entry["total"], 0.0)
+            self.assertLessEqual(entry["total"], 1.0)
+            self.assertTrue(paths.stage_file(next(s for s in STAGES if s.slug == slug)).exists())
+
+    def test_polish_rounds_do_not_consume_the_repair_budget(self) -> None:
+        """`--max-attempts` bounds a stage that is failing. A stage being improved
+        would otherwise look like one that was thrashing, and would have nothing
+        left if a later round did break something."""
+        _operator, manager = self.build(
+            evolution=EvolutionConfig(enabled=True, rounds=3), max_stage_attempts=2
+        )
+        self.assertTrue(self.drive(manager))
+        paths = self.only_run()
+        manifest = load_run_manifest(paths.run_manifest)
+        self.assertTrue(all(entry.settled for entry in manifest.stages))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,286 @@
+"""Routing: the agent proposes, the graph disposes.
+
+Everything here is about the disagreement path. When the backend picks a live move
+and explains itself, there is nothing to test but a passthrough. The design lives
+in what happens when it picks a blocked move, picks a move that does not exist,
+picks without a reason, or asks to go back somewhere it has already been for the
+same reason — and in the guarantee that every one of those degrades to the forward
+edge rather than to a stall.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.router import ROUTING_MODES, RoutingDecision, StageRouter, format_decision, routing_summary
+from src.stage_graph import FINISH, GraphState, StageGraph, Visit, enter, leave
+from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
+from tests import prereg_support
+
+
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+
+
+class FakeRoutingOperator:
+    """Stands in for a backend CLI at the two private seams the router uses.
+
+    Serving the boundary rather than stubbing `StageRouter._ask` keeps the prompt
+    construction, the JSON recovery and the exit-code handling under test; a stub
+    at the method would assert only that the fake was called.
+    """
+
+    fake_mode = False
+
+    def __init__(self, response: str, *, exit_code: int = 0) -> None:
+        self.response = response
+        self.exit_code = exit_code
+        self.prompts: list[str] = []
+
+    def _prepare_invocation(self, prompt_path, session_id, *, paths, resume):
+        self.prompts.append(read_text(prompt_path))
+        return (["fake-backend"], paths.run_root, None)
+
+    def _run_streaming_command(self, *, command, cwd, stage, attempt_no, paths, mode, stdin_text):
+        return (self.exit_code, self.response, "", session_placeholder := None, {})
+
+
+class RouterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.stage_file(STAGE_06), "# Stage 06: Analysis\n\nBody.\n")
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        write_text(self.paths.results_dir / "metrics.json", json.dumps({"acc": 0.7}))
+        write_text(
+            self.paths.experiment_manifest, json.dumps({"experiments": [{"id": "e1"}]})
+        )
+        self.graph = StageGraph.adaptive()
+
+    def choose(self, response: str, *, state: GraphState | None = None, mode: str = "agent"):
+        operator = FakeRoutingOperator(response)
+        router = StageRouter(operator, mode=mode)
+        decision = router.choose(
+            paths=self.paths,
+            stage=STAGE_06,
+            graph=self.graph,
+            state=state or GraphState(),
+        )
+        return decision, operator
+
+    # -- the agreement path --------------------------------------------------
+
+    def test_a_live_move_with_a_reason_is_taken(self) -> None:
+        decision, _ = self.choose(
+            json.dumps({"target": "05_experimentation", "reason": "H1 rests on a single seed."})
+        )
+        self.assertEqual(decision.target, "05_experimentation")
+        self.assertEqual(decision.kind, "revisit")
+        self.assertTrue(decision.agent_directed)
+        self.assertEqual(decision.refusal, "")
+
+    def test_the_default_is_recorded_even_when_the_agent_agrees(self) -> None:
+        """An agreement is evidence about the topology too. Without both on record
+        the archive cannot tell a confirmed default from a default nobody was asked
+        about."""
+        self.adjudicate()
+        decision, _ = self.choose(
+            json.dumps({"target": "07_writing", "reason": "Everything is adjudicated."})
+        )
+        self.assertEqual(decision.target, "07_writing")
+        self.assertEqual(decision.default_target, "07_writing")
+        self.assertTrue(decision.agent_directed)
+
+    def adjudicate(self) -> None:
+        """Open the writing edge: frozen hypotheses, a verdict on each, a figure."""
+        prereg_support.write_hypothesis_manifest(self.paths)
+        prereg_support.freeze_preregistration(self.paths)
+        write_text(self.paths.figures_dir / "fig.png", "x" * 64)
+        prereg = json.loads(self.paths.preregistration.read_text(encoding="utf-8"))
+        write_text(
+            self.paths.hypothesis_outcomes,
+            json.dumps(
+                {
+                    "preregistration_digest": prereg["digest"],
+                    "outcomes": [
+                        {
+                            "id": prereg_support.HYPOTHESIS_ID,
+                            "verdict": "refuted",
+                            "rationale": "The gap did not clear the rule.",
+                            "evidence": ["results/metrics.json"],
+                        }
+                    ],
+                }
+            ),
+        )
+
+    # -- refusals ------------------------------------------------------------
+
+    def test_a_blocked_move_is_refused_and_falls_forward(self) -> None:
+        """Writing is closed until the hypotheses are adjudicated, and an agent
+        asked where to go next reaches for the deliverable."""
+        prereg_support.write_hypothesis_manifest(self.paths)
+        prereg_support.freeze_preregistration(self.paths)
+        decision, _ = self.choose(
+            json.dumps({"target": "07_writing", "reason": "The results look conclusive."})
+        )
+        self.assertNotEqual(decision.target, "07_writing")
+        self.assertFalse(decision.agent_directed)
+        self.assertIn("07_writing", decision.refusal)
+
+    def test_a_move_that_does_not_exist_is_refused(self) -> None:
+        decision, _ = self.choose(json.dumps({"target": "04_implementation", "reason": "Rebuild."}))
+        self.assertFalse(decision.agent_directed)
+        self.assertIn("not a move", decision.refusal)
+
+    def test_a_choice_with_no_reason_is_refused(self) -> None:
+        decision, _ = self.choose(json.dumps({"target": "05_experimentation", "reason": "   "}))
+        self.assertFalse(decision.agent_directed)
+        self.assertIn("no stated reason", decision.refusal)
+
+    def test_going_back_for_the_same_reason_twice_is_refused(self) -> None:
+        state = GraphState(
+            path=[
+                Visit(
+                    stage="06_analysis",
+                    entered_at="t",
+                    chose="05_experimentation",
+                    kind="revisit",
+                    reason="Only one seed was run.",
+                )
+            ]
+        )
+        decision, _ = self.choose(
+            json.dumps({"target": "05_experimentation", "reason": "only one seed was run."}),
+            state=state,
+        )
+        self.assertFalse(decision.agent_directed)
+        self.assertIn("same reason", decision.refusal)
+
+    def test_going_back_for_a_different_reason_is_allowed(self) -> None:
+        state = GraphState(
+            path=[
+                Visit(
+                    stage="06_analysis",
+                    entered_at="t",
+                    chose="05_experimentation",
+                    kind="revisit",
+                    reason="Only one seed was run.",
+                )
+            ]
+        )
+        decision, _ = self.choose(
+            json.dumps(
+                {"target": "05_experimentation", "reason": "The ablation condition was never run."}
+            ),
+            state=state,
+        )
+        self.assertTrue(decision.agent_directed)
+
+    def test_unreadable_output_falls_forward_rather_than_stalling(self) -> None:
+        decision, _ = self.choose("I think we should probably continue to the next stage.")
+        self.assertFalse(decision.agent_directed)
+        self.assertIn("no readable decision", decision.refusal)
+
+    def test_a_backend_that_exits_nonzero_does_not_end_the_run(self) -> None:
+        operator = FakeRoutingOperator("", exit_code=3)
+        decision = StageRouter(operator, mode="agent").choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+        )
+        self.assertFalse(decision.agent_directed)
+        self.assertTrue(decision.target)
+
+    def test_every_refusal_is_written_where_it_can_be_read_later(self) -> None:
+        self.choose(json.dumps({"target": "04_implementation", "reason": "Rebuild."}))
+        rows = [
+            json.loads(line)
+            for line in read_text(self.paths.evolution_dir / "routing_refusals.jsonl").splitlines()
+            if line.strip()
+        ]
+        self.assertEqual(rows[-1]["stage"], STAGE_06.slug)
+        self.assertTrue(rows[-1]["fell_back_to"])
+
+    # -- when to ask ---------------------------------------------------------
+
+    def test_off_never_asks(self) -> None:
+        decision, operator = self.choose(
+            json.dumps({"target": "05_experimentation", "reason": "H1 rests on one seed."}),
+            mode="off",
+        )
+        self.assertEqual(operator.prompts, [])
+        self.assertFalse(decision.agent_directed)
+
+    def test_auto_does_not_ask_where_there_is_only_one_move(self) -> None:
+        """On a linear graph `auto` costs nothing, which is what makes it a safe
+        default for someone turning routing on for the first time."""
+        operator = FakeRoutingOperator(json.dumps({"target": FINISH, "reason": "done"}))
+        StageRouter(operator, mode="auto").choose(
+            paths=self.paths,
+            stage=STAGE_06,
+            graph=StageGraph.linear(),
+            state=GraphState(),
+        )
+        self.assertEqual(operator.prompts, [])
+
+    def test_auto_asks_where_the_answer_can_differ(self) -> None:
+        operator = FakeRoutingOperator(
+            json.dumps({"target": "05_experimentation", "reason": "H1 rests on one seed."})
+        )
+        StageRouter(operator, mode="auto").choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+        )
+        self.assertEqual(len(operator.prompts), 1)
+
+    def test_an_unknown_mode_is_refused_at_construction(self) -> None:
+        with self.assertRaises(ValueError):
+            StageRouter(None, mode="vibes")
+        self.assertEqual(set(ROUTING_MODES), {"off", "auto", "agent"})
+
+    # -- the prompt ----------------------------------------------------------
+
+    def test_the_prompt_shows_blocked_moves_with_the_reason_they_are_blocked(self) -> None:
+        prereg_support.write_hypothesis_manifest(self.paths)
+        prereg_support.freeze_preregistration(self.paths)
+        _, operator = self.choose(
+            json.dumps({"target": "05_experimentation", "reason": "H1 rests on one seed."})
+        )
+        prompt = operator.prompts[0]
+        self.assertIn("07_writing", prompt)
+        self.assertIn(prereg_support.HYPOTHESIS_ID, prompt)
+
+    # -- reporting -----------------------------------------------------------
+
+    def test_the_summary_counts_edges_rather_than_stages(self) -> None:
+        """The same target reached from two sources is two different decisions."""
+        state = GraphState()
+        enter(self.paths, state, STAGE_06)
+        leave(
+            self.paths,
+            state,
+            chose="05_experimentation",
+            kind="revisit",
+            reason="thin",
+            default_choice="07_writing",
+            agent_directed=True,
+            score_total=0.6,
+        )
+        summary = routing_summary(self.paths)
+        self.assertEqual(summary["edges"], {"06_analysis->05_experimentation": 1})
+        self.assertEqual(summary["revisits"], 1)
+        self.assertEqual(summary["agent_directed"], 1)
+
+    def test_the_terminal_line_says_who_chose(self) -> None:
+        self.assertIn("agent", format_decision(RoutingDecision("07_writing", "advance", "r", "07_writing", True)))
+        self.assertIn(
+            "refused",
+            format_decision(RoutingDecision("07_writing", "advance", "r", "07_writing", False, "nope")),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -1,0 +1,334 @@
+"""The fitness function, and the property the self-improvement loop rests on.
+
+Most of these are about what the rubric *refuses* to reward. A score that only
+goes up when the work gets better is not demonstrated by scoring good work highly;
+it is demonstrated by scoring padded prose, invented numbers and a rewritten
+conclusion exactly as low as they deserve. The last of those is the one that
+matters: a scored loop pointed at a fitness function that notices which way a
+result went is an automated p-hacker with a budget.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.rubric import (
+    RUBRIC_VERSION,
+    CRITERIA_BY_KEY,
+    StageScore,
+    format_score_for_prompt,
+    score_stage,
+    verdict_digest,
+)
+from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+from tests import prereg_support
+
+
+STAGE_01 = next(stage for stage in STAGES if stage.number == 1)
+STAGE_05 = next(stage for stage in STAGES if stage.number == 5)
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+
+
+def stage_markdown(
+    stage,
+    *,
+    what_i_did: str = "Ran the sweep in `workspace/code/run_sweep.py` over five seeds.",
+    key_results: str = "Accuracy reached 74.1% against a 58.2% baseline over 5 seeds.",
+    files: str = "- `workspace/results/metrics.json`\n- `workspace/code/run_sweep.py`",
+    ledger: str | None = None,
+) -> str:
+    ledger = ledger or (
+        "- Open Questions: whether the effect survives a larger context window.\n"
+        "- Locked Decisions: the held-out split is frozen at the 2024 partition.\n"
+        "- Assumptions: the retrieval index is complete for the evaluation period.\n"
+        "- Rejected Alternatives: fine-tuning the base model, which the budget cannot cover.\n"
+    )
+    return (
+        f"# {stage.stage_title}\n\n"
+        "## Objective\n\nEstablish the effect.\n\n"
+        "## Previously Approved Stage Summaries\n\nNone yet.\n\n"
+        f"## What I Did\n\n{what_i_did}\n\n"
+        f"## Key Results\n\n{key_results}\n\n"
+        f"## Files Produced\n\n{files}\n\n"
+        f"## Decision Ledger\n\n{ledger}\n"
+        "## Suggestions for Refinement\n\n"
+        "1. Add a second baseline.\n2. Widen the sweep.\n3. Record per-seed variance.\n\n"
+        "## Your Options\n\n"
+        "1. Use suggestion 1\n2. Use suggestion 2\n3. Use suggestion 3\n"
+        "4. Refine with your own feedback\n5. Approve and continue\n6. Abort\n"
+    )
+
+
+class RubricTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    def build_complete_run(self) -> None:
+        """A run carrying every artifact the validity chain expects at Stage 06."""
+        prereg_support.write_hypothesis_manifest(self.paths)
+        prereg_support.write_experimental_protocol(self.paths)
+        write_text(self.paths.code_dir / "run_sweep.py", "print('sweep')\n" * 5)
+        write_text(
+            self.paths.results_dir / "metrics.json",
+            json.dumps({"baseline": 0.582, "treatment": 0.741, "seeds": 5}),
+        )
+        write_text(self.paths.data_dir / "splits.json", json.dumps({"test": list(range(40))}))
+        write_text(self.paths.figures_dir / "effect.png", "x" * 200)
+        write_text(
+            self.paths.literature_dir / "evidence_ledger.json",
+            json.dumps({"entries": [{"claim": "prior work", "source": "smith2024"}]}),
+        )
+        prereg_support.freeze_preregistration(self.paths)
+        write_text(
+            self.paths.experiment_manifest,
+            json.dumps({"experiments": [{"id": "e1", "command": "python run_sweep.py", "seeds": 5}]}),
+        )
+        self.write_outcomes("supported")
+
+    def write_outcomes(self, verdict: str) -> None:
+        prereg = json.loads(self.paths.preregistration.read_text(encoding="utf-8"))
+        write_text(
+            self.paths.hypothesis_outcomes,
+            json.dumps(
+                {
+                    "preregistration_digest": prereg["digest"],
+                    "outcomes": [
+                        {
+                            "id": prereg_support.HYPOTHESIS_ID,
+                            "verdict": verdict,
+                            "rationale": "The held-out gap exceeds the decision rule threshold.",
+                            "evidence": ["results/metrics.json"],
+                        }
+                    ],
+                }
+            ),
+        )
+
+    # -- the property the loop depends on ------------------------------------
+
+    def test_flipping_every_verdict_does_not_move_the_score(self) -> None:
+        """Outcome blindness, measured end to end rather than argued for.
+
+        The construction guard in `_verdict_blind_outcomes` is where the property
+        is enforced; this is the control that proves the guard is on the path a
+        real score takes. Written against the artifact on disk, so a criterion
+        added later that reads `hypothesis_outcomes.json` directly fails here.
+        """
+        self.build_complete_run()
+        markdown = stage_markdown(STAGE_06)
+
+        totals = {}
+        for verdict in ("supported", "refuted", "inconclusive", "not_tested"):
+            self.write_outcomes(verdict)
+            totals[verdict] = score_stage(
+                paths=self.paths, stage=STAGE_06, markdown=markdown
+            ).total
+
+        self.assertEqual(
+            len(set(round(value, 9) for value in totals.values())),
+            1,
+            msg=f"the rubric preferred an outcome: {totals}",
+        )
+
+    def test_the_verdict_digest_moves_when_a_verdict_does(self) -> None:
+        """Drift detection is only useful if it detects drift.
+
+        The mirror of the test above: the *score* must not move and the *digest*
+        must. One without the other is a loop that either cannot improve evidence
+        or cannot notice a rewritten conclusion.
+        """
+        self.build_complete_run()
+        before = verdict_digest(self.paths)
+        self.write_outcomes("refuted")
+        self.assertNotEqual(before, verdict_digest(self.paths))
+        self.assertTrue(before)
+
+    # -- criteria that must not be gameable ----------------------------------
+
+    def test_padding_prose_does_not_raise_the_score(self) -> None:
+        self.build_complete_run()
+        lean = stage_markdown(STAGE_06)
+        padded = stage_markdown(
+            STAGE_06,
+            what_i_did=(
+                "Ran the sweep in `workspace/code/run_sweep.py` over five seeds. "
+                + "The methodology was applied with considerable care and rigour throughout. " * 40
+            ),
+        )
+        self.assertLessEqual(
+            score_stage(paths=self.paths, stage=STAGE_06, markdown=padded).total,
+            score_stage(paths=self.paths, stage=STAGE_06, markdown=lean).total + 1e-9,
+        )
+
+    def test_a_number_that_appears_in_no_artifact_is_caught(self) -> None:
+        """The deep-review check: a fluent write-up quoting a metric nothing measured.
+
+        Every other gate passes this draft. Its sections are present, the files it
+        names exist, the prose is quantified — the number is simply invented.
+        """
+        self.build_complete_run()
+        honest = score_stage(
+            paths=self.paths,
+            stage=STAGE_06,
+            markdown=stage_markdown(STAGE_06, key_results="Accuracy reached 74.1% from 58.2%."),
+        )
+        invented = score_stage(
+            paths=self.paths,
+            stage=STAGE_06,
+            markdown=stage_markdown(STAGE_06, key_results="Accuracy reached 91.7% from 58.2%."),
+        )
+        self.assertEqual(honest.by_key["numeric_fidelity"].score, 1.0)
+        self.assertLess(invented.by_key["numeric_fidelity"].score, 1.0)
+        self.assertIn("91.7", invented.by_key["numeric_fidelity"].shortfall)
+
+    def test_a_percentage_is_matched_against_its_fraction(self) -> None:
+        """`74.1%` is the same measurement as `0.741`, and a rubric that says
+        otherwise would send every polish round after a number that is already right."""
+        self.build_complete_run()
+        score = score_stage(
+            paths=self.paths,
+            stage=STAGE_06,
+            markdown=stage_markdown(STAGE_06, key_results="Accuracy reached 74.1%, over 58.2%."),
+        )
+        self.assertEqual(score.by_key["numeric_fidelity"].score, 1.0)
+
+    def test_a_reference_that_does_not_resolve_lowers_grounding(self) -> None:
+        self.build_complete_run()
+        resolving = score_stage(paths=self.paths, stage=STAGE_06, markdown=stage_markdown(STAGE_06))
+        broken = score_stage(
+            paths=self.paths,
+            stage=STAGE_06,
+            markdown=stage_markdown(
+                STAGE_06,
+                what_i_did="Wrote `workspace/results/ablation.json`, which does not exist.",
+            ),
+        )
+        self.assertLess(broken.by_key["grounding"].score, resolving.by_key["grounding"].score)
+        self.assertIn("ablation.json", broken.by_key["grounding"].shortfall)
+
+    def test_a_decision_ledger_repeating_itself_scores_below_a_real_one(self) -> None:
+        self.build_complete_run()
+        real = score_stage(paths=self.paths, stage=STAGE_06, markdown=stage_markdown(STAGE_06))
+        repeated = score_stage(
+            paths=self.paths,
+            stage=STAGE_06,
+            markdown=stage_markdown(
+                STAGE_06,
+                ledger=(
+                    "- Open Questions: the approach seems reasonable overall.\n"
+                    "- Locked Decisions: the approach seems reasonable overall.\n"
+                    "- Assumptions: the approach seems reasonable overall.\n"
+                    "- Rejected Alternatives: None\n"
+                ),
+            ),
+        )
+        self.assertLess(
+            repeated.by_key["traceability"].score, real.by_key["traceability"].score
+        )
+
+    def test_a_stage_describing_intentions_scores_below_one_reporting_work(self) -> None:
+        self.build_complete_run()
+        done = score_stage(paths=self.paths, stage=STAGE_06, markdown=stage_markdown(STAGE_06))
+        planned = score_stage(
+            paths=self.paths,
+            stage=STAGE_06,
+            markdown=stage_markdown(
+                STAGE_06,
+                what_i_did=(
+                    "We will run the sweep in `workspace/code/run_sweep.py`. We plan to measure "
+                    "accuracy. The design is intended to isolate the effect and should improve "
+                    "over the baseline. The ablation is to be run next."
+                ),
+            ),
+        )
+        self.assertLess(planned.by_key["commitment"].score, done.by_key["commitment"].score)
+
+    # -- structure -----------------------------------------------------------
+
+    def test_criteria_that_cannot_apply_are_not_scored_as_failures(self) -> None:
+        """Stage 01 has no experiment manifest to produce and must not be graded as
+        if it failed to produce one, or the ratchet would prefer late stages for a
+        reason with nothing to do with their quality."""
+        score = score_stage(paths=self.paths, stage=STAGE_01, markdown=stage_markdown(STAGE_01))
+        self.assertNotIn("numeric_fidelity", score.by_key)
+        self.assertNotIn("artifact_breadth", score.by_key)
+        self.assertIn("grounding", score.by_key)
+
+    def test_weakest_orders_by_recoverable_weight_not_raw_score(self) -> None:
+        score = StageScore(
+            stage_slug="06_analysis",
+            attempt_no=1,
+            rubric_version=RUBRIC_VERSION,
+            criteria=(
+                _criterion("traceability", 0.4, weight=1.5),
+                _criterion("grounding", 0.6, weight=3.0),
+                _criterion("contract", 1.0, weight=2.0),
+            ),
+            total=0.6,
+        )
+        weakest = score.weakest()
+        self.assertEqual([item.key for item in weakest], ["grounding", "traceability"])
+        self.assertNotIn("contract", [item.key for item in weakest])
+
+    def test_a_saturated_criterion_carries_no_shortfall(self) -> None:
+        """A directive built from a criterion at full marks asks for churn."""
+        self.build_complete_run()
+        score = score_stage(paths=self.paths, stage=STAGE_06, markdown=stage_markdown(STAGE_06))
+        for item in score.criteria:
+            if item.score >= 1.0:
+                self.assertEqual(item.shortfall, "", msg=f"{item.key} is saturated but asks for work")
+
+    def test_a_score_round_trips_through_json(self) -> None:
+        self.build_complete_run()
+        score = score_stage(paths=self.paths, stage=STAGE_06, markdown=stage_markdown(STAGE_06))
+        restored = StageScore.from_dict(json.loads(json.dumps(score.to_dict())))
+        self.assertEqual(restored.rubric_version, score.rubric_version)
+        self.assertAlmostEqual(restored.total, score.total, places=4)
+        self.assertEqual(
+            {item.key: round(item.score, 4) for item in restored.criteria},
+            {item.key: round(item.score, 4) for item in score.criteria},
+        )
+
+    def test_the_prompt_rendering_names_the_shortfall_not_only_the_number(self) -> None:
+        self.build_complete_run()
+        score = score_stage(
+            paths=self.paths,
+            stage=STAGE_06,
+            markdown=stage_markdown(STAGE_06, key_results="Accuracy reached 91.7%."),
+        )
+        rendered = format_score_for_prompt(score)
+        self.assertIn("91.7", rendered)
+        self.assertIn("Where the points are", rendered)
+
+    def test_scoring_does_not_write_anything(self) -> None:
+        """The rubric is read by a loop that reverts drafts. A scorer with a side
+        effect would make the measurement depend on how many times it was taken."""
+        self.build_complete_run()
+        before = sorted(p.relative_to(self.paths.run_root).as_posix() for p in self.paths.run_root.rglob("*"))
+        score_stage(paths=self.paths, stage=STAGE_06, markdown=stage_markdown(STAGE_06))
+        after = sorted(p.relative_to(self.paths.run_root).as_posix() for p in self.paths.run_root.rglob("*"))
+        self.assertEqual(before, after)
+
+
+def _criterion(key: str, score: float, *, weight: float):
+    from src.rubric import CriterionScore
+
+    return CriterionScore(
+        key=key,
+        title=CRITERIA_BY_KEY[key].title,
+        weight=weight,
+        score=score,
+        observed="synthetic",
+        shortfall="raise it",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stage_graph.py
+++ b/tests/test_stage_graph.py
@@ -1,0 +1,288 @@
+"""The stage topology, and the moves it refuses.
+
+The default graph has to behave exactly like the list it replaced — that is the
+first test here and the reason the linear topology is a real graph rather than a
+branch around one. The rest are about the adaptive topology, where the run picks
+its own route and the interesting question is not which moves it can make but
+which it cannot.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.stage_graph import (
+    DEFAULT_MAX_VISITS,
+    FINISH,
+    GUARDS,
+    Edge,
+    GraphState,
+    StageGraph,
+    Visit,
+    enter,
+    format_route,
+    leave,
+    load_graph_state,
+    save_graph_state,
+    stage_for_slug,
+)
+from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+from tests import prereg_support
+
+
+class LinearTopologyTests(unittest.TestCase):
+    """The default must be the old pipeline, edge for edge."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+
+    def test_the_default_graph_walks_01_through_08_and_finishes(self) -> None:
+        graph = StageGraph.linear()
+        state = GraphState()
+        route = []
+        current = STAGES[0].slug
+        while current != FINISH:
+            route.append(current)
+            move = graph.default_move(self.paths, current, state)
+            self.assertIsNotNone(move, msg=f"no move out of {current} on the default graph")
+            current = move.target
+        self.assertEqual(route, [stage.slug for stage in STAGES])
+
+    def test_no_forward_move_on_the_linear_graph_is_guarded(self) -> None:
+        """A guard on the only edge out of a node could only ever halt the run, and
+        the condition it would halt on is already a stage validation error with a
+        better message. Two gates over one condition is one too many."""
+        for edge in StageGraph.linear().edges:
+            self.assertEqual(edge.guard, "always", msg=f"{edge.source}->{edge.target} is guarded")
+
+    def test_every_registered_guard_is_wired_to_an_edge(self) -> None:
+        """A guard nobody wired is a check nobody runs.
+
+        It reads as protection in a review and enforces nothing, and the adaptive
+        topology is the only place guards apply — so an orphan is invisible until
+        someone assumes the condition is being checked.
+        """
+        wired = {edge.guard for edge in StageGraph.adaptive().edges}
+        self.assertEqual(set(GUARDS) - wired, set())
+
+    def test_an_edge_with_an_unknown_guard_is_refused_at_construction(self) -> None:
+        """A guard name that does not resolve would silently pass."""
+        with self.assertRaises(ValueError):
+            Edge("06_analysis", "07_writing", "advance", "why", guard="looks_fine")
+
+    def test_an_edge_with_an_unhandled_kind_is_refused_at_construction(self) -> None:
+        """A revisit is budgeted and justified differently from an advance, and the
+        archive learns their payoffs separately. An unknown kind would be treated
+        as neither."""
+        with self.assertRaises(ValueError):
+            Edge("06_analysis", "07_writing", "sideways", "why")
+
+    def test_an_empty_run_offers_every_linear_move(self) -> None:
+        state = GraphState()
+        for stage in STAGES:
+            self.assertTrue(
+                StageGraph.linear().admissible_moves(self.paths, stage.slug, state),
+                msg=f"{stage.slug} has no live move on an empty run",
+            )
+
+
+class AdaptiveTopologyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        self.graph = StageGraph.adaptive()
+
+    def targets(self, slug: str, state: GraphState | None = None) -> set[str]:
+        return {
+            move.target
+            for move in self.graph.admissible_moves(self.paths, slug, state or GraphState())
+        }
+
+    # -- what the graph refuses ---------------------------------------------
+
+    def test_writing_is_closed_until_every_hypothesis_has_a_verdict(self) -> None:
+        """The gate a self-routing agent must not be able to talk past.
+
+        Writing up before adjudication is how a manuscript claims a result the run
+        never established, and an agent asked where to go next will reach for the
+        deliverable.
+        """
+        self.assertNotIn("07_writing", self.targets("06_analysis"))
+
+        self.build_adjudicated_run()
+        self.assertIn("07_writing", self.targets("06_analysis"))
+
+    def test_a_blocked_move_says_which_hypothesis_is_missing_a_verdict(self) -> None:
+        """A guard that fails without saying what would satisfy it turns the
+        routing decision into a guess, and the agent into a random walker."""
+        self.build_adjudicated_run(adjudicate=False)
+        blocked = next(
+            move
+            for move in self.graph.moves(self.paths, "06_analysis", GraphState())
+            if move.target == "07_writing"
+        )
+        self.assertFalse(blocked.admissible)
+        self.assertIn(prereg_support.HYPOTHESIS_ID, blocked.blocked_because)
+
+    def test_a_blocked_move_is_still_shown_to_the_router(self) -> None:
+        """Hiding it would be the obvious design and it is the wrong one: an agent
+        that can see why writing is closed routes to what opens it."""
+        moves = self.graph.moves(self.paths, "06_analysis", GraphState())
+        self.assertIn("07_writing", {move.target for move in moves})
+        rendered = self.graph.describe_for_prompt(moves)
+        self.assertIn("07_writing", rendered)
+        self.assertIn("**no**", rendered)
+
+    def test_a_stage_cannot_be_entered_past_its_visit_budget(self) -> None:
+        state = GraphState()
+        for _ in range(DEFAULT_MAX_VISITS):
+            state.path.append(Visit(stage="05_experimentation", entered_at="t"))
+        self.assertNotIn("05_experimentation", self.targets("06_analysis", state))
+
+    def test_the_step_limit_stops_the_walk_wherever_it_is(self) -> None:
+        state = GraphState(max_steps=2)
+        state.path.extend(
+            [Visit(stage="01_literature_survey", entered_at="t"), Visit(stage="02_hypothesis_generation", entered_at="t")]
+        )
+        self.assertEqual(self.targets("02_hypothesis_generation", state), set())
+
+    def test_a_revisit_repeating_its_own_reason_is_recognised(self) -> None:
+        """Going back to Stage 05 a third time because 'more repeats are needed' is
+        not iteration. The check is on the reason, so a *different* reason is never
+        penalised for the earlier trip."""
+        state = GraphState()
+        state.path.append(
+            Visit(
+                stage="06_analysis",
+                entered_at="t",
+                chose="05_experimentation",
+                kind="revisit",
+                reason="Only one seed was run, so H1 cannot be decided.",
+            )
+        )
+        self.assertTrue(
+            self.graph.repeats_a_previous_reason(
+                state, "05_experimentation", "only one seed was run, so h1 cannot be decided."
+            )
+        )
+        self.assertFalse(
+            self.graph.repeats_a_previous_reason(
+                state, "05_experimentation", "The ablation condition was never run at all."
+            )
+        )
+
+    def test_final_stage_prunes_moves_past_it(self) -> None:
+        """`--final-stage 07` means the run does not owe a dissemination package, so
+        the edge into one must not be on the menu."""
+        stage_07 = stage_for_slug("07_writing")
+        targets = {
+            move.target
+            for move in self.graph.moves(
+                self.paths, "07_writing", GraphState(), final_stage=stage_07
+            )
+        }
+        self.assertNotIn("08_dissemination", targets)
+
+    # -- what the graph allows ----------------------------------------------
+
+    def test_analysis_can_send_the_run_back_to_the_experiment(self) -> None:
+        """The move a linear list cannot express, and the reason the graph exists."""
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        self.assertIn("05_experimentation", self.targets("06_analysis"))
+
+    def test_the_default_move_out_of_every_adaptive_node_is_the_forward_one(self) -> None:
+        """A refusal or a routing failure degrades to the old pipeline, not a stall."""
+        self.build_adjudicated_run()
+        for index, stage in enumerate(STAGES):
+            expected = STAGES[index + 1].slug if index + 1 < len(STAGES) else FINISH
+            move = self.graph.default_move(self.paths, stage.slug, GraphState())
+            self.assertIsNotNone(move, msg=f"no default move out of {stage.slug}")
+            self.assertEqual(move.target, expected, msg=f"default out of {stage.slug}")
+
+    # -- state ---------------------------------------------------------------
+
+    def test_the_path_survives_a_reload(self) -> None:
+        state = load_graph_state(self.paths)
+        enter(self.paths, state, STAGES[0])
+        leave(
+            self.paths,
+            state,
+            chose="02_hypothesis_generation",
+            kind="advance",
+            reason="The survey named the gap.",
+            default_choice="02_hypothesis_generation",
+            agent_directed=True,
+            score_total=0.71,
+        )
+        reloaded = load_graph_state(self.paths)
+        self.assertEqual(len(reloaded.path), 1)
+        self.assertEqual(reloaded.path[0].chose, "02_hypothesis_generation")
+        self.assertTrue(reloaded.path[0].agent_directed)
+        self.assertAlmostEqual(reloaded.path[0].score_total or 0.0, 0.71)
+
+    def test_the_route_marks_backward_moves(self) -> None:
+        state = GraphState(
+            path=[
+                Visit(stage="06_analysis", entered_at="t", chose="05_experimentation", kind="revisit"),
+                Visit(stage="05_experimentation", entered_at="t", chose=FINISH, kind="finish"),
+            ]
+        )
+        rendered = format_route(state)
+        self.assertIn("↩", rendered)
+        self.assertIn("finish", rendered)
+
+    def test_explicit_limits_override_what_was_stored(self) -> None:
+        save_graph_state(self.paths, GraphState(max_steps=4, max_visits=1))
+        state = load_graph_state(self.paths, max_steps=11, max_visits=2)
+        self.assertEqual((state.max_steps, state.max_visits), (11, 2))
+
+    def test_an_unknown_topology_is_refused_rather_than_defaulted(self) -> None:
+        with self.assertRaises(ValueError):
+            StageGraph.named("whatever-sounds-good")
+
+    # -- helpers -------------------------------------------------------------
+
+    def build_adjudicated_run(self, *, adjudicate: bool = True) -> None:
+        prereg_support.write_hypothesis_manifest(self.paths)
+        prereg_support.write_experimental_protocol(self.paths)
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        write_text(self.paths.data_dir / "splits.json", json.dumps({"test": [1, 2]}))
+        write_text(self.paths.results_dir / "metrics.json", json.dumps({"acc": 0.7}))
+        write_text(self.paths.figures_dir / "fig.png", "x" * 64)
+        write_text(self.paths.report_file, "# Report\n\nBody.\n")
+        write_text(
+            self.paths.experiment_manifest,
+            json.dumps({"experiments": [{"id": "e1", "command": "python run.py"}]}),
+        )
+        prereg_support.freeze_preregistration(self.paths)
+        if adjudicate:
+            prereg = json.loads(self.paths.preregistration.read_text(encoding="utf-8"))
+            write_text(
+                self.paths.hypothesis_outcomes,
+                json.dumps(
+                    {
+                        "preregistration_digest": prereg["digest"],
+                        "outcomes": [
+                            {
+                                "id": prereg_support.HYPOTHESIS_ID,
+                                "verdict": "refuted",
+                                "rationale": "The gap did not clear the decision rule.",
+                                "evidence": ["results/metrics.json"],
+                            }
+                        ],
+                    }
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
AutoR could refine a stage and it could abort. It could not go back. So its response to "Stage 06 shows the design was wrong" was to write up the wrong design more carefully — and its response to a refinement that made a stage *worse* was to promote it, because "later" was the only ordering the loop had.

Six modules. **All off by default**: a run that passes none of the new flags walks 01 through 08 exactly as before, through the new engine, which is what keeps the default path exercised by every test of the adaptive one.

```bash
python main.py --goal "..." --stage-graph adaptive --routing auto \
               --evolve --archive ~/.autor/archive
```

## The stages are a directed graph

`src/stage_graph.py`, `src/router.py`

Nodes are stages, edges are moves. The default topology has one edge out of each node and *is* the old sequence. `--stage-graph adaptive` adds ten backward moves for conditions that actually occur: results insufficient to decide a hypothesis (`06→05`), a confound the results cannot repair (`06→03`), evidence that refutes and points somewhere specific (`06→02`), a claim with no analysis behind it (`07→06`).

`--routing auto` lets the backend choose — but only among moves AutoR has already ruled admissible by evaluating each edge's guard against artifacts on disk.

- **AutoR decides what is possible.** The gate into `07_writing` requires every preregistered hypothesis to carry a verdict. An agent asked where to go next reaches for the deliverable, and a gated edge is not on its menu.
- **The agent decides what is sensible**, and says why.
- **Blocked moves are still shown, with the reason.** An agent that can see "`07_writing` is closed because H2 has no verdict" routes to what opens it. One shown only the open moves picks the best of them and never learns what it missed.

Four refusals — blocked, nonexistent, unreasoned, and *the same reason twice* — each fall back to the forward edge, so the worst case is the linear pipeline rather than a stall. Bounded by `--graph-max-visits` (3) and `--graph-max-steps` (20).

## Drafts are measured and ratcheted

`src/rubric.py`, `src/evolution.py`, `src/pareto.py`

Eight criteria read off disk, not off the prose. The champion is what gets promoted, not the last draft; a round that scores worse is reverted in place, so the reviewer sees the best candidate the run produced. Candidates that lose on the total but hold some criterion stay on a Pareto frontier, and a later round merges them.

`numeric_fidelity` checks every reported measurement against the results artifacts, matching `74.1%` against `0.741`. It is the one gate that catches a fluent write-up quoting a metric that exists nowhere in the run — every other gate passes such a draft.

Polish rounds are budgeted separately from `--max-attempts`, which bounds a stage that is *failing* rather than one being improved.

## The harness learns across runs

`src/archive.py`

Each edge is compared against runs that **reached the same node and did not take it**. A believable payoff produces a child topology with one edge's priority moved one step, explaining itself in the archive. `--archive-report` prints what it has learned.

A learned prior can only reorder preferences. It cannot open a guarded edge, add one, or remove one.

## What the loop is not allowed to do

A fitness function plus a loop is an optimiser, and in a research pipeline the cheapest way to raise a score is to change the finding. `src/preregistration.py` already stops a human-driven version of that; a scored improvement loop would reintroduce it with a budget.

- **No criterion reads a verdict value.** Adjudications are routed through a blinding function that collapses them to a boolean before scoring can see them. A hypothesis *refuted* cleanly with the evidence on disk outscores one supported on an assertion.
- **Blindness removes the gradient, not the possibility.** A polish round that moves any verdict is reverted outright with a `verdict_drift` row, whatever it scored. Since the rubric is blind, a rewritten conclusion scores the same — which is exactly why this check cannot be a score comparison.
- **A revision a human asked for always stands**, whatever it measures. The ratchet governs AutoR's own rounds, not the direction it is given.

Both properties are tested end to end rather than argued for: one test flips every verdict on disk and asserts the total does not move, the next asserts the digest does.

## Two defects the tests found

- `contract` inherited the outcomes gate's asymmetry — `inconclusive` needs no evidence pointer, so marking every hypothesis inconclusive was a cheaper route to a clean score. Split so the artifact side is owned by `artifact_breadth` and `reproducibility`, which apply the same requirement to every verdict.
- `design_artifacts` was a guard nobody had wired. Now on the edge into Stage 04, with a test that fails on the next orphan.

## Prior work, and where this departs from it

Extends the Darwin Gödel Machine (archive + empirical fitness + parent sampling), GEPA (reflective mutation, Pareto frontier), The AI Scientist v2/v3 (candidate tree, deep reviewer), and ADAS (meta-level topology search). Each optimises against an external ground truth — a benchmark pass rate. Research has none, which is the whole problem. Substituting a *rigour* measurement for a *quality* judgement is what makes the loop safe to run; making it blind to the finding is what stops it becoming an automated p-hacker. DGM's unit of variation also becomes the topology rather than agent source: a harness people run on their own machines should not rewrite its own Python between runs, and a topology diffs, reverts, and can be validated before use.

## Testing

679 tests pass (583 before, 96 new), mostly of the refusals. `tests/test_graph_walk.py` drives the real manager loop and asserts a default run still produces the exact route `01 → … → 08`, never calls the router, and that a backward decision redirects the walk and marks the downstream stages stale.

Docs: [`docs/self-improvement.md`](docs/self-improvement.md), plus CLI reference, run artifacts, and README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)