### PR TITLE
Widen Stage 02's hypotheses instead of narrowing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Useful feature | **Self-improving review policy** | Every correction the reviewer demands becomes a standing rule checked on all later stages, recorded in an auditable `review_policy.json` with the stage and attempt that produced it. |
 | Useful feature | **Resume, redo, and rollback controls** | Long research runs can continue in place, retry a stage, or roll downstream state back without starting over. |
 | Useful feature | **Deliberating review panel** | Instead of one reviewer agent at the approval gate, `--review-panel` seats a PI, domain expert, methodologist, reproducibility engineer and adversarial reviewer who review independently, cross-examine, then converge — and a blocking objection cannot be approved over. Each run measures the panel against its own single-pass baseline and reports when it did not earn its cost. |
+| Useful feature | **Divergent ideation panel** | `--ideation-panel` widens Stage 02 with proposers working from distinct lenses - mechanism, contrarian, adjacent field, null/artifact, regime - deduplicated and scored into a candidate pool the stage chooses from. It decides nothing, and reports when the extra proposers added nothing. |
 | Useful feature | **Two output formats** | Stage 07 writes a benchmark-ready markdown report (`report/report.md` + PNG figures) by default, or a venue-aware LaTeX paper package with a compiled PDF via `--output-format latex`. |
 
 In practice, that means AutoR is useful not only because of the high-level framing, but also because it handles real research chores: literature organization, experiment manifests, citation verification, artifact indexing, manuscript packaging, and recoverable long-running workflows.
@@ -299,6 +300,7 @@ AI handles execution load; humans steer the research when direction actually mat
 | Replace the single reviewer with a deliberating panel | `python main.py --review-panel --goal "..."` |
 | Give the panel a researcher persona to stand in for | `python main.py --review-panel --persona docs/persona-example.md --goal "..."` |
 | Seat the panel across different models | `python main.py --review-panel --panel-models pi=opus skeptic=codex:default --goal "..."` |
+| Widen Stage 02's hypotheses with a proposer panel | `python main.py --ideation-panel --goal "..."` |
 | Choose the execution backend | `python main.py --operator claude` or `python main.py --operator codex` |
 | Choose the reviewer backend separately | `python main.py --full-auto --review-operator claude --review-model opus` |
 | Choose a Claude model | `python main.py --operator claude --model sonnet` or `python main.py --operator claude --model opus` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ detail behind it.
 | Understand what a run leaves on disk | [Run Artifacts](run-artifacts.md) |
 | Know exactly what a stage must produce to be accepted | [Stage Contract](stage-contract.md) |
 | Replace the reviewer agent with a panel that argues before it decides | [Review Panel](review-panel.md) |
+| Widen Stage 02's hypotheses with a panel that proposes instead of deciding | [Ideation Panel](ideation-panel.md) |
 | Configure venues, backends, sandboxes, or API keys | [Configuration](configuration.md) |
 | Use or script the browser UI | [Studio Guide & HTTP API](studio.md) |
 | Understand how the code is organized | [Architecture](architecture.md) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -196,6 +196,18 @@ converted to a refinement in code. Each run also writes
 baseline so it can report that it did not earn its cost. Full description, including the
 pre-registered evidence against multi-agent deliberation, in [Review Panel](review-panel.md).
 
