### PR TITLE
Turn self-improvement on by default, and fix the two checks that could never pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Control model | Human approval by default, with an optional strict reviewer-agent gate for unattended runs |
 | Research unit | A reproducible run under `runs/<run_id>/` |
 | Workflow shape | Nine stages as a **directed graph** the run navigates; the linear sequence is one path through it |
-| Improvement | Drafts are measured and ratcheted, so a stage can only get better — and the score is blind to what the run concluded |
+| Improvement | On by default: drafts are measured and ratcheted, so a stage can only get better — and the score is blind to what the run concluded |
 | Quality bar | Artifact-backed outputs, not markdown-only summaries |
 | Recovery | Resume, redo-stage, rollback-stage, stage-local continuation |
 
@@ -142,7 +142,7 @@ It is:
 
 Latest mainline updates:
 
-- **2026-08-06**: Added recursive self-improvement. The nine stages are now a **directed graph** the run navigates (`--stage-graph adaptive`), with the agent choosing the move out of each node among the ones AutoR's guards leave open (`--routing auto`). Stage drafts are scored against a rigour rubric read off disk and iterated under a champion ratchet, so a stage can only improve (`--evolve`); a round that scores worse is reverted, and a round that changes a hypothesis verdict is rejected outright. An optional cross-run archive learns which moves pay (`--archive`). All of it is off by default: a run that passes none of these flags walks 01 through 08 exactly as before, through the same engine. See [Recursive Self-Improvement](docs/self-improvement.md).
+- **2026-08-06**: **Recursive self-improvement is now the default.** The nine stages are a **directed graph** the run navigates: an analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it, and the move into Stage 07 stays closed until every hypothesis carries a verdict. The stage that just ran chooses the next move, among the ones AutoR's guards leave open. Every valid draft is scored against a rigour rubric read off disk and held to a champion ratchet, so the draft that gets promoted is the best one the run produced rather than the last one — that half costs nothing, because the rubric never calls a backend. Two improvement rounds per stage are budgeted on top, and a stage the rubric has nothing to say about spends none of them. A round that scores worse is reverted; a round that changes a hypothesis verdict is rejected outright. Each finished run records its route and measured fitness in a cross-run archive, which compares every graph edge against runs that reached the same node and did not take it. Opt out with `--stage-graph linear`, `--routing off`, `--no-evolve`, `--no-archive`. See [Recursive Self-Improvement](docs/self-improvement.md).
 - **2026-06-02**: Added a configurable Codex sandbox mode. Codex-backed runs still default to `workspace-write`, but users who intentionally need remote GPU or SSH execution can now opt into `--codex-sandbox danger-full-access`; the setting is persisted in `run_config.json` and preserved on resume.
 - **2026-05-10**: Refined the terminal-first run experience. Stage 00 now uses a dedicated clarification flow: the first intake pass asks the user questions one by one with selectable options, custom answers, and skip; the revised intake brief then uses a compact refine / approve / abort menu instead of showing the normal suggestion template. The terminal UI also keeps colored frames on wrapped body rows, handles long lines and wide characters more reliably, and the Codex backend now uses the current `--sandbox workspace-write` execution flag instead of the deprecated Codex CLI `--full-auto` flag.
 - **2026-04-20**: Added an optional `--full-auto` approval mode. The execution loop is unchanged, but the manual approval gate can now be replaced by a strict simulated reviewer agent backed by Claude or Codex, with reviewer settings persisted in `run_config.json`.
@@ -333,18 +333,22 @@ For Codex-backed runs, AutoR defaults to `--codex-sandbox workspace-write`. If a
 Valid stage identifiers include `03`, `3`, and `03_study_design`.
 
 ```bash
-# Let the run navigate its own topology: backward moves enabled, agent routing.
-python main.py --goal "..." --stage-graph adaptive --routing auto
+# Self-improvement is on by default. This run navigates the stage graph, scores
+# every draft, keeps the best, and records its route in ~/.autor/archive.
+python main.py --goal "..."
 
-# Measured self-improvement rounds inside each stage.
-python main.py --goal "..." --evolve --evolve-rounds 3
+# What the archive has learned across runs so far.
+python main.py --archive-report
 
-# Everything, plus a cross-run archive that learns which moves pay.
-python main.py --goal "..." --stage-graph adaptive --routing auto \
-               --evolve --archive ~/.autor/archive
+# Spend more on improvement, or none at all.
+python main.py --goal "..." --evolve-rounds 4
+python main.py --goal "..." --evolve-rounds 0     # measure and ratchet, no extra passes
 
-# What the archive has learned so far.
-python main.py --archive ~/.autor/archive --archive-report
+# Opt out entirely: the strict 01-through-08 sequence, last draft wins.
+python main.py --goal "..." --stage-graph linear --routing off --no-evolve --no-archive
+
+# Let the archive pick the topology, once it has something to say.
+python main.py --goal "..." --archive-steer
 ```
 
 ### Studio (browser UI)
@@ -464,9 +468,10 @@ flowchart TD
 
 ### The Stage Graph
 
-The nine stages are nodes in a directed graph. The default topology has one edge
-out of each node, which is the sequence above. `--stage-graph adaptive` adds the
-backward moves, and the run chooses.
+The nine stages are nodes in a directed graph, and that graph is what a run walks
+by default. Forward edges advance; backward edges exist for the conditions that
+actually occur in research. `--stage-graph linear` restores the strict sequence,
+which is the same graph with the backward edges removed.
 
 ```mermaid
 flowchart LR
@@ -496,26 +501,45 @@ be written up. That check is over artifacts on disk, so it is not something an
 agent can argue its way past — a gated edge is simply not on the menu it chooses
 from.
 
-A refusal or a routing failure falls back to the forward edge, so the worst case
-is the linear pipeline rather than a stall. Two budgets bound the walk:
-`--graph-max-visits` per stage and `--graph-max-steps` overall.
+**A backward move is only ever a deliberate choice.** The default is always the
+forward edge, and when a guard has closed it the default advances anyway and lets
+the stage's own validation — unchanged, and still refusing a Stage 07 that writes
+up unadjudicated hypotheses — be the gate it always was. A guard is a routing
+preference; the gate is the gate. So a refusal, a routing failure, or a run nobody
+is steering all come out as the linear pipeline rather than as a stall, and going
+back is something the run does on purpose or not at all.
+
+Two budgets bound the walk: `--graph-max-visits` per stage and `--graph-max-steps`
+overall.
 
 ### Self-Improvement Rounds
 
-With `--evolve`, a stage that produces a valid draft is measured against a rigour
-rubric read off disk — do the paths it names resolve, do the numbers it reports
-appear in a results file, did it produce artifacts during *this* execution, is the
-decision ledger four different things. AutoR then spends further rounds targeting
-the criteria that lost points.
+Every valid stage draft is measured against a rigour rubric read off disk — do the
+paths it names resolve, do the numbers it reports appear in a results file, did it
+produce artifacts during *this* execution, is the decision ledger four different
+things rather than one sentence four times.
 
-The best-scoring draft is what gets promoted. A round that scores worse is
-reverted, so a stage can only improve. A round that changes a hypothesis verdict
-is rejected outright, whatever it scored — the rubric is blind to what the run
-concluded, which removes the incentive, and the drift check removes the
-possibility.
+**Measuring is free and always on.** The rubric reads the run off disk and never
+calls a backend, so the property it buys costs nothing: the draft that gets
+promoted is the best one the run produced, not the last one. That is the half that
+was missing before — AutoR could iterate, but "later" was the only ordering it had,
+so a refinement that dropped a resolving reference was promoted on exactly the same
+terms as one that fixed something.
 
-A revision a *human* asked for always stands. The ratchet governs AutoR's own
-rounds, not the direction it is given.
+**Improvement rounds are the half that costs**, and they are budgeted separately
+from `--max-attempts`, which bounds a stage that is *failing* rather than one being
+improved. Two per stage by default, and a stage whose rubric has no shortfall worth
+acting on spends none of them — a round aimed at a criterion already at full marks
+produces churn, so AutoR does not buy one. `--evolve-rounds 0` measures without
+polishing; `--no-evolve` restores the old behaviour entirely.
+
+A round that scores worse is reverted, so a stage can only improve. A round that
+changes a hypothesis verdict is rejected outright, whatever it scored — the rubric
+is blind to what the run concluded, which removes the incentive, and the drift
+check removes the possibility.
+
+A revision a *human* asked for always stands, whatever it measures. The ratchet
+governs AutoR's own rounds, not the direction it is given.
 
 Full mechanism, and the reasoning behind each refusal, in
 [docs/self-improvement.md](docs/self-improvement.md).
@@ -889,11 +913,13 @@ A run with only markdown notes does not pass validation.
 
 - optional intake stage and resource ingestion
 - 9-stage workflow: optional intake plus eight formal research stages
-- the stages as a navigable directed graph, with guarded backward moves
-- agent-chosen routing constrained to the moves the guards leave open
-- measured self-improvement rounds under a champion ratchet
-- an outcome-blind rigour rubric, and verdict-drift rejection
-- an optional cross-run archive of topology variants and edge payoffs
+- the stages as a navigable directed graph, with guarded backward moves (default)
+- agent-chosen routing constrained to the moves the guards leave open (default)
+- an outcome-blind rigour rubric and a champion ratchet on every draft (default)
+- measured improvement rounds, budgeted and skipped where there is no headroom
+- verdict-drift rejection, so an improvement round cannot move a finding
+- a cross-run archive of routes and edge payoffs, recording by default and
+  steering only when asked
 - mandatory human approval after every stage
 - Claude Code or Codex as the execution layer
 - Stage 00 clarification Q&A plus a compact intake approval flow

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -252,20 +252,22 @@ Neither flag does anything without `--resume-run`.
 
 ### Stage graph and self-improvement
 
-All of these are off by default. See [Recursive Self-Improvement](self-improvement.md)
-for the mechanism and the reasoning behind each refusal.
+On by default. See [Recursive Self-Improvement](self-improvement.md) for the
+mechanism and the reasoning behind each refusal.
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--stage-graph {linear,adaptive}` | `linear` | How the run moves between stages. `linear` is one edge out of each node, which is the sequence AutoR has always run. `adaptive` adds ten backward moves, so an analysis that exposes a design flaw can send the run to Stage 03 instead of writing up around it. The move into Stage 07 is guarded on every hypothesis having a verdict. Preserved on resume. |
-| `--routing {off,auto,agent}` | `off` | Who chooses the move out of a completed stage. `off` always takes the graph's default edge. `auto` asks the backend wherever more than one move is live — on a linear graph that is never, so it costs nothing there. `agent` asks at every node. AutoR decides which moves are available by evaluating guards against artifacts on disk; the backend only chooses among those, and a choice outside the menu falls back to the forward edge. Preserved on resume. |
+| `--stage-graph {linear,adaptive}` | `adaptive` | How the run moves between stages. `adaptive` is the eight stages as a directed graph with backward moves: an analysis that exposes a design flaw sends the run back to Stage 03 instead of writing up around it, and the move into Stage 07 stays closed until every hypothesis carries a verdict. `linear` restores the strict sequence — the same graph with the backward edges removed. Preserved on resume. |
+| `--routing {off,auto,agent}` | `auto` | Who chooses the move out of a completed stage. `auto` asks the backend only where more than one move is live, so a linear run never pays for it. `agent` asks at every node; `off` always takes the graph's default edge. AutoR decides which moves are available by evaluating guards against artifacts on disk; the backend only chooses among those, and a choice outside the menu falls back to the forward edge. Preserved on resume. |
 | `--graph-max-steps N` | `20` | Stage executions allowed in one walk. Only bites in adaptive mode; a linear walk cannot exceed eight. |
 | `--graph-max-visits N` | `3` | Times one stage may be entered. A revisit is a productive move; the fourth entry into the same stage is a loop. |
