### PR TITLE
Give Claude Code a real web_search tool, not a paragraph about one

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,7 @@ to a CLI directly; the operators never decide what stage runs next.
 | --- | --- |
 | [`src/platform/foundry.py`](../src/platform/foundry.py) | Post-approval packaging: paper package and release package. |
 | [`src/diagram_gen.py`](../src/diagram_gen.py) | Optional Gemini method-diagram generation, injected into `report.md` or `method.tex` depending on the run's output format. The only module with a third-party dependency. |
+| [`src/mcp_web_search.py`](../src/mcp_web_search.py) | An MCP server exposing Gemini search as a real `web_search` tool, so the capability sits where the disabled built-in used to: in the tool list, and in the trace as a named call. Stdlib JSON-RPC over stdio. |
 | [`src/prompts/`](../src/prompts) | One markdown template per stage, plus intake and bootstrap templates. Editing these changes agent behaviour with no code change. |
 | [`src/skills/`](../src/skills) | Agent skills, installed into each run's `.claude/skills/` by [`src/run_skills.py`](../src/run_skills.py). Pull-based counterpart to the prompt templates: loaded only when the model judges one relevant. The install path is load-bearing — the operator runs with `cwd=run_root`, so skills left in the AutoR checkout are never discovered. |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -121,6 +121,32 @@ question about the current environment, and freezing today's answer would make a
 resumed run assert something about the deployment that may no longer be true. A run
 recorded before this field existed reads as `auto`.
 
+#### How the agent reaches it
+
+With `--operator claude`, search is handed over as a **real MCP tool**,
+`mcp__autor-search__web_search`, not as a prompt paragraph asking the agent to
+remember to run a script. AutoR adds `--mcp-config` pointing at a config it writes
+to `operator_state/mcp_config.json` inside the run, so the run records what tools
+its agent was given, not only what it was told.
+
+Two things follow from it being a tool rather than an instruction:
+
+- **The model reaches for it.** A tool in the tool list competes far better than a
+  paragraph in a long prompt.
+- **Every search is legible in the trace.** `logs_raw.jsonl` shows a named call with
+  structured arguments, instead of an opaque shell command indistinguishable from
+  the hundreds of others a stage runs.
+
+A failed or ungrounded search comes back as an MCP tool *error* rather than a
+protocol error, so the model can read the reason and retry instead of the call
+simply ending.
+
+`--strict-mcp-config` is deliberately **not** passed: that would also drop whatever
+MCP servers you have configured for your own environment.
+
+`--operator codex` gets the shell command instead, which remains the documented
+fallback and is what `tools/web_search.py` is for.
+
 #### What "can actually run" means
 
 Injecting the search block tells every stage prompt that the built-in `WebSearch`

--- a/main.py
+++ b/main.py
@@ -300,8 +300,11 @@ def create_operator(
     fake_mode: bool,
     ui: TerminalUI,
     stage_timeout: int,
+    web_search_mcp: bool = False,
 ) -> OperatorProtocol:
     if operator_name == "codex":
+        # Codex reaches search through the CLI script instead: it takes no --mcp-config
+        # here, and its sandbox is the separate question documented in the CLI reference.
         return CodexOperator(
             model=model,
             codex_sandbox=codex_sandbox,
@@ -309,7 +312,13 @@ def create_operator(
             ui=ui,
             stage_timeout=stage_timeout,
         )
-    return ClaudeOperator(model=model, fake_mode=fake_mode, ui=ui, stage_timeout=stage_timeout)
+    return ClaudeOperator(
+        model=model,
+        fake_mode=fake_mode,
+        ui=ui,
+        stage_timeout=stage_timeout,
+        web_search_mcp=web_search_mcp,
+    )
 
 
 def create_reviewer(
@@ -522,6 +531,7 @@ def main() -> int:
             fake_mode=args.fake_operator,
             ui=ui,
             stage_timeout=args.stage_timeout,
+            web_search_mcp=web_search_context is not None,
         )
         reviewer = None
         if approval_mode == "agent":
@@ -583,6 +593,7 @@ def main() -> int:
         fake_mode=args.fake_operator,
         ui=ui,
         stage_timeout=args.stage_timeout,
+        web_search_mcp=web_search_context is not None,
     )
     reviewer = None
     if approval_mode == "agent":

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -255,7 +255,16 @@ def default_model_for(backend: str) -> str:
     return "default" if backend == "codex" else "sonnet"
 
 