+### Ideation panel
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--ideation-panel` | off | Widen Stage 02's hypotheses with proposers working from distinct lenses. Candidates are deduplicated, scored, and injected as material. It decides nothing. |
+| `--ideation-lenses LENS...` | all five | Seat only these lenses: `mechanism`, `contrarian`, `adjacent`, `null`, `regime`. |
+| `--ideation-models LENS=MODEL...` | - | Assign a model per lens, as `lens=model` or `lens=backend:model`. |
+| `--ideas-per-proposer N` | `2` | Candidates each proposer may return. |
+
+The pool records how much the proposers beyond the first actually added, so a run can report
+that it widened nothing. Full description in [Ideation Panel](ideation-panel.md).
+
 ### Stopping early
 
 | Flag | Default | Description |

--- a/docs/ideation-panel.md
+++ b/docs/ideation-panel.md
@@ -1,0 +1,99 @@
+# The ideation panel
+
+[`--review-panel`](review-panel.md) seats a room to **converge** on one gate decision.
+`--ideation-panel` does the opposite job with the same machinery, because that is where the
+evidence for multi-agent systems actually points.
+
+```bash
+python main.py --ideation-panel --goal "..."
+python main.py --ideation-panel --ideation-lenses mechanism null regime --goal "..."
+python main.py --ideation-panel --ideation-models mechanism=opus null=codex:default --goal "..."
+```
+
+---
+
+## Why divergence rather than debate
+
+AgentPanel ([arXiv:2608.03283](https://arxiv.org/abs/2608.03283)) beat centralized multi-agent
+debate on two ideation benchmarks, and its own reading of why is not that the agents argued
+better. A heterogeneous population **widened the candidate pool** and left the selecting to a
+human: *"the value of multi-agent scientific systems lies not only in improving individual
+responses, but also in expanding and organizing a diverse candidate pool for human comparison,
+selection, and refinement."*
+
+Its gains concentrate in **feasibility** — 5.08 vs 4.08 on LiveIdeaBench, 0.28 vs 0.11 and
+0.31 vs 0.04 on IdeaBench — not originality. More agents did not produce wilder ideas. They
+produced more usable ones.
+
+So Stage 02 gets a pool, not a verdict. **Nothing in this module decides anything.**
+
+## The lenses
+
+Five proposers, blind to each other, each looking somewhere different:
+
+| Lens | Looks for |
+| --- | --- |
+| `mechanism` | What process would have to be true for the pattern to arise. |
+| `contrarian` | What the world looks like if the obvious reading is wrong. |
+| `adjacent` | A mechanism standard in a neighbouring field and unusual in this one. |
+| `null` | Confounds, selection effects, artifacts — the boring explanations that must be excluded first. |
+| `regime` | Where the effect should strengthen, invert, or vanish with scale or population. |
+
+Lenses are the generation-side answer to correlated seats. Five agents asked for "a good
+hypothesis" return five versions of the obvious one; these five return five different objects.
+
+Each proposer may return an **empty list**. A lens with nothing real to offer on this goal
+costs the panel nothing by staying silent, and costs it the diversity it exists for by
+restating the obvious hypothesis.
+
+## What Stage 02 receives
+
+Candidates are deduplicated, scored on novelty / feasibility / relevance, ranked, and injected
+into the Stage 02 prompt as **material, not a decision**. The stage is asked to say which it
+took and why it left the rest.
+
+Artifacts land in `workspace/notes/idea_pool.json` and `idea_pool.md`.
+
+## Measuring whether it widened anything
+
+Same discipline as the review panel, for the same reason.
+
+Havranek and Irsova ([arXiv:2607.14713](https://arxiv.org/abs/2607.14713)) found a plain single
+pass beating two multi-agent tools, and the mechanism they report is that the reports *"tended
+to raise much the same points."* A pool of five restatements is that null in another costume.
+
+So **the first proposer is the single-pass baseline** — one lens, one call, no sight of anyone
+else — and the pool records how much of itself the others actually added:
+
+```json
+{
+  "proposed": 7,
+  "distinct": 3,
+  "collapsed_as_duplicates": 4,
+  "added_by_other_proposers": 0,
+  "verdict": "All 3 distinct hypotheses came from the baseline proposer; the other proposers restated it, at 5 proposer calls. On this run the panel widened nothing — consider --ideation-lenses with fewer seats, or dropping it."
+}
+```
+
+Duplicate detection is plain Python, not a model call: asking a model whether five of its own
+ideas are really the same idea is the wrong instrument for catching a collapsed pool. The
+threshold (0.5 Jaccard over content words) is **calibrated rather than guessed** — rewordings
+of one claim score 0.60–0.78, a related-but-distinct claim about the same variables scores
+0.28, unrelated claims score 0.00. Titles are excluded from the comparison, because two
+proposers naming one idea differently is exactly the collapse this has to catch.
+
+## Cost
+
+`lenses + 1` calls per Stage 02 attempt — six by default, once per attempt. Cheaper than the
+review panel, which pays per gate.
+
+## Limits worth knowing
+
+- **The pool is material, not a dependency.** A panel that cannot be reached logs the failure
+  and Stage 02 generates hypotheses the ordinary way.
+- **Scoring is one call over the whole pool**, not independent critics per candidate. It orders
+  material a later reader judges anyway; paying per candidate would spend more on ranking the
+  pool than on generating it.
+- **A widened pool is not a better hypothesis.** AgentPanel measured candidate quality, not
+  downstream research outcomes, and neither does this. If `added_by_other_proposers` stays 0
+  across your runs, the honest reading is that one proposer was enough.

--- a/main.py
+++ b/main.py
@@ -157,6 +157,33 @@ def parse_args() -> argparse.Namespace:
              "five prompts against one model are five correlated reads wearing five hats.",
     )
     parser.add_argument(
+        "--ideation-panel",
+        action="store_true",
+        help="Widen Stage 02's hypotheses with a panel of proposers working from distinct "
+             "lenses (mechanism, contrarian, adjacent field, null/artifact, regime). They "
+             "propose blind to each other; candidates are deduplicated, scored on novelty, "
+             "feasibility and relevance, and handed to the stage as material to choose from. "
+             "It decides nothing.",
+    )
+    parser.add_argument(
+        "--ideation-lenses",
+        nargs="+",
+        metavar="LENS",
+        help="Seat only these ideation lenses. Defaults to all five.",
+    )
+    parser.add_argument(
+        "--ideation-models",
+        nargs="+",
+        metavar="LENS=MODEL",
+        help="Assign a model per ideation lens, as lens=model or lens=backend:model.",
+    )
+    parser.add_argument(
+        "--ideas-per-proposer",
+        type=int,
+        default=2,
+        help="Candidate hypotheses each proposer may return. Defaults to 2.",
+    )
+    parser.add_argument(
         "--panel-rounds",
         type=int,
         default=2,
@@ -632,6 +659,24 @@ def resolve_search_context(ui: TerminalUI, *, mode: str, operator: str, codex_sa
     return resolve_web_search_context(mode, readiness=readiness)
 
 
+
+def create_ideation_panel(args, *, backend_name: str, model: str, ui: TerminalUI):
+    """Build the Stage 02 proposer panel, or None when it is not requested."""
+    if not getattr(args, "ideation_panel", False):
+        return None
+    from src.ideation_panel import IdeationPanel, apply_lens_models, resolve_lenses
+
+    return IdeationPanel(
+        apply_lens_models(resolve_lenses(args.ideation_lenses), args.ideation_models),
+        backend_name=backend_name,
+        model=model,
+        fake_mode=args.fake_operator,
+        ui=ui,
+        stage_timeout=args.stage_timeout,
+        ideas_per_proposer=args.ideas_per_proposer,
+    )
+
+
 def main() -> int:
     args = parse_args()
     repo_root = Path(__file__).resolve().parent
@@ -745,6 +790,9 @@ def main() -> int:
             graph_max_visits=args.graph_max_visits,
             web_search_mode=web_search_mode,
         )
+        manager.ideation_panel = create_ideation_panel(
+            args, backend_name=review_operator, model=review_model, ui=ui
+        )
         completed = manager.resume_run(
             run_root,
             start_stage=start_stage or rollback_stage,
@@ -816,6 +864,10 @@ def main() -> int:
         graph_max_steps=args.graph_max_steps,
         graph_max_visits=args.graph_max_visits,
         web_search_mode=web_search_mode,
+    )
+
+    manager.ideation_panel = create_ideation_panel(
+        args, backend_name=review_operator, model=review_model, ui=ui
     )
 
     goal = resolve_goal(args, unattended=unattended)

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -182,6 +182,33 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
              "five prompts against one model are five correlated reads wearing five hats.",
     )
     parser.add_argument(
+        "--ideation-panel",
+        action="store_true",
+        help="Widen Stage 02's hypotheses with a panel of proposers working from distinct "
+             "lenses (mechanism, contrarian, adjacent field, null/artifact, regime). They "
+             "propose blind to each other; candidates are deduplicated, scored on novelty, "
+             "feasibility and relevance, and handed to the stage as material to choose from. "
+             "It decides nothing.",
+    )
+    parser.add_argument(
+        "--ideation-lenses",
+        nargs="+",
+        metavar="LENS",
+        help="Seat only these ideation lenses. Defaults to all five.",
+    )
+    parser.add_argument(
+        "--ideation-models",
+        nargs="+",
+        metavar="LENS=MODEL",
+        help="Assign a model per ideation lens, as lens=model or lens=backend:model.",
+    )
+    parser.add_argument(
+        "--ideas-per-proposer",
+        type=int,
+        default=2,
+        help="Candidate hypotheses each proposer may return. Defaults to 2.",
+    )
+    parser.add_argument(
         "--panel-rounds",
         type=int,
         default=2,
@@ -398,6 +425,19 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         artifact_roots=[workspace],
         cross_reviewer=resolve_cross_reviewer(args.cross_review, args.cross_review_model),
     )
+
+    if args.ideation_panel:
+        from src.ideation_panel import IdeationPanel, apply_lens_models, resolve_lenses
+
+        manager.ideation_panel = IdeationPanel(
+            apply_lens_models(resolve_lenses(args.ideation_lenses), args.ideation_models),
+            backend_name=review_backend,
+            model=review_model,
+            fake_mode=args.fake_operator,
+            ui=ui,
+            stage_timeout=args.stage_timeout,
+            ideas_per_proposer=args.ideas_per_proposer,
+        )
 
     pipeline_completed = False
     try:

--- a/src/ideation_panel.py
+++ b/src/ideation_panel.py
@@ -1,0 +1,587 @@
+"""Many agents for divergence, not convergence.
+
+:mod:`src.review_panel` seats a room to *converge* on one gate decision. This module does the
+opposite job with the same machinery, because the evidence for multi-agent systems points that
+way rather than at deliberation.
+
+AgentPanel (`arXiv:2608.03283 <https://arxiv.org/abs/2608.03283>`_) beat centralized multi-agent
+debate on two ideation benchmarks, and its own reading of why is not that the agents argued
+better. It is that a heterogeneous population *widened the candidate pool* and left the
+selecting to a human: "the value of multi-agent scientific systems lies not only in improving
+individual responses, but also in expanding and organizing a diverse candidate pool for human
+comparison, selection, and refinement." Its measured gains concentrate in **feasibility**
+(5.08 vs 4.08 on LiveIdeaBench, 0.28 vs 0.11 on IdeaBench), not originality — more agents did
+not produce wilder ideas, they produced more usable ones.
+
+So Stage 02 gets a pool, not a verdict. Proposers work from distinct lenses, blind to each
+other, may abstain, and their candidates are deduplicated, scored, and handed to the stage as
+material to choose from. Nothing here decides anything.
+
+**The failure mode this is built against.** Havranek and Irsova
+(`arXiv:2607.14713 <https://arxiv.org/abs/2607.14713>`_) found a plain single pass beating two
+multi-agent tools, and the mechanism they report is that the reports "tended to raise much the
+same points". A pool of five restatements of one idea is that null in another costume, so the
+first proposer is treated as a single-pass baseline and the pool records how much of itself
+the other proposers actually added. When that number is zero, the artifact says so.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .approval_agent import AutomatedReviewer
+from .terminal_ui import TerminalUI
+from .utils import RunPaths, StageSpec, append_log_entry, read_text, truncate_text, write_text
+
+
+#: Words too common to carry meaning when deciding whether two hypotheses are the same one.
+_STOPWORDS = frozenset(
+    """a an and are as at be been but by can for from had has have how if in into is it its
+    may not of on or that the their them then there these this to was were what when which
+    will with would we our us""".split()
+)
+
+#: Jaccard overlap of content words above which two statements are treated as one idea.
+#:
+#: Calibrated on realistic hypothesis sentences rather than guessed: rewordings of one claim
+#: score 0.60-0.78, a related-but-distinct claim about the same variables scores 0.28, and
+#: unrelated claims score 0.00. 0.5 sits in that gap, so a restatement collapses and a genuine
+#: variant survives. Deliberately blunt — the point is to notice a pool that has collapsed,
+#: not to adjudicate whether two phrasings are subtly different.
+DUPLICATE_THRESHOLD = 0.5
+
+#: Where the pool lands. Stage 02's own artifacts live under workspace/notes.
+IDEA_POOL_FILENAME = "idea_pool.json"
+
+
+@dataclass(frozen=True)
+class ProposerLens:
+    """One way of looking for a hypothesis.
+
+    Lenses are the generation-side answer to correlated seats. Five agents asked for "a good
+    hypothesis" return five versions of the obvious one; five agents asked for the mechanism,
+    the contradiction, the import from another field, the boring explanation, and the regime
+    change return five different objects.
+    """
+
+    key: str
+    title: str
+    charter: str
+    backend: str | None = None
+    model: str | None = None
+
+
+DEFAULT_LENSES: tuple[ProposerLens, ...] = (
+    ProposerLens(
+        key="mechanism",
+        title="Mechanism",
+        charter=(
+            "Propose hypotheses about the underlying mechanism — what process would have to be "
+            "true for the observed pattern to arise. Prefer a claim that names the moving parts "
+            "over one that names the outcome."
+        ),
+    ),
+    ProposerLens(
+        key="contrarian",
+        title="Contrarian",
+        charter=(
+            "Propose hypotheses that contradict the expected answer. If the obvious reading of "
+            "the goal is X, ask what the world looks like if not-X holds, and what evidence "
+            "would already exist if it did. Do not be contrarian for its own sake; be "
+            "contrarian where the obvious reading is under-defended."
+        ),
+    ),
+    ProposerLens(
+        key="adjacent",
+        title="Adjacent Field",
+        charter=(
+            "Propose hypotheses by importing a mechanism, model, or method that is standard in "
+            "a neighbouring field and unusual in this one. Name the field you are borrowing "
+            "from and why the analogy holds."
+        ),
+    ),
+    ProposerLens(
+        key="null",
+        title="Null and Artifact",
+        charter=(
+            "Propose the boring explanations that must be ruled out before anything interesting "
+            "can be claimed: confounds, selection effects, measurement artifacts, and the "
+            "possibility that the effect is absent. These are hypotheses, and a study that "
+            "cannot exclude them has not found anything."
+        ),
+    ),
+    ProposerLens(
+        key="regime",
+        title="Regime and Scale",
+        charter=(
+            "Propose hypotheses about how the effect changes with scale, regime, or population — "
+            "where it should strengthen, invert, or vanish. A claim that specifies where it "
+            "fails is more testable than one that claims it holds everywhere."
+        ),
+    ),
+)
+
+LENSES_BY_KEY = {lens.key: lens for lens in DEFAULT_LENSES}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    idea_id: str
+    proposer: str
+    proposer_title: str
+    backend: str
+    model: str
+    title: str
+    statement: str
+    rationale: str = ""
+    prediction: str = ""
+    novelty: float | None = None
+    feasibility: float | None = None
+    relevance: float | None = None
+    duplicate_of: str | None = None
+
+    @property
+    def mean_score(self) -> float | None:
+        scores = [s for s in (self.novelty, self.feasibility, self.relevance) if s is not None]
+        return round(sum(scores) / len(scores), 2) if scores else None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["mean_score"] = self.mean_score
+        return payload
+
+
+@dataclass
+class IdeaPool:
+    candidates: list[Candidate] = field(default_factory=list)
+    abstentions: list[str] = field(default_factory=list)
+    unreachable: list[str] = field(default_factory=list)
+    proposer_calls: int = 0
+    baseline_proposer: str = ""
+
+    @property
+    def distinct(self) -> list[Candidate]:
+        return [candidate for candidate in self.candidates if candidate.duplicate_of is None]
+
+    def ranked(self) -> list[Candidate]:
+        """Distinct candidates, best first. Unscored candidates keep their proposal order."""
+        return sorted(
+            self.distinct,
+            key=lambda c: (c.mean_score is None, -(c.mean_score or 0.0)),
+        )
+
+    def effect(self) -> dict[str, Any]:
+        """What the extra proposers added over the first one.
+
+        The first proposer is the single-pass baseline: one lens, one call, no sight of anyone
+        else. If every distinct hypothesis in the pool traces back to it, the other proposers
+        restated it, and the pool should say so rather than presenting five entries as five
+        ideas.
+        """
+        distinct = self.distinct
+        from_baseline = [c for c in distinct if c.proposer == self.baseline_proposer]
+        added = [c for c in distinct if c.proposer != self.baseline_proposer]
+        proposed = len(self.candidates)
+        return {
+            "proposed": proposed,
+            "distinct": len(distinct),
+            "collapsed_as_duplicates": proposed - len(distinct),
+            "baseline_proposer": self.baseline_proposer,
+            "from_baseline_proposer": len(from_baseline),
+            "added_by_other_proposers": len(added),
+            "abstentions": len(self.abstentions),
+            "unreachable": len(self.unreachable),
+            "proposer_calls": self.proposer_calls,
+            "verdict": _pool_verdict(len(distinct), len(added), self.proposer_calls),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+            "ranked": [candidate.idea_id for candidate in self.ranked()],
+            "abstained": self.abstentions,
+            "unreachable": self.unreachable,
+            "effect": self.effect(),
+        }
+
+
+def _pool_verdict(distinct: int, added: int, calls: int) -> str:
+    if distinct == 0:
+        return "No candidate hypotheses survived; the stage proceeds without a pool."
+    if added == 0:
+        return (
+            f"All {distinct} distinct hypotheses came from the baseline proposer; the other "
+            f"proposers restated it, at {calls} proposer calls. On this run the panel widened "
+            "nothing — consider --ideation-lenses with fewer seats, or dropping it."
+        )
+    return (
+        f"{added} of {distinct} distinct hypotheses came from proposers beyond the baseline, "
+        f"at {calls} proposer calls."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Near-duplicate detection
+# ---------------------------------------------------------------------------
+
+
+def _content_words(text: str) -> frozenset[str]:
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    return frozenset(word for word in words if len(word) > 2 and word not in _STOPWORDS)
+
+
+def similarity(left: str, right: str) -> float:
+    """Jaccard overlap of content words. 1.0 means the same words in any order."""
+    a, b = _content_words(left), _content_words(right)
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def mark_duplicates(candidates: list[Candidate], threshold: float = DUPLICATE_THRESHOLD) -> list[Candidate]:
+    """Fold near-identical hypotheses into their first occurrence.
+
+    Done in plain Python rather than with a model call: the measurement exists to catch a pool
+    that has collapsed into restatements, and asking a model whether five of its own ideas are
+    really the same idea is the wrong instrument for that.
+    """
+    resolved: list[Candidate] = []
+    for candidate in candidates:
+        # Compare the claim only. Titles are noise here: two proposers giving one idea two
+        # different names is precisely the collapse this is meant to catch, and folding the
+        # titles into the comparison dilutes the overlap enough to miss it.
+        match = next(
+            (
+                kept
+                for kept in resolved
+                if kept.duplicate_of is None
+                and similarity(candidate.statement, kept.statement) >= threshold
+            ),
+            None,
+        )
+        resolved.append(
+            candidate if match is None else Candidate(**{**candidate.__dict__, "duplicate_of": match.idea_id})
+        )
+    return resolved
+
+
+def resolve_lenses(keys: list[str] | None) -> tuple[ProposerLens, ...]:
+    if not keys:
+        return DEFAULT_LENSES
+    lenses: list[ProposerLens] = []
+    for key in keys:
+        normalized = key.strip().lower()
+        if normalized not in LENSES_BY_KEY:
+            known = ", ".join(sorted(LENSES_BY_KEY))
+            raise ValueError(f"Unknown ideation lens: {key}. Known lenses: {known}.")
+        lens = LENSES_BY_KEY[normalized]
+        if lens not in lenses:
+            lenses.append(lens)
+    return tuple(lenses)
+
+
+def apply_lens_models(lenses: tuple[ProposerLens, ...], assignments: list[str] | None) -> tuple[ProposerLens, ...]:
+    """Assign a backend and model per lens from ``lens=[backend:]model`` strings."""
+    if not assignments:
+        return lenses
+    by_key = {lens.key: lens for lens in lenses}
+    updated = dict(by_key)
+    for raw in assignments:
+        if "=" not in raw:
+            raise ValueError(
+                f"Bad ideation model assignment: {raw!r}. Expected lens=model or lens=backend:model."
+            )
+        key, _, spec = raw.partition("=")
+        key, spec = key.strip().lower(), spec.strip()
+        if key not in by_key:
+            known = ", ".join(sorted(by_key))
+            raise ValueError(f"Unknown ideation lens in model assignment: {key}. Seated lenses: {known}.")
+        if not spec:
+            raise ValueError(f"Bad ideation model assignment: {raw!r}. No model given.")
+        backend, _, model = spec.partition(":") if ":" in spec else (None, "", spec)
+        model = model.strip()
+        if not model:
+            raise ValueError(f"Bad ideation model assignment: {raw!r}. No model given.")
+        current = updated[key]
+        updated[key] = ProposerLens(
+            **{**current.__dict__, "backend": (backend or current.backend), "model": model}
+        )
+    return tuple(updated[lens.key] for lens in lenses)
+
+
+# ---------------------------------------------------------------------------
+# The panel
+# ---------------------------------------------------------------------------
+
+
+class IdeationPanel:
+    """Widen Stage 02's candidate pool. Decides nothing."""
+
+    def __init__(
+        self,
+        lenses: tuple[ProposerLens, ...] = DEFAULT_LENSES,
+        *,
+        backend_name: str,
+        model: str,
+        fake_mode: bool = False,
+        ui: TerminalUI | None = None,
+        stage_timeout: int = 14400,
+        ideas_per_proposer: int = 2,
+        score_pool: bool = True,
+    ) -> None:
+        if not lenses:
+            raise ValueError("An ideation panel needs at least one lens.")
+        self.lenses = lenses
+        self.backend_name = backend_name
+        self.model = model
+        self.fake_mode = fake_mode
+        self.ui = ui or TerminalUI()
+        self.ideas_per_proposer = max(1, ideas_per_proposer)
+        self.score_pool = score_pool
+        self._members = {
+            lens.key: AutomatedReviewer(
+                lens.backend or backend_name,
+                model=lens.model or model,
+                fake_mode=fake_mode,
+                ui=self.ui,
+                stage_timeout=stage_timeout,
+            )
+            for lens in lenses
+        }
+
+    def build_pool(self, *, paths: RunPaths, stage: StageSpec, attempt_no: int) -> IdeaPool:
+        pool = IdeaPool(baseline_proposer=self.lenses[0].key)
+        if self.fake_mode:
+            return pool
+
+        for index, lens in enumerate(self.lenses):
+            member = self._members[lens.key]
+            self.ui.show_status(f"Ideation panel: {lens.title} is proposing hypotheses...", level="info")
+            exit_code, stdout_text, _stderr = member.run_prompt(
+                paths=paths,
+                stage=stage,
+                attempt_no=attempt_no,
+                prompt=self._proposal_prompt(paths=paths, lens=lens),
+                label=f"ideate_{lens.key}",
+            )
+            pool.proposer_calls += 1
+            if exit_code != 0:
+                pool.unreachable.append(lens.key)
+                continue
+            payload = member._extract_json_payload(stdout_text)  # noqa: SLF001
+            if not isinstance(payload, dict):
+                pool.unreachable.append(lens.key)
+                continue
+            raw_ideas = payload.get("hypotheses")
+            if not isinstance(raw_ideas, list) or not raw_ideas:
+                # A proposer with nothing to add is silent rather than padding the pool.
+                pool.abstentions.append(lens.key)
+                continue
+            for position, raw in enumerate(raw_ideas[: self.ideas_per_proposer], start=1):
+                candidate = self._candidate_from(raw, lens=lens, member=member, position=position, index=index)
+                if candidate is not None:
+                    pool.candidates.append(candidate)
+
+        pool.candidates = mark_duplicates(pool.candidates)
+        if self.score_pool and pool.distinct:
+            self._score(pool, paths=paths, stage=stage, attempt_no=attempt_no)
+        return pool
+
+    def _candidate_from(
+        self, raw: Any, *, lens: ProposerLens, member: AutomatedReviewer, position: int, index: int
+    ) -> Candidate | None:
+        if not isinstance(raw, dict):
+            return None
+        statement = str(raw.get("statement") or raw.get("hypothesis") or "").strip()
+        if not statement:
+            return None
+        return Candidate(
+            idea_id=f"{lens.key}-{position}",
+            proposer=lens.key,
+            proposer_title=lens.title,
+            backend=member.backend_name,
+            model=member.model,
+            title=str(raw.get("title") or "").strip() or f"{lens.title} hypothesis {position}",
+            statement=statement,
+            rationale=str(raw.get("rationale") or "").strip(),
+            prediction=str(raw.get("prediction") or raw.get("testable_prediction") or "").strip(),
+        )
+
+    def _score(self, pool: IdeaPool, *, paths: RunPaths, stage: StageSpec, attempt_no: int) -> None:
+        """Score the distinct pool on the dimensions the ideation benchmarks use.
+
+        One call over the whole pool rather than one per candidate: the scores are for ordering
+        material a later reader will judge anyway, and paying per candidate would spend more on
+        ranking the pool than on generating it.
+        """
+        scorer = self._members[self.lenses[0].key]
+        self.ui.show_status("Ideation panel: scoring the candidate pool...", level="info")
+        exit_code, stdout_text, _stderr = scorer.run_prompt(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            prompt=self._scoring_prompt(pool, paths=paths),
+            label="ideate_score",
+        )
+        if exit_code != 0:
+            return
+        payload = scorer._extract_json_payload(stdout_text)  # noqa: SLF001
+        if not isinstance(payload, dict) or not isinstance(payload.get("scores"), list):
+            return
+
+        by_id = {str(entry.get("idea_id")): entry for entry in payload["scores"] if isinstance(entry, dict)}
+        scored: list[Candidate] = []
+        for candidate in pool.candidates:
+            entry = by_id.get(candidate.idea_id)
+            if entry is None or candidate.duplicate_of is not None:
+                scored.append(candidate)
+                continue
+            scored.append(
+                Candidate(
+                    **{
+                        **candidate.__dict__,
+                        "novelty": _score_value(entry.get("novelty")),
+                        "feasibility": _score_value(entry.get("feasibility")),
+                        "relevance": _score_value(entry.get("relevance")),
+                    }
+                )
+            )
+        pool.candidates = scored
+
+    # -- prompts --------------------------------------------------------------
+
+    def _proposal_prompt(self, *, paths: RunPaths, lens: ProposerLens) -> str:
+        return (
+            f"# AutoR Ideation Panel: {lens.title}\n\n"
+            f"You are the **{lens.title}** proposer on a hypothesis-generation panel. Other "
+            "proposers are working from different lenses on the same goal. You cannot see them "
+            "and should not guess at them — the panel's value is that your candidates are not "
+            "downstream of anyone else's.\n\n"
+            f"## Your Lens\n\n{lens.charter}\n\n"
+            "## What To Produce\n\n"
+            f"At most {self.ideas_per_proposer} candidate hypotheses, each one specific enough "
+            "to be wrong. A hypothesis that no observation could contradict is not a candidate.\n\n"
+            "- State it as a claim, not a topic. \"X increases Y through Z\" is a claim; "
+            "\"the relationship between X and Y\" is a topic.\n"
+            "- Give the prediction that would distinguish it from the obvious alternative.\n"
+            "- Ground it in the run's actual goal and literature, not in generic domain knowledge.\n"
+            "- If your lens has nothing real to offer on this goal, return an empty list. An "
+            "empty list costs the panel nothing; a restatement of the obvious hypothesis costs "
+            "it the diversity it exists for.\n\n"
+            "## Return Format\n\n"
+            "Return JSON only, no prose outside the object:\n"
+            '{"hypotheses":[{"title":"","statement":"","rationale":"","prediction":""}]}\n\n'
+            "# Research Goal\n\n"
+            f"{truncate_text(_excerpt(paths.user_input), max_chars=4000)}\n\n"
+            "# Approved Memory\n\n"
+            f"{truncate_text(_excerpt(paths.memory), max_chars=10000)}\n\n"
+            "# Literature Directory\n\n"
+            f"`{paths.literature_dir.resolve()}` — read it before proposing.\n"
+        )
+
+    def _scoring_prompt(self, pool: IdeaPool, *, paths: RunPaths) -> str:
+        listing = "\n\n".join(
+            f"### {candidate.idea_id}\n"
+            f"**{candidate.title}**\n\n{candidate.statement}"
+            + (f"\n\nPrediction: {candidate.prediction}" if candidate.prediction else "")
+            for candidate in pool.distinct
+        )
+        ids = ", ".join(candidate.idea_id for candidate in pool.distinct)
+        return (
+            "# AutoR Ideation Panel: Pool Scoring\n\n"
+            "Score each candidate hypothesis below. You are ordering material for a researcher "
+            "to choose from, not picking a winner.\n\n"
+            "Score each on 0-10:\n\n"
+            "- **novelty** — is this something the field has not already settled?\n"
+            "- **feasibility** — could it actually be tested with the data and effort this run "
+            "has? This is the dimension that separates a useful pool from a creative one.\n"
+            "- **relevance** — does it answer the research goal as stated, rather than an "
+            "adjacent question that is easier?\n\n"
+            "Be willing to score low. A pool where everything scores 8 has not been read.\n\n"
+            "## Return Format\n\n"
+            "Return JSON only:\n"
+            '{"scores":[{"idea_id":"","novelty":0,"feasibility":0,"relevance":0}]}\n\n'
+            f"Score exactly these ids: {ids}\n\n"
+            "# Research Goal\n\n"
+            f"{truncate_text(_excerpt(paths.user_input), max_chars=3000)}\n\n"
+            "# Candidates\n\n"
+            f"{listing}\n"
+        )
+
+
+def _score_value(raw: Any) -> float | None:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, min(10.0, round(value, 2)))
+
+
+def _excerpt(path) -> str:
+    return read_text(path).strip() if path.exists() else "(missing)"
+
+
+# ---------------------------------------------------------------------------
+# Artifacts and prompt injection
+# ---------------------------------------------------------------------------
+
+
+def record_idea_pool(paths: RunPaths, pool: IdeaPool, stage: StageSpec, attempt_no: int) -> dict[str, Any]:
+    payload = {"stage": stage.slug, "attempt": attempt_no, **pool.to_dict()}
+    paths.notes_dir.mkdir(parents=True, exist_ok=True)
+    write_text(paths.notes_dir / IDEA_POOL_FILENAME, json.dumps(payload, indent=2, ensure_ascii=False))
+    write_text(paths.notes_dir / "idea_pool.md", format_pool_for_prompt(pool))
+    append_log_entry(
+        paths.logs,
+        f"{stage.slug} attempt {attempt_no} idea_pool",
+        (
+            f"proposed: {payload['effect']['proposed']}\n"
+            f"distinct: {payload['effect']['distinct']}\n"
+            f"added beyond baseline: {payload['effect']['added_by_other_proposers']}\n"
+            f"{payload['effect']['verdict']}"
+        ),
+    )
+    return payload
+
+
+def format_pool_for_prompt(pool: IdeaPool) -> str:
+    """Render the pool as material for Stage 02 to select from and sharpen."""
+    ranked = pool.ranked()
+    if not ranked:
+        return (
+            "No candidate hypotheses were produced by the ideation panel. Generate hypotheses "
+            "from the goal and literature as usual.\n"
+        )
+
+    lines = [
+        "These candidate hypotheses were proposed independently by agents working from "
+        "different lenses, then deduplicated and scored. They are **material, not a decision**: "
+        "adopt, merge, sharpen, or reject them on their evidence, and say in your stage summary "
+        "which you took and why you left the rest.",
+        "",
+    ]
+    for candidate in ranked:
+        score = candidate.mean_score
+        header = f"### {candidate.idea_id} — {candidate.title}"
+        if score is not None:
+            header += (
+                f"  _(novelty {candidate.novelty}, feasibility {candidate.feasibility}, "
+                f"relevance {candidate.relevance})_"
+            )
+        lines.extend([header, f"_Lens: {candidate.proposer_title}_", "", candidate.statement, ""])
+        if candidate.rationale:
+            lines.extend([f"Rationale: {candidate.rationale}", ""])
+        if candidate.prediction:
+            lines.extend([f"Distinguishing prediction: {candidate.prediction}", ""])
+
+    collapsed = pool.effect()["collapsed_as_duplicates"]
+    if collapsed:
+        lines.append(
+            f"_{collapsed} further proposal(s) were folded in as restatements of the above._"
+        )
+    if pool.abstentions:
+        lines.append(f"_Lenses with nothing to add on this goal: {', '.join(pool.abstentions)}._")
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/manager.py
+++ b/src/manager.py
@@ -93,6 +93,7 @@ from .stage_graph import (
 from .diagram_gen import post_writing_diagram_hook
 from .terminal_ui import TerminalUI
 from .platform.foundry import generate_paper_package, generate_release_package
+from .ideation_panel import IdeationPanel, format_pool_for_prompt, record_idea_pool
 from .writing_manifest import (
     build_writing_manifest,
     format_manifest_for_prompt,
@@ -189,6 +190,7 @@ class ResearchManager:
         self._redo_start_stage: StageSpec | None = None
         self._research_diagram: bool = False
         self._final_stage: StageSpec | None = None
+        self.ideation_panel: IdeationPanel | None = None
         self._jump_target_stage: StageSpec | None = None
         self.unattended = unattended
         self.max_auto_skips = max_auto_skips
@@ -550,6 +552,23 @@ class ResearchManager:
                 return None
             current = stage_for_slug(move.target)
         return current
+
+    def _build_idea_pool(self, paths: RunPaths, stage: StageSpec, attempt_no: int) -> str:
+        """Widen Stage 02's candidate pool before it writes anything.
+
+        Best-effort: a panel that cannot be reached must not stop the stage from generating
+        hypotheses the ordinary way, because the pool is material rather than a dependency.
+        """
+        assert self.ideation_panel is not None
+        try:
+            pool = self.ideation_panel.build_pool(paths=paths, stage=stage, attempt_no=attempt_no)
+        except Exception as exc:  # noqa: BLE001 - the stage proceeds without the pool
+            append_log_entry(paths.logs, f"{stage.slug} idea_pool_failed", str(exc))
+            self.ui.show_status(f"Ideation panel failed: {exc}", level="warn")
+            return "The ideation panel did not run. Generate hypotheses as usual.\n"
+
+        record_idea_pool(paths, pool, stage, attempt_no)
+        return format_pool_for_prompt(pool)
 
     def _generate_writing_review(self, paths: RunPaths) -> dict[str, object]:
         """Produce the Stage 07 triage artifact that matches this run's output format.
@@ -1965,6 +1984,13 @@ class ResearchManager:
                     + format_resources_for_intake_prompt(ctx.resources)
                     + "\n"
                 )
+        if stage.slug == "02_hypothesis_generation" and self.ideation_panel is not None:
+            stage_template = (
+                stage_template.rstrip()
+                + "\n\n## Candidate Hypothesis Pool\n\n"
+                + self._build_idea_pool(paths, stage, attempt_no)
+                + "\n"
+            )
         if stage.slug == "07_writing":
             manifest = build_writing_manifest(paths)
             stage_template = (

--- a/tests/test_ideation_panel.py
+++ b/tests/test_ideation_panel.py
@@ -1,0 +1,457 @@
+"""Stage 02's candidate pool: many agents for divergence, measured as such.
+
+The pool exists to widen what Stage 02 chooses from. So the tests that matter are the ones
+that would fail if it stopped widening anything — a pool of five restatements is the
+single-pass null in another costume, and the artifact has to be able to say so.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.ideation_panel import (
+    DEFAULT_LENSES,
+    DUPLICATE_THRESHOLD,
+    IDEA_POOL_FILENAME,
+    Candidate,
+    IdeaPool,
+    IdeationPanel,
+    ProposerLens,
+    apply_lens_models,
+    format_pool_for_prompt,
+    mark_duplicates,
+    record_idea_pool,
+    resolve_lenses,
+    similarity,
+)
+from src.terminal_ui import TerminalUI
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    read_text,
+    write_text,
+)
+
+
+STAGE_02 = next(stage for stage in STAGES if stage.slug == "02_hypothesis_generation")
+
+_MECHANISM = (
+    "Remittance inflows raise household consumption because they relax liquidity constraints "
+    "in credit-poor households."
+)
+_RESTATED = (
+    "Because credit-poor households face liquidity constraints, remittance inflows increase "
+    "their consumption."
+)
+_VARIANT = (
+    "Remittance inflows raise household consumption only in economies with shallow financial "
+    "markets."
+)
+_UNRELATED = (
+    "The observed correlation is a selection artifact: households that receive remittances "
+    "differ systematically in unobserved ways."
+)
+
+
+def _candidate(idea_id: str, proposer: str, statement: str, title: str = "t") -> Candidate:
+    return Candidate(
+        idea_id=idea_id, proposer=proposer, proposer_title=proposer,
+        backend="claude", model="sonnet", title=title, statement=statement,
+    )
+
+
+class SimilarityTests(unittest.TestCase):
+    """The threshold is calibrated, so the calibration is what gets pinned."""
+
+    def test_a_rewording_scores_above_the_threshold(self) -> None:
+        self.assertGreaterEqual(similarity(_MECHANISM, _RESTATED), DUPLICATE_THRESHOLD)
+
+    def test_a_genuine_variant_scores_below_it(self) -> None:
+        self.assertLess(similarity(_MECHANISM, _VARIANT), DUPLICATE_THRESHOLD)
+
+    def test_an_unrelated_claim_scores_near_zero(self) -> None:
+        self.assertLess(similarity(_MECHANISM, _UNRELATED), 0.2)
+
+    def test_the_threshold_sits_in_the_gap_it_was_calibrated_for(self) -> None:
+        # If someone retunes this, the calibration in the module docstring must move with it.
+        self.assertLess(similarity(_MECHANISM, _VARIANT), DUPLICATE_THRESHOLD)
+        self.assertGreaterEqual(similarity(_MECHANISM, _RESTATED), DUPLICATE_THRESHOLD)
+
+    def test_similarity_is_symmetric_and_bounded(self) -> None:
+        self.assertEqual(similarity(_MECHANISM, _RESTATED), similarity(_RESTATED, _MECHANISM))
+        self.assertEqual(similarity(_MECHANISM, _MECHANISM), 1.0)
+        self.assertEqual(similarity("", _MECHANISM), 0.0)
+
+
+class DeduplicationTests(unittest.TestCase):
+    def test_a_restatement_collapses_into_the_first_occurrence(self) -> None:
+        resolved = mark_duplicates([
+            _candidate("mechanism-1", "mechanism", _MECHANISM),
+            _candidate("contrarian-1", "contrarian", _RESTATED),
+        ])
+        self.assertIsNone(resolved[0].duplicate_of)
+        self.assertEqual(resolved[1].duplicate_of, "mechanism-1")
+
+    def test_a_different_title_cannot_hide_the_same_claim(self) -> None:
+        # Two proposers naming one idea differently is the collapse this must catch, so the
+        # title is deliberately excluded from the comparison.
+        resolved = mark_duplicates([
+            _candidate("mechanism-1", "mechanism", _MECHANISM, title="Liquidity channel"),
+            _candidate("contrarian-1", "contrarian", _RESTATED, title="A completely different name"),
+        ])
+        self.assertEqual(resolved[1].duplicate_of, "mechanism-1")
+
+    def test_a_genuine_variant_survives(self) -> None:
+        resolved = mark_duplicates([
+            _candidate("mechanism-1", "mechanism", _MECHANISM),
+            _candidate("regime-1", "regime", _VARIANT),
+        ])
+        self.assertIsNone(resolved[1].duplicate_of)
+
+    def test_a_duplicate_never_absorbs_a_later_candidate(self) -> None:
+        resolved = mark_duplicates([
+            _candidate("a-1", "a", _MECHANISM),
+            _candidate("b-1", "b", _RESTATED),
+            _candidate("c-1", "c", _RESTATED),
+        ])
+        # Both restatements point at the original, not at each other.
+        self.assertEqual([c.duplicate_of for c in resolved], [None, "a-1", "a-1"])
+
+
+class PoolEffectTests(unittest.TestCase):
+    """The pool must be able to report that the extra proposers added nothing."""
+
+    def test_a_pool_of_restatements_says_it_widened_nothing(self) -> None:
+        pool = IdeaPool(
+            candidates=mark_duplicates([
+                _candidate("mechanism-1", "mechanism", _MECHANISM),
+                _candidate("contrarian-1", "contrarian", _RESTATED),
+                _candidate("regime-1", "regime", _RESTATED),
+            ]),
+            baseline_proposer="mechanism",
+            proposer_calls=5,
+        )
+        effect = pool.effect()
+        self.assertEqual(effect["distinct"], 1)
+        self.assertEqual(effect["collapsed_as_duplicates"], 2)
+        self.assertEqual(effect["added_by_other_proposers"], 0)
+        self.assertIn("widened nothing", effect["verdict"])
+
+    def test_a_genuinely_diverse_pool_reports_what_was_added(self) -> None:
+        pool = IdeaPool(
+            candidates=mark_duplicates([
+                _candidate("mechanism-1", "mechanism", _MECHANISM),
+                _candidate("regime-1", "regime", _VARIANT),
+                _candidate("null-1", "null", _UNRELATED),
+            ]),
+            baseline_proposer="mechanism",
+            proposer_calls=5,
+        )
+        effect = pool.effect()
+        self.assertEqual(effect["distinct"], 3)
+        self.assertEqual(effect["added_by_other_proposers"], 2)
+        self.assertIn("2 of 3 distinct hypotheses", effect["verdict"])
+
+    def test_an_empty_pool_is_reported_rather_than_crashing(self) -> None:
+        pool = IdeaPool(baseline_proposer="mechanism", proposer_calls=5)
+        self.assertIn("No candidate hypotheses survived", pool.effect()["verdict"])
+
+    def test_ranking_puts_the_best_scored_candidate_first(self) -> None:
+        strong = Candidate(**{**_candidate("a-1", "a", _MECHANISM).__dict__,
+                              "novelty": 8.0, "feasibility": 9.0, "relevance": 9.0})
+        weak = Candidate(**{**_candidate("b-1", "b", _UNRELATED).__dict__,
+                            "novelty": 2.0, "feasibility": 3.0, "relevance": 4.0})
+        pool = IdeaPool(candidates=[weak, strong], baseline_proposer="a")
+        self.assertEqual([c.idea_id for c in pool.ranked()], ["a-1", "b-1"])
+
+    def test_unscored_candidates_sort_after_scored_ones(self) -> None:
+        scored = Candidate(**{**_candidate("a-1", "a", _MECHANISM).__dict__, "novelty": 1.0})
+        unscored = _candidate("b-1", "b", _UNRELATED)
+        pool = IdeaPool(candidates=[unscored, scored], baseline_proposer="a")
+        self.assertEqual([c.idea_id for c in pool.ranked()], ["a-1", "b-1"])
+
+
+class LensTests(unittest.TestCase):
+    def test_the_default_lenses_are_five_distinct_mandates(self) -> None:
+        self.assertEqual(len(DEFAULT_LENSES), 5)
+        self.assertEqual(len({lens.charter for lens in DEFAULT_LENSES}), 5)
+
+    def test_a_subset_keeps_the_callers_order(self) -> None:
+        self.assertEqual([l.key for l in resolve_lenses(["null", "mechanism"])], ["null", "mechanism"])
+
+    def test_an_unknown_lens_is_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            resolve_lenses(["brainstorm"])
+
+    def test_models_can_be_assigned_per_lens(self) -> None:
+        lenses = apply_lens_models(DEFAULT_LENSES, ["mechanism=opus", "null=codex:default"])
+        by_key = {lens.key: lens for lens in lenses}
+        self.assertEqual(by_key["mechanism"].model, "opus")
+        self.assertEqual((by_key["null"].backend, by_key["null"].model), ("codex", "default"))
+        self.assertIsNone(by_key["regime"].model)
+
+    def test_a_malformed_assignment_is_refused(self) -> None:
+        for bad in ("mechanism", "mechanism=", "nobody=opus"):
+            with self.assertRaises(ValueError, msg=bad):
+                apply_lens_models(DEFAULT_LENSES, [bad])
+
+
+class PanelRunTests(unittest.TestCase):
+    def _panel(self, script: dict[str, object], **kwargs):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Does remittance inflow raise household consumption?")
+        write_text(paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025")
+
+        panel = IdeationPanel(
+            kwargs.pop("lenses", DEFAULT_LENSES),
+            backend_name="claude", model="sonnet",
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+            **kwargs,
+        )
+
+        def make(key):
+            def run_prompt(*, paths, stage, attempt_no, prompt, label):
+                response = script.get("__score__" if label == "ideate_score" else key)
+                if response == "__FAIL__":
+                    return 1, "", "boom"
+                return 0, json.dumps(response if response is not None else {"hypotheses": []}), ""
+            return run_prompt
+
+        for lens in panel.lenses:
+            panel._members[lens.key].run_prompt = make(lens.key)
+        return panel, paths
+
+    def _build(self, script, **kwargs):
+        panel, paths = self._panel(script, **kwargs)
+        return panel.build_pool(paths=paths, stage=STAGE_02, attempt_no=1), paths
+
+    def test_candidates_from_every_lens_reach_the_pool(self) -> None:
+        script = {
+            lens.key: {"hypotheses": [{"title": lens.key, "statement": f"Claim {lens.key} " + lens.key * 6}]}
+            for lens in DEFAULT_LENSES
+        }
+        script["__score__"] = {"scores": []}
+        pool, _ = self._build(script)
+        self.assertEqual(len(pool.distinct), 5)
+
+    def test_an_empty_list_is_recorded_as_an_abstention(self) -> None:
+        script = {lens.key: {"hypotheses": []} for lens in DEFAULT_LENSES}
+        script["mechanism"] = {"hypotheses": [{"title": "m", "statement": _MECHANISM}]}
+        script["__score__"] = {"scores": []}
+        pool, _ = self._build(script)
+        self.assertEqual(len(pool.abstentions), 4)
+        self.assertEqual(len(pool.distinct), 1)
+
+    def test_an_unreachable_proposer_does_not_stop_the_pool(self) -> None:
+        script = {lens.key: {"hypotheses": [{"title": "t", "statement": f"Claim {lens.key * 8}"}]}
+                  for lens in DEFAULT_LENSES}
+        script["regime"] = "__FAIL__"
+        script["__score__"] = {"scores": []}
+        pool, _ = self._build(script)
+        self.assertEqual(pool.unreachable, ["regime"])
+        self.assertEqual(len(pool.distinct), 4)
+
+    def test_ideas_per_proposer_is_a_cap(self) -> None:
+        many = {"hypotheses": [{"title": f"t{i}", "statement": f"Distinct claim number {i} " + "word" * i}
+                               for i in range(6)]}
+        script = {lens.key: many for lens in DEFAULT_LENSES}
+        script["__score__"] = {"scores": []}
+        pool, _ = self._build(script, lenses=resolve_lenses(["mechanism"]), ideas_per_proposer=2)
+        self.assertEqual(len(pool.candidates), 2)
+
+    def test_scores_land_on_the_right_candidates(self) -> None:
+        script = {
+            "mechanism": {"hypotheses": [{"title": "m", "statement": _MECHANISM}]},
+            "null": {"hypotheses": [{"title": "n", "statement": _UNRELATED}]},
+            "__score__": {"scores": [
+                {"idea_id": "mechanism-1", "novelty": 4, "feasibility": 9, "relevance": 9},
+                {"idea_id": "null-1", "novelty": 3, "feasibility": 8, "relevance": 9},
+            ]},
+        }
+        pool, _ = self._build(script, lenses=resolve_lenses(["mechanism", "null"]))
+        by_id = {c.idea_id: c for c in pool.distinct}
+        self.assertEqual(by_id["mechanism-1"].feasibility, 9.0)
+        self.assertEqual(by_id["null-1"].novelty, 3.0)
+
+    def test_a_failed_scoring_call_leaves_the_pool_usable(self) -> None:
+        script = {
+            "mechanism": {"hypotheses": [{"title": "m", "statement": _MECHANISM}]},
+            "__score__": "__FAIL__",
+        }
+        pool, _ = self._build(script, lenses=resolve_lenses(["mechanism"]))
+        self.assertEqual(len(pool.distinct), 1)
+        self.assertIsNone(pool.distinct[0].novelty)
+
+    def test_an_out_of_range_score_is_clamped(self) -> None:
+        script = {
+            "mechanism": {"hypotheses": [{"title": "m", "statement": _MECHANISM}]},
+            "__score__": {"scores": [{"idea_id": "mechanism-1", "novelty": 99, "feasibility": -4,
+                                      "relevance": "not a number"}]},
+        }
+        pool, _ = self._build(script, lenses=resolve_lenses(["mechanism"]))
+        candidate = pool.distinct[0]
+        self.assertEqual((candidate.novelty, candidate.feasibility, candidate.relevance), (10.0, 0.0, None))
+
+    def test_a_candidate_with_no_statement_is_dropped(self) -> None:
+        script = {
+            "mechanism": {"hypotheses": [{"title": "empty"}, {"title": "m", "statement": _MECHANISM}]},
+            "__score__": {"scores": []},
+        }
+        pool, _ = self._build(script, lenses=resolve_lenses(["mechanism"]))
+        self.assertEqual(len(pool.candidates), 1)
+
+    def test_fake_mode_returns_an_empty_pool_without_calling_anything(self) -> None:
+        panel, paths = self._panel({}, fake_mode=True)
+        pool = panel.build_pool(paths=paths, stage=STAGE_02, attempt_no=1)
+        self.assertEqual(pool.candidates, [])
+        self.assertEqual(pool.proposer_calls, 0)
+
+    def test_an_empty_roster_is_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            IdeationPanel((), backend_name="claude", model="sonnet")
+
+
+class ArtifactTests(unittest.TestCase):
+    def _paths_with_pool(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.memory, "# Approved Run Memory\n")
+        pool = IdeaPool(
+            candidates=mark_duplicates([
+                _candidate("mechanism-1", "mechanism", _MECHANISM, title="Liquidity channel"),
+                _candidate("contrarian-1", "contrarian", _RESTATED),
+                _candidate("null-1", "null", _UNRELATED, title="Selection artifact"),
+            ]),
+            abstentions=["regime"],
+            baseline_proposer="mechanism",
+            proposer_calls=5,
+        )
+        return paths, pool
+
+    def test_the_pool_is_written_where_stage_02_artifacts_live(self) -> None:
+        paths, pool = self._paths_with_pool()
+        record_idea_pool(paths, pool, STAGE_02, 1)
+        payload = json.loads(read_text(paths.notes_dir / IDEA_POOL_FILENAME))
+        self.assertEqual(payload["stage"], STAGE_02.slug)
+        self.assertEqual(payload["effect"]["collapsed_as_duplicates"], 1)
+        self.assertTrue((paths.notes_dir / "idea_pool.md").exists())
+
+    def test_the_verdict_reaches_the_run_log(self) -> None:
+        paths, pool = self._paths_with_pool()
+        record_idea_pool(paths, pool, STAGE_02, 1)
+        self.assertIn("distinct hypotheses came from proposers", read_text(paths.logs))
+
+    def test_the_prompt_block_presents_material_not_a_decision(self) -> None:
+        _paths, pool = self._paths_with_pool()
+        rendered = format_pool_for_prompt(pool)
+        self.assertIn("material, not a decision", rendered)
+        self.assertIn("Liquidity channel", rendered)
+        self.assertIn("Selection artifact", rendered)
+        # The restatement is folded in, and the fact that it was is disclosed.
+        self.assertNotIn("contrarian-1", rendered)
+        self.assertIn("folded in as restatements", rendered)
+        self.assertIn("regime", rendered)
+
+    def test_an_empty_pool_tells_the_stage_to_proceed_normally(self) -> None:
+        rendered = format_pool_for_prompt(IdeaPool(baseline_proposer="mechanism"))
+        self.assertIn("Generate hypotheses", rendered)
+
+
+class ManagerIntegrationTests(unittest.TestCase):
+    def test_the_pool_is_injected_into_the_stage_02_prompt(self) -> None:
+        import io as _io
+        from unittest.mock import MagicMock
+        from src.manager import ResearchManager
+
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        root = Path(tmp_dir.name)
+        runs_dir = root / "runs"
+        runs_dir.mkdir()
+        paths = build_run_paths(runs_dir / "20260101_000000")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Goal")
+        write_text(paths.memory, "# Approved Run Memory\n\n## Approved Stage Summaries\n\n_None yet._\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025")
+
+        operator = MagicMock()
+        operator.model = "sonnet"
+        operator.backend_name = "claude"
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=runs_dir,
+            operator=operator,
+            ui=TerminalUI(output_stream=_io.StringIO(), interactive=False),
+        )
+        panel = IdeationPanel(
+            resolve_lenses(["mechanism"]), backend_name="claude", model="sonnet",
+            ui=TerminalUI(output_stream=_io.StringIO(), interactive=False),
+        )
+        panel._members["mechanism"].run_prompt = lambda **kw: (
+            0, json.dumps({"hypotheses": [{"title": "m", "statement": _MECHANISM}]}), ""
+        ) if kw["label"] != "ideate_score" else (0, json.dumps({"scores": []}), "")
+        manager.ideation_panel = panel
+
+        prompt = manager._build_stage_prompt(paths, STAGE_02, None, False)
+
+        self.assertIn("Candidate Hypothesis Pool", prompt)
+        self.assertIn(_MECHANISM, prompt)
+        self.assertTrue((paths.notes_dir / IDEA_POOL_FILENAME).exists())
+
+    def test_a_failing_panel_does_not_stop_the_stage(self) -> None:
+        import io as _io
+        from unittest.mock import MagicMock
+        from src.manager import ResearchManager
+
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        root = Path(tmp_dir.name)
+        runs_dir = root / "runs"
+        runs_dir.mkdir()
+        paths = build_run_paths(runs_dir / "20260101_000000")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Goal")
+        write_text(paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025")
+
+        operator = MagicMock()
+        operator.model = "sonnet"
+        operator.backend_name = "claude"
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=runs_dir,
+            operator=operator,
+            ui=TerminalUI(output_stream=_io.StringIO(), interactive=False),
+        )
+        broken = IdeationPanel(
+            resolve_lenses(["mechanism"]), backend_name="claude", model="sonnet",
+            ui=TerminalUI(output_stream=_io.StringIO(), interactive=False),
+        )
+
+        def explode(**_kwargs):
+            raise RuntimeError("panel is down")
+
+        broken.build_pool = explode
+        manager.ideation_panel = broken
+
+        prompt = manager._build_stage_prompt(paths, STAGE_02, None, False)
+
+        # The pool is material, not a dependency.
+        self.assertIn("did not run", prompt)
+        self.assertIn("panel is down", read_text(paths.logs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#120 and #126 seated a room to **converge** on a gate decision. That is one half of what the multi-agent evidence supports, and arguably the weaker half.

## The other half

AgentPanel ([arXiv:2608.03283](https://arxiv.org/abs/2608.03283)) beat centralized multi-agent debate on two ideation benchmarks, and its own reading of why is *not* that the agents argued better. A heterogeneous population **widened the candidate pool** and left the selecting to a human:

> the value of multi-agent scientific systems lies not only in improving individual responses, but also in expanding and organizing a diverse candidate pool for human comparison, selection, and refinement

Its gains concentrate in **feasibility** — 5.08 vs 4.08 on LiveIdeaBench; 0.28 vs 0.11 and 0.31 vs 0.04 on IdeaBench — not originality. More agents did not produce wilder ideas. They produced more usable ones.

So `--ideation-panel` gives Stage 02 a **pool, not a verdict**.

## The lenses

Five proposers, blind to each other, each looking somewhere different:

| Lens | Looks for |
|:---|:---|
| `mechanism` | What process would have to be true for the pattern to arise |
| `contrarian` | What the world looks like if the obvious reading is wrong |
| `adjacent` | A mechanism standard in a neighbouring field, unusual in this one |
| `null` | Confounds, selection effects, artifacts — the boring explanations to exclude first |
| `regime` | Where the effect should strengthen, invert, or vanish |

Lenses are the generation-side answer to correlated seats: five agents asked for "a good hypothesis" return five versions of the obvious one; these five return five different objects. A lens with nothing real to offer returns an empty list rather than padding the pool.

Candidates are deduplicated, scored on novelty/feasibility/relevance, ranked, and injected into the Stage 02 prompt as **material, not a decision**. Nothing in the module decides anything, and a panel that cannot be reached logs the failure while the stage proceeds normally.

## Same falsifiability discipline as #126

Havranek & Irsova ([arXiv:2607.14713](https://arxiv.org/abs/2607.14713)) found a plain single pass beating two multi-agent tools, and the reported mechanism is that the reports *"tended to raise much the same points."* A pool of five restatements is that null in another costume.

So **the first proposer is the single-pass baseline**, and `workspace/notes/idea_pool.json` records how much the others actually added:

> All 3 distinct hypotheses came from the baseline proposer; the other proposers restated it, at 5 proposer calls. On this run the panel widened nothing — consider `--ideation-lenses` with fewer seats, or dropping it.

## On the duplicate detection

Plain Python, not a model call — asking a model whether five of its own ideas are the same idea is the wrong instrument for catching a collapsed pool.

The 0.5 Jaccard threshold is **calibrated, not guessed**: rewordings of one claim score 0.60–0.78, a related-but-distinct claim about the same variables scores 0.28, unrelated claims 0.00. The threshold sits in that gap, and a test pins the calibration so retuning it forces the documented basis to move too.

I also **found and fixed a bug in my own first cut**: I was comparing `title + statement`, and a planted restatement failed to collapse because the two proposers had named it differently — which is precisely the case this must catch. Comparison is now on the claim alone.

## Verification

891 tests, 35 new. Mutation-verified:

| Mutant | Tests killed |
|:---|:---|
| restore `title` into the duplicate comparison | 1 |
| effect always claims a widened pool | 1 |
| empty proposal counts as a candidate, not an abstention | 1 |

Control passes. Also exercised end to end with a planted restatement: 4 proposed → 3 distinct, 1 collapsed, 1 abstention, correct verdict.

## Cost

`lenses + 1` calls per Stage 02 attempt — six by default, once per attempt. Cheaper than the review panel, which pays per gate. Off by default.

Limits are written down in [docs/ideation-panel.md](docs/ideation-panel.md), including the one that matters: a widened pool is not a better hypothesis, and neither AgentPanel nor this measures downstream research outcomes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)