-| `--evolve` | off | Score each valid stage draft against a rigour rubric read off disk, then spend further rounds targeting the criteria that lost points. The best-scoring draft is promoted; a round that scores worse is reverted. A round that changes a hypothesis verdict is rejected outright. A revision a human asked for always stands. |
-| `--evolve-rounds N` | `3` with `--evolve` | Self-improvement rounds per stage. Implies `--evolve` when above zero. Budgeted separately from `--max-attempts`, which bounds a stage that is *failing* rather than one being improved. Rounds also stop after two consecutive rounds with no gain. Preserved on resume. |
-| `--evolve-stages STAGE [STAGE ...]` | all | Restrict self-improvement to these stage slugs or numbers, e.g. `06_analysis` or `5 6 7`. |
-| `--archive PATH` | — | Directory holding the cross-run topology archive. AutoR records this run's route and measured fitness there, compares each edge against runs that reached the same node and did not take it, and samples the topology it runs from what the archive has learned. Requires `--evolve`, which is what produces the fitness. A learned prior only reorders which move is preferred; it can never open a guarded edge. |
-| `--archive-report` | off | Print what the archive at `--archive` has learned, and exit. |
+| `--evolve` / `--no-evolve` | on | Score every valid draft against a rigour rubric read off disk and run the champion ratchet: the best-scoring draft is promoted, not the last one, and a self-initiated round that scores worse is reverted. Costs nothing — the rubric never calls a backend. `--no-evolve` restores the old behaviour, where whichever draft came last was promoted. Preserved on resume. |
+| `--evolve-rounds N` | `2` | Improvement rounds per stage beyond the first draft. This is the half that costs backend calls. A stage whose rubric has no shortfall worth acting on spends none of them, and a `--fake-operator` run spends none at all. Budgeted separately from `--max-attempts`, which bounds a stage that is failing rather than one being improved. `0` measures without polishing. Preserved on resume. |
+| `--evolve-stages STAGE [...]` | all | Restrict improvement rounds to these stage slugs or numbers, e.g. `06_analysis` or `5 6 7`. |
+| `--archive PATH` | `~/.autor/archive` | Where the cross-run archive lives. Each finished run records its route and measured fitness, and each edge is compared against runs that reached the same node and did not take it. Recording only. |
+| `--no-archive` | off | Do not record this run in the archive. |
+| `--archive-steer` / `--no-archive-steer` | **off** | Let the archive choose the topology this run uses, rather than only recording what it did. A run silently using a different topology from the one asked for is not a surprise a research tool gets to spring on anyone; turn this on once `--archive-report` shows the archive has something to say. A learned prior only reorders which move is preferred — it can never open a guarded edge. Preserved on resume. |
+| `--archive-report` | off | Print what the archive has learned, and exit. |
 
 ### Optional enhancements
 

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -84,9 +84,11 @@ The settings the run was started with, so a resume reproduces them.
   "review_operator": "claude",
   "review_model": "sonnet",
   "codex_sandbox": "workspace-write",
-  "stage_graph": "linear",
-  "routing_mode": "off",
-  "evolve_rounds": 0,
+  "stage_graph": "adaptive",
+  "routing_mode": "auto",
+  "evolve_rounds": 2,
+  "evolve_measure": true,
+  "archive_steer": false,
   "web_search": "auto",
   "created_at": "2026-03-30T10:12:22"
 }
@@ -102,9 +104,11 @@ The settings the run was started with, so a resume reproduces them.
 | `review_operator` | `claude` or `codex`; defaults to `operator`. |
 | `review_model` | Reviewer model; defaults to `sonnet` (Claude) or `default` (Codex). |
 | `codex_sandbox` | `read-only`, `workspace-write`, or `danger-full-access`. |
-| `stage_graph` | `linear` (default) or `adaptive`. See [Recursive Self-Improvement](self-improvement.md). |
-| `routing_mode` | `off` (default), `auto`, or `agent`. Who chooses the move out of a completed stage. |
-| `evolve_rounds` | Self-improvement rounds per stage; `0` is off. |
+| `stage_graph` | `adaptive` (default) or `linear`. See [Recursive Self-Improvement](self-improvement.md). |
+| `routing_mode` | `auto` (default), `agent`, or `off`. Who chooses the move out of a completed stage. |
+| `evolve_measure` | Whether every valid draft is scored and the champion ratchet runs. `true` by default; costs no backend call. |
+| `evolve_rounds` | Improvement rounds per stage; `2` by default, `0` measures without polishing. |
+| `archive_steer` | Whether the cross-run archive may choose this run's topology, as opposed to only recording what it did. `false` by default. |
 | `web_search` | `auto`, `gemini`, or `native`. The mode, not the resolved backend. Absent in runs created before it existed, and read as `auto`. |
 | `created_at` | ISO-8601 to the second. Preserved across rewrites. |
 

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -7,24 +7,40 @@ topology accumulates across runs.
 This page is the whole mechanism: what each part does, what it refuses to do, and
 why the refusals are the load-bearing half.
 
-Everything here is off by default. A run that passes none of these flags walks 01
-through 08 exactly as it always did — through the same engine, which is what keeps
-the default path exercised by every test of the new one.
+All of it is on by default. The strict 01-through-08 sequence is still there and
+still runs through the same engine — which is what keeps it exercised by every test
+of the adaptive path.
 
 ```bash
-# The stages as a graph, with the agent choosing the move out of each node.
-python main.py --goal "..." --stage-graph adaptive --routing auto
+# Everything below is what this does.
+python main.py --goal "..."
 
-# Measured improvement rounds inside each stage.
-python main.py --goal "..." --evolve --evolve-rounds 3
+# What the archive has learned across runs so far.
+python main.py --archive-report
 
-# Both, plus a cross-run archive that learns which moves pay.
-python main.py --goal "..." --stage-graph adaptive --routing auto \
-               --evolve --archive ~/.autor/archive
+# Spend more on improvement, or none at all.
+python main.py --goal "..." --evolve-rounds 4
+python main.py --goal "..." --evolve-rounds 0     # measure and ratchet, no extra passes
 
-# What the archive has learned so far.
-python main.py --archive ~/.autor/archive --archive-report
+# Opt out entirely.
+python main.py --goal "..." --stage-graph linear --routing off --no-evolve --no-archive
 ```
+
+### What each default costs
+
+| | Default | Backend calls it adds |
+| --- | --- | --- |
+| `--stage-graph adaptive` | on | none |
+| `--routing auto` | on | one short prompt per node with more than one live move |
+| measuring + the ratchet | on | **none** — the rubric reads the run off disk |
+| `--evolve-rounds 2` | on | up to two stage executions per stage, none where the rubric sees no headroom |
+| archive recording | on | none |
+| `--archive-steer` | **off** | none |
+
+The split between measuring and polishing is the reason the defaults are
+defensible. They were one setting to begin with, which made the free half opt-in
+for no reason: a run that never polishes still gets the property that matters most,
+that the promoted draft is the best one rather than the most recent.
 
 ---
 
@@ -73,15 +89,43 @@ halt on is already a stage validation error with a better message. Two gates ove
 one condition is one gate too many, and the one that fires second is the one
 nobody maintains.
 
+### A guard is a routing preference, not a gate
+
+A closed edge is removed from the *menu the agent chooses from*. It is not removed
+from the graph. When a guard has closed the forward edge and nobody has chosen
+anything else, the run advances anyway, and the route records that the precondition
+was unmet.
+
+This looks like a hole and is the opposite of one. The correctness gate is the
+stage's own validation, which is unchanged and still refuses a Stage 07 that writes
+up unadjudicated hypotheses. Treating the guard as an absolute barrier would mean a
+run that genuinely cannot satisfy it produces *nothing*, where the linear pipeline
+would have produced a deliverable and failed the gate honestly. Halting is not the
+safer outcome; it is the same refusal with the evidence thrown away.
+
+**The default never goes backward.** That was tried and it was wrong, observably:
+Stage 04's forward guard fails when `workspace/code` holds nothing executable, the
+only backward edge out of Stage 04 leads to study design, and study design is not
+the stage that writes code. The default would have sent the run somewhere that
+could not fix what blocked it, attached the guard's message as though it were a
+justification, and done it again next time round. Which backward edge addresses a
+given block is a judgement about the research, not a computation over the graph —
+so it belongs to the agent, and a run nobody is steering goes straight down the
+pipeline.
+
+A budget block is different and is never overridden. A guard says something about
+the research; a budget says something about the run, and the run stopping is what a
+budget is for.
+
 ---
 
 ## 2. Routing
 
 `src/router.py`
 
-`--routing auto` asks the backend to choose wherever more than one move is live.
-On a linear graph that is never, so `auto` costs nothing there. `--routing agent`
-asks at every node.
+`--routing auto`, the default, asks the backend to choose wherever more than one
+move is live. On a linear graph that is never, so `auto` costs nothing there.
+`--routing agent` asks at every node; `--routing off` always takes the default.
 
 The division of labour is the point:
 
@@ -125,7 +169,8 @@ draft replaces the old one. Nothing compared the two. A refinement that dropped 
 resolving file reference or replaced a measured number with a hedge was promoted
 on exactly the same terms as one that fixed something. "Refine" was a hope.
 
