### PR TITLE
Give the archive a way into its own blind spot

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,30 @@ flowchart TD
 
 The stage loop is controlled by AutoR, not by Claude.
 
+### The graph learns which moves pay — including ones it has never made
+
+The stages are a directed graph, and an archive across runs learns which edges are
+worth preferring. That learning had a blind spot with no exit: payoffs compare runs
+that *took* an edge against runs that did not, so an edge nothing has ever taken has
+no evidence in either direction, is never proposed, is never preferred, and is
+therefore never taken. The backward edges — the reason the graph exists at all —
+start unpreferred, so they are exactly the ones the loop stranded.
+
+So there are two proposers, not one:
+
+| | reads | produces |
+|:---|:---|:---|
+| **exploit** | believable payoffs | prefer an edge that has been paying |
+| **explore** | edges with *zero* observations | buy one trial for an edge never tried |
+
+Exploration buys a trial, never a verdict. An explored edge that does not pay is
+deprioritised again by the ordinary proposer once its payoff becomes believable, so
+exploration cannot ratchet anything in by itself. And like every variant it only
+reorders preferences: it never opens a guarded edge, adds one, or removes one — the
+guards are the correctness argument for letting an agent route at all, and the
+component that learns from outcomes is precisely the one that must not be able to
+weaken them.
+
 ### Obligations carried forward
 
 The reviewer's insight used to be captured only when it refused. But most stages are

--- a/src/archive.py
+++ b/src/archive.py
@@ -29,6 +29,17 @@ component that must not be able to weaken them — the cheapest way to raise mea
 fitness across an archive would be to stop checking whether hypotheses were
 adjudicated before writing up.
 
+**Exploit and explore are separate proposers.** :meth:`Archive.propose_variant`
+reads believable payoffs, and a payoff is only believable once runs have both
+taken an edge and skipped it. That makes it structurally unable to reach an edge
+nothing has taken: no takers, so no evidence either way, so never preferred, so
+never taken. The backward edges the graph exists for are the ones that start
+unpreferred, so they are the ones the loop strands.
+:meth:`Archive.propose_exploration` is the entry into that blind spot — it buys a
+trial for one never-taken edge, and nothing more. An explored edge that does not
+pay is deprioritised again by the ordinary proposer as soon as its payoff becomes
+believable, so exploration cannot ratchet anything in on its own.
+
 **Promotion needs the improvement to replay.** DGM promotes on a benchmark delta.
 A rigour score on a research run is noisier than a SWE-bench pass rate, so a
 variant here stays unpromoted until it has been observed ``min_observations``
@@ -251,18 +262,27 @@ def _mean(values: Sequence[float]) -> float:
     return sum(values) / len(values) if values else 0.0
 
 
-def edge_payoffs(records: Iterable[RunRecord]) -> dict[str, EdgePayoff]:
+def edge_payoffs(
+    records: Iterable[RunRecord],
+    known_edges: Iterable[str] | None = None,
+) -> dict[str, EdgePayoff]:
     """For each edge, runs that took it against runs that were at the same node and did not.
 
     The comparison is against *runs that reached the source*, not against every run
     in the archive. Comparing "took 06→05" against the whole archive would credit
     the edge with the difference between runs that got as far as Stage 06 and runs
     that did not, which has nothing to do with the edge.
+
+    ``known_edges`` is the topology's declared edge set. Without it the candidate
+    edges are only those some run already took, so an edge nothing has ever taken
+    is not merely unbelievable — it is invisible, and cannot be reasoned about at
+    all. Passing the declared set makes it appear with ``taken_runs == 0``, which
+    is what :meth:`Archive.unexplored_edges` needs in order to notice it.
     """
     usable = [record for record in records if record.rubric_version == RUBRIC_VERSION]
     payoffs: dict[str, EdgePayoff] = {}
 
