### PR TITLE
Measure whether Stage 02 actually used the pool it was given

### DIFF
--- a/docs/ideation-panel.md
+++ b/docs/ideation-panel.md
@@ -82,6 +82,36 @@ of one claim score 0.60–0.78, a related-but-distinct claim about the same vari
 0.28, unrelated claims score 0.00. Titles are excluded from the comparison, because two
 proposers naming one idea differently is exactly the collapse this has to catch.
 
+## Was any of it used?
+
+Widening the pool and being useful are different claims, and the literature turns on the
+distinction. Havranek and Irsova had authors rank *perceived* usefulness and say plainly it is
+"not realized improvement". AgentPanel ends on its ideas being "speculative candidates that
+require expert validation".
+
+So once Stage 02 is approved, each pooled candidate is checked against the approved summary and
+marked adopted or not. The verdict then stops describing the pool and starts describing the
+outcome:
+
+| Outcome | Verdict says |
+| --- | --- |
+| Not yet approved | "...Whether any of them were used is not yet measured." |
+| Stage adopted none | "...Stage 02 adopted none of them and generated its own hypotheses instead, so the pool cost its calls and changed nothing." |
+| Only baseline adopted | "...Stage 02 adopted 2, all from the baseline proposer — a single pass would have supplied everything the stage used." |
+| Others adopted | "...Stage 02 adopted 3, 2 of them from proposers beyond the baseline." |
+
+The check is textual and local, not a model call. Asking a model whether a stage used an idea
+it was shown invites it to say yes, which is the failure this measurement exists to detect.
+
+The adoption bar (0.35) sits **below** the duplicate bar (0.5) on purpose: a stage that took a
+candidate is expected to sharpen and reword it, not paste it. Blocks shorter than 40 characters
+are excluded, and that floor is load-bearing rather than hygiene — against a hypothesis with
+few content words, the fragment "Reported class-size effect" scores 0.57, so without the floor
+a section heading would read as adoption.
+
+Measurement is best-effort and runs after approval: nothing here can unapprove a stage, and a
+run that never seated a panel is a no-op.
+
 ## Cost
 
 `lenses + 1` calls per Stage 02 attempt — six by default, once per attempt. Cheaper than the
@@ -94,6 +124,11 @@ review panel, which pays per gate.
 - **Scoring is one call over the whole pool**, not independent critics per candidate. It orders
   material a later reader judges anyway; paying per candidate would spend more on ranking the
   pool than on generating it.
-- **A widened pool is not a better hypothesis.** AgentPanel measured candidate quality, not
-  downstream research outcomes, and neither does this. If `added_by_other_proposers` stays 0
-  across your runs, the honest reading is that one proposer was enough.
+- **Adoption is not impact.** Knowing Stage 02 built on a candidate says nothing about whether
+  the resulting research was better. AgentPanel measured candidate quality, not downstream
+  outcomes, and this measures uptake, not outcomes either. It closes one gap, not the gap.
+- **Textual adoption can be fooled both ways.** A stage that adopts an idea and rewrites it
+  completely reads as non-adoption; a stage that rejects an idea while discussing it at length
+  can read as adoption. The numbers are a signal across runs, not a verdict on one.
+- **If `adopted` stays 0 across your runs**, the honest reading is that Stage 02 does better
+  from the goal and literature alone, and the panel should be turned off.

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -822,6 +822,20 @@ Required: non-empty string `overall_status`; booleans `pdf_available` and
 Validated by `validate_layout_review` in
 [`src/writing_manifest.py`](../src/writing_manifest.py).
 