-`--evolve` supplies the missing ordering.
+Measuring supplies the missing ordering, and it is on by default because it costs
+nothing to have.
 
 ### The rubric
 
@@ -195,8 +240,20 @@ that is *failing*. Charging improvement rounds to the repair budget would make a
 stage being made better look like one that was thrashing, and would leave nothing
 if a later round broke something.
 
-Rounds stop at `--evolve-rounds`, or after two consecutive rounds with no gain.
-Most stages are done after one targeted fix.
+Rounds stop at `--evolve-rounds`, after two consecutive rounds with no gain, or —
+before any round is paid for — when no criterion has a shortfall worth `min_gain`.
+That last stop is what makes the default affordable: the other two only fire *after*
+a stage execution has been bought, so without it a clean stage would pay two rounds
+to reword a draft already at the ceiling of what the rubric can see.
+
+A stage re-entered by a backward move gets a fresh round budget. Its champion
+survives — that is the ratchet — but a stage doing new work because a later stage
+found a problem should not be charged for the rounds its previous visit spent.
+
+`--fake-operator` runs spend no rounds at all. A scripted operator emits the same
+draft whatever the directive says, so every round would be bought, measured as a
+regression and reverted. Measuring still happens, which is how the fake pipeline
+keeps exercising the ratchet and the ledger.
 
 ---
 
@@ -240,6 +297,17 @@ Three refusals hold this together:
 Parents are sampled by fitness with a novelty bonus for under-observed variants.
 Pure fitness-proportional sampling locks onto whatever won first and stops
 generating the observations that would overturn it.
+
+### Recording is on; steering is not
+
+The archive records every run by default, because recording is free and it is the
+only thing that could ever justify a change to the topology — and it cannot be
+built retroactively. Whether it is allowed to *act* on what it records is a
+separate question with a separate flag, `--archive-steer`, and that one is off.
+
+A run silently using a different topology from the one the operator asked for is
+not a surprise a research tool gets to spring on anyone. Turn steering on
+deliberately, once `--archive-report` shows the archive has something to say.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -25,10 +25,17 @@ from src.web_search import (
     web_search_notice,
 )
 from src.archive import Archive, resolve_graph