-    edges = {edge for record in usable for edge in record.edges}
+    edges = {edge for record in usable for edge in record.edges} | set(known_edges or ())
     for edge in sorted(edges):
         source = edge.split("->", 1)[0]
         reached = [
@@ -477,6 +497,91 @@ class Archive:
                 f"{best.taken_mean:.3f} over {best.taken_runs} run(s) against "
                 f"{best.skipped_mean:.3f} over {best.skipped_runs} that reached the same node "
                 f"and did not ({best.delta:+.3f})."
+            ),
+            promoted=False,
+            created_at=_now(),
+        )
+        existing = self.variants()
+        if any(item.variant_id == variant.variant_id for item in existing):
+            return None
+        self._save_variants([*existing, variant])
+        return variant
+
+    def unexplored_edges(self, graph: StageGraph) -> list[str]:
+        """Declared edges no archived run has ever taken, in priority order.
+
+        These are the archive's blind spot. :func:`edge_payoffs` compares runs that
+        took an edge against runs that did not, so an edge with no takers yields no
+        evidence in either direction, and :meth:`propose_variant` — which only reads
+        believable payoffs — can never reach it. Left alone the arrangement is a
+        closed loop: never taken, so never evidenced, so never preferred, so never
+        taken. The backward edges the graph exists for are exactly the ones that
+        start unpreferred, so exactly the ones the loop strands.
+        """
+        declared = [f"{edge.source}->{edge.target}" for edge in graph.edges]
+        taken = {edge for record in self.runs() for edge in record.edges}
+        by_priority = {f"{edge.source}->{edge.target}": edge.priority for edge in graph.edges}
+        return sorted(
+            (edge for edge in declared if edge not in taken),
+            key=lambda edge: (by_priority.get(edge, 0), edge),
+        )
+
+    def propose_exploration(self, *, graph: StageGraph | None = None) -> Variant | None:
+        """Derive a child that makes one never-taken edge preferable enough to try.
+
+        The counterpart to :meth:`propose_variant`. That one exploits evidence; this
+        one is how the evidence comes to exist. Both produce the same kind of
+        ``Variant``, promoted on the same replay conditions, so exploration buys a
+        trial and never a conclusion — an explored edge that does not pay is
+        deprioritised again by the ordinary proposer once its payoff is believable.
+
+        Deliberately conservative:
+
+        * **One edge, one step.** Same attributability rule the exploit proposer
+          follows. A variant that opens three unexplored edges at once cannot be told
+          apart from one that got lucky on a single edge.
+        * **Only when the archive is worth trusting.** With fewer than
+          ``min_observations`` runs the incumbent is barely evidenced either, and
+          deviating from it is noise rather than exploration.
+        * **Never a guard.** It moves a priority. An edge whose guard fails stays
+          inadmissible and is never taken however preferred it is, which is what
+          keeps the correctness argument in :mod:`src.stage_graph` intact.
+        """
+        parent = self.incumbent()
+        base_graph = graph or StageGraph.named(parent.topology)
+        if len(self.runs()) < self.min_observations:
+            return None
+
+        # Priority 0 is already the default move out of its node. An edge that
+        # preferred and still untaken is not waiting on the prior — its guard is
+        # closed, or the node is never reached — and nudging it changes nothing.
+        # So exploration only has something to offer edges that lost the ordering.
+        by_priority = {f"{e.source}->{e.target}": e.priority for e in base_graph.edges}
+        candidates = [
+            edge for edge in self.unexplored_edges(base_graph) if by_priority.get(edge, 0) > 0
+        ]
+        if not candidates:
+            return None
+
+        edge_key = candidates[0]
+        source, target = edge_key.split("->", 1)
+        current = by_priority[edge_key]
+
+        priorities = dict(parent.edge_priority)
+        priorities[edge_key] = max(0, current - 1)
+        if priorities == parent.edge_priority:
+            return None
+
+        variant = Variant(
+            variant_id=_variant_id(parent, edge_key, priorities[edge_key]),
+            topology=parent.topology,
+            edge_priority=priorities,
+            parent_id=parent.variant_id,
+            generation=parent.generation + 1,
+            note=(
+                f"`{edge_key}` preferred one step to explore it: no archived run has "
+                f"taken it, so it has no payoff in either direction and the ordinary "
+                f"proposer cannot reach it. Exploratory — it buys a trial, not a verdict."
             ),
             promoted=False,
             created_at=_now(),

--- a/tests/test_archive_exploration.py
+++ b/tests/test_archive_exploration.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.archive import (
+    RUBRIC_VERSION,
+    Archive,
+    RunRecord,
+    edge_payoffs,
+)
+from src.stage_graph import StageGraph
+from src.utils import append_jsonl
+
+
+def _record(run_id: str, edges: list[str], fitness: float = 0.5) -> RunRecord:
+    return RunRecord(
+        run_id=run_id,
+        variant_id="baseline",
+        rubric_version=RUBRIC_VERSION,
+        edges={edge: 1 for edge in edges},
+        stage_fitness={"05_experimentation": fitness, "06_analysis": fitness},
+        route="",
+        steps=len(edges),
+        revisits=0,
+        agent_directed=0,
+        recorded_at="2026-08-06T00:00:00",
+    )
+
+
+class EdgeVisibilityTest(unittest.TestCase):
+    """An edge nothing has taken must still be visible, or it cannot be reasoned about."""
+
+    def test_an_untaken_edge_is_invisible_without_the_declared_set(self) -> None:
+        payoffs = edge_payoffs([_record("r1", ["01_literature_survey->02_hypothesis_generation"], 0.5)])
+        self.assertNotIn("06_analysis->05_experimentation", payoffs)
+
+    def test_the_declared_set_makes_it_visible_with_zero_takers(self) -> None:
+        payoffs = edge_payoffs(
+            [_record("r1", ["01_literature_survey->02_hypothesis_generation"], 0.5)],
+            known_edges=["06_analysis->05_experimentation"],
+        )
+        self.assertIn("06_analysis->05_experimentation", payoffs)
+        self.assertEqual(payoffs["06_analysis->05_experimentation"].taken_runs, 0)
+
+    def test_a_visible_untaken_edge_is_still_not_believable(self) -> None:
+        """Visibility is not evidence. It must not become promotable by being seen."""
+        payoffs = edge_payoffs([_record("r1", ["a->b"], 0.5)], known_edges=["x->y"])
+        self.assertFalse(payoffs["x->y"].believable(min_observations=2))
+
+    def test_taken_edges_are_unaffected_by_the_declared_set(self) -> None:
+        records = [_record("r1", ["a->b"], 0.8), _record("r2", ["a->c"], 0.4)]
+        without = edge_payoffs(records)
+        with_declared = edge_payoffs(records, known_edges=["a->b", "a->c", "a->z"])
+        self.assertEqual(without["a->b"].to_dict(), with_declared["a->b"].to_dict())
+
+
+class ArchiveTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.archive = Archive(Path(self._tmp.name) / "archive", min_observations=2)
+        self.graph = StageGraph.adaptive()
+
+    def _add(self, run_id: str, edges: list[str], fitness: float = 0.5) -> None:
+        append_jsonl(self.archive.runs_file, _record(run_id, edges, fitness).to_dict())
+
+
+class UnexploredEdgeTest(ArchiveTestBase):
+    def test_an_empty_archive_reports_every_declared_edge_unexplored(self) -> None:
+        declared = {f"{e.source}->{e.target}" for e in self.graph.edges}
+        self.assertEqual(set(self.archive.unexplored_edges(self.graph)), declared)
+
+    def test_a_taken_edge_stops_being_unexplored(self) -> None:
+        edge = f"{self.graph.edges[0].source}->{self.graph.edges[0].target}"
+        self._add("r1", [edge])
+        self.assertNotIn(edge, self.archive.unexplored_edges(self.graph))
+
+    def test_a_linear_topology_offers_exploration_nothing(self) -> None:
+        """Every edge is priority 0, so there is no ordering to correct."""
+        linear = StageGraph.linear()
+        for index in range(3):
+            self._add(f"r{index}", ["01_literature_survey->02_hypothesis_generation"])
+        self.assertIsNone(self.archive.propose_exploration(graph=linear))
+
+    def test_unexplored_edges_come_back_in_priority_order(self) -> None:
+        ordered = self.archive.unexplored_edges(self.graph)
+        by_priority = {f"{e.source}->{e.target}": e.priority for e in self.graph.edges}
+        self.assertEqual(ordered, sorted(ordered, key=lambda e: (by_priority[e], e)))
+
+
+class ProposeExplorationTest(ArchiveTestBase):
+    """The proposer that gives the archive an entry into its own blind spot."""
+
+    def _nonzero_priority_edge(self) -> str:
+        edge = next(e for e in self.graph.edges if e.priority > 0)
+        return f"{edge.source}->{edge.target}"
+
+    def test_a_thin_archive_proposes_nothing(self) -> None:
+        """With almost no runs the incumbent is barely evidenced; deviating is noise."""
+        self._add("r1", ["01_literature_survey->02_hypothesis_generation"])
+        self.assertIsNone(self.archive.propose_exploration(graph=self.graph))
+
+    def test_an_unexplored_edge_is_proposed_once_the_archive_is_worth_trusting(self) -> None:
+        for index in range(3):
+            self._add(f"r{index}", ["01_literature_survey->02_hypothesis_generation"])
+        variant = self.archive.propose_exploration(graph=self.graph)
+        self.assertIsNotNone(variant)
+        self.assertEqual(len(variant.edge_priority), 1)
+        self.assertIn("no archived run has", variant.note)
+
+    def test_the_proposal_moves_exactly_one_edge_by_one_step(self) -> None:
+        for index in range(3):
+            self._add(f"r{index}", ["01_literature_survey->02_hypothesis_generation"])
+        variant = self.archive.propose_exploration(graph=self.graph)
+        edge_key, new_priority = next(iter(variant.edge_priority.items()))
+        source, target = edge_key.split("->", 1)
+        original = next(
+            e.priority for e in self.graph.edges if e.source == source and e.target == target
+        )
+        self.assertEqual(new_priority, original - 1)
+
+    def test_it_arrives_unpromoted_so_it_buys_a_trial_not_a_verdict(self) -> None:
+        for index in range(3):
+            self._add(f"r{index}", ["01_literature_survey->02_hypothesis_generation"])
+        self.assertFalse(self.archive.propose_exploration(graph=self.graph).promoted)
+
+    def test_the_same_proposal_is_not_made_twice(self) -> None:
+        for index in range(3):
+            self._add(f"r{index}", ["01_literature_survey->02_hypothesis_generation"])
+        self.assertIsNotNone(self.archive.propose_exploration(graph=self.graph))
+        self.assertIsNone(self.archive.propose_exploration(graph=self.graph))
+
+    def test_nothing_is_proposed_once_every_edge_has_been_tried(self) -> None:
+        declared = [f"{e.source}->{e.target}" for e in self.graph.edges]
+        for index in range(3):
+            self._add(f"r{index}", declared)
+        self.assertIsNone(self.archive.propose_exploration(graph=self.graph))
+
+    def test_exploration_never_touches_a_guard(self) -> None:
+        """The safety argument: it reorders preferences and nothing else."""
+        for index in range(3):
+            self._add(f"r{index}", ["01_literature_survey->02_hypothesis_generation"])
+        variant = self.archive.propose_exploration(graph=self.graph)
+        applied = variant.apply_to(self.graph)
+
+        before = {(e.source, e.target): e.guard for e in self.graph.edges}
+        after = {(e.source, e.target): e.guard for e in applied.edges}
+        self.assertEqual(set(before), set(after), "no edge added or removed")
+        for key, guard in before.items():
+            self.assertIs(after[key], guard, f"guard changed on {key}")
+
+
+class ClosedLoopRegressionTest(ArchiveTestBase):
+    """The defect this exists for: exploit-only learning can never reach an untaken edge."""
+
+    def test_the_exploit_proposer_alone_never_reaches_an_untaken_edge(self) -> None:
+        taken = "01_literature_survey->02_hypothesis_generation"
+        for index in range(6):
+            self._add(f"r{index}", [taken], fitness=0.5 + 0.01 * index)
+
+        exploit = self.archive.propose_variant(graph=self.graph)
+        touched = set(exploit.edge_priority) if exploit else set()
+        untaken = set(self.archive.unexplored_edges(self.graph))
+        self.assertTrue(untaken, "fixture must leave something unexplored")
+        self.assertFalse(touched & untaken, "exploit proposer cannot reach an untaken edge")
+
+        # ...and the explore proposer can.
+        explore = self.archive.propose_exploration(graph=self.graph)
+        self.assertIsNotNone(explore)
+        self.assertTrue(set(explore.edge_priority) & untaken)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
You were right that the graph is the interesting part. Looking at it, the self-evolution had a hole with no exit.

## The closed loop

`edge_payoffs` builds its candidate set from `record.edges` — edges some run **actually traversed** — and compares takers against skippers. An edge nothing has taken is therefore not merely *unbelievable*, it is **absent from the payoff table entirely**. `propose_variant` reads only believable payoffs, so it can never reach one:

```
never taken → no payoff → never proposed → never preferred → never taken
```

The edges this strands are the ones the graph exists for. The default topology prefers the forward edge at every node, so **every backward edge starts unpreferred** — and "analysis found the design was wrong" was a move the archive could never learn to make. The module's own docstring says the backward edges are the reason it exists; they were also the ones it was structurally blind to.

## Two changes

- **`edge_payoffs` accepts the declared edge set**, so an untaken edge appears with `taken_runs == 0` instead of vanishing. Visibility only — it is still not believable, and cannot be promoted for having been seen. A test pins that.
- **`Archive.propose_exploration`** is a second proposer beside the exploit one. It promotes a single never-taken edge by a single priority step, using the same `Variant` type and the same replay-based promotion.

| | reads | produces |
|:---|:---|:---|
| **exploit** (existing) | believable payoffs | prefer an edge that has been paying |
| **explore** (new) | edges with *zero* observations | buy one trial for an edge never tried |

**Exploration buys a trial, never a verdict.** An explored edge that does not pay is deprioritised again by the ordinary proposer once its payoff becomes believable, so exploration cannot ratchet anything in by itself.

## Deliberately narrow

- Nothing proposed until the archive has enough runs for the *incumbent* to be evidenced — below that, deviating is noise, not exploration.
- One edge, one step, matching the exploit proposer's attributability rule.
- A priority-0 edge is skipped: it is already the default, so if it is untaken its guard is closed or its node is unreachable, and reordering changes neither.

## Guards are untouched

That is the whole safety argument — a variant reorders preferences and cannot open, add, or remove an edge. The cheapest way to raise mean fitness across an archive would be to stop checking whether hypotheses were adjudicated before writing up, so the learning component must not be able to weaken a guard. The test asserts **guard identity** across the applied variant rather than trusting the prose.

## The test that carries the argument

```python
exploit = archive.propose_variant(graph=graph)        # six runs of evidence
untaken = set(archive.unexplored_edges(graph))
assert not (set(exploit.edge_priority) & untaken)      # cannot reach it
assert set(archive.propose_exploration(graph=graph).edge_priority) & untaken   # this can
```

1055 tests pass, 16 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)