### PR TITLE
Let an approving reviewer say what a later stage still owes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Useful feature | **Automated experiment manifests** | Machine-readable experiment and result files make runs inspectable, comparable, and reusable downstream. |
 | Useful feature | **Citation verification and writing checks** | Writing expects citation verification, figure-link checks, and self-review artifacts before Stage 07 is considered complete. |
 | Useful feature | **Artifact indexing across stages** | `artifact_index.json` and related manifests help later stages find data, results, and figures without guessing from filenames. |
+| Useful feature | **Obligations carried forward** | An approving reviewer records what a later stage still owes; the debt is injected into that stage and its review, and only a reviewer can discharge it. |
 | Useful feature | **Cross-model review veto** | When the reviewer approves, a different model family audits that approval and can send the stage back. A veto, never an override, so it can only tighten the gate. |
 | Useful feature | **Self-improving review policy** | Every correction the reviewer demands becomes a standing rule checked on all later stages, recorded in an auditable `review_policy.json` with the stage and attempt that produced it. |
 | Useful feature | **Resume, redo, and rollback controls** | Long research runs can continue in place, retry a stage, or roll downstream state back without starting over. |
@@ -466,6 +467,35 @@ flowchart TD
 - Stages 01-08 use the standard six-action review menu: `1 / 2 / 3` continue with an AI refinement suggestion, `4` continues with custom feedback, `5` approves, and `6` aborts.
 
 The stage loop is controlled by AutoR, not by Claude.
+
+### Obligations carried forward
+
+The reviewer's insight used to be captured only when it refused. But most stages are
+approved, and an approval discarded everything the reviewer noticed — which is where most
+of the review actually lives. A real reviewer approving a literature survey says "fine, but
+you owe me a power analysis at design time", and then checks.
+
+An approving reviewer can now attach **obligations** to a later stage. Each is injected into
+that stage's prompt *and* into its review, so the reviewer who inherits one is asked whether
+it was met:
+
+```
+approval ──obligation──▶ later stage prompt ──▶ that stage's review ──▶ discharged
+                                                          │
+                                                 not met ─┴──▶ refusal
+```
+
+Recorded in `runs/<run_id>/obligations.json`. Three rules keep it from becoming theatre:
+
+- **Only a reviewer may discharge one.** The stage that owes it cannot mark its own
+  homework — it can do the work and say so, and a reviewer decides.
+- **Deferral is counted, never silent.** A stage may push an obligation later, but it stays
+  open and its deferral count is shown to every subsequent reviewer, so "carried forward"
+  cannot quietly become "dropped".
+- **Bounded and deduplicated**, so a reviewer restating itself cannot manufacture rigour.
+
+Together with the two mechanisms below, refusals teach rules, approvals set debts, and a
+different model family can veto either.
 
 ### Cross-model review
 

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import json
 import re
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from .operator import ClaudeOperator
+from .obligations import format_for_review_prompt, load_ledger
 from .review_policy import format_policy_for_prompt, load_policy
 from .operator_codex import CodexOperator
 from .terminal_ui import TerminalUI
@@ -50,6 +51,11 @@ class ReviewDecision:
     reason: str = ""
     feedback: str = ""
     raw_response: str = ""
+    #: What a later stage still owes, attached when approving. This is where most of a
+    #: review's value lives: an approval used to discard everything the reviewer noticed.
+    carry_forward: list[Any] = field(default_factory=list)
+    #: Inherited obligation ids this stage actually discharged.
+    discharged: list[str] = field(default_factory=list)
 
 
 class AutomatedReviewer:
@@ -212,9 +218,19 @@ class AutomatedReviewer:
             "- Otherwise choose custom_feedback and write concrete reviewer instructions.\n"
             "- Use abort only if the run is blocked badly enough that automatic continuation would be irresponsible.\n\n"
             "Return JSON only, with no prose outside the JSON object:\n"
-            '{"decision":"approve|suggestion_1|suggestion_2|suggestion_3|custom_feedback|abort","feedback":"","reason":""}\n\n'
+            '{"decision":"approve|suggestion_1|suggestion_2|suggestion_3|custom_feedback|abort",'
+            '"feedback":"","reason":"",'
+            '"carry_forward":[{"obligation":"","target_stage":""}],"discharged":[]}\n\n'
             "Rules for JSON fields:\n"
             "- `decision` is required.\n"
+            "- `carry_forward` is how you approve without letting go. When you approve but "
+            "something still needs doing, record it here instead of only mentioning it in "
+            "`reason`: each entry is injected into the prompt of the stage it targets and "
+            "into that stage's review, so it will actually be checked. `target_stage` is a "
+            "stage slug or number and may be omitted to mean 'any later stage'. Use it for "
+            "real debts, not for wishes.\n"
+            "- `discharged` lists the ids of inherited obligations this stage genuinely met. "
+            "Discharge on work present in this stage, never on a promise or a restatement.\n"
             "- `feedback` must be non-empty when `decision` is `custom_feedback`.\n"
             "- `reason` should be concise and specific.\n\n"
             "# Run Context\n\n"