+### `workspace/notes/idea_pool.json`
+
+Written only when `--ideation-panel` is active. The Stage 02 candidate pool, with every
+proposal, which ones were folded in as restatements, their novelty/feasibility/relevance
+scores, and an `effect` block.
+
+`effect` answers two separate questions. Before Stage 02 is approved it can only report
+whether the panel **widened** anything (`added_by_other_proposers`); afterwards it also
+reports whether anything was **used** (`adopted`, `adopted_from_other_proposers`,
+`adoption_measured`). Its `verdict` is one sentence, written to be unflattering when that is
+the truth. A readable `idea_pool.md` sits beside it.
+
+See [Ideation Panel](ideation-panel.md).
+
 ### `workspace/reviews/panel/`
 
 Written only when `--review-panel` is active. Per gate, `<stage>_attempt_NN.json` and a

--- a/src/ideation_panel.py
+++ b/src/ideation_panel.py
@@ -142,6 +142,8 @@ class Candidate:
     feasibility: float | None = None
     relevance: float | None = None
     duplicate_of: str | None = None
+    #: Filled after Stage 02 is approved: did the stage actually build on this candidate?
+    adopted: bool | None = None
 
     @property
     def mean_score(self) -> float | None:
@@ -173,6 +175,10 @@ class IdeaPool:
             key=lambda c: (c.mean_score is None, -(c.mean_score or 0.0)),
         )
 