-def create_operator(backend: str, *, model: str, codex_sandbox: str, fake_mode: bool, ui: TerminalUI, stage_timeout: int):
+def create_operator(
+    backend: str,
+    *,
+    model: str,
+    codex_sandbox: str,
+    fake_mode: bool,
+    ui: TerminalUI,
+    stage_timeout: int,
+    web_search_mcp: bool = False,
+):
     if backend == "codex":
         return CodexOperator(
             model=model,
@@ -264,7 +273,13 @@ def create_operator(backend: str, *, model: str, codex_sandbox: str, fake_mode: 
             ui=ui,
             stage_timeout=stage_timeout,
         )
-    return ClaudeOperator(model=model, fake_mode=fake_mode, ui=ui, stage_timeout=stage_timeout)
+    return ClaudeOperator(
+        model=model,
+        fake_mode=fake_mode,
+        ui=ui,
+        stage_timeout=stage_timeout,
+        web_search_mcp=web_search_mcp,
+    )
 
 
 def run(args: argparse.Namespace) -> BenchmarkResult:
@@ -308,6 +323,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
             "Fix it, or use --web-search auto to fall back to native search."
         )
 
+    web_search_context = resolve_web_search_context(args.web_search, readiness=readiness)
     operator = create_operator(
         operator_backend,
         model=model,
@@ -315,6 +331,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         fake_mode=args.fake_operator,
         ui=ui,
         stage_timeout=args.stage_timeout,
+        web_search_mcp=web_search_context is not None,
     )
     synthesizer = None if args.no_synthesis else ReportSynthesizer(operator)
 
@@ -374,7 +391,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         unattended=True,
         max_auto_skips=args.max_auto_skips,
         max_stage_attempts=args.max_attempts,
-        web_search_context=resolve_web_search_context(args.web_search, readiness=readiness),
+        web_search_context=web_search_context,
         web_search_mode=args.web_search,
         # Stages are told to keep code/, outputs/ and report/images/ up to date in the
         # benchmark workspace, so 'Files Produced' must resolve against it too.