+
+#: Where the cross-run archive lives when nobody says otherwise. Under the user's
+#: home rather than the checkout: it outlives any one clone, and an archive inside
+#: the repo would be wiped by the next fresh clone that was supposed to inherit it.
+DEFAULT_ARCHIVE_DIR = "~/.autor/archive"
 from src.evolution import DEFAULT_ROUNDS, EvolutionConfig
 from src.stage_graph import DEFAULT_MAX_STEPS, DEFAULT_MAX_VISITS
 from src.utils import (
     CODEX_SANDBOX_CHOICES,
+    DEFAULT_ROUTING_MODE,
+    DEFAULT_STAGE_GRAPH,
     DEFAULT_CODEX_SANDBOX,
     DEFAULT_OUTPUT_FORMAT,
     DEFAULT_VENUE,
@@ -316,21 +323,23 @@ def parse_args() -> argparse.Namespace:
         "--stage-graph",
         choices=list(STAGE_GRAPH_CHOICES),
         help=(
-            "How the run moves between stages. 'linear' (the default) runs 01 through 08 in "
-            "order, which is one edge out of every node. 'adaptive' adds the backward moves: "
-            "an analysis that exposes a design flaw can send the run back to Stage 03 instead "
-            "of writing up around it. Preserved when resuming."
+            f"How the run moves between stages. Defaults to '{DEFAULT_STAGE_GRAPH}', which is the "
+            "eight stages as a directed graph with backward moves: an analysis that exposes a "
+            "design flaw sends the run back to Stage 03 instead of writing up around it, and the "
+            "move into Stage 07 is closed until every hypothesis has a verdict. 'linear' restores "
+            "the strict 01-through-08 sequence. Preserved when resuming."
         ),
     )
     parser.add_argument(
         "--routing",
         choices=list(ROUTING_MODE_CHOICES),
         help=(
-            "Who chooses the move out of a completed stage. 'off' (the default) always takes "
-            "the graph's default edge. 'auto' asks the backend wherever more than one move is "
-            "available, which on a linear graph is never. 'agent' asks at every node. AutoR "
-            "decides which moves are available by evaluating each edge's guard against the "
-            "artifacts on disk; the backend only chooses among those. Preserved when resuming."
+            f"Who chooses the move out of a completed stage. Defaults to '{DEFAULT_ROUTING_MODE}', "
+            "which asks the backend only where more than one move is available - never on a "
+            "linear graph, and at a handful of nodes on an adaptive one. 'agent' asks at every "
+            "node; 'off' always takes the graph's default edge. AutoR decides which moves are "
+            "available by evaluating each edge's guard against the artifacts on disk; the backend "
+            "only chooses among those. Preserved when resuming."
         ),
     )
     parser.add_argument(
@@ -352,23 +361,27 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--evolve",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help=(
-            "Turn on self-improvement rounds. After a stage produces a valid draft, AutoR scores "
-            "it against a rigour rubric read off disk, then spends up to --evolve-rounds further "
-            "rounds targeting the criteria that lost points. The best-scoring draft is what gets "
-            "promoted, and a round that scores worse is reverted, so a stage can only improve. "
-            "The score is blind to what the run concluded, and a round that changes a hypothesis "
-            "verdict is rejected outright."
+            "Score every valid stage draft against a rigour rubric read off disk and run the "
+            "champion ratchet: the best-scoring draft is what gets promoted, not the last one, "
+            "and a self-initiated round that scores worse is reverted. On by default because it "
+            "costs nothing - the rubric reads the run off disk and never calls a backend. The "
+            "score is blind to what the run concluded, and a round that changes a hypothesis "
+            "verdict is rejected outright. --no-evolve restores the old behaviour, where "
+            "whichever draft came last was the one promoted."
         ),
     )
     parser.add_argument(
         "--evolve-rounds",
         type=int,
         help=(
-            f"Self-improvement rounds per stage. Implies --evolve when above zero. Defaults to "
-            f"{DEFAULT_ROUNDS} with --evolve. These rounds are budgeted separately from "
-            "--max-attempts, which bounds a stage that is failing rather than one being improved."
+            "Improvement rounds per stage, beyond the first draft. This is the half that costs "
+            f"backend calls, so it is the number to turn down; defaults to {DEFAULT_ROUNDS}. A "
+            "stage whose rubric has no shortfall worth acting on spends none of them. Budgeted "
+            "separately from --max-attempts, which bounds a stage that is failing rather than "
+            "one being improved. Zero measures without polishing. Preserved when resuming."
         ),
     )
     parser.add_argument(
@@ -376,20 +389,37 @@ def parse_args() -> argparse.Namespace:
         nargs="+",
         metavar="STAGE",
         help=(
-            "Restrict self-improvement to these stage slugs or numbers (for example '06_analysis' "
-            "or '5 6 7'). Defaults to every stage."
+            "Restrict improvement rounds to these stage slugs or numbers (for example "
+            "'06_analysis' or '5 6 7'). Defaults to every stage."
         ),
     )
     parser.add_argument(
         "--archive",
         metavar="PATH",
         help=(
-            "Directory holding the cross-run topology archive. When set, AutoR records this "
-            "run's route and measured fitness there, compares each graph edge against runs that "
-            "reached the same node and did not take it, and samples the topology it runs from "
-            "what the archive has learned. Requires --evolve, which is what produces the "
-            "fitness. A learned prior only reorders which move is preferred; it can never open "
-            "a guarded edge."
+            "Directory holding the cross-run topology archive. Defaults to "
+            f"'{DEFAULT_ARCHIVE_DIR}'. Each finished run records its route and measured fitness "
+            "there, and each graph edge is compared against runs that reached the same node and "
+            "did not take it. Recording only: the archive does not change the topology a run "
+            "uses unless --archive-steer says so."
+        ),
+    )
+    parser.add_argument(
+        "--no-archive",
+        action="store_true",
+        help="Do not record this run in the cross-run archive.",
+    )
+    parser.add_argument(
+        "--archive-steer",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Let the archive choose the topology this run uses, instead of only recording what "
+            "the run did. Off by default: a run silently using a different topology from the one "
+            "asked for is not a surprise a research tool gets to spring on anyone. Turn it on "
+            "once --archive-report shows the archive has something to say. A learned prior only "
+            "reorders which move is preferred; it can never open a guarded edge. Preserved when "
+            "resuming."
         ),
     )
     parser.add_argument(
@@ -409,37 +439,46 @@ def parse_args() -> argparse.Namespace:
 def resolve_walk_settings(args: argparse.Namespace, existing: dict | None = None) -> dict:
     """CLI flags over the resumed run's settings over the defaults.
 
-    A flag that was not passed must not overwrite what the run was started with,
-    which is why every one of these is checked for presence rather than read for
-    its value: `--stage-graph` defaults to None here, not to "linear", so resuming
-    an adaptive run without repeating the flag keeps it adaptive.
+    Every one of these is checked for *presence* rather than read for its value,
+    because a flag that was not passed must not overwrite what the run was started
+    with: `--stage-graph` defaults to None here, not to the global default, so
+    resuming a linear run without repeating the flag keeps it linear even though a
+    fresh run would be adaptive.
     """
     current = dict(existing or {})
     if args.stage_graph:
         current["stage_graph"] = args.stage_graph
     if args.routing:
         current["routing_mode"] = args.routing
+    if args.evolve is not None:
+        current["evolve_measure"] = bool(args.evolve)
+        if not args.evolve:
+            # Polishing without measuring is not a state that means anything: the
+            # rounds are steered by the score, and there would be nothing to steer
+            # them with.
+            current["evolve_rounds"] = 0
     if args.evolve_rounds is not None:
         current["evolve_rounds"] = max(0, args.evolve_rounds)
-    elif args.evolve and not current.get("evolve_rounds"):
-        current["evolve_rounds"] = DEFAULT_ROUNDS
+        if args.evolve_rounds > 0:
+            current["evolve_measure"] = True
+    if args.archive_steer is not None:
+        current["archive_steer"] = bool(args.archive_steer)
     return normalize_walk_settings(current)
 
 
 def build_evolution_config(walk: dict, args: argparse.Namespace) -> EvolutionConfig:
-    rounds = int(walk["evolve_rounds"])
     stages: tuple[str, ...] = ()
     if args.evolve_stages:
         resolved = [resolve_stage(value) for value in args.evolve_stages]
-        unknown = [
-            value for value, stage in zip(args.evolve_stages, resolved) if stage is None
-        ]
+        unknown = [value for value, stage in zip(args.evolve_stages, resolved) if stage is None]
         if unknown:
-            raise ValueError(
-                "--evolve-stages does not recognise: " + ", ".join(unknown)
-            )
+            raise ValueError("--evolve-stages does not recognise: " + ", ".join(unknown))
         stages = tuple(stage.slug for stage in resolved if stage is not None)
-    return EvolutionConfig(enabled=rounds > 0, rounds=rounds or DEFAULT_ROUNDS, stages=stages)
+    return EvolutionConfig(
+        measure=bool(walk["evolve_measure"]),
+        rounds=int(walk["evolve_rounds"]),
+        stages=stages,
+    )
 
 
 def default_model_for_operator(operator_name: str) -> str:
@@ -603,7 +642,16 @@ def _build_resource_entries(paths: list[str]) -> list[ResourceEntry]:
 
 
 def open_archive(args: argparse.Namespace) -> Archive | None:
-    return Archive(Path(args.archive).expanduser().resolve()) if args.archive else None
+    """The archive this invocation records into, or ``None`` if it was declined.
+
+    Recording is on by default and costs nothing but a line of JSON, because the
+    archive is the only thing that could ever justify a change to the topology and
+    it cannot be built retroactively. Whether it is allowed to *act* on what it
+    records is a separate question, answered by `--archive-steer`.
+    """
+    if args.no_archive:
+        return None
+    return Archive(Path(args.archive or DEFAULT_ARCHIVE_DIR).expanduser().resolve())
 
 
 def record_into_archive(
@@ -625,7 +673,7 @@ def record_into_archive(
         if record is None:
             ui.show_status(
                 "Nothing was recorded in the archive: this run has no measured stages. "
-                "Pass --evolve so stages are scored.",
+                "Drop --no-evolve so stages are scored.",
                 level="warn",
             )
             return
@@ -741,7 +789,9 @@ def main() -> int:
         output_format = resolve_output_format(args.output_format or existing_config.get("output_format"))
         walk = resolve_walk_settings(args, existing_config)
         archive = open_archive(args)
-        graph, variant_id = resolve_graph(archive, walk["stage_graph"])
+        graph, variant_id = resolve_graph(
+            archive if walk["archive_steer"] else None, walk["stage_graph"]
+        )
         web_search_mode = normalize_web_search_mode(args.web_search or existing_config.get("web_search"))
         web_search_context = resolve_search_context(
             ui, mode=web_search_mode, operator=operator_name, codex_sandbox=codex_sandbox
@@ -788,6 +838,7 @@ def main() -> int:
             evolution=build_evolution_config(walk, args),
             graph_max_steps=args.graph_max_steps,
             graph_max_visits=args.graph_max_visits,
+            archive_steer=bool(walk["archive_steer"]),
             web_search_mode=web_search_mode,
         )
         manager.ideation_panel = create_ideation_panel(
@@ -820,7 +871,9 @@ def main() -> int:
     final_stage = resolve_stage(args.final_stage)
     walk = resolve_walk_settings(args)
     archive = open_archive(args)
-    graph, variant_id = resolve_graph(archive, walk["stage_graph"])
+    graph, variant_id = resolve_graph(
+        archive if walk["archive_steer"] else None, walk["stage_graph"]
+    )
     operator = create_operator(
         operator_name,
         model=model,
@@ -863,6 +916,7 @@ def main() -> int:
         evolution=build_evolution_config(walk, args),
         graph_max_steps=args.graph_max_steps,
         graph_max_visits=args.graph_max_visits,
+        archive_steer=bool(walk["archive_steer"]),
         web_search_mode=web_search_mode,
     )
 

--- a/src/evolution.py
+++ b/src/evolution.py
@@ -65,14 +65,36 @@ DEFAULT_MIN_GAIN = 0.005
 #: and stopping on the first flat round would never reach the merge.
 DEFAULT_PATIENCE = 2
 
-#: Rounds per stage when evolution is on and no budget is given. Chosen so a
-#: default run pays for a first draft, one targeted fix, and a merge.
-DEFAULT_ROUNDS = 3
+#: Polish rounds per stage when nothing is specified.
+#:
+#: Two rather than three because the third is almost never the one that pays: a
+#: stage responds to its first targeted fix or it does not, and :attr:`patience`
+#: stops a flat stage before the budget does anyway. Two leaves room for the merge
+#: round that a Pareto frontier occasionally earns.
+DEFAULT_ROUNDS = 2
 
 
 @dataclass(frozen=True)
 class EvolutionConfig:
-    enabled: bool = False
+    """What the improvement loop is allowed to spend.
+
+    Split into two settings because they cost completely different things, and
+    conflating them was making the cheap half opt-in for no reason.
+
+    ``measure`` scores every valid draft, runs the champion ratchet, rejects a
+    round that moved a verdict, and writes the ledger. All of that is disk reads —
+    :mod:`src.rubric` never calls a backend — so it is on by default. A run that
+    measures and never polishes still gets the property that matters most: the
+    draft that gets promoted is the best one the run produced, not the last one.
+
+    ``rounds`` buys further attempts at a stage that already passed validation.
+    Each one is a full stage execution, so this is where the money goes, and it is
+    the number to turn down.
+    """
+
+    #: Score every draft and run the ratchet. Free; off only for a caller who wants
+    #: the old behaviour exactly.
+    measure: bool = True
     #: Polish rounds allowed per stage, beyond the first draft. These do not consume
     #: the stage's repair budget: a stage that is being improved is not a stage that
     #: is failing, and charging improvement rounds against `--max-attempts` would
@@ -83,14 +105,23 @@ class EvolutionConfig:
     #: Stages to evolve. Empty means all of them.
     stages: tuple[str, ...] = ()
 
+    @property
+    def enabled(self) -> bool:
+        """Whether this config does anything at all.
+
+        Kept so a caller can ask the question without knowing which of the two
+        settings turned it off.
+        """
+        return self.measure
+
     def applies_to(self, stage: StageSpec) -> bool:
-        if not self.enabled:
+        if not self.measure:
             return False
         return not self.stages or stage.slug in self.stages
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "enabled": self.enabled,
+            "measure": self.measure,
             "rounds": self.rounds,
             "min_gain": self.min_gain,
             "patience": self.patience,
@@ -361,25 +392,62 @@ class EvolutionController:
     def should_continue(self, paths: RunPaths, stage: StageSpec) -> bool:
         """Whether another polish round is worth paying for.
 
-        Two independent stops. The budget bounds the spend; the patience counter
-        stops a stage that has stopped responding, which is the common case — most
-        stages are done after one targeted fix, and the remaining rounds would be
-        spent rewording a draft that is already at the ceiling of what the rubric
-        can see.
+        Four stops, and the last one is what makes this affordable to leave on. The
+        budget bounds the spend and the patience counter stops a stage that has
+        stopped responding — but both of those only fire *after* a round has been
+        paid for. :meth:`recoverable_headroom` fires before: if no criterion has a
+        named shortfall worth ``min_gain``, there is nothing for a round to do, and
+        AutoR would be buying a stage execution to reword a draft that is already at
+        the ceiling of what the rubric can see. A clean stage costs nothing.
         """
         if not self.config.applies_to(stage):
+            return False
+        if self.config.rounds <= 0:
             return False
         state = self.state(paths, stage)
         if state.rounds_spent >= self.config.rounds:
             return False
         if state.flat_rounds >= self.config.patience:
             return False
-        if state.champion is not None and state.champion.total >= 1.0 - 1e-9:
+        if state.champion is None:
             return False
-        return True
+        if state.champion.total >= 1.0 - 1e-9:
+            return False
+        return self.recoverable_headroom(state.champion) >= self.config.min_gain
+
+    def recoverable_headroom(self, champion: StageScore) -> float:
+        """How much of the total a round could plausibly recover.
+
+        Weighted over criteria that are both below full marks *and* carry a named
+        shortfall. A criterion scoring 0.6 with nothing to say about what would
+        raise it is not headroom — it is a measurement the rubric cannot turn into
+        an instruction, and a round aimed at it produces churn.
+        """
+        total_weight = sum(item.weight for item in champion.criteria) or 1.0
+        return (
+            sum(
+                (1.0 - item.score) * item.weight
+                for item in champion.criteria
+                if item.score < 1.0 and item.shortfall
+            )
+            / total_weight
+        )
 
     def begin_round(self, paths: RunPaths, stage: StageSpec) -> None:
         self.state(paths, stage).rounds_spent += 1
+
+    def begin_stage(self, paths: RunPaths, stage: StageSpec) -> None:
+        """Give a stage a fresh round budget each time the run enters it.
+
+        The champion deliberately survives — that is the ratchet, and a revisit's
+        first draft replaces it only by being `directed`, which it is. The *budget*
+        does not survive: a stage re-entered because a later stage found a problem
+        is doing new work, and charging it for the rounds its previous visit spent
+        would leave the visit that actually needs improvement with nothing.
+        """
+        state = self.state(paths, stage)
+        state.rounds_spent = 0
+        state.flat_rounds = 0
 
     def next_directive(self, paths: RunPaths, stage: StageSpec) -> str:
         """The instruction for the next polish round.

--- a/src/manager.py
+++ b/src/manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime
 import shutil
 import sys
@@ -102,6 +103,8 @@ from .writing_manifest import (
 )
 from .utils import (
     DEFAULT_REFINEMENT_SUGGESTIONS,
+    DEFAULT_ROUTING_MODE,
+    DEFAULT_STAGE_GRAPH,
     FIXED_STAGE_OPTIONS,
     INTAKE_STAGE,
     MAX_STAGE_ATTEMPTS,
@@ -134,6 +137,7 @@ from .utils import (
     strip_markdown_section,
     parse_refinement_suggestions,
     read_attempt_count,
+    read_polish_count,
     read_text,
     required_stage_output_template,
     selected_output_format,
@@ -141,6 +145,7 @@ from .utils import (
     validate_stage_artifacts,
     validate_stage_markdown,
     write_attempt_count,
+    write_polish_count,
     write_stage_handoff,
     write_text,
 )
@@ -166,10 +171,11 @@ class ResearchManager:
         web_search_mode: str | None = None,
         artifact_roots: list[Path] | None = None,
         stage_graph: StageGraph | None = None,
-        routing_mode: str = "off",
+        routing_mode: str = DEFAULT_ROUTING_MODE,
         evolution: EvolutionConfig | None = None,
         graph_max_steps: int | None = None,
         graph_max_visits: int | None = None,
+        archive_steer: bool = False,
         cross_reviewer: GeminiCrossReviewer | None = None,
     ) -> None:
         self.project_root = project_root
@@ -222,11 +228,11 @@ class ResearchManager:
             "results": [root / "outputs" for root in self.artifact_roots],
             "figures": [root / "report" / "images" for root in self.artifact_roots],
         }
-        # The stages are a graph. The default topology has exactly one edge out of
-        # each node, so a caller that asks for nothing gets the sequence AutoR has
-        # always run — through the same walk that the adaptive topology uses, so
-        # the default path keeps being exercised by every test of either.
-        self.stage_graph = stage_graph or StageGraph.linear()
+        # The stages are a graph. A caller that names no topology gets the adaptive
+        # one, which can go back when a later stage shows an earlier one was wrong.
+        # `StageGraph.linear()` is still a real graph through the same walk, so the
+        # strict sequence keeps being exercised by every test of either.
+        self.stage_graph = stage_graph or StageGraph.named(DEFAULT_STAGE_GRAPH)
         self.graph_max_steps = graph_max_steps
         self.graph_max_visits = graph_max_visits
         self.router = StageRouter(
@@ -234,7 +240,22 @@ class ResearchManager:
             mode=routing_mode,
             fake_mode=bool(getattr(operator, "fake_mode", False)),
         )
-        evolution_config = evolution or EvolutionConfig()
+        # Measuring is on unless a caller turns it off: scoring a draft and running
+        # the ratchet spends no backend call, and the property it buys — the draft
+        # that gets promoted is the best one the run produced rather than the last
+        # one — is the whole reason any of this exists.
+        requested_evolution = evolution if evolution is not None else EvolutionConfig()
+        # A fake operator cannot improve anything: it emits the same scripted draft
+        # whatever the directive says, so every round would be bought, measured as a
+        # regression and reverted. Applied here rather than at the CLI so the number
+        # the operator *asked* for is what reaches run_config.json — zeroing it there
+        # would mean resuming a fake run with a real backend silently inherited a
+        # budget of nothing.
+        evolution_config = (
+            replace(requested_evolution, rounds=0)
+            if getattr(operator, "fake_mode", False)
+            else requested_evolution
+        )
         self.evolution = (
             EvolutionController(
                 evolution_config,
@@ -251,7 +272,9 @@ class ResearchManager:
         self._walk_settings = {
             "stage_graph": self.stage_graph.name,
             "routing_mode": self.router.mode,
-            "evolve_rounds": evolution_config.rounds if evolution_config.enabled else 0,
+            "evolve_rounds": requested_evolution.rounds if requested_evolution.measure else 0,
+            "evolve_measure": requested_evolution.measure,
+            "archive_steer": archive_steer,
         }
 
     def run(
@@ -1429,8 +1452,15 @@ class ResearchManager:
         # that is *failing*. Charging them to the same budget would make a stage
         # that is being made better look like one that is thrashing, and would
         # leave nothing for the repair path if a later round did break something.
-        polish_rounds = 0
+        #
+        # Read from disk rather than started at zero: the attempt number is run-wide
+        # and a stage can be entered more than once, so a per-entry counter would
+        # under-report retries on the second visit.
+        polish_rounds = read_polish_count(paths, stage)
+        entry_polish_rounds = polish_rounds
         is_polish_round = False
+        if self.evolution is not None:
+            self.evolution.begin_stage(paths, stage)
         revision_feedback: str | None = None
         continue_session = False
         last_validation_errors: list[str] = []
@@ -1469,7 +1499,7 @@ class ResearchManager:
                 pass
 
         while True:
-            if loop_attempts - polish_rounds >= self.max_stage_attempts:
+            if loop_attempts - (polish_rounds - entry_polish_rounds) >= self.max_stage_attempts:
                 error = (
                     f"Exceeded {self.max_stage_attempts} attempts in the current stage run. "
                     f"Last validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
@@ -1491,7 +1521,14 @@ class ResearchManager:
                     last_validation_errors=last_validation_errors,
                 )
             loop_attempts += 1
-            mark_stage_running_manifest(paths, stage, attempt_no)
+            # The manifest's `attempt_count` means "how many tries did this stage
+            # need" — a diagnostic for a gate the operator could not clear, and what
+            # `test_no_stage_needed_a_retry` reads to notice a new artifact gate that
+            # fake mode was never taught to satisfy. A polish round is not a try that
+            # failed, so it does not count here; the improvement ledger owns that
+            # accounting. Feeding both numbers into one field would leave neither
+            # question answerable.
+            mark_stage_running_manifest(paths, stage, attempt_no - polish_rounds)
             write_attempt_count(paths, stage, attempt_no)
             self._print(f"\nRunning {stage.stage_title} (attempt {attempt_no})...")
             prompt = self._build_stage_prompt(paths, stage, revision_feedback, continue_session,
@@ -1727,6 +1764,7 @@ class ResearchManager:
                     if directive:
                         self.evolution.begin_round(paths, stage)
                         polish_rounds += 1
+                        write_polish_count(paths, stage, polish_rounds)
                         is_polish_round = True
                         revision_feedback = directive
                         continue_session = True
@@ -1739,7 +1777,7 @@ class ResearchManager:
             mark_stage_human_review_manifest(
                 paths,
                 stage,
-                attempt_no,
+                attempt_no - polish_rounds,
                 self._stage_file_paths(stage_markdown),
             )
             append_log_entry(
@@ -1820,7 +1858,7 @@ class ResearchManager:
                 mark_stage_approved_manifest(
                     paths,
                     stage,
-                    attempt_no,
+                    attempt_no - polish_rounds,
                     self._stage_file_paths(stage_markdown),
                 )
                 if stage.slug == "04_implementation":

--- a/src/router.py
+++ b/src/router.py
@@ -123,7 +123,7 @@ class StageRouter:
             return RoutingDecision(
                 default.target,
                 default.edge.kind,
-                default.edge.rationale,
+                _default_reason(default, moves),
                 default_target,
                 agent_directed=False,
             )
@@ -195,6 +195,7 @@ class StageRouter:
             agent_directed=False,
             refusal=detail,
         )
+
 
     # -- the ask -------------------------------------------------------------
 
@@ -309,6 +310,23 @@ class StageRouter:
             "- Choose `finish` only if the run has produced what it set out to produce.",
         ]
         return "\n".join(sections)
+
+
+def _default_reason(default: Move, moves: list[Move]) -> str:
+    """Why the graph took this edge with nobody asked.
+
+    The default is always a forward move, so there are two cases: it was open, or it
+    was taken with its precondition unmet because nothing else could be. The second
+    has to say so on the route — the archive later learns from these, and a step
+    recorded as an ordinary advance when the guard was failing is a mislabelled
+    observation.
+    """
+    if default.last_resort:
+        return (
+            f"No move out of this stage is open and there is nowhere left to go back to, so the "
+            f"run advances with the precondition unmet: {default.guard.reason}"
+        )
+    return default.edge.rationale
 
 
 def _read(path: Path) -> str:

--- a/src/rubric.py
+++ b/src/rubric.py
@@ -750,12 +750,20 @@ def _score_reproducibility(paths: RunPaths, stage: StageSpec) -> CriterionScore:
     checks: list[tuple[str, bool, str]] = []
 
     if stage.number >= 1:
-        ledger = paths.literature_dir / "evidence_ledger.json"
+        # Delegated rather than reimplemented. An earlier version of this check
+        # looked for `workspace/literature/evidence_ledger.json`, a file no part of
+        # AutoR writes, so it failed on every run and docked the criterion for work
+        # that had in fact been done. `validate_literature_evidence` is the shipped
+        # definition of what a literature evidence base has to be; there should not
+        # be a second one here to drift from it.
+        from .evidence_ledger import validate_literature_evidence
+
         checks.append(
             (
-                "literature evidence ledger",
-                isinstance(_load_json(ledger), (dict, list)),
-                "Write workspace/literature/evidence_ledger.json so each cited claim points at a source.",
+                "literature evidence base",
+                not validate_literature_evidence(paths),
+                "Write workspace/literature/sources.json and claims.json so each claim names the "
+                "source_ids behind it.",
             )
         )
     if stage.number >= 3:
@@ -779,12 +787,13 @@ def _score_reproducibility(paths: RunPaths, stage: StageSpec) -> CriterionScore:
         )
     if stage.number >= 5:
         manifest = _load_json(paths.experiment_manifest)
+        indexed = manifest.get("result_artifacts") if isinstance(manifest, dict) else None
         checks.append(
             (
                 "experiment manifest",
-                isinstance(manifest, dict) and bool(manifest.get("experiments")),
-                "Record every experiment in workspace/results/experiment_manifest.json with its "
-                "command, config and seeds.",
+                bool(indexed),
+                "Produce result files under workspace/results so experiment_manifest.json indexes "
+                "them; a result nothing indexes cannot be found by the analysis stage.",
             )
         )
     if stage.number >= 6:

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -44,7 +44,7 @@ exist.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
@@ -128,15 +128,29 @@ def _guard_runnable_code(paths: RunPaths, state: "GraphState") -> GuardResult:
 
 
 def _guard_results_exist(paths: RunPaths, state: "GraphState") -> GuardResult:
+    """Results on disk, and the manifest that indexes them.
+
+    ``result_artifacts`` is the key :mod:`src.experiment_manifest` actually writes.
+    An earlier version of this guard looked for ``experiments``, which nothing in
+    AutoR has ever produced — so the guard could not be satisfied by any run, and
+    the forward move out of Stage 05 was permanently closed. A precondition no real
+    run can meet is not a strict gate, it is a broken one.
+    """
     count = _count_files_with_suffixes(paths.results_dir, RESULT_SUFFIXES)
     manifest = _load_json(paths.experiment_manifest)
-    has_manifest = isinstance(manifest, dict) and bool(manifest.get("experiments"))
-    if count and has_manifest:
-        return GuardResult(True, f"{count} result artifact(s) and a populated experiment manifest")
+    indexed = manifest.get("result_artifacts") if isinstance(manifest, dict) else None
+    if count and indexed:
+        return GuardResult(
+            True, f"{count} result artifact(s), {len(indexed)} indexed in the experiment manifest"
+        )
+    if not count:
+        return GuardResult(
+            False, "no experiment has produced a machine-readable result under workspace/results"
+        )
     return GuardResult(
         False,
-        "no experiment has produced a machine-readable result under workspace/results "
-        "with a matching entry in experiment_manifest.json",
+        "results exist but experiment_manifest.json indexes none of them, so nothing "
+        "downstream can tell which experiment produced what",
     )
 
 
@@ -465,6 +479,12 @@ def save_graph_state(paths: RunPaths, state: GraphState) -> None:
 # ----------------------------------------------------------------------------
 
 
+#: Why a move is unavailable. The distinction decides whether the walk may fall
+#: through it: a guard is a statement about the *research* and can be overridden as
+#: a last resort, while a budget is a statement about the *run* and cannot.
+BLOCK_KINDS = ("guard", "visits", "steps")
+
+
 @dataclass(frozen=True)
 class Move:
     """An edge the run is allowed to take right now, and why."""
@@ -476,6 +496,9 @@ class Move:
     #: closed will route to what opens it, whereas an agent shown a shorter menu
     #: will pick the wrong item off it and never know what it missed.
     blocked_because: str = ""
+    blocked_kind: str = ""
+    #: Taken because nothing else was available, with its guard still failing.
+    last_resort: bool = False
 
     @property
     def admissible(self) -> bool:
@@ -544,17 +567,21 @@ class StageGraph:
                     continue
 
             guard = edge.guard_fn()(paths, state)
-            blocked = ""
+            blocked, kind = "", ""
             if not guard.ok:
-                blocked = guard.reason
+                blocked, kind = guard.reason, "guard"
             elif edge.target != FINISH and state.visits(edge.target) >= state.max_visits:
-                blocked = (
+                blocked, kind = (
                     f"{edge.target} has already been entered {state.visits(edge.target)} times, "
-                    f"which is the per-stage limit"
+                    f"which is the per-stage limit",
+                    "visits",
                 )
             elif state.steps >= state.max_steps:
-                blocked = f"the run has taken {state.steps} steps, which is the limit for this graph"
-            results.append(Move(edge, guard, blocked))
+                blocked, kind = (
+                    f"the run has taken {state.steps} steps, which is the limit for this graph",
+                    "steps",
+                )
+            results.append(Move(edge, guard, blocked, kind))
         return results
 
     def admissible_moves(self, paths: RunPaths, slug: str, state: GraphState, **kwargs: Any) -> list[Move]:
@@ -563,13 +590,64 @@ class StageGraph:
     def default_move(self, paths: RunPaths, slug: str, state: GraphState, **kwargs: Any) -> Move | None:
         """What AutoR takes when nothing chooses: the lowest-priority live edge.
 
-        Priority 0 is the advance edge at every node, so with all guards passing
-        this reproduces the old sequence exactly.
+        **The default is always the forward edge.** Not merely the lowest-priority
+        live one: a backward move is only ever correct as a deliberate choice with a
+        reason attached, and the router refuses an unreasoned one for exactly that
+        reason. A default that could silently reverse the run would be able to do
+        what no explicit decision is allowed to do.
+
+        **When nothing is live, the forward edge is taken anyway.** A guard is a
+        routing preference, not a correctness gate — the correctness gate is the
+        stage's own validation, which is unchanged and still refuses a Stage 07
+        that writes up unadjudicated hypotheses. Treating a failed guard as an
+        absolute barrier would mean a run that genuinely cannot satisfy it bounces
+        between backward edges until its visit budget runs out and then halts with
+        nothing, where the linear pipeline would have produced a deliverable and
+        failed the stage gate honestly. Halting is not the safer outcome; it is the
+        same refusal with the evidence thrown away.
+
+        A budget block is different and is never overridden: a guard says something
+        about the research, a budget says something about the run, and the run
+        stopping is exactly what a budget is for.
         """
-        moves = self.admissible_moves(paths, slug, state, **kwargs)
-        if not moves:
+        moves = self.moves(paths, slug, state, **kwargs)
+        by_rank = lambda move: (move.edge.priority, move.edge.target)  # noqa: E731
+        forward = [move for move in moves if move.edge.kind in {"advance", "finish"}]
+
+        live_forward = [move for move in forward if move.admissible]
+        if live_forward:
+            return min(live_forward, key=by_rank)
+
+        # A budget said stop. Unlike a guard, that is not a statement about the
+        # research and there is nothing to route around.
+        if any(move.blocked_kind in {"steps", "visits"} for move in forward):
             return None
-        return min(moves, key=lambda move: (move.edge.priority, move.edge.target))
+
+        # Forward is shut by a guard, and the default does **not** go back.
+        #
+        # It is tempting: the backward edges exist for exactly this, and the guard
+        # message reads like a reason. It is wrong, and observably so. Stage 04's
+        # forward guard fails when `workspace/code` holds nothing executable; the
+        # only backward edge out of 04 goes to 03, and study design is not the stage
+        # that writes code. The default would send the run somewhere that cannot fix
+        # the thing that blocked it, attach the guard's message as though it were a
+        # justification, and do it again next time round.
+        #
+        # Which backward edge addresses a given block is a judgement about the
+        # research, not a computation over the graph. That is the agent's call, and
+        # the whole arrangement here is that AutoR decides what is *possible* and the
+        # agent decides what is *sensible*. So the default advances with the
+        # precondition unmet and lets the stage's own validation — unchanged, and
+        # still refusing a Stage 07 that writes up unadjudicated hypotheses — be the
+        # correctness gate it always was. A guard is a routing preference; the gate
+        # is the gate.
+        if forward:
+            return replace(min(forward, key=by_rank), last_resort=True)
+
+        # No forward edge is declared here at all. Only reachable on a hand-built
+        # topology; the shipped ones give every node one.
+        live = [move for move in moves if move.admissible]
+        return min(live, key=by_rank) if live else None
 
     def repeats_a_previous_reason(self, state: GraphState, target: str, reason: str) -> bool:
         """Whether this exact justification has already sent the run to ``target``.

--- a/src/utils.py
+++ b/src/utils.py
@@ -349,19 +349,44 @@ def normalize_codex_sandbox(value: Any) -> str:
 #: How the run moves between stages. ``linear`` is the historical sequence, one
 #: edge out of each node. ``adaptive`` adds the backward moves and lets the run
 #: return to an earlier stage when a later one shows it has to.
-DEFAULT_STAGE_GRAPH = "linear"
+#:
+#: Adaptive is the default because the failure it prevents is the expensive one: a
+#: run that reaches Stage 06, discovers the design cannot answer the question, and
+#: writes it up anyway because there was nowhere else to go. `--stage-graph linear`
+#: restores the strict sequence.
+DEFAULT_STAGE_GRAPH = "adaptive"
 STAGE_GRAPH_CHOICES = ("linear", "adaptive")
 
 #: Who picks the edge. ``off`` always takes the graph's default, which on a linear
 #: topology is the only one. ``auto`` asks the backend wherever more than one move
 #: is live; ``agent`` asks at every node.
-DEFAULT_ROUTING_MODE = "off"
+#:
+#: ``auto`` is the default: it asks only where the answer can differ, so a linear
+#: run never pays for it, and an adaptive run pays a short prompt at the handful of
+#: nodes with a real choice. The stage that just ran is the only party that knows
+#: whether its results decided anything, and not asking it throws that away.
+DEFAULT_ROUTING_MODE = "auto"
 ROUTING_MODE_CHOICES = ("off", "auto", "agent")
 
-#: Self-improvement rounds per stage. Zero is off, which is the default: the loop
-#: costs a backend call per round, and a caller who has not asked for it should not
-#: be paying for it.
-DEFAULT_EVOLVE_ROUNDS = 0
+#: Polish rounds per stage. See :class:`src.evolution.EvolutionConfig` — this is the
+#: half that costs backend calls, and it is bounded further by a headroom check, so
+#: a stage the rubric has nothing to say about spends none of it.
+DEFAULT_EVOLVE_ROUNDS = 2
+
+#: Whether every valid draft is scored and the champion ratchet runs. Free: the
+#: rubric reads the run off disk and never calls a backend. Persisted alongside the
+#: rounds budget so a resumed run keeps the arrangement it started under.
+DEFAULT_EVOLVE_MEASURE = True
+
+#: Whether the cross-run archive is allowed to change the topology a run uses, as
+#: opposed to merely recording what the run did.
+#:
+#: Off by default, and the split is the point. Recording is free and builds the only
+#: dataset that could ever justify a change. Steering means a run silently uses a
+#: different topology from the one the operator asked for, and "the harness quietly
+#: rerouted itself on run 47" is not a surprise a research tool gets to spring on
+#: someone. Turn it on deliberately, once the archive has something to say.
+DEFAULT_ARCHIVE_STEER = False
 
 
 def normalize_walk_settings(source: "Mapping[str, Any]") -> dict[str, Any]:
@@ -379,10 +404,14 @@ def normalize_walk_settings(source: "Mapping[str, Any]") -> dict[str, Any]:
         rounds_value = max(0, int(rounds))
     except (TypeError, ValueError):
         rounds_value = DEFAULT_EVOLVE_ROUNDS
+    measure = source.get("evolve_measure")
+    steer = source.get("archive_steer")
     return {
         "stage_graph": graph if graph in STAGE_GRAPH_CHOICES else DEFAULT_STAGE_GRAPH,
         "routing_mode": routing if routing in ROUTING_MODE_CHOICES else DEFAULT_ROUTING_MODE,
         "evolve_rounds": rounds_value,
+        "evolve_measure": DEFAULT_EVOLVE_MEASURE if measure is None else bool(measure),
+        "archive_steer": DEFAULT_ARCHIVE_STEER if steer is None else bool(steer),
     }
 WEB_SEARCH_MODE_CHOICES = ("auto", "gemini", "native")
 DEFAULT_WEB_SEARCH_MODE = "auto"
@@ -1863,6 +1892,31 @@ def _has_recent_files_with_suffixes(directory: Path, suffixes: set[str], cutoff_
 
 def _count_non_markdown_files(directory: Path) -> int:
     return sum(1 for path in _existing_files(directory) if path.suffix.lower() not in {".md", ".txt"})
+
+
+def _polish_count_path(paths: RunPaths, stage: StageSpec) -> Path:
+    return paths.operator_state_dir / f"{stage.slug}.polish_count.txt"
+
+
+def read_polish_count(paths: RunPaths, stage: StageSpec) -> int:
+    """Improvement rounds this stage has spent, across every entry into it.
+
+    Persisted for the same reason the attempt count is: a stage can be entered more
+    than once — a resume, a rollback, a graph revisit — and the attempt number keeps
+    counting up across all of them. Subtracting a per-entry polish counter from a
+    run-wide attempt number would under-report retries on the second visit, which is
+    exactly the number the fake-pipeline gate reads to notice an artifact gate that
+    fake mode cannot clear.
+    """
+    path = _polish_count_path(paths, stage)
+    if not path.exists():
+        return 0
+    text = read_text(path).strip()
+    return int(text) if text.isdigit() else 0
+
+
+def write_polish_count(paths: RunPaths, stage: StageSpec, count: int) -> None:
+    write_text(_polish_count_path(paths, stage), str(count))
 
 
 def read_attempt_count(paths: RunPaths, stage: StageSpec) -> int:

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -14,6 +14,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from src.evolution import EvolutionConfig
 from src.manager import ResearchManager
 from src.manifest import load_run_manifest
 from src.operator import ClaudeOperator
@@ -146,6 +147,9 @@ class TestRunStageMaxAttempts(unittest.TestCase):
             runs_dir=self.runs_dir,
             operator=self.operator,
             ui=self.ui,
+            # Improvement rounds off: this file measures the retry window and the
+            # recovery path, and a polish round is an operator call that is neither.
+            evolution=EvolutionConfig(rounds=0),
         )
 
     def tearDown(self):

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -31,7 +31,7 @@ class RatchetTests(unittest.TestCase):
         self.paths = build_run_paths(Path(self._tmp.name) / "run")
         ensure_run_layout(self.paths)
         write_text(self.paths.user_input, "goal")
-        self.controller = EvolutionController(EvolutionConfig(enabled=True, rounds=3))
+        self.controller = EvolutionController(EvolutionConfig(rounds=3))
         self.build_run()
 
     def build_run(self) -> None:
@@ -159,7 +159,7 @@ class RatchetTests(unittest.TestCase):
     # -- round scheduling ----------------------------------------------------
 
     def test_the_round_budget_is_respected(self) -> None:
-        controller = EvolutionController(EvolutionConfig(enabled=True, rounds=2))
+        controller = EvolutionController(EvolutionConfig(rounds=2))
         self.controller = controller
         self.offer(stage_markdown(STAGE_06, key_results="Things improved."), 1, polish=False)
         spent = 0
@@ -172,7 +172,7 @@ class RatchetTests(unittest.TestCase):
     def test_a_stage_that_stops_responding_stops_being_polished(self) -> None:
         """Most stages are done after one targeted fix. Spending the rest of the
         budget rewording a draft at the ceiling is the common waste."""
-        controller = EvolutionController(EvolutionConfig(enabled=True, rounds=8, patience=2))
+        controller = EvolutionController(EvolutionConfig(rounds=8, patience=2))
         self.controller = controller
         self.offer(stage_markdown(STAGE_06), 1, polish=False)
         flat = stage_markdown(STAGE_06, key_results="Things improved.")
@@ -191,7 +191,7 @@ class RatchetTests(unittest.TestCase):
 
     def test_a_config_that_excludes_a_stage_does_not_polish_it(self) -> None:
         controller = EvolutionController(
-            EvolutionConfig(enabled=True, rounds=3, stages=("05_experimentation",))
+            EvolutionConfig(rounds=3, stages=("05_experimentation",))
         )
         self.assertFalse(controller.should_continue(self.paths, STAGE_06))
 
@@ -203,7 +203,7 @@ class RatchetTests(unittest.TestCase):
         strong = stage_markdown(STAGE_06)
         self.offer(strong, 1, polish=False)
 
-        resumed = EvolutionController(EvolutionConfig(enabled=True, rounds=3))
+        resumed = EvolutionController(EvolutionConfig(rounds=3))
         state = resumed.state(self.paths, STAGE_06)
         self.assertIsNotNone(state.champion)
 
@@ -227,7 +227,7 @@ class RatchetTests(unittest.TestCase):
             self.controller.stage_dir(self.paths, STAGE_06) / "champion.json",
             json.dumps(stale.to_dict()),
         )
-        fresh = EvolutionController(EvolutionConfig(enabled=True, rounds=1))
+        fresh = EvolutionController(EvolutionConfig(rounds=1))
         self.assertIsNone(fresh.state(self.paths, STAGE_06).champion)
 
     def test_the_run_summary_omits_stages_that_were_never_measured(self) -> None:

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -21,7 +21,8 @@ from src.evolution import EvolutionConfig
 from src.manager import ResearchManager
 from src.manifest import load_run_manifest
 from src.router import RoutingDecision
-from src.stage_graph import FINISH, StageGraph, load_graph_state
+from src.rubric import score_stage
+from src.stage_graph import FINISH, GUARDS, GraphState, StageGraph, load_graph_state
 from src.utils import STAGES, build_run_paths, load_run_config, read_text
 from tests.test_manager_smoke import REPO_ROOT, ScriptedSmokeOperator
 
@@ -74,11 +75,16 @@ class GraphWalkTests(unittest.TestCase):
         self.assertEqual(len(roots), 1)
         return build_run_paths(roots[0])
 
-    # -- the default has to be what it always was ----------------------------
+    # -- what a run that asks for nothing gets -------------------------------
 
-    def test_a_default_run_still_walks_01_through_08(self) -> None:
-        """The regression that would matter most. A run that asked for nothing new
-        must produce the same route it always did, through the new engine."""
+    def test_the_default_run_is_adaptive_and_still_reaches_the_end(self) -> None:
+        """The default topology can go back, but nothing pushes it back on its own.
+
+        Every backward move needs a reason, and nobody supplies one here, so the
+        route is the plain sequence. This is the regression that would matter most:
+        turning the graph on by default must not change where an ordinary run ends
+        up, only what it is *able* to do.
+        """
         _operator, manager = self.build()
         self.assertTrue(self.drive(manager))
 
@@ -86,15 +92,49 @@ class GraphWalkTests(unittest.TestCase):
         state = load_graph_state(paths)
         self.assertEqual([visit.stage for visit in state.path], [stage.slug for stage in STAGES])
         self.assertEqual(state.path[-1].chose, FINISH)
-        self.assertFalse(any(visit.agent_directed for visit in state.path))
+        self.assertEqual(load_run_config(paths)["stage_graph"], "adaptive")
+        self.assertEqual(load_run_config(paths)["routing_mode"], "auto")
+
+    def test_an_explicit_linear_run_walks_the_strict_sequence(self) -> None:
+        _operator, manager = self.build(stage_graph=StageGraph.linear())
+        self.assertTrue(self.drive(manager))
+        paths = self.only_run()
+        self.assertEqual(
+            [visit.stage for visit in load_graph_state(paths).path],
+            [stage.slug for stage in STAGES],
+        )
         self.assertEqual(load_run_config(paths)["stage_graph"], "linear")
 
-    def test_a_default_run_never_calls_the_router(self) -> None:
-        """`routing off` is the default, and a default that quietly spent a backend
-        call per stage boundary would be a cost nobody asked for."""
-        _operator, manager = self.build()
+    def test_routing_off_never_calls_the_router(self) -> None:
+        """The escape hatch has to actually be an escape hatch: a run that turned
+        routing off must not spend a backend call per stage boundary."""
+        _operator, manager = self.build(routing_mode="off")
         with patch.object(manager.router, "_ask", side_effect=AssertionError("router was asked")):
             self.assertTrue(self.drive(manager))
+
+    def test_a_router_that_cannot_be_reached_does_not_derail_the_walk(self) -> None:
+        """Routing is on by default, so its failure mode is now everyone's.
+
+        The backend here has none of the private methods the router calls, which is
+        the harshest version of "the routing call did not work". The run has to come
+        out the same as one that never asked.
+        """
+        _operator, manager = self.build()
+        self.assertTrue(self.drive(manager))
+        state = load_graph_state(self.only_run())
+        self.assertEqual([visit.stage for visit in state.path], [stage.slug for stage in STAGES])
+        self.assertFalse(any(visit.agent_directed for visit in state.path))
+
+    def test_the_default_move_is_never_a_backward_one(self) -> None:
+        """A revisit taken by default carries no reason, and the router refuses an
+        unreasoned revisit. A default able to do what no explicit decision may do
+        would be the one path around that rule.
+        """
+        _operator, manager = self.build()
+        self.assertTrue(self.drive(manager))
+        for visit in load_graph_state(self.only_run()).path:
+            if not visit.agent_directed:
+                self.assertNotEqual(visit.kind, "revisit", msg=f"{visit.stage} reversed by default")
 
     # -- the walk follows the router -----------------------------------------
 
@@ -189,6 +229,56 @@ class GraphWalkTests(unittest.TestCase):
         self.assertLessEqual(state.steps, 6)
         self.assertIn("step limit", state.halted_because)
 
+    # -- the checks have to be satisfiable -----------------------------------
+
+    def test_every_guard_passes_on_a_completed_run(self) -> None:
+        """A precondition no real run can meet is not a strict gate, it is a broken one.
+
+        This is the test that was missing. Two checks shipped reading keys nothing
+        in AutoR writes — `experiment_manifest.experiments`, which does not exist
+        (the real key is `result_artifacts`), and a
+        `workspace/literature/evidence_ledger.json` that no writer produces. Both
+        failed silently on every run: the forward move out of Stage 05 was
+        permanently shut and the reproducibility criterion permanently docked, and
+        nothing anywhere said so, because a guard that always fails looks exactly
+        like a guard protecting you from something.
+
+        Asserting against a run driven all the way through, rather than against a
+        fixture, is the point — a fixture would have been built from the same wrong
+        assumption as the code.
+        """
+        _operator, manager = self.build(stage_graph=StageGraph.linear(), routing_mode="off")
+        self.assertTrue(self.drive(manager))
+        paths = self.only_run()
+
+        failing = {
+            name: fn(paths, GraphState()).reason
+            for name, fn in sorted(GUARDS.items())
+            if not fn(paths, GraphState()).ok
+        }
+        self.assertEqual(failing, {}, msg=f"guards unsatisfiable by a completed run: {failing}")
+
+    def test_every_reproducibility_check_passes_on_a_completed_run(self) -> None:
+        """The same trap on the rubric side: a criterion that can never reach 1.00
+        is a constant subtracted from every score, not a measurement."""
+        _operator, manager = self.build(stage_graph=StageGraph.linear(), routing_mode="off")
+        self.assertTrue(self.drive(manager))
+        paths = self.only_run()
+
+        shortfalls = {}
+        for stage in STAGES:
+            score = score_stage(
+                paths=paths,
+                stage=stage,
+                markdown=read_text(paths.stage_file(stage)),
+            )
+            item = score.by_key.get("reproducibility")
+            if item is not None and item.score < 1.0:
+                shortfalls[stage.slug] = item.observed
+        self.assertEqual(
+            shortfalls, {}, msg=f"validity-chain checks unsatisfiable by a completed run: {shortfalls}"
+        )
+
     # -- settings survive a resume -------------------------------------------
 
     def test_the_walk_settings_are_preserved_on_resume(self) -> None:
@@ -197,7 +287,7 @@ class GraphWalkTests(unittest.TestCase):
         _operator, manager = self.build(
             stage_graph=StageGraph.adaptive(),
             routing_mode="auto",
-            evolution=EvolutionConfig(enabled=True, rounds=2),
+            evolution=EvolutionConfig(rounds=2),
         )
         self.drive(manager)
         paths = self.only_run()
@@ -209,7 +299,7 @@ class GraphWalkTests(unittest.TestCase):
     # -- evolution through the real loop -------------------------------------
 
     def test_evolution_promotes_the_champion_and_writes_a_ledger(self) -> None:
-        _operator, manager = self.build(evolution=EvolutionConfig(enabled=True, rounds=2))
+        _operator, manager = self.build(evolution=EvolutionConfig(rounds=2))
         self.assertTrue(self.drive(manager))
 
         paths = self.only_run()
@@ -236,7 +326,7 @@ class GraphWalkTests(unittest.TestCase):
         would otherwise look like one that was thrashing, and would have nothing
         left if a later round did break something."""
         _operator, manager = self.build(
-            evolution=EvolutionConfig(enabled=True, rounds=3), max_stage_attempts=2
+            evolution=EvolutionConfig(rounds=3), max_stage_attempts=2
         )
         self.assertTrue(self.drive(manager))
         paths = self.only_run()

--- a/tests/test_manager_smoke.py
+++ b/tests/test_manager_smoke.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 
 from src.approval_agent import ReviewDecision
 from src.intake import load_intake_context
+from src.evolution import EvolutionConfig
 from src.manager import ResearchManager
 from src.manifest import load_run_manifest
 from src.project_bootstrap import StageAssessment
@@ -671,6 +672,12 @@ class ManagerSmokeTests(unittest.TestCase):
             runs_dir=runs_dir,
             operator=operator,
             output_stream=io.StringIO(),
+            # Improvement rounds off: these tests count operator invocations to
+            # measure the retry, session-reuse and round mechanics, and a polish
+            # round is an invocation that is none of those. Measuring stays on, so
+            # the ratchet is still exercised; `tests/test_graph_walk.py` is where
+            # the rounds themselves are tested.
+            evolution=EvolutionConfig(rounds=0),
         )
         return runs_dir, operator, manager
 
@@ -826,6 +833,7 @@ class ManagerSmokeTests(unittest.TestCase):
                 approval_mode="agent",
                 review_operator="claude",
                 review_model="sonnet",
+                evolution=EvolutionConfig(rounds=0),
             )
             paths = manager._create_run("Smoke-test automated approval mode.", venue="neurips_2025")
 

--- a/tests/test_research_rounds.py
+++ b/tests/test_research_rounds.py
@@ -20,6 +20,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from src.evolution import EvolutionConfig
 from src.manager import ResearchManager
 from src.research_rounds import (
     DECISIONS,
@@ -259,6 +260,12 @@ class ManagerLoopTest(unittest.TestCase):
             operator=operator,
             output_stream=io.StringIO(),
             max_rounds=max_rounds,
+            # Improvement rounds off: these tests count operator invocations to
+            # measure the retry, session-reuse and round mechanics, and a polish
+            # round is an invocation that is none of those. Measuring stays on, so
+            # the ratchet is still exercised; `tests/test_graph_walk.py` is where
+            # the rounds themselves are tested.
+            evolution=EvolutionConfig(rounds=0),
         )
         return operator, manager
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -121,17 +121,39 @@ class RouterTests(unittest.TestCase):
 
     # -- refusals ------------------------------------------------------------
 
-    def test_a_blocked_move_is_refused_and_falls_forward(self) -> None:
-        """Writing is closed until the hypotheses are adjudicated, and an agent
-        asked where to go next reaches for the deliverable."""
+    def test_a_blocked_move_is_refused_even_when_the_fallback_goes_there_anyway(self) -> None:
+        """Writing is closed until the hypotheses are adjudicated, and an agent asked
+        where to go next reaches for the deliverable.
+
+        The run still ends up at Stage 07, because the default is always the forward
+        edge and taking it with the precondition unmet beats halting with nothing —
+        the stage's own validation is the correctness gate and will refuse a write-up
+        of unadjudicated hypotheses. What must not survive is the *attribution*: this
+        was not the agent's decision, the refusal is on the record with the reason,
+        and the route says the precondition was unmet. Otherwise the archive later
+        learns from a step labelled as a considered choice that was nothing of the
+        kind.
+        """
         prereg_support.write_hypothesis_manifest(self.paths)
         prereg_support.freeze_preregistration(self.paths)
         decision, _ = self.choose(
             json.dumps({"target": "07_writing", "reason": "The results look conclusive."})
         )
-        self.assertNotEqual(decision.target, "07_writing")
         self.assertFalse(decision.agent_directed)
         self.assertIn("07_writing", decision.refusal)
+        self.assertIn(prereg_support.HYPOTHESIS_ID, decision.refusal)
+
+    def test_a_default_taken_with_its_guard_failing_says_so_on_the_route(self) -> None:
+        """A step recorded as an ordinary advance when its precondition was unmet is
+        a mislabelled observation, and the archive learns from these."""
+        prereg_support.write_hypothesis_manifest(self.paths)
+        prereg_support.freeze_preregistration(self.paths)
+        decision = StageRouter(None, mode="off").choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+        )
+        self.assertEqual(decision.target, "07_writing")
+        self.assertIn("precondition unmet", decision.reason)
+        self.assertIn(prereg_support.HYPOTHESIS_ID, decision.reason)
 
     def test_a_move_that_does_not_exist_is_refused(self) -> None:
         decision, _ = self.choose(json.dumps({"target": "04_implementation", "reason": "Rebuild."}))


### PR DESCRIPTION
The graph and the ratchet shipped **off** by default in #129, which made the headline feature something you had to know to ask for. Turning them on found three things that being off had hidden.

```bash
python main.py --goal "..."          # graph + routing + measurement + 2 rounds + archive recording
python main.py --archive-report      # what the archive has learned across runs
```

Opt-outs: `--stage-graph linear`, `--routing off`, `--no-evolve`, `--evolve-rounds 0`, `--no-archive`.

## What each default costs

| | Default | Backend calls it adds |
| --- | --- | --- |
| `--stage-graph adaptive` | on | none |
| `--routing auto` | on | one short prompt per node with >1 live move |
| measuring + the ratchet | on | **none** — the rubric reads the run off disk |
| `--evolve-rounds 2` | on | ≤2 stage executions per stage, none where the rubric sees no headroom |
| archive recording | on | none |
| `--archive-steer` | **off** | none |

## 1. The measurement was free and gated behind the expensive half

`EvolutionConfig` had one switch for two very different costs. Split into `measure` (on — scoring and the champion ratchet spend no backend call) and `rounds` (2 — the half that buys stage executions), plus a headroom check that fires *before* a round is bought, so a stage the rubric has nothing to say about spends nothing.

That split is what makes the defaults defensible. A run that never polishes still gets the property that matters most: the promoted draft is the best one the run produced, not the last one.

Fake-mode runs spend no rounds — a scripted operator emits the same draft whatever the directive says. Applied at the operator rather than the CLI, so the number the operator *asked* for is still what reaches `run_config.json`; zeroing it there would mean resuming a fake run with a real backend silently inherited a budget of nothing.

## 2. Two checks read keys nothing in AutoR writes

- `experiment_manifest.experiments` **does not exist**. The real key is `result_artifacts`.
- There is no `workspace/literature/evidence_ledger.json`. The evidence base is `sources.json` + `claims.json`, and `validate_literature_evidence` is its shipped definition — now delegated to rather than restated.

Both failed silently on **every run**: the forward move out of Stage 05 was permanently shut, and the reproducibility criterion permanently docked. Nothing said so, because a guard that always fails looks exactly like a guard protecting you from something. Off by default, neither was reachable.

`test_every_guard_passes_on_a_completed_run` and its rubric counterpart drive a run all the way through and assert every check is satisfiable — against a real run rather than a fixture, since a fixture would have been built from the same wrong assumption as the code.

## 3. A guard is a routing preference, not a gate

A closed edge leaves the menu the agent chooses from; it does not leave the graph. When the forward edge is shut and nobody has chosen otherwise, the run advances with the precondition unmet and the route records that. The correctness gate is the stage's own validation — unchanged, and still refusing a Stage 07 that writes up unadjudicated hypotheses. A run that halts here produces nothing, where the linear pipeline would have produced a deliverable and failed the gate honestly. Halting is the same refusal with the evidence thrown away.

**The default never goes backward.** Tried first, and wrong in a way only running it showed: Stage 04's guard fails when `workspace/code` holds nothing executable, the only backward edge out of 04 leads to study design, and study design is not the stage that writes code. The default sent the run somewhere that could not fix what blocked it and attached the guard's message as a justification — and did it again next time round. Which backward edge addresses a block is a judgement about the research, so it belongs to the agent. A run nobody is steering goes straight down the pipeline.

## Also

- **`attempt_count` means retries again.** A polish round is not a try that failed, and conflating them blinded `test_no_stage_needed_a_retry`, which is how a new artifact gate that fake mode cannot clear gets noticed. The polish counter is persisted per stage: the attempt number is run-wide and a stage can be entered more than once, so subtracting a per-entry counter under-reported retries on the second visit.
- **A re-entered stage gets a fresh round budget.** Its champion survives — that is the ratchet — but a stage doing new work because a later stage found a problem should not be charged for its previous visit's rounds.
- **Archive recording is on; steering is not.** Recording is free and is the only thing that could ever justify a change to the topology, and it cannot be built retroactively. A run silently using a different topology from the one asked for is not a surprise a research tool gets to spring on anyone.

## Testing

993 pass (up from 916; +77). New: guard and rubric satisfiability against a completed run, the default-is-never-backward property, last-resort attribution, explicit-linear parity, and routing-off costing nothing.

Existing tests that count operator invocations to measure retry, session-reuse and round mechanics now pin `evolution=EvolutionConfig(rounds=0)` — a polish round is an invocation that is none of those. Measuring stays on in all of them, so the ratchet is still exercised.

Docs: README (news, at-a-glance, commands, both How-It-Works sections, scope), `docs/self-improvement.md`, `docs/cli-reference.md`, `docs/run-artifacts.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)