@@ -229,6 +245,7 @@ class AutomatedReviewer:
             f"- stage draft under review: `{paths.stage_tmp_file(stage).resolve()}`\n"
             f"- approved stage path: `{paths.stage_file(stage).resolve()}`\n\n"
             + self._standing_rules_block(paths)
+            + self._obligations_block(paths, stage)
             + "# Suggested Refinements\n\n"
             f"1. {suggestions[0]}\n"
             f"2. {suggestions[1]}\n"
@@ -248,6 +265,13 @@ class AutomatedReviewer:
             "# Recent Log Excerpt\n\n"
             f"{self._read_excerpt(paths.logs, max_chars=5000, tail=True)}\n"
         )
+
+    def _obligations_block(self, paths: RunPaths, stage: StageSpec) -> str:
+        """Ask this review whether the debts it inherited were actually paid."""
+        rendered = format_for_review_prompt(load_ledger(paths), stage)
+        if not rendered:
+            return ""
+        return "# Inherited Obligations\n\n" + rendered + "\n\n"
 
     def _standing_rules_block(self, paths: RunPaths) -> str:
         """Render the rules earlier reviews produced, so this review inherits them.
@@ -297,12 +321,16 @@ class AutomatedReviewer:
         if choice == "4" and not feedback:
             feedback = reason or "The stage is not ready. Revise it with concrete, artifact-backed improvements before continuing."
 
+        carry_forward = payload.get("carry_forward")
+        discharged = payload.get("discharged")
         return ReviewDecision(
             choice=choice,
             decision_token=token,
             reason=reason,
             feedback=feedback,
             raw_response=raw_response,
+            carry_forward=list(carry_forward) if isinstance(carry_forward, list) else [],
+            discharged=[str(item) for item in discharged] if isinstance(discharged, list) else [],
         )
 
     def _extract_json_payload(self, raw_response: str) -> dict[str, Any] | None:

--- a/src/manager.py
+++ b/src/manager.py
@@ -16,6 +16,14 @@ from .bootstrap import (
 )
 from .approval_agent import AutomatedReviewer, ReviewDecision
 from .cross_reviewer import GeminiCrossReviewer
+from .obligations import (
+    discharge_obligations,
+    format_for_stage_prompt,
+    ledger_summary,
+    load_ledger,
+    note_deferrals,
+    record_obligations,
+)
 from .review_policy import load_policy, policy_summary, record_correction
 from .project_bootstrap import (
     format_project_context_for_prompt,
@@ -1826,6 +1834,7 @@ class ResearchManager:
                 attempt_no=attempt_no,
                 previous_validation_errors=previous_validation_errors,
                 web_search_context=self.web_search_context,
+                obligations_context=format_for_stage_prompt(load_ledger(paths), stage),
             )
 
         user_request = read_text(paths.user_input)
@@ -1833,6 +1842,7 @@ class ResearchManager:
             stage, stage_template, user_request, approved_memory, handoff_context, revision_feedback,
             intake_context_text=intake_context_text,
             web_search_context=self.web_search_context,
+            obligations_context=format_for_stage_prompt(load_ledger(paths), stage),
         )
 
     def _display_stage_output(self, stage: StageSpec, markdown: str) -> None:
@@ -1900,6 +1910,7 @@ class ResearchManager:
         self._record_review_correction(
             paths=paths, stage=stage, attempt_no=attempt_no, decision=decision, suggestions=suggestions
         )
+        self._settle_obligations(paths=paths, stage=stage, attempt_no=attempt_no, decision=decision)
 
         cross = self._apply_cross_review(
             paths=paths, stage=stage, attempt_no=attempt_no, decision=decision,
@@ -1909,6 +1920,57 @@ class ResearchManager:
             return cross
 
         return decision.choice, decision.feedback or None
+
+    def _settle_obligations(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        decision: ReviewDecision,
+    ) -> None:
+        """Close the obligations this stage met, and record the ones it created.
+
+        Discharges are applied first: an approval that both settles an inherited debt and
+        raises a new one should not have the new one immediately counted as deferred.
+        Deferral is only recorded on approval, because a refused stage gets another attempt
+        at the same obligations and has not deferred anything yet.
+        """
+        closed = discharge_obligations(
+            paths, stage=stage, obligation_ids=decision.discharged, note=decision.reason
+        )
+        for obligation in closed:
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} attempt {attempt_no} obligation_discharged",
+                f"{obligation.obligation_id}: {obligation.text}",
+            )
+
+        approved = decision.choice == "5"
+        if approved:
+            deferred = note_deferrals(paths, stage=stage)
+            if deferred:
+                append_log_entry(
+                    paths.logs,
+                    f"{stage.slug} attempt {attempt_no} obligations_deferred",
+                    f"{deferred} obligation(s) carried past this stage without being discharged.",
+                )
+
+        added = record_obligations(paths, stage=stage, entries=decision.carry_forward)
+        for obligation in added:
+            target = obligation.target_stage or "any later stage"
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} attempt {attempt_no} obligation_recorded",
+                f"{obligation.obligation_id} -> {target}: {obligation.text}",
+            )
+
+        if closed or added:
+            self.ui.show_status(
+                f"Obligations: +{len(added)} new, {len(closed)} discharged; "
+                f"{ledger_summary(load_ledger(paths))}.",
+                level="info",
+            )
 
     def _apply_cross_review(
         self,

--- a/src/obligations.py
+++ b/src/obligations.py
@@ -1,0 +1,306 @@
+"""Obligations a reviewer carries forward when it approves a stage.
+
+The approval gate learns from its refusals (:mod:`src.review_policy`), but most stages are
+approved, and an approval discarded everything the reviewer noticed. That is where most of
+the review actually lives. A real reviewer approving a literature survey says "fine, but
+you owe me a power analysis at design time" — and then checks. Here the observation was
+written into a log line and forgotten.
+
+An approving reviewer can now attach **obligations**: specific things a later stage must
+discharge. Each one is injected into the prompts of the stages it targets, and into the
+review of those stages, so the reviewer that inherits an obligation is asked whether it was
+met. An obligation that is neither discharged nor explicitly deferred is grounds to refuse.
+
+That closes the other half of the loop:
+
+    approval ──obligation──▶ later stage prompt ──▶ that stage's review ──▶ discharged
+                                                              │
+                                                     not met ─┴──▶ refusal
+
+The design constraints that keep it honest:
+
+* **Only the reviewer can discharge an obligation.** The stage that owes it cannot mark its
+  own homework; it can only do the work and say so. Otherwise an executor under pressure
+  closes its own debts.
+* **Deferral is recorded, not silent.** A stage may push an obligation later, but the
+  obligation stays open and its deferral count is visible, so "carried forward" cannot
+  quietly mean "dropped".
+* **Bounded and deduplicated**, like the review policy, so a reviewer repeating itself
+  cannot manufacture the appearance of rigour.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .utils import STAGES, RunPaths, StageSpec
+
+
+LEDGER_VERSION = 1
+
+#: An obligation set has to stay readable inside a stage prompt.
+MAX_OBLIGATIONS = 30
+
+#: Below this an obligation is not checkable ("do better", "be careful").
+MIN_OBLIGATION_CHARS = 20
+
+OPEN, DISCHARGED = "open", "discharged"
+
+
+@dataclass
+class Obligation:
+    obligation_id: str
+    text: str
+    origin_stage: str
+    target_stage: str | None = None
+    status: str = OPEN
+    deferrals: int = 0
+    discharged_by: str | None = None
+    discharge_note: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def applies_to(self, stage: StageSpec) -> bool:
+        """Whether *stage* is on the hook for this obligation.
+
+        An untargeted obligation applies to every stage after the one that raised it, so a
+        reviewer that does not name a stage still gets its point carried rather than lost.
+        """
+        if self.status != OPEN:
+            return False
+        if self.target_stage:
+            return self.target_stage == stage.slug
+        origin = _stage_number(self.origin_stage)
+        return origin is not None and stage.number > origin
+
+
+@dataclass
+class ObligationLedger:
+    version: int = LEDGER_VERSION
+    obligations: list[Obligation] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"version": self.version, "obligations": [o.to_dict() for o in self.obligations]}
+
+    @classmethod
+    def from_dict(cls, payload: Any) -> "ObligationLedger":
+        if not isinstance(payload, dict):
+            return cls()
+        items: list[Obligation] = []
+        for entry in payload.get("obligations") or []:
+            if not isinstance(entry, dict):
+                continue
+            text = str(entry.get("text") or "").strip()
+            if not text:
+                continue
+            items.append(
+                Obligation(
+                    obligation_id=str(entry.get("obligation_id") or f"O{len(items) + 1:03d}"),
+                    text=text,
+                    origin_stage=str(entry.get("origin_stage") or "unknown"),
+                    target_stage=(str(entry["target_stage"]) if entry.get("target_stage") else None),
+                    status=str(entry.get("status") or OPEN),
+                    deferrals=int(entry.get("deferrals") or 0),
+                    discharged_by=(str(entry["discharged_by"]) if entry.get("discharged_by") else None),
+                    discharge_note=str(entry.get("discharge_note") or ""),
+                )
+            )
+        return cls(version=int(payload.get("version") or LEDGER_VERSION), obligations=items)
+
+    def open_for(self, stage: StageSpec) -> list[Obligation]:
+        return [o for o in self.obligations if o.applies_to(stage)]
+
+    def by_id(self, obligation_id: str) -> Obligation | None:
+        wanted = (obligation_id or "").strip().upper()
+        return next((o for o in self.obligations if o.obligation_id.upper() == wanted), None)
+
+
+def _stage_number(slug: str) -> int | None:
+    for stage in STAGES:
+        if stage.slug == slug:
+            return stage.number
+    match = re.match(r"^(\d+)", slug or "")
+    return int(match.group(1)) if match else None
+
+
+def normalize_stage_slug(value: str | None) -> str | None:
+    """Resolve however a reviewer chose to name a stage.
+
+    Accepts ``05``, ``5``, ``05_experimentation`` and the display name (``Study Design``,
+    ``Stage 03: Study Design``). Live testing showed models reach for the display name, and
+    silently degrading that to "any later stage" loses the targeting the reviewer intended.
+    """
+    if not value:
+        return None
+    normalized = re.sub(r"[^a-z0-9]+", "", str(value).strip().lower())
+    if not normalized:
+        return None
+    # "stage03" / "stage3": a bare prefix carries no information, so drop it and match the
+    # number. Unlike the CLI's stage identifiers, leniency here is free — the alternative
+    # is silently losing the targeting the reviewer asked for.
+    bare = re.sub(r"^stage(?=\d)", "", normalized)
+    for stage in STAGES:
+        candidates = {
+            re.sub(r"[^a-z0-9]+", "", stage.slug.lower()),
+            str(stage.number),
+            f"{stage.number:02d}",
+            re.sub(r"[^a-z0-9]+", "", stage.display_name.lower()),
+            re.sub(r"[^a-z0-9]+", "", stage.stage_title.lower()),
+        }
+        if normalized in candidates or bare in candidates:
+            return stage.slug
+    return None
+
+
+def ledger_path(paths: RunPaths) -> Path:
+    return paths.run_root / "obligations.json"
+
+
+def load_ledger(paths: RunPaths) -> ObligationLedger:
+    path = ledger_path(paths)
+    if not path.exists():
+        return ObligationLedger()
+    try:
+        return ObligationLedger.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError):
+        return ObligationLedger()
+
+
+def save_ledger(paths: RunPaths, ledger: ObligationLedger) -> Path:
+    path = ledger_path(paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(ledger.to_dict(), indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path
+
+
+def _key(text: str) -> str:
+    lowered = re.sub(r"\s+", " ", (text or "").strip().lower())
+    return re.sub(r"[^a-z0-9 ]+", "", lowered).strip()
+
+
+def record_obligations(
+    paths: RunPaths,
+    *,
+    stage: StageSpec,
+    entries: list[Any],
+) -> list[Obligation]:
+    """Record what an approving reviewer said a later stage still owes."""
+    ledger = load_ledger(paths)
+    existing = {_key(o.text) for o in ledger.obligations}
+    added: list[Obligation] = []
+
+    for entry in entries or []:
+        if isinstance(entry, dict):
+            text = str(entry.get("obligation") or entry.get("text") or "").strip()
+            target = normalize_stage_slug(entry.get("target_stage") or entry.get("stage"))
+        else:
+            text, target = str(entry or "").strip(), None
+
+        text = " ".join(text.split())
+        if len(text) < MIN_OBLIGATION_CHARS:
+            continue
+        key = _key(text)
+        if not key or key in existing or len(ledger.obligations) >= MAX_OBLIGATIONS:
+            continue
+
+        obligation = Obligation(
+            obligation_id=f"O{len(ledger.obligations) + 1:03d}",
+            text=text,
+            origin_stage=stage.slug,
+            target_stage=target,
+        )
+        ledger.obligations.append(obligation)
+        existing.add(key)
+        added.append(obligation)
+
+    if added:
+        save_ledger(paths, ledger)
+    return added
+
+
+def discharge_obligations(
+    paths: RunPaths,
+    *,
+    stage: StageSpec,
+    obligation_ids: list[Any],
+    note: str = "",
+) -> list[Obligation]:
+    """Close obligations a reviewer confirms were met. Only a reviewer may call this."""
+    ledger = load_ledger(paths)
+    closed: list[Obligation] = []
+    for raw_id in obligation_ids or []:
+        obligation = ledger.by_id(str(raw_id))
+        if obligation is None or obligation.status != OPEN:
+            continue
+        obligation.status = DISCHARGED
+        obligation.discharged_by = stage.slug
+        obligation.discharge_note = " ".join(str(note or "").split())[:500]
+        closed.append(obligation)
+    if closed:
+        save_ledger(paths, ledger)
+    return closed
+
+
+def note_deferrals(paths: RunPaths, *, stage: StageSpec) -> int:
+    """Mark still-open obligations that applied to this stage as deferred once more.
+
+    Deferral is allowed but never silent: the count is written down and shown to every
+    later reviewer, so an obligation cannot be carried forward indefinitely unnoticed.
+    """
+    ledger = load_ledger(paths)
+    deferred = 0
+    for obligation in ledger.obligations:
+        if obligation.applies_to(stage):
+            obligation.deferrals += 1
+            deferred += 1
+    if deferred:
+        save_ledger(paths, ledger)
+    return deferred
+
+
+def format_for_stage_prompt(ledger: ObligationLedger, stage: StageSpec) -> str:
+    """Tell a stage what earlier reviews decided it owes."""
+    items = ledger.open_for(stage)
+    if not items:
+        return ""
+    lines = [
+        "Earlier reviews approved previous stages on the condition that these be addressed. "
+        "Discharge each one in this stage, or state explicitly why it belongs later and what "
+        "you did instead. Silently ignoring one is grounds for this stage to be rejected.",
+        "",
+    ]
+    for obligation in items:
+        aged = f" (deferred {obligation.deferrals}x)" if obligation.deferrals else ""
+        lines.append(f"- `{obligation.obligation_id}` (from {obligation.origin_stage}){aged}: {obligation.text}")
+    return "\n".join(lines)
+
+
+def format_for_review_prompt(ledger: ObligationLedger, stage: StageSpec) -> str:
+    """Ask the reviewer of this stage whether the inherited obligations were met."""
+    items = ledger.open_for(stage)
+    if not items:
+        return ""
+    lines = [
+        "An earlier review approved a previous stage on the condition that these be "
+        "addressed here. For each, decide whether this stage actually discharged it. List "
+        "the ids that were genuinely met in `discharged`. Do not discharge one on a promise "
+        "or a restatement — only on work present in this stage. An obligation neither met "
+        "nor explicitly and reasonably deferred is grounds to refuse.",
+        "",
+    ]
+    for obligation in items:
+        aged = f" (already deferred {obligation.deferrals}x)" if obligation.deferrals else ""
+        lines.append(f"- `{obligation.obligation_id}` (from {obligation.origin_stage}){aged}: {obligation.text}")
+    return "\n".join(lines)
+
+
+def ledger_summary(ledger: ObligationLedger) -> str:
+    if not ledger.obligations:
+        return "no carried-forward obligations"
+    open_count = sum(1 for o in ledger.obligations if o.status == OPEN)
+    return f"{open_count} open / {len(ledger.obligations)} total carried-forward obligation(s)"

--- a/src/utils.py
+++ b/src/utils.py
@@ -679,6 +679,7 @@ def build_prompt(
     revision_feedback: str | None = None,
     intake_context_text: str | None = None,
     web_search_context: str | None = None,
+    obligations_context: str | None = None,
 ) -> str:
     sections = [
         "# Stage Instructions",
@@ -705,6 +706,10 @@ def build_prompt(
         "# Original User Request",
         user_request.strip(),
     ]
+    if obligations_context:
+        sections.extend(["# Obligations Carried Forward", obligations_context.strip()])
+    if obligations_context:
+        sections.extend(["# Obligations Carried Forward", obligations_context.strip()])
     if web_search_context:
         sections.extend(["# Web Search Capability", web_search_context.strip()])
     if intake_context_text:
@@ -733,6 +738,7 @@ def build_continuation_prompt(
     attempt_no: int = 1,
     previous_validation_errors: list[str] | None = None,
     web_search_context: str | None = None,
+    obligations_context: str | None = None,
 ) -> str:
     current_draft = paths.stage_tmp_file(stage)
     current_final = paths.stage_file(stage)

--- a/tests/test_obligations.py
+++ b/tests/test_obligations.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.approval_agent import AutomatedReviewer, ReviewDecision
+from src.manager import ResearchManager
+from src.obligations import (
+    DISCHARGED,
+    MAX_OBLIGATIONS,
+    MIN_OBLIGATION_CHARS,
+    OPEN,
+    ObligationLedger,
+    discharge_obligations,
+    format_for_review_prompt,
+    format_for_stage_prompt,
+    ledger_path,
+    ledger_summary,
+    load_ledger,
+    normalize_stage_slug,
+    note_deferrals,
+    record_obligations,
+)
+from src.terminal_ui import TerminalUI
+from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
+
+
+STAGE_01, STAGE_03, STAGE_05 = STAGES[0], STAGES[2], STAGES[4]
+DEBT = "State a power analysis and justify the sample size before running any experiment."
+OTHER = "Report a confidence interval for every metric, computed from the raw measurements."
+
+
+class LedgerTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.memory, "# Memory\n")
+
+
+class RecordTest(LedgerTestBase):
+    def test_an_approval_can_leave_a_debt(self) -> None:
+        added = record_obligations(
+            self.paths, stage=STAGE_01,
+            entries=[{"obligation": DEBT, "target_stage": "03_study_design"}],
+        )
+        self.assertEqual(len(added), 1)
+        self.assertEqual(added[0].target_stage, STAGE_03.slug)
+        self.assertEqual(added[0].status, OPEN)
+
+    def test_the_ledger_is_an_auditable_artifact(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        payload = json.loads(ledger_path(self.paths).read_text(encoding="utf-8"))
+        self.assertEqual(payload["obligations"][0]["origin_stage"], STAGE_01.slug)
+
+    def test_a_bare_string_is_accepted(self) -> None:
+        self.assertEqual(len(record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])), 1)
+
+    def test_a_target_stage_may_be_a_number(self) -> None:
+        added = record_obligations(self.paths, stage=STAGE_01, entries=[{"obligation": DEBT, "target_stage": "5"}])
+        self.assertEqual(added[0].target_stage, STAGE_05.slug)
+
+    def test_an_unrecognised_target_becomes_any_later_stage(self) -> None:
+        added = record_obligations(self.paths, stage=STAGE_01, entries=[{"obligation": DEBT, "target_stage": "nonsense"}])
+        self.assertIsNone(added[0].target_stage)
+
+    def test_a_thin_obligation_is_refused(self) -> None:
+        self.assertEqual(record_obligations(self.paths, stage=STAGE_01, entries=["do better", ""]), [])
+
+    def test_the_length_floor_holds_at_the_boundary(self) -> None:
+        self.assertEqual(record_obligations(self.paths, stage=STAGE_01, entries=["x" * (MIN_OBLIGATION_CHARS - 1)]), [])
+        self.assertEqual(len(record_obligations(self.paths, stage=STAGE_01, entries=["y" * MIN_OBLIGATION_CHARS])), 1)
+
+    def test_a_restatement_is_not_a_second_debt(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        self.assertEqual(record_obligations(self.paths, stage=STAGE_03, entries=["  " + DEBT.upper() + " "]), [])
+
+    def test_the_ledger_is_bounded(self) -> None:
+        record_obligations(
+            self.paths, stage=STAGE_01,
+            entries=[f"Distinct carried obligation number {i} long enough to be checkable." for i in range(MAX_OBLIGATIONS + 8)],
+        )
+        self.assertEqual(len(load_ledger(self.paths).obligations), MAX_OBLIGATIONS)
+
+    def test_a_corrupt_ledger_does_not_take_the_run_down(self) -> None:
+        ledger_path(self.paths).write_text("nonsense", encoding="utf-8")
+        self.assertEqual(load_ledger(self.paths).obligations, [])
+        self.assertEqual(len(record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])), 1)
+
+
+class TargetingTest(LedgerTestBase):
+    def test_a_targeted_obligation_reaches_only_its_stage(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[{"obligation": DEBT, "target_stage": "03_study_design"}])
+        ledger = load_ledger(self.paths)
+        self.assertEqual(len(ledger.open_for(STAGE_03)), 1)
+        self.assertEqual(ledger.open_for(STAGE_05), [])
+
+    def test_an_untargeted_obligation_reaches_every_later_stage(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        ledger = load_ledger(self.paths)
+        self.assertEqual(len(ledger.open_for(STAGE_03)), 1)
+        self.assertEqual(len(ledger.open_for(STAGE_05)), 1)
+
+    def test_an_obligation_never_applies_to_the_stage_that_raised_it(self) -> None:
+        record_obligations(self.paths, stage=STAGE_03, entries=[DEBT])
+        self.assertEqual(load_ledger(self.paths).open_for(STAGE_03), [])
+
+    def test_it_does_not_apply_to_earlier_stages(self) -> None:
+        record_obligations(self.paths, stage=STAGE_03, entries=[DEBT])
+        self.assertEqual(load_ledger(self.paths).open_for(STAGE_01), [])
+
+    def test_normalize_accepts_every_spelling_a_reviewer_reaches_for(self) -> None:
+        # The display-name forms come from a live model, which returned "Study Design".
+        for spelling in ("03_study_design", "3", "03", "Study Design", "study design",
+                         "Stage 03: Study Design", "stage03", "Stage 3"):
+            self.assertEqual(normalize_stage_slug(spelling), STAGE_03.slug, spelling)
+
+    def test_normalize_still_rejects_a_non_stage(self) -> None:
+        for junk in ("nonsense", "", None, "   ", "Stage 99"):
+            self.assertIsNone(normalize_stage_slug(junk), junk)
+
+
+class DischargeTest(LedgerTestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT, OTHER])
+
+    def test_a_discharged_obligation_stops_being_carried(self) -> None:
+        closed = discharge_obligations(self.paths, stage=STAGE_03, obligation_ids=["O001"], note="done")
+        self.assertEqual(len(closed), 1)
+        ledger = load_ledger(self.paths)
+        self.assertEqual(ledger.by_id("O001").status, DISCHARGED)
+        self.assertEqual(ledger.by_id("O001").discharged_by, STAGE_03.slug)
+        self.assertEqual([o.obligation_id for o in ledger.open_for(STAGE_05)], ["O002"])
+
+    def test_discharging_the_same_one_twice_is_a_no_op(self) -> None:
+        discharge_obligations(self.paths, stage=STAGE_03, obligation_ids=["O001"])
+        self.assertEqual(discharge_obligations(self.paths, stage=STAGE_05, obligation_ids=["O001"]), [])
+
+    def test_an_unknown_id_is_ignored(self) -> None:
+        self.assertEqual(discharge_obligations(self.paths, stage=STAGE_03, obligation_ids=["O999", ""]), [])
+
+    def test_ids_are_matched_case_insensitively(self) -> None:
+        self.assertEqual(len(discharge_obligations(self.paths, stage=STAGE_03, obligation_ids=["o001"])), 1)
+
+
+class DeferralTest(LedgerTestBase):
+    def test_a_deferral_is_counted_not_silent(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        note_deferrals(self.paths, stage=STAGE_03)
+        note_deferrals(self.paths, stage=STAGE_05)
+        self.assertEqual(load_ledger(self.paths).by_id("O001").deferrals, 2)
+
+    def test_the_deferral_count_is_shown_to_later_reviewers(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        note_deferrals(self.paths, stage=STAGE_03)
+        self.assertIn("already deferred 1x", format_for_review_prompt(load_ledger(self.paths), STAGE_05))
+
+    def test_a_discharged_obligation_is_not_deferred(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        discharge_obligations(self.paths, stage=STAGE_03, obligation_ids=["O001"])
+        self.assertEqual(note_deferrals(self.paths, stage=STAGE_05), 0)
+
+
+class RenderingTest(LedgerTestBase):
+    def test_an_empty_ledger_renders_nothing(self) -> None:
+        self.assertEqual(format_for_stage_prompt(ObligationLedger(), STAGE_03), "")
+        self.assertEqual(format_for_review_prompt(ObligationLedger(), STAGE_03), "")
+
+    def test_the_stage_prompt_says_ignoring_one_is_grounds_for_rejection(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        rendered = format_for_stage_prompt(load_ledger(self.paths), STAGE_03)
+        self.assertIn(DEBT, rendered)
+        self.assertIn("grounds for this stage to be rejected", rendered)
+
+    def test_the_review_prompt_forbids_discharging_on_a_promise(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        rendered = format_for_review_prompt(load_ledger(self.paths), STAGE_03)
+        self.assertIn("not on a promise", rendered.replace("Do not discharge one on a promise", "not on a promise"))
+        self.assertIn("grounds to refuse", rendered)
+
+    def test_summary_counts_open_versus_total(self) -> None:
+        self.assertIn("no carried-forward", ledger_summary(ObligationLedger()))
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT, OTHER])
+        discharge_obligations(self.paths, stage=STAGE_03, obligation_ids=["O001"])
+        self.assertIn("1 open / 2 total", ledger_summary(load_ledger(self.paths)))
+
+
+class ReviewSchemaTest(LedgerTestBase):
+    def _reviewer(self) -> AutomatedReviewer:
+        return AutomatedReviewer("claude", model="opus", fake_mode=True,
+                                 ui=TerminalUI(output_stream=io.StringIO(), interactive=False))
+
+    def test_the_prompt_asks_for_carry_forward_on_approval(self) -> None:
+        prompt = self._reviewer()._build_review_prompt(
+            paths=self.paths, stage=STAGE_01, attempt_no=1,
+            stage_markdown="# Stage 01: Literature Survey\n", suggestions=["a", "b", "c"],
+        )
+        self.assertIn("carry_forward", prompt)
+        self.assertIn("approve without letting go", prompt)
+
+    def test_inherited_obligations_reach_the_next_review(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        prompt = self._reviewer()._build_review_prompt(
+            paths=self.paths, stage=STAGE_03, attempt_no=1,
+            stage_markdown="# Stage 03: Study Design\n", suggestions=["a", "b", "c"],
+        )
+        self.assertIn("Inherited Obligations", prompt)
+        self.assertIn(DEBT, prompt)
+
+    def test_carry_forward_and_discharged_are_parsed(self) -> None:
+        raw = json.dumps({
+            "decision": "approve", "reason": "ok",
+            "carry_forward": [{"obligation": DEBT, "target_stage": "03"}],
+            "discharged": ["O001"],
+        })
+        decision = self._reviewer()._parse_decision(raw)
+        self.assertEqual(decision.choice, "5")
+        self.assertEqual(decision.discharged, ["O001"])
+        self.assertEqual(decision.carry_forward[0]["obligation"], DEBT)
+
+    def test_a_decision_without_the_new_fields_still_parses(self) -> None:
+        decision = self._reviewer()._parse_decision('{"decision":"approve","reason":"ok"}')
+        self.assertEqual(decision.carry_forward, [])
+        self.assertEqual(decision.discharged, [])
+
+    def test_malformed_new_fields_are_ignored_not_fatal(self) -> None:
+        decision = self._reviewer()._parse_decision(
+            '{"decision":"approve","reason":"ok","carry_forward":"nope","discharged":5}'
+        )
+        self.assertEqual(decision.carry_forward, [])
+        self.assertEqual(decision.discharged, [])
+
+
+class StubOperator:
+    model = "opus"
+    backend_name = "claude"
+
+
+class ManagerSettlementTest(LedgerTestBase):
+    """The loop only closes if the real decision funnel settles the ledger."""
+
+    def _manager(self) -> ResearchManager:
+        return ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=self.paths.run_root.parent,
+            operator=StubOperator(),
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+
+    def _settle(self, stage, choice, *, carry=None, discharged=None):
+        self._manager()._settle_obligations(
+            paths=self.paths, stage=stage, attempt_no=1,
+            decision=ReviewDecision(choice=choice, decision_token="t", reason="r",
+                                    carry_forward=carry or [], discharged=discharged or []),
+        )
+        return load_ledger(self.paths)
+
+    def test_an_approval_records_its_obligations(self) -> None:
+        ledger = self._settle(STAGE_01, "5", carry=[{"obligation": DEBT, "target_stage": "03"}])
+        self.assertEqual(len(ledger.obligations), 1)
+        self.assertIn("obligation_recorded", read_text(self.paths.logs))
+
+    def test_a_later_approval_discharges_and_logs(self) -> None:
+        self._settle(STAGE_01, "5", carry=[DEBT])
+        ledger = self._settle(STAGE_03, "5", discharged=["O001"])
+        self.assertEqual(ledger.by_id("O001").status, DISCHARGED)
+        self.assertIn("obligation_discharged", read_text(self.paths.logs))
+
+    def test_an_undischarged_obligation_is_recorded_as_deferred(self) -> None:
+        self._settle(STAGE_01, "5", carry=[DEBT])
+        ledger = self._settle(STAGE_03, "5")
+        self.assertEqual(ledger.by_id("O001").deferrals, 1)
+        self.assertIn("obligations_deferred", read_text(self.paths.logs))
+
+    def test_a_refusal_does_not_defer(self) -> None:
+        """A refused stage gets another attempt; it has not carried anything past itself."""
+        self._settle(STAGE_01, "5", carry=[DEBT])
+        ledger = self._settle(STAGE_03, "4")
+        self.assertEqual(ledger.by_id("O001").deferrals, 0)
+
+    def test_settling_in_one_decision_does_not_defer_what_it_just_raised(self) -> None:
+        self._settle(STAGE_01, "5", carry=[DEBT])
+        ledger = self._settle(STAGE_03, "5", discharged=["O001"], carry=[OTHER])
+        self.assertEqual(ledger.by_id("O001").status, DISCHARGED)
+        self.assertEqual(ledger.by_id("O002").deferrals, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The gate learns from its **refusals** (#121). But most stages are **approved**, and an approval threw away everything the reviewer noticed — which is where most of the review actually lives.

One of the pilot reviews said exactly the right thing, and was wrong about the mechanism:

> *"The remaining gaps … are Stage 03/04/07 work and are already **recorded as carried-forward obligations**, not Stage 01 blockers."*

**Nothing recorded them.** They went into a log line and were never seen again. This builds the thing that review assumed existed.

## The loop

An approving reviewer attaches obligations via `carry_forward`. Each is injected into the prompt of the stage it targets **and** into that stage's review, so the reviewer who inherits one is asked whether it was met:

```
approval ──obligation──▶ later stage prompt ──▶ that stage's review ──▶ discharged
                                                          │
                                                 not met ─┴──▶ refusal
```

Recorded in `runs/<run_id>/obligations.json`.

## Three constraints against theatre

- **Only a reviewer may discharge one.** The stage that owes it cannot mark its own homework — it does the work and says so, a reviewer decides. Otherwise an executor under pressure closes its own debts.
- **Deferral is counted, never silent.** An obligation may be pushed later, but it stays open and its deferral count is shown to every subsequent reviewer (`already deferred 2x`), so "carried forward" cannot quietly become "dropped".
- **Bounded and deduplicated**, so a reviewer restating itself cannot manufacture rigour.

Ordering matters and is tested: discharges apply *before* deferrals are counted, so an approval that both settles an old debt and raises a new one doesn't immediately mark the new one deferred. A refusal defers nothing — the stage gets another attempt and hasn't carried anything past itself.

## What live testing changed

Asked to approve a survey missing a power analysis, a real model returned:

```json
{"decision": "approve",
 "carry_forward": [{"obligation": "Conduct and explicitly state a formal power analysis.",
                    "target_stage": "Study Design"}]}
```

It named the target **"Study Design"** — a display name my normalizer rejected, which would have silently degraded the obligation to "any later stage" and lost the targeting the reviewer intended. It now accepts display names, stage titles, and `stage03` forms alongside slugs and numbers. Being lenient about spelling costs nothing here; losing targeting silently costs the whole point.

## Composition

Three mechanisms, one loop at different scopes:

| | teaches from | scope |
|:---|:---|:---|
| #121 review policy | refusals | all later stages |
| **this** | **approvals** | **the stage that owes it** |
| #128 cross-model veto | a different model family | any approval |

857 tests pass, 37 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)