--- a/src/mcp_web_search.py
+++ b/src/mcp_web_search.py
@@ -1,0 +1,209 @@
+"""An MCP server exposing Gemini-backed web search to the coding agent.
+
+Claude Code on Vertex AI ships with the built-in ``WebSearch`` tool disabled, which
+guts Stage 01. :mod:`src.web_search` already replaces the capability, but only as a
+shell script the prompt asks the agent to remember to run. That has two costs:
+
+* **A paragraph is not a tool.** An instruction competes with everything else in a long
+  prompt, and the model is markedly more reliable at reaching for something that appears
+  in its actual tool list.
+* **A Bash call is not auditable as a search.** Every search currently arrives in
+  ``logs_raw.jsonl`` as an opaque shell invocation, indistinguishable from the hundreds
+  of other commands a stage runs. AutoR's whole claim is that a run is inspectable; "which
+  searches did Stage 01 actually perform, and what came back" should be answerable from
+  the log without parsing shell strings.
+
+Serving the same function over MCP puts search back where the disabled tool used to be:
+in the tool list, and in the trace as a named tool call with structured arguments.
+
+The transport is newline-delimited JSON-RPC 2.0 on stdin/stdout, per the MCP stdio
+binding. It is written against the standard library only, like the rest of AutoR --
+nothing here needs an SDK.
+
+Run directly for a protocol smoke test::
+
+    echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | python3 -m src.mcp_web_search
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, TextIO
+
+if __package__ in (None, ""):  # pragma: no cover - direct `python3 src/mcp_web_search.py`
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.web_search import (  # noqa: E402
+    DEFAULT_MAX_RESULTS,
+    WebSearchError,
+    format_response_markdown,
+    gemini_web_search,
+)
+
+SERVER_NAME = "autor-search"
+SERVER_VERSION = "1.0.0"
+
+#: Echoed back when the client does not name one. The client's own version wins, because
+#: MCP negotiates down and a server that insists on its favourite is a server that stops
+#: working the next time the CLI updates.
+FALLBACK_PROTOCOL_VERSION = "2025-06-18"
+
+#: JSON-RPC reserved codes. Tool *failures* are not protocol errors: they come back as a
+#: normal result with isError set, so the model can read the reason and retry.
+METHOD_NOT_FOUND = -32601
+INTERNAL_ERROR = -32603
+
+WEB_SEARCH_TOOL = {
+    "name": "web_search",
+    "description": (
+        "Search the web and return a synthesised answer plus the source URLs it is "
+        "grounded in. Use this instead of the built-in WebSearch tool, which is disabled "
+        "in this deployment. Every citation you record must come from a URL this tool "
+        "actually returned; never invent a reference, DOI, or arXiv identifier. The "
+        "'supported_claims' under each source are this model's own wording, not text "
+        "from the page -- to quote a source, fetch it and quote what it says."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "The search query.",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": f"Maximum grounded sources to report. Defaults to {DEFAULT_MAX_RESULTS}.",
+                "minimum": 1,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+def _text_result(text: str, *, is_error: bool = False) -> dict[str, Any]:
+    return {"content": [{"type": "text", "text": text}], "isError": is_error}
+
+
+def call_web_search(
+    arguments: dict[str, Any],
+    *,
+    search: Callable[..., Any] = gemini_web_search,
+) -> dict[str, Any]:
+    """Run one search and shape it as an MCP tool result.
+
+    A failed or ungrounded search is reported as ``isError`` rather than raised: the model
+    can act on "that returned nothing citable, try another query", whereas a protocol
+    error just terminates the call with nothing it can use.
+    """
+    query = str(arguments.get("query") or "").strip()
+    if not query:
+        return _text_result("web_search requires a non-empty 'query'.", is_error=True)
+
+    max_results = arguments.get("max_results")
+    kwargs: dict[str, Any] = {}
+    if isinstance(max_results, int) and not isinstance(max_results, bool) and max_results > 0:
+        kwargs["max_results"] = max_results
+
+    try:
+        response = search(query, **kwargs)
+    except WebSearchError as exc:
+        return _text_result(f"Search failed: {exc}", is_error=True)
+    except Exception as exc:  # noqa: BLE001 - never take the agent's session down
+        return _text_result(f"Search failed unexpectedly: {exc}", is_error=True)
+
+    body = format_response_markdown(response)
+    if not response.grounded:
+        return _text_result(
+            body
+            + "\nNo citable source came back. Treat the answer as unverified and retry "
+            "with a different query rather than citing it.",
+            is_error=True,
+        )
+    return _text_result(body)
+
+
+def handle_message(
+    message: dict[str, Any],
+    *,
+    search: Callable[..., Any] = gemini_web_search,
+) -> dict[str, Any] | None:
+    """Answer one JSON-RPC message, or None when it is a notification."""
+    method = message.get("method")
+    message_id = message.get("id")
+    is_notification = "id" not in message
+
+    if method == "initialize":
+        params = message.get("params") or {}
+        result: dict[str, Any] = {
+            "protocolVersion": params.get("protocolVersion") or FALLBACK_PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+        }
+    elif method == "tools/list":
+        result = {"tools": [WEB_SEARCH_TOOL]}
+    elif method == "tools/call":
+        params = message.get("params") or {}
+        name = params.get("name")
+        if name != WEB_SEARCH_TOOL["name"]:
+            return _error(message_id, METHOD_NOT_FOUND, f"Unknown tool: {name}")
+        result = call_web_search(params.get("arguments") or {}, search=search)
+    elif is_notification:
+        # `notifications/initialized` and friends: acknowledged by saying nothing, which
+        # is what the spec requires. Answering a notification is itself a protocol error.
+        return None
+    elif method in {"ping"}:
+        result = {}
+    else:
+        return _error(message_id, METHOD_NOT_FOUND, f"Unknown method: {method}")
+
+    if is_notification:
+        return None
+    return {"jsonrpc": "2.0", "id": message_id, "result": result}
+
+
+def _error(message_id: Any, code: int, text: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": message_id, "error": {"code": code, "message": text}}
+
+
+def serve(
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    *,
+    search: Callable[..., Any] = gemini_web_search,
+) -> int:
+    """Read newline-delimited JSON-RPC from stdin until EOF."""
+    stdin = stdin if stdin is not None else sys.stdin
+    stdout = stdout if stdout is not None else sys.stdout
+
+    for line in stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            # No id to answer against, and the spec's parse-error reply needs one. Drop it
+            # rather than guessing; the client will time the request out.
+            continue
+        if not isinstance(message, dict):
+            continue
+        try:
+            response = handle_message(message, search=search)
+        except Exception as exc:  # noqa: BLE001 - a crash here kills the agent's whole stage
+            response = _error(message.get("id"), INTERNAL_ERROR, str(exc))
+        if response is None:
+            continue
+        stdout.write(json.dumps(response, ensure_ascii=False) + "\n")
+        stdout.flush()
+    return 0
+
+
+def main() -> int:  # pragma: no cover - process entry point
+    return serve()
+
+
+if __name__ == "__main__":  # pragma: no cover - process entry point
+    raise SystemExit(main())

--- a/src/operator.py
+++ b/src/operator.py
@@ -39,6 +39,7 @@ class ClaudeOperator:
         output_stream: TextIO = sys.stdout,
         ui: TerminalUI | None = None,
         stage_timeout: int = 14400,
+        web_search_mcp: bool = False,
     ) -> None:
         self.command = command
         self.model = model
@@ -46,6 +47,11 @@ class ClaudeOperator:
         self.output_stream = output_stream
         self.ui = ui or TerminalUI(output_stream=output_stream)
         self.stage_timeout = stage_timeout
+        # Whether to hand the agent a real `web_search` tool over MCP. Claude Code on
+        # Vertex has the built-in WebSearch disabled, and a tool in the tool list is both
+        # more reliably reached for than a prompt paragraph and legible in the trace as a
+        # named call rather than an opaque shell command.
+        self.web_search_mcp = web_search_mcp
 
     def run_stage(
         self,
@@ -1431,10 +1437,29 @@ Original stderr:
         tools: str | None = None,
     ) -> tuple[list[str], Path, str | None]:
         return (
-            self._build_cli_command(prompt_path, session_id, resume=resume, tools=tools),
+            self._build_cli_command(
+                prompt_path,
+                session_id,
+                resume=resume,
+                tools=tools,
+                mcp_config=self._mcp_config_path(paths),
+            ),
             paths.run_root,
             None,
         )
+
+    def _mcp_config_path(self, paths: RunPaths) -> Path | None:
+        """Materialize the search server's config inside the run, or None if unused.
+
+        Written into `operator_state/` rather than a temp file so it sits with the prompts
+        and session IDs: a run should be able to say what tools its agent was given, not
+        only what it was told.
+        """
+        if not self.web_search_mcp:
+            return None
+        from .web_search import write_mcp_config
+
+        return write_mcp_config(paths.operator_state_dir / "mcp_config.json")
 
     def _build_cli_command(
         self,
@@ -1443,6 +1468,7 @@ Original stderr:
         *,
         resume: bool,
         tools: str | None = None,
+        mcp_config: Path | None = None,
     ) -> list[str]:
         command = [
             self.command,
@@ -1452,6 +1478,10 @@ Original stderr:
             "bypassPermissions",
             "--dangerously-skip-permissions",
         ]
+        if mcp_config is not None:
+            # Not --strict-mcp-config: that would also drop whatever servers the user has
+            # configured for their own environment, which is not AutoR's call to make.
+            command.extend(["--mcp-config", str(mcp_config)])
         if tools:
             command.extend(["--tools", tools])
         if resume:

--- a/src/web_search.py
+++ b/src/web_search.py
@@ -84,6 +84,12 @@ GROUNDING_REDIRECT_HOST = "vertexaisearch.cloud.google.com"
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DIAGRAM_CONFIG_PATH = REPO_ROOT / "configs" / "diagram_config.yaml"
 WEB_SEARCH_SCRIPT = REPO_ROOT / "tools" / "web_search.py"
+MCP_SERVER_MODULE = "src.mcp_web_search"
+
+#: The MCP server name, and therefore the prefix Claude Code gives its tools:
+#: ``mcp__autor-search__web_search``.
+MCP_SERVER_NAME = "autor-search"
+MCP_TOOL_NAME = f"mcp__{MCP_SERVER_NAME}__web_search"
 
 
 class WebSearchError(RuntimeError):
@@ -749,20 +755,59 @@ def web_search_notice(
     )
 
 
+def build_mcp_config(*, repo_root: Path | None = None) -> dict[str, object]:
+    """The `--mcp-config` payload that hands the agent a real `web_search` tool.
+
+    Launched with AutoR's own interpreter and PYTHONPATH so the child resolves
+    `src.web_search` and its credentials exactly the way the parent already verified,
+    rather than depending on whatever `python3` the agent's PATH happens to find.
+    """
+    root = (repo_root or REPO_ROOT).resolve()
+    return {
+        "mcpServers": {
+            MCP_SERVER_NAME: {
+                "command": sys.executable or "python3",
+                "args": ["-m", MCP_SERVER_MODULE],
+                "env": {"PYTHONPATH": str(root)},
+                "cwd": str(root),
+            }
+        }
+    }
+
+
+def write_mcp_config(destination: Path, *, repo_root: Path | None = None) -> Path:
+    """Write the MCP config into the run, where it is auditable alongside the prompts."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        json.dumps(build_mcp_config(repo_root=repo_root), indent=2) + "\n", encoding="utf-8"
+    )
+    return destination
+
+
 def build_web_search_prompt_section(
     *,
     script_path: Path | None = None,
     model: str | None = None,
+    mcp: bool = True,
 ) -> str:
     """Build the prompt block that redirects operators away from the native search tool."""
     resolved_script = (script_path or WEB_SEARCH_SCRIPT).resolve()
     interpreter = search_command_prefix()