+    @property
+    def adoption_measured(self) -> bool:
+        return any(candidate.adopted is not None for candidate in self.distinct)
+
     def effect(self) -> dict[str, Any]:
         """What the extra proposers added over the first one.
 
@@ -195,7 +201,18 @@ class IdeaPool:
             "abstentions": len(self.abstentions),
             "unreachable": len(self.unreachable),
             "proposer_calls": self.proposer_calls,
-            "verdict": _pool_verdict(len(distinct), len(added), self.proposer_calls),
+            "adoption_measured": self.adoption_measured,
+            "adopted": sum(1 for c in distinct if c.adopted),
+            "adopted_from_baseline_proposer": sum(1 for c in from_baseline if c.adopted),
+            "adopted_from_other_proposers": sum(1 for c in added if c.adopted),
+            "verdict": _pool_verdict(
+                distinct=len(distinct),
+                added=len(added),
+                calls=self.proposer_calls,
+                adoption_measured=self.adoption_measured,
+                adopted=sum(1 for c in distinct if c.adopted),
+                adopted_from_others=sum(1 for c in added if c.adopted),
+            ),
         }
 
     def to_dict(self) -> dict[str, Any]:
@@ -208,18 +225,56 @@ class IdeaPool:
         }
 
 
-def _pool_verdict(distinct: int, added: int, calls: int) -> str:
+def _pool_verdict(
+    *,
+    distinct: int,
+    added: int,
+    calls: int,
+    adoption_measured: bool = False,
+    adopted: int = 0,
+    adopted_from_others: int = 0,
+) -> str:
+    """One sentence about what the panel produced, and — once known — what was used.
+
+    Widening and being useful are different claims, and the multi-agent feedback literature
+    turns on the distinction: authors ranking reports measured *perceived* usefulness "rather
+    than realized improvement", and AgentPanel's own conclusion is that its ideas "remain
+    speculative candidates that require expert validation". Until Stage 02 has actually been
+    approved this can only report the first claim, and it says which one it is making.
+    """
     if distinct == 0:
         return "No candidate hypotheses survived; the stage proceeds without a pool."
+
     if added == 0:
-        return (
+        widened = (
             f"All {distinct} distinct hypotheses came from the baseline proposer; the other "
             f"proposers restated it, at {calls} proposer calls. On this run the panel widened "
             "nothing — consider --ideation-lenses with fewer seats, or dropping it."
         )
+    else:
+        widened = (
+            f"{added} of {distinct} distinct hypotheses came from proposers beyond the "
+            f"baseline, at {calls} proposer calls."
+        )
+
+    if not adoption_measured:
+        return widened + " Whether any of them were used is not yet measured."
+    if adopted == 0:
+        return (
+            widened
+            + " Stage 02 adopted none of them and generated its own hypotheses instead, so the "
+            "pool cost its calls and changed nothing."
+        )
+    if adopted_from_others == 0:
+        return (
+            widened
+            + f" Stage 02 adopted {adopted}, all from the baseline proposer — a single pass "
+            "would have supplied everything the stage used."
+        )
     return (
-        f"{added} of {distinct} distinct hypotheses came from proposers beyond the baseline, "
-        f"at {calls} proposer calls."
+        widened
+        + f" Stage 02 adopted {adopted}, {adopted_from_others} of them from proposers beyond "
+        "the baseline."
     )
 
 
@@ -527,6 +582,76 @@ def _excerpt(path) -> str:
 # ---------------------------------------------------------------------------
 # Artifacts and prompt injection
 # ---------------------------------------------------------------------------
+
+
+#: A pooled hypothesis counts as adopted when some paragraph of the approved stage summary
+#: overlaps it this much. Lower than :data:`DUPLICATE_THRESHOLD` on purpose: a stage that took
+#: a candidate is expected to sharpen and re-word it, not paste it, so the bar for "this is the
+#: same hypothesis, developed" sits below the bar for "these two proposers said one thing".
+ADOPTION_THRESHOLD = 0.35
+
+
+def _paragraphs(markdown: str) -> list[str]:
+    """Split an approved stage summary into the units a hypothesis could live in."""
+    blocks: list[str] = []
+    for block in re.split(r"\n\s*\n", markdown):
+        cleaned = re.sub(r"^[#>\-*\d.\s]+", "", block.strip())
+        if len(cleaned) >= 40:
+            blocks.append(cleaned)
+    return blocks
+
+
+def measure_adoption(pool: IdeaPool, stage_markdown: str, threshold: float = ADOPTION_THRESHOLD) -> IdeaPool:
+    """Mark which pooled candidates the approved stage actually built on.
+
+    This is the measurement both papers say is missing. Havranek and Irsova had authors rank
+    *perceived* usefulness and note plainly that it is not realized improvement; AgentPanel
+    ends on its ideas being "speculative candidates that require expert validation". A pool
+    that widened the options and was then ignored has not helped, and until this runs the pool
+    cannot tell those two outcomes apart.
+
+    Deliberately textual and local rather than a model call. Asking a model whether a stage
+    used an idea it was shown invites it to say yes, which is the failure this measurement
+    exists to detect.
+    """
+    blocks = _paragraphs(stage_markdown)
+    measured: list[Candidate] = []
+    for candidate in pool.candidates:
+        if candidate.duplicate_of is not None:
+            measured.append(candidate)
+            continue
+        best = max((similarity(candidate.statement, block) for block in blocks), default=0.0)
+        measured.append(Candidate(**{**candidate.__dict__, "adopted": best >= threshold}))
+    pool.candidates = measured
+    return pool
+
+
+def load_idea_pool(paths: RunPaths) -> IdeaPool | None:
+    """Rebuild the pool written earlier in this stage, or None when there is not one."""
+    path = paths.notes_dir / IDEA_POOL_FILENAME
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(read_text(path))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("candidates"), list):
+        return None
+
+    fields = set(Candidate.__dataclass_fields__)
+    candidates = [
+        Candidate(**{key: value for key, value in raw.items() if key in fields})
+        for raw in payload["candidates"]
+        if isinstance(raw, dict) and raw.get("statement")
+    ]
+    effect = payload.get("effect") if isinstance(payload.get("effect"), dict) else {}
+    return IdeaPool(
+        candidates=candidates,
+        abstentions=list(payload.get("abstained") or []),
+        unreachable=list(payload.get("unreachable") or []),
+        proposer_calls=int(effect.get("proposer_calls") or 0),
+        baseline_proposer=str(effect.get("baseline_proposer") or ""),
+    )
 
 
 def record_idea_pool(paths: RunPaths, pool: IdeaPool, stage: StageSpec, attempt_no: int) -> dict[str, Any]:

--- a/src/manager.py
+++ b/src/manager.py
@@ -101,7 +101,13 @@ from .stage_graph import (
 from .diagram_gen import post_writing_diagram_hook
 from .terminal_ui import TerminalUI
 from .platform.foundry import generate_paper_package, generate_release_package
-from .ideation_panel import IdeationPanel, format_pool_for_prompt, record_idea_pool
+from .ideation_panel import (
+    IdeationPanel,
+    format_pool_for_prompt,
+    load_idea_pool,
+    measure_adoption,
+    record_idea_pool,
+)
 from .writing_manifest import (
     build_writing_manifest,
     format_manifest_for_prompt,
@@ -577,6 +583,21 @@ class ResearchManager:
 
         record_idea_pool(paths, pool, stage, attempt_no)
         return format_pool_for_prompt(pool)
+
+    def _measure_pool_adoption(self, paths: RunPaths, stage: StageSpec, stage_markdown: str) -> None:
+        """Record which pooled hypotheses the approved stage actually built on.
+
+        Runs whether or not this run seated an ideation panel — a pool written by an earlier
+        resumed attempt still deserves its outcome measured. Best-effort throughout: the
+        stage is already approved, and nothing here may unapprove it.
+        """
+        try:
+            pool = load_idea_pool(paths)
+            if pool is None or not pool.distinct:
+                return
+            record_idea_pool(paths, measure_adoption(pool, stage_markdown), stage, 0)
+        except Exception as exc:  # noqa: BLE001 - measurement must not disturb an approval
+            append_log_entry(paths.logs, f"{stage.slug} idea_pool_adoption_failed", str(exc))
 
     def _generate_writing_review(self, paths: RunPaths) -> dict[str, object]:
         """Produce the Stage 07 triage artifact that matches this run's output format.
@@ -1831,6 +1852,8 @@ class ResearchManager:
                     attempt_no,
                     self._stage_file_paths(stage_markdown),
                 )
+                if stage.slug == "02_hypothesis_generation":
+                    self._measure_pool_adoption(paths, stage, stage_markdown)
                 if stage.slug == "04_implementation":
                     self._freeze_preregistration(paths)
                 self._run_validity_review(paths, stage, stage_markdown)

--- a/tests/test_ideation_panel.py
+++ b/tests/test_ideation_panel.py
@@ -14,6 +14,7 @@ import unittest
 from pathlib import Path
 
 from src.ideation_panel import (
+    ADOPTION_THRESHOLD,
     DEFAULT_LENSES,
     DUPLICATE_THRESHOLD,
     IDEA_POOL_FILENAME,
@@ -23,7 +24,9 @@ from src.ideation_panel import (
     ProposerLens,
     apply_lens_models,
     format_pool_for_prompt,
+    load_idea_pool,
     mark_duplicates,
+    measure_adoption,
     record_idea_pool,
     resolve_lenses,
     similarity,
@@ -455,3 +458,228 @@ class ManagerIntegrationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AdoptionTests(unittest.TestCase):
+    """Widening the pool and being used are different claims, and only one was measured.
+
+    Havranek and Irsova had authors rank perceived usefulness and say plainly it is "not
+    realized improvement"; AgentPanel ends on its ideas being "speculative candidates that
+    require expert validation". A pool that widened the options and was then ignored has not
+    helped, so the outcome is measured rather than assumed.
+    """
+
+    def _pool(self) -> IdeaPool:
+        return IdeaPool(
+            candidates=mark_duplicates([
+                _candidate("mechanism-1", "mechanism", _MECHANISM),
+                _candidate("null-1", "null", _UNRELATED),
+            ]),
+            baseline_proposer="mechanism",
+            proposer_calls=5,
+        )
+
+    def test_a_hypothesis_the_stage_developed_counts_as_adopted(self) -> None:
+        pool = measure_adoption(self._pool(), (
+            "# Stage 02\n\n## Key Results\n\n"
+            "H1: We hypothesise that remittance inflows increase consumption in credit-poor "
+            "households by relaxing their liquidity constraints, and will test it against the "
+            "transitory-income alternative.\n"
+        ))
+        by_id = {c.idea_id: c for c in pool.distinct}
+        self.assertTrue(by_id["mechanism-1"].adopted)
+        self.assertFalse(by_id["null-1"].adopted)
+
+    def test_a_stage_that_ignored_the_pool_is_reported_as_such(self) -> None:
+        pool = measure_adoption(self._pool(), (
+            "# Stage 02\n\n## Key Results\n\n"
+            "H1: Trade openness drives productivity convergence across regions, which we will "
+            "test with a gravity specification on the panel of bilateral flows.\n"
+        ))
+        effect = pool.effect()
+        self.assertTrue(effect["adoption_measured"])
+        self.assertEqual(effect["adopted"], 0)
+        self.assertIn("adopted none of them", effect["verdict"])
+        self.assertIn("cost its calls and changed nothing", effect["verdict"])
+
+    def test_adoption_only_from_the_baseline_says_a_single_pass_would_have_done(self) -> None:
+        pool = measure_adoption(self._pool(), (
+            "# Stage 02\n\n## Key Results\n\n"
+            "H1: Remittance inflows increase household consumption in credit-poor households "
+            "because they relax liquidity constraints.\n"
+        ))
+        self.assertIn("a single pass would have supplied", pool.effect()["verdict"])
+
+    def test_adoption_beyond_the_baseline_is_credited(self) -> None:
+        pool = measure_adoption(self._pool(), (
+            "# Stage 02\n\n## Key Results\n\n"
+            "H1: Remittance inflows increase consumption in credit-poor households by relaxing "
+            "liquidity constraints.\n\n"
+            "H2: The observed correlation may be a selection artifact, since households that "
+            "receive remittances differ systematically in unobserved ways; we will test this "
+            "with household fixed effects.\n"
+        ))
+        effect = pool.effect()
+        self.assertEqual(effect["adopted"], 2)
+        self.assertEqual(effect["adopted_from_other_proposers"], 1)
+        self.assertIn("1 of them from proposers beyond the baseline", effect["verdict"])
+
+    def test_before_measurement_the_verdict_does_not_claim_usefulness(self) -> None:
+        effect = self._pool().effect()
+        self.assertFalse(effect["adoption_measured"])
+        self.assertIn("not yet measured", effect["verdict"])
+
+    def test_a_duplicate_is_never_credited_with_adoption(self) -> None:
+        pool = IdeaPool(
+            candidates=mark_duplicates([
+                _candidate("mechanism-1", "mechanism", _MECHANISM),
+                _candidate("contrarian-1", "contrarian", _RESTATED),
+            ]),
+            baseline_proposer="mechanism",
+        )
+        measure_adoption(pool, f"# Stage 02\n\n## Key Results\n\n{_MECHANISM}\n")
+        folded = next(c for c in pool.candidates if c.duplicate_of is not None)
+        self.assertIsNone(folded.adopted)
+
+    def test_a_short_fragment_cannot_be_mistaken_for_adoption(self) -> None:
+        """The length floor is load-bearing, and this is the case that shows it.
+
+        A hypothesis with few content words is easy to falsely match: the fragment
+        "Reported class-size effect" scores 0.57 against the statement below, well over the
+        0.35 bar, purely because Jaccard's union is small. Only the length floor stops a
+        heading fragment from being read as the stage having adopted the idea.
+        """
+        short = "Publication bias inflates the reported class-size effect."
+        pool = IdeaPool(
+            candidates=[_candidate("a-1", "mechanism", short)],
+            baseline_proposer="mechanism",
+        )
+        # The fragment on its own would clear the bar; as a heading it must not.
+        self.assertGreater(similarity(short, "Reported class-size effect"), ADOPTION_THRESHOLD)
+
+        measure_adoption(pool, "# Stage 02\n\n## Reported class-size effect\n\n## Files Produced\n")
+
+        self.assertEqual(pool.effect()["adopted"], 0)
+
+    def test_boilerplate_headings_alone_are_never_adoption(self) -> None:
+        pool = measure_adoption(self._pool(), "# Stage 02\n\n## Key Results\n\n## Files Produced\n")
+        self.assertEqual(pool.effect()["adopted"], 0)
+
+
+class PoolRoundTripTests(unittest.TestCase):
+    def _written(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.memory, "# Approved Run Memory\n")
+        pool = IdeaPool(
+            candidates=mark_duplicates([
+                _candidate("mechanism-1", "mechanism", _MECHANISM),
+                _candidate("contrarian-1", "contrarian", _RESTATED),
+                _candidate("null-1", "null", _UNRELATED),
+            ]),
+            abstentions=["regime"],
+            baseline_proposer="mechanism",
+            proposer_calls=5,
+        )
+        record_idea_pool(paths, pool, STAGE_02, 1)
+        return paths
+
+    def test_a_written_pool_can_be_read_back(self) -> None:
+        paths = self._written()
+        pool = load_idea_pool(paths)
+        self.assertIsNotNone(pool)
+        assert pool is not None
+        self.assertEqual(len(pool.distinct), 2)
+        self.assertEqual(pool.baseline_proposer, "mechanism")
+        self.assertEqual(pool.proposer_calls, 5)
+        self.assertEqual(pool.abstentions, ["regime"])
+
+    def test_duplicate_marks_survive_the_round_trip(self) -> None:
+        pool = load_idea_pool(self._written())
+        assert pool is not None
+        folded = next(c for c in pool.candidates if c.idea_id == "contrarian-1")
+        self.assertEqual(folded.duplicate_of, "mechanism-1")
+
+    def test_a_missing_or_corrupt_pool_reads_as_none(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(paths)
+        self.assertIsNone(load_idea_pool(paths))
+        write_text(paths.notes_dir / IDEA_POOL_FILENAME, "{ not json")
+        self.assertIsNone(load_idea_pool(paths))
+
+    def test_the_measured_outcome_is_written_back(self) -> None:
+        paths = self._written()
+        pool = load_idea_pool(paths)
+        assert pool is not None
+        measure_adoption(pool, f"# Stage 02\n\n## Key Results\n\n{_MECHANISM} We will test it.\n")
+        record_idea_pool(paths, pool, STAGE_02, 0)
+
+        payload = json.loads(read_text(paths.notes_dir / IDEA_POOL_FILENAME))
+        self.assertTrue(payload["effect"]["adoption_measured"])
+        self.assertEqual(payload["effect"]["adopted"], 1)
+        self.assertIn("a single pass would have supplied", payload["effect"]["verdict"])
+
+
+class AdoptionIntegrationTests(unittest.TestCase):
+    def _manager_and_paths(self):
+        import io as _io
+        from unittest.mock import MagicMock
+        from src.manager import ResearchManager
+
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        runs_dir = Path(tmp_dir.name) / "runs"
+        runs_dir.mkdir()
+        paths = build_run_paths(runs_dir / "20260101_000000")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Goal")
+        write_text(paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025")
+
+        operator = MagicMock()
+        operator.model = "sonnet"
+        operator.backend_name = "claude"
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=runs_dir,
+            operator=operator,
+            ui=TerminalUI(output_stream=_io.StringIO(), interactive=False),
+        )
+        return manager, paths
+
+    def test_approving_stage_02_measures_the_pool(self) -> None:
+        manager, paths = self._manager_and_paths()
+        record_idea_pool(
+            paths,
+            IdeaPool(
+                candidates=mark_duplicates([_candidate("mechanism-1", "mechanism", _MECHANISM)]),
+                baseline_proposer="mechanism",
+                proposer_calls=5,
+            ),
+            STAGE_02,
+            1,
+        )
+
+        manager._measure_pool_adoption(
+            paths, STAGE_02,
+            f"# Stage 02\n\n## Key Results\n\n{_MECHANISM} We will test it against the alternative.\n",
+        )
+
+        payload = json.loads(read_text(paths.notes_dir / IDEA_POOL_FILENAME))
+        self.assertTrue(payload["effect"]["adoption_measured"])
+        self.assertEqual(payload["effect"]["adopted"], 1)
+
+    def test_a_run_with_no_pool_is_a_no_op(self) -> None:
+        manager, paths = self._manager_and_paths()
+        manager._measure_pool_adoption(paths, STAGE_02, "# Stage 02\n\nNo pool was ever written.\n")
+        self.assertFalse((paths.notes_dir / IDEA_POOL_FILENAME).exists())
+
+    def test_a_corrupt_pool_cannot_disturb_an_approval(self) -> None:
+        manager, paths = self._manager_and_paths()
+        write_text(paths.notes_dir / IDEA_POOL_FILENAME, "{ not json")
+        manager._measure_pool_adoption(paths, STAGE_02, "# Stage 02\n\nApproved.\n")
+        self.assertEqual(read_text(paths.notes_dir / IDEA_POOL_FILENAME), "{ not json\n")


### PR DESCRIPTION
#131 could report whether the ideation panel **widened** the candidate pool. It could not report whether any of the widening was **used** — and the docs said so:

> a widened pool is not a better hypothesis... neither AgentPanel nor this measures downstream research outcomes

That gap is the one both papers name:

- Havranek & Irsova had authors rank *perceived* usefulness and state plainly it is **"not realized improvement."**
- AgentPanel ends on its ideas being **"speculative candidates that require expert validation."**

A pool that widened the options and was then ignored has not helped, and until now the artifact could not tell that outcome from success.

## What changed

After Stage 02 is approved, each pooled candidate is checked against the approved summary. The verdict stops describing the pool and starts describing the outcome:

| Outcome | Verdict |
|:---|:---|
| Not yet approved | "…Whether any of them were used is not yet measured." |
| Adopted none | "…Stage 02 adopted none of them and generated its own hypotheses instead, so the pool cost its calls and changed nothing." |
| Only baseline adopted | "…Stage 02 adopted 2, all from the baseline proposer — **a single pass would have supplied everything the stage used.**" |
| Others adopted | "…Stage 02 adopted 3, 2 of them from proposers beyond the baseline." |

Before approval it refuses to let a diversity number stand in for a usefulness claim.

The check is **textual and local, not a model call**. Asking a model whether a stage used an idea it was shown invites it to say yes, which is precisely the failure this measurement exists to detect. The adoption bar (0.35) sits *below* the duplicate bar (0.5) on purpose: a stage that took a candidate is expected to sharpen and reword it, not paste it.

Best-effort and post-approval throughout — nothing here can unapprove a stage, a corrupt pool file is ignored, and a run that never seated a panel is a no-op.

## A test that held nothing, found by mutation

Worth calling out because it nearly shipped.

Removing the 40-character block floor killed **no test**, so the floor looked like decoration. It is not: against a hypothesis with few content words, the fragment `"Reported class-size effect"` scores **0.57** — well over the 0.35 bar — so without the floor a section heading reads as adoption.

My original test used a *long* hypothesis, where short blocks mathematically cannot reach the bar. It passed with or without the mechanism it claimed to check. Replaced with one that pins the case that actually matters, and which the mutant now kills.

## Verification

1,039 tests, 14 new. Mutation-verified:

| Mutant | Tests killed |
|:---|:---|
| mark everything adopted | 5 |
| drop the "not yet measured" wording | 1 |
| remove the 40-char block floor | 1 (0 before the test was fixed) |

Control passes.

## Limits, written down

- **Adoption is not impact.** Knowing Stage 02 built on a candidate says nothing about whether the research got better. This closes one gap, not the gap.
- **Textual adoption can be fooled both ways** — a fully rewritten idea reads as non-adoption; a rejected idea discussed at length can read as adoption. A signal across runs, not a verdict on one.
- If `adopted` stays 0 across your runs, the honest reading is that Stage 02 does better from the goal and literature alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)