+    tool_paragraph = (
+        f"**Use the `{MCP_TOOL_NAME}` tool.** It takes `query` and an optional "
+        "`max_results`, and is the replacement for the disabled built-in. Prefer it over "
+        "the shell command below: a failed or ungrounded search comes back marked as an "
+        "error, so you can tell 'nothing citable was found' from 'the search worked'.\n\n"
+        if mcp
+        else ""
+    )
     backend = resolve_backend(model)
     provider = backend.describe() if backend else f"Gemini ({resolve_search_model(model)})"
     return (
         "The built-in `WebSearch` tool is **disabled** in this deployment. Calling it will "
         "fail or silently return nothing, so do not rely on it.\n\n"
-        "Use this Gemini-backed replacement instead, through a shell command:\n\n"
+        f"{tool_paragraph}"
+        "The same search is also available as a shell command:\n\n"
         "```bash\n"
         f'{interpreter} "{resolved_script}" "your search query here"\n'
         f'{interpreter} "{resolved_script}" "your search query here" --json --max-results 8\n'

--- a/tests/test_mcp_web_search.py
+++ b/tests/test_mcp_web_search.py
@@ -1,0 +1,331 @@
+"""The MCP server that hands the coding agent a real `web_search` tool.
+
+Driven at the protocol level rather than through the SDK: MCP is plain JSON-RPC over
+stdio here, and a test that spoke to a mock client would only prove the mock agrees with
+itself.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src import mcp_web_search
+from src.mcp_web_search import call_web_search, handle_message, serve
+from src.web_search import (
+    MCP_SERVER_NAME,
+    MCP_TOOL_NAME,
+    SearchResult,
+    WebSearchError,
+    WebSearchResponse,
+    build_mcp_config,
+    build_web_search_prompt_section,
+    write_mcp_config,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _grounded(query: str = "q", **_: object) -> WebSearchResponse:
+    return WebSearchResponse(
+        query, "gemini-test", "An answer.", "vertex",
+        [SearchResult("A Paper", "https://arxiv.org/abs/1", ["A claim."])],
+    )
+
+
+def _ungrounded(query: str = "q", **_: object) -> WebSearchResponse:
+    return WebSearchResponse(query, "gemini-test", "An answer with nothing behind it.")
+
+
+class ProtocolTest(unittest.TestCase):
+    def test_initialize_declares_the_tools_capability(self) -> None:
+        reply = handle_message({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2025-06-18"},
+        })
+        self.assertEqual(reply["id"], 1)
+        self.assertIn("tools", reply["result"]["capabilities"])
+        self.assertEqual(reply["result"]["serverInfo"]["name"], MCP_SERVER_NAME)
+
+    def test_it_echoes_the_client_protocol_version(self) -> None:
+        """MCP negotiates down. A server that insists on its favourite version stops
+        working the next time the client updates."""
+        reply = handle_message({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2099-01-01"},
+        })
+        self.assertEqual(reply["result"]["protocolVersion"], "2099-01-01")
+
+    def test_a_client_that_names_no_version_gets_the_fallback(self) -> None:
+        reply = handle_message({"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+        self.assertEqual(
+            reply["result"]["protocolVersion"], mcp_web_search.FALLBACK_PROTOCOL_VERSION
+        )
+
+    def test_tools_list_advertises_web_search_with_a_query_parameter(self) -> None:
+        reply = handle_message({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+        tools = reply["result"]["tools"]
+        self.assertEqual([t["name"] for t in tools], ["web_search"])
+        schema = tools[0]["inputSchema"]
+        self.assertEqual(schema["required"], ["query"])
+        self.assertIn("max_results", schema["properties"])
+
+    def test_the_advertised_description_carries_the_anti_fabrication_rule(self) -> None:
+        """The tool description is the only instruction that travels with the tool."""
+        description = handle_message(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+        )["result"]["tools"][0]["description"]
+        self.assertIn("never invent a reference", description.lower())
+        self.assertIn("not text from the page", description)
+
+    def test_a_notification_is_answered_with_silence(self) -> None:
+        """Replying to a notification is itself a protocol violation."""
+        self.assertIsNone(handle_message({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+
+    def test_a_known_method_without_an_id_is_also_answered_with_silence(self) -> None:
+        """A notification is defined by the absent id, not by the method name. Replying
+        to `initialize` sent as a notification is the same protocol violation as replying
+        to `notifications/initialized`."""
+        for method in ("initialize", "tools/list", "ping"):
+            with self.subTest(method=method):
+                self.assertIsNone(handle_message({"jsonrpc": "2.0", "method": method}))
+
+    def test_a_tool_call_without_an_id_runs_nothing_back(self) -> None:
+        self.assertIsNone(handle_message(
+            {"jsonrpc": "2.0", "method": "tools/call",
+             "params": {"name": "web_search", "arguments": {"query": "q"}}},
+            search=_grounded,
+        ))
+
+    def test_an_unknown_method_is_an_error_not_a_crash(self) -> None:
+        reply = handle_message({"jsonrpc": "2.0", "id": 3, "method": "tools/nope"})
+        self.assertEqual(reply["error"]["code"], mcp_web_search.METHOD_NOT_FOUND)
+
+    def test_an_unknown_tool_name_is_rejected(self) -> None:
+        reply = handle_message({
+            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": {"name": "rm_rf", "arguments": {}},
+        })
+        self.assertEqual(reply["error"]["code"], mcp_web_search.METHOD_NOT_FOUND)
+
+
+class ToolCallTest(unittest.TestCase):
+    def _call(self, arguments, search=_grounded):
+        return handle_message(
+            {"jsonrpc": "2.0", "id": 9, "method": "tools/call",
+             "params": {"name": "web_search", "arguments": arguments}},
+            search=search,
+        )["result"]
+
+    def test_a_grounded_search_returns_the_sources(self) -> None:
+        result = self._call({"query": "attention sinks"})
+        self.assertFalse(result["isError"])
+        self.assertIn("https://arxiv.org/abs/1", result["content"][0]["text"])
+
+    def test_the_query_reaches_the_search(self) -> None:
+        seen = {}
+
+        def record(query, **kwargs):
+            seen["query"], seen["kwargs"] = query, kwargs
+            return _grounded(query)
+
+        self._call({"query": "grokking"}, search=record)
+        self.assertEqual(seen["query"], "grokking")
+
+    def test_max_results_is_forwarded_when_sensible(self) -> None:
+        seen = {}
+
+        def record(query, **kwargs):
+            seen.update(kwargs)
+            return _grounded(query)
+
+        self._call({"query": "q", "max_results": 3}, search=record)
+        self.assertEqual(seen.get("max_results"), 3)
+
+    def test_a_nonsense_max_results_is_dropped_rather_than_passed_on(self) -> None:
+        for value in (0, -1, True, "three", None):
+            with self.subTest(value=value):
+                seen = {}
+
+                def record(query, **kwargs):
+                    seen.update(kwargs)
+                    return _grounded(query)
+
+                self._call({"query": "q", "max_results": value}, search=record)
+                self.assertNotIn("max_results", seen)
+
+    def test_an_empty_query_is_an_error_without_calling_the_search(self) -> None:
+        def explode(*args, **kwargs):
+            raise AssertionError("must not search")
+
+        result = self._call({"query": "   "}, search=explode)
+        self.assertTrue(result["isError"])
+        self.assertIn("non-empty", result["content"][0]["text"])
+
+    def test_a_search_failure_is_a_tool_error_not_a_protocol_error(self) -> None:
+        """The model can act on a tool error; a protocol error just ends the call."""
+        def fail(*args, **kwargs):
+            raise WebSearchError("no backend configured")
+
+        result = self._call({"query": "q"}, search=fail)
+        self.assertTrue(result["isError"])
+        self.assertIn("no backend configured", result["content"][0]["text"])
+
+    def test_an_unexpected_exception_never_escapes(self) -> None:
+        """An uncaught exception here takes down the agent's whole stage."""
+        def boom(*args, **kwargs):
+            raise RuntimeError("kaboom")
+
+        result = self._call({"query": "q"}, search=boom)
+        self.assertTrue(result["isError"])
+        self.assertIn("kaboom", result["content"][0]["text"])
+
+    def test_an_ungrounded_answer_is_flagged_as_an_error(self) -> None:
+        """An answer with no citable source is the failure this module exists to prevent,
+        so it must not look like a successful search."""
+        result = self._call({"query": "q"}, search=_ungrounded)
+        self.assertTrue(result["isError"])
+        self.assertIn("No citable source", result["content"][0]["text"])
+
+    def test_an_ungrounded_answer_still_returns_the_text(self) -> None:
+        """Flagged, but not withheld: the answer may still be a useful lead."""
+        result = self._call({"query": "q"}, search=_ungrounded)
+        self.assertIn("An answer with nothing behind it.", result["content"][0]["text"])
+
+    def test_the_result_never_presents_claims_as_page_quotations(self) -> None:
+        body = self._call({"query": "q"})["content"][0]["text"]
+        self.assertNotIn("> A claim.", body)
+        self.assertIn("not text from the page", body)
+
+
+class StdioLoopTest(unittest.TestCase):
+    def _drive(self, lines):
+        out = io.StringIO()
+        serve(io.StringIO("".join(f"{line}\n" for line in lines)), out, search=_grounded)
+        return [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+
+    def test_a_session_replies_only_to_requests(self) -> None:
+        replies = self._drive([
+            json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
+            json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+            json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+        ])
+        self.assertEqual([r["id"] for r in replies], [1, 2])
+
+    def test_a_malformed_line_does_not_end_the_session(self) -> None:
+        replies = self._drive(["not json at all", json.dumps({"jsonrpc": "2.0", "id": 7, "method": "tools/list"})])
+        self.assertEqual([r["id"] for r in replies], [7])
+
+    def test_blank_lines_are_ignored(self) -> None:
+        replies = self._drive(["", "   ", json.dumps({"jsonrpc": "2.0", "id": 8, "method": "tools/list"})])
+        self.assertEqual(len(replies), 1)
+
+    def test_every_reply_is_one_line_of_json(self) -> None:
+        out = io.StringIO()
+        serve(io.StringIO(json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}) + "\n"), out)
+        self.assertEqual(len(out.getvalue().strip().splitlines()), 1)
+
+
+class SubprocessContractTest(unittest.TestCase):
+    """The config says `python -m src.mcp_web_search`; prove that actually starts."""
+
+    def test_the_module_runs_as_a_server_and_answers(self) -> None:
+        config = build_mcp_config()[ "mcpServers"][MCP_SERVER_NAME]
+        proc = subprocess.run(
+            [config["command"], *config["args"]],
+            cwd=config["cwd"],
+            env={"PYTHONPATH": config["env"]["PYTHONPATH"], "PATH": "/usr/bin:/bin"},
+            input=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}) + "\n",
+            text=True, capture_output=True, timeout=60,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        payload = json.loads(proc.stdout.strip().splitlines()[0])
+        self.assertEqual(payload["result"]["tools"][0]["name"], "web_search")
+
+
+class McpConfigTest(unittest.TestCase):
+    def test_it_names_this_interpreter_not_a_bare_python(self) -> None:
+        server = build_mcp_config()["mcpServers"][MCP_SERVER_NAME]
+        self.assertEqual(server["command"], sys.executable)
+
+    def test_the_child_can_import_the_repo(self) -> None:
+        """Without PYTHONPATH the child cannot resolve `src.web_search` and the server
+        dies on import, which the agent sees only as a missing tool."""
+        server = build_mcp_config()["mcpServers"][MCP_SERVER_NAME]
+        self.assertEqual(server["env"]["PYTHONPATH"], str(REPO_ROOT))
+        self.assertEqual(Path(server["cwd"]), REPO_ROOT)
+
+    def test_the_advertised_tool_name_matches_the_server_name(self) -> None:
+        """Claude Code derives mcp__<server>__<tool>; a mismatch means the prompt points
+        at a tool that does not exist."""
+        self.assertEqual(MCP_TOOL_NAME, f"mcp__{MCP_SERVER_NAME}__web_search")
+        self.assertIn(MCP_SERVER_NAME, build_mcp_config()["mcpServers"])
+
+    def test_writing_it_puts_it_inside_the_run(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            written = write_mcp_config(Path(tmp) / "operator_state" / "mcp_config.json")
+            self.assertTrue(written.exists())
+            self.assertIn(MCP_SERVER_NAME, json.loads(written.read_text())["mcpServers"])
+
+
+class OperatorWiringTest(unittest.TestCase):
+    def _command(self, *, web_search_mcp: bool):
+        import tempfile
+
+        from src.operator import ClaudeOperator
+        from src.utils import build_run_paths, ensure_run_layout
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(paths)
+        operator = ClaudeOperator(web_search_mcp=web_search_mcp)
+        command, _, _ = operator._prepare_invocation(
+            paths.prompt_cache_dir / "p.md", "sid", paths=paths, resume=False
+        )
+        return command, paths
+
+    def test_the_claude_command_loads_the_server_when_search_is_active(self) -> None:
+        command, paths = self._command(web_search_mcp=True)
+        self.assertIn("--mcp-config", command)
+        written = Path(command[command.index("--mcp-config") + 1])
+        self.assertEqual(written.parent, paths.operator_state_dir)
+
+    def test_no_flag_when_search_is_not_active(self) -> None:
+        command, _ = self._command(web_search_mcp=False)
+        self.assertNotIn("--mcp-config", command)
+
+    def test_the_config_lands_in_the_run_for_audit(self) -> None:
+        """A run should be able to say what tools its agent was given, not only what it
+        was told."""
+        command, paths = self._command(web_search_mcp=True)
+        written = Path(command[command.index("--mcp-config") + 1])
+        self.assertTrue(written.exists())
+        self.assertTrue(str(written).startswith(str(paths.run_root)))
+
+    def test_it_does_not_use_strict_mcp_config(self) -> None:
+        """--strict-mcp-config would also drop the user's own servers, which is not
+        AutoR's call to make."""
+        command, _ = self._command(web_search_mcp=True)
+        self.assertNotIn("--strict-mcp-config", command)
+
+
+class PromptSectionNamesTheToolTest(unittest.TestCase):
+    def test_the_section_names_the_tool_when_one_is_provided(self) -> None:
+        self.assertIn(MCP_TOOL_NAME, build_web_search_prompt_section())
+
+    def test_it_falls_back_to_the_shell_command_for_backends_without_mcp(self) -> None:
+        section = build_web_search_prompt_section(mcp=False)
+        self.assertNotIn(MCP_TOOL_NAME, section)
+        self.assertIn("tools/web_search.py", section)
+
+    def test_the_shell_command_survives_alongside_the_tool(self) -> None:
+        """The script is the fallback, not a casualty of adding the tool."""
+        self.assertIn("tools/web_search.py", build_web_search_prompt_section())


### PR DESCRIPTION
Claude Code on Vertex AI ships with the built-in `WebSearch` tool **disabled** — confirmed directly on this box, where `CLAUDE_CODE_USE_VERTEX` and `ANTHROPIC_VERTEX_PROJECT_ID` are both set. `src/web_search.py` already replaces the capability, but only as a shell script the prompt asks the agent to remember to run.

That costs twice:

- **A paragraph is not a tool.** An instruction competes with everything else in a long stage prompt; a model reaches far more reliably for something in its actual tool list.
- **A Bash call is not auditable as a search.** Every search arrived in `logs_raw.jsonl` as an opaque shell invocation, indistinguishable from the hundreds of other commands a stage runs. AutoR's claim is that a run is inspectable — *"which searches did Stage 01 perform, and what came back"* should be answerable without parsing shell strings.

## What this adds

`src/mcp_web_search.py` serves the same `gemini_web_search` over MCP — stdlib JSON-RPC on stdio, no SDK — so search sits where the disabled built-in used to: **in the tool list**, and **in the trace as a named call** with structured arguments. `ClaudeOperator` passes `--mcp-config`, writing the config to `operator_state/mcp_config.json` so the run records what tools its agent was given, not only what it was told.

Design points worth stating:

| Decision | Why |
| --- | --- |
| A failed or ungrounded search is an MCP **tool error**, not a protocol error | The model can act on "nothing citable came back, try another query". A protocol error just ends the call with nothing usable. |
| The ungrounded case still returns the answer text | Flagged, not withheld — it may be a useful lead, it is just not citable. |
| **No** `--strict-mcp-config` | That would also drop whatever MCP servers you have configured for your own environment. Not AutoR's call. |
| Launched with `sys.executable` + explicit `PYTHONPATH` | The child resolves `src.web_search` and its credentials the way the parent already verified, rather than depending on the agent's `PATH`. |
| Codex keeps the shell command | It takes no `--mcp-config` here, and its sandbox is the separate unresolved question already documented. |

## Verified against the real CLI, not only in tests

```
$ claude --mcp-config <config> -p "list tools starting with mcp__"
mcp__autor-search__web_search
```

A live Vertex search returns resolved publisher URLs, including the arXiv entry carrying its **real paper title** rather than the bare domain grounding supplies:

```
1. [Why Streaming LLMs Need Attention Sinks | Adam Butterworth](https://www.adambutterworth.com/posts/attention-sinks)
2. [Attention Sink Phenomenon in Transformers](https://www.emergentmind.com/topics/attention-sink-phenomenon)
3. [[2309.17453] Efficient Streaming Language Models with Attention Sinks](https://arxiv.org/abs/2309.17453)
```

Driving Claude end to end, it calls the tool with `{"query": "...", "max_results": 3}` and reports those URLs.

**And the anti-fabrication path works against a real model.** On a query Gemini answered *without* grounding, the tool returned `isError` and Claude replied:

> The search returned no source URLs — the provider's response came back with "No grounded sources were returned," flagged as unverified. So there's no first URL to give you, **and I'm not going to invent one.**

That is the whole point of the feature, demonstrated rather than asserted.

## Verification

- **856 tests green** (+36), `py_compile` clean, both environments (deps installed, and `google`/`pyyaml` blocked the way CI has them).
- **Mutation swept with a control run: 18 mutants, all killed** — ungrounded reported as success, tool errors raised as protocol errors, the notification branch deleted, the trailing silence guard deleted, an unknown tool accepted, the protocol version not echoed, the config losing `PYTHONPATH` or using a bare `python3`, the tool-name prefix drifting from the server name, and the operator wiring in both directions.
- One survivor was a **no-op mutation** (the trailing `is_notification` guard already covered it); one was **real** — a known method sent without an `id` still got a reply — and got a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)