### PR TITLE
Hold shared prompt rules once, and stop sending the same history twice

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -42,6 +42,7 @@ from .intake import (
 from .artifact_index import format_artifact_index_for_prompt, write_artifact_index
 from .experiment_manifest import format_experiment_manifest_for_prompt, write_experiment_manifest
 from .hypothesis_manifest import write_hypothesis_manifest
+from .prompt_fragments import compose_stage_template
 from .validity_review import ValidityReviewer, format_findings_for_prompt
 from .research_rounds import (
     ROUND_CLOSING_STAGE_NUMBER,
@@ -1660,8 +1661,13 @@ class ResearchManager:
         attempt_no: int = 1,
         previous_validation_errors: list[str] | None = None,
     ) -> str:
-        template = load_prompt_template(self.prompt_dir, stage, output_format=selected_output_format(paths))
-        stage_template = format_stage_template(template, stage, paths)
+        output_format = selected_output_format(paths)
+        template = load_prompt_template(self.prompt_dir, stage, output_format=output_format)
+        # Shared rules are composed in before substitution, so a fragment can use
+        # the same placeholder vocabulary as the templates without introducing a
+        # token of its own.
+        composed = compose_stage_template(template, stage, output_format)
+        stage_template = format_stage_template(composed, stage, paths)
         handoff_context = build_handoff_context(paths, upto_stage=stage)
 
         # A run can arrive at Stage 05 without ever passing through Stage 04's

--- a/src/prompt_fragments.py
+++ b/src/prompt_fragments.py
@@ -1,0 +1,104 @@
+"""Prompt text that belongs to every stage, held once instead of copied ten times.
+
+Ten stage templates each restated the same rules about where a stage may write,
+who promotes the draft, and who decides progression. Five identical lines across
+ten files is not a style problem: it is five places to forget when the rule
+changes, and the copies had already drifted — Stage 01 alone carried an extra
+"Do not approve the stage yourself" line, and the ordering differed between
+files for no reason.
+
+Two of these fragments are *derived from the constants the validators use*
+rather than written as prose. The accepted-extension lists were hand-copied into
+three prompts and two of the copies were already incomplete subsets of
+``MACHINE_DATA_SUFFIXES`` and ``RESULT_SUFFIXES``. A sentence generated from the
+constant cannot drift from it; a sentence describing the constant can, and had.
+
+Composition happens in ``_build_stage_prompt`` *before* placeholder
+substitution, so fragments may use the same ``{{TOKEN}}`` vocabulary as the
+templates and get expanded for free. No new token is introduced.
+"""
+
+from __future__ import annotations
+
+from .utils import (
+    FIGURE_SUFFIXES,
+    MACHINE_DATA_SUFFIXES,
+    RENDERABLE_IMAGE_SUFFIXES,
+    RESULT_SUFFIXES,
+    StageSpec,
+)
+
+
+STAGE_HEADER = "# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}"
+
+
+#: Where a stage may write, and who decides what happens next. One semantic
+#: cluster, none of it stage-specific. Appended after the stage's own
+#: instructions rather than merged into each template's Filesystem section,
+#: because the bullets that remain there are genuine per-stage directory
+#: routing.
+RUN_SAFETY = """## Run Safety
+
+- Write only under `{{WORKSPACE_ROOT}}`.
+- Put this attempt's stage summary at `{{STAGE_OUTPUT_PATH}}`. The manager validates and
+  promotes it to `{{STAGE_FINAL_OUTPUT_PATH}}`; never write that path yourself.
+- You do not approve this stage or decide what runs next."""
+
+
+def _extensions(suffixes: set[str]) -> str:
+    return ", ".join(f"`{item}`" for item in sorted(suffixes))
+
+
+def artifact_formats(stage: StageSpec, output_format: str) -> str:
+    """The extensions a stage's gate can actually see, straight from the constants.
+
+    The Stage 06 markdown branch resolves a real contradiction rather than
+    restating a rule: ``FIGURE_SUFFIXES`` accepts SVG and PDF, so an SVG figure
+    passes Stage 06's gate — and ``RENDERABLE_IMAGE_SUFFIXES`` does not, so the
+    same figure is invisible to the reviewer one stage later. Saying so at the
+    point the figure is created is cheaper than a Stage 07 failure that reads as
+    "no figures".
+    """
+    if stage.number == 3:
+        return (
+            "## Accepted Machine-Readable Formats\n\n"
+            "Dataset artifacts under `{{WORKSPACE_DATA_DIR}}` must use one of these extensions, "
+            f"or the stage gate does not see them: {_extensions(MACHINE_DATA_SUFFIXES)}."
+        )
+    if stage.number == 5:
+        return (
+            "## Accepted Machine-Readable Formats\n\n"
+            "Result artifacts under `{{WORKSPACE_RESULTS_DIR}}` must use one of these extensions, "
+            f"or the stage gate does not see them: {_extensions(RESULT_SUFFIXES)}."
+        )
+    if stage.number == 6:
+        if output_format == "markdown":
+            return (
+                "## Accepted Figure Formats\n\n"
+                "This run is in markdown mode. Save figures under `{{WORKSPACE_FIGURES_DIR}}` as "
+                "**PNG**. Stage 06 would accept "
+                f"{_extensions(FIGURE_SUFFIXES)}, but Stage 07 only attaches "
+                f"{_extensions(RENDERABLE_IMAGE_SUFFIXES)} to the report, so an SVG or PDF figure "
+                "passes here and counts as no figure at all one stage later."
+            )
+        return (
+            "## Accepted Figure Formats\n\n"
+            "Figures under `{{WORKSPACE_FIGURES_DIR}}` must use one of these extensions: "
+            f"{_extensions(FIGURE_SUFFIXES)}."
+        )
+    return ""
+
+
+def stage_fragments(stage: StageSpec, output_format: str) -> list[str]:
+    """Shared blocks for this stage, in the order they should appear."""
+    return [block for block in (artifact_formats(stage, output_format),) if block]
+
+
+def compose_stage_template(template: str, stage: StageSpec, output_format: str) -> str:
+    """Assemble the full pre-substitution stage instruction text.
+
+    Order matters: the stage's own instructions first, then the format rules
+    that constrain them, then the safety rules that constrain everything.
+    """
+    parts = [STAGE_HEADER, template.strip(), *stage_fragments(stage, output_format), RUN_SAFETY]
+    return "\n\n".join(part for part in parts if part)

--- a/src/prompts/00_intake.md
+++ b/src/prompts/00_intake.md
@@ -1,6 +1,4 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the research intake stage for a serious research workflow. Your role is to act as a Socratic interviewer: analyze the user's research goal and any resources they have provided, then produce a clear, structured research brief that will guide all downstream stages.
+You are executing the research intake stage. Your role is a Socratic interviewer, not a planner: any assumption you made on the user's behalf that would change the experiment must become one of the three clarification questions, not a sentence in the brief.
 
 ## Mission
 
@@ -12,16 +10,14 @@ Given the user's research goal (and any pre-loaded resources), produce a thoroug
 - If the user has pre-loaded resources (PDFs, code, datasets, .bib files, notes), examine them and summarize what each contributes.
 - Identify ambiguities, missing context, or implicit assumptions in the goal that later stages would need resolved.
 - Suggest which pipeline stages can leverage pre-existing resources and which will need to start from scratch.
-- Propose a concrete, actionable research direction based on the goal and available materials.
+- Propose a concrete, actionable research direction that rests only on what the user stated or provided. Where the direction only holds under an assumption you supplied, that assumption is a question, not a decision.
 - If resources are sufficient to skip or accelerate certain stages (e.g., literature already surveyed, dataset already available), note this explicitly.
 
 ## Filesystem Requirements
 
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
 - Put intake analysis notes under `{{WORKSPACE_NOTES_DIR}}`.
 - If you catalog or index user-provided resources, put the index under `{{WORKSPACE_NOTES_DIR}}`.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
+- Write the stage summary draft for the current attempt to `{{STAGE_OUTPUT_PATH}}`. The workflow manager promotes that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`; do not write there yourself.
 
 ## Quality Bar
 

--- a/src/prompts/01_literature_survey.md
+++ b/src/prompts/01_literature_survey.md
@@ -1,6 +1,4 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the literature survey stage for a serious research workflow whose target is publication-grade work, not a toy demonstration.
+You are writing the Related Work section that an author of one of these papers will referee. The failure here is a gap asserted from what you failed to recall: every "no prior work does X" is a search result or it is not a finding. Record such claims in `claims.json` with the searches you ran and what they returned. Use the `citation-discipline` skill before you write `sources.json` — a reference recalled from memory is a fabrication Stage 07 has to retract.
 
 ## Mission
 
@@ -19,14 +17,13 @@ Given the user's research goal, build a high-quality research landscape overview
 
 ## Filesystem Requirements
 
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
 - Put reading notes, paper summaries, bibliographic notes, and topic maps under `{{WORKSPACE_LITERATURE_DIR}}`.
-- Write `{{WORKSPACE_LITERATURE_DIR}}/sources.json` as a structured source catalog with stable `source_id` values.
-- Write `{{WORKSPACE_LITERATURE_DIR}}/claims.json` as a structured survey claim ledger whose `source_ids` point back to `sources.json`.
+- Write `{{WORKSPACE_LITERATURE_DIR}}/sources.json`: a `sources` list whose entries each carry a stable, unique `source_id` and a `title`.
+- Write `{{WORKSPACE_LITERATURE_DIR}}/claims.json`: a `claims` list whose entries each carry a `claim_id`, a `statement`, and a `source_ids` list naming entries that exist in `sources.json`.
+- A claim that an area is unexplored carries, in addition, the query strings you ran and what each returned. A gap you did not search for is not a gap, and it is the claim the rest of the run will rest on.
 - Put temporary thinking or unresolved questions under `{{WORKSPACE_NOTES_DIR}}`.
 - If you create structured survey tables, place them in `{{WORKSPACE_LITERATURE_DIR}}`.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
+- Write the stage summary draft for the current attempt to `{{STAGE_OUTPUT_PATH}}`. The workflow manager promotes that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`; do not write there yourself.
 
 ## Quality Bar
 
@@ -44,7 +41,7 @@ Additional expectations for this stage:
 
 - `Objective` should describe the exact research question and survey objective.
 - `Previously Approved Stage Summaries` should summarize approved earlier context in readable form.
-- `What I Did` should explain how the literature landscape was mapped.
+- `What I Did` should explain how the literature landscape was mapped, including which searches you ran.
 - `Key Results` should include:
   - major research clusters or schools of thought
   - representative prior approaches
@@ -56,8 +53,5 @@ Additional expectations for this stage:
 
 ## Important Constraints
 
-- Do not control workflow progression.
-- Do not approve the stage yourself.
-- Do not write outside the current run directory.
 - Do not produce a shallow reading list in place of actual synthesis.
-- Do not leave substantive survey claims ungrounded when they belong in `claims.json`.
+- Every survey claim a later stage could act on belongs in `claims.json` with its `source_ids`. Do not decide on your own that a claim is too minor to record — the gap claim and the "standard baseline is X" claim are exactly the ones that get skipped.

--- a/src/prompts/02_hypothesis_generation.md
+++ b/src/prompts/02_hypothesis_generation.md
@@ -1,6 +1,4 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the hypothesis generation stage for a serious research workflow whose target is publication-grade work.
+An engineering goal in hypothesis clothing is the failure here — a decision rule that no plausible outcome could fail. State, for each empirical hypothesis, what the literature would predict and what result would surprise you; if no outcome would surprise anyone, it is not a hypothesis.
 
 ## Mission
 
@@ -18,11 +16,9 @@ Transform the approved literature-grounded context into strong, testable, non-tr
 
 ## Filesystem Requirements
 
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
 - Put hypothesis notes, assumption maps, and decision matrices under `{{WORKSPACE_NOTES_DIR}}`.
 - Put any literature-linked support tables under `{{WORKSPACE_LITERATURE_DIR}}`.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
+- Write the stage summary draft for the current attempt to `{{STAGE_OUTPUT_PATH}}`. The workflow manager promotes that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`; do not write there yourself.
 
 ## Quality Bar
 
@@ -64,7 +60,10 @@ Additional expectations for this stage:
   These hypotheses are **frozen** when Stage 04 is approved, before any result exists,
   and Stage 06 must return a verdict on each one. Write hypotheses you are willing to
   have refuted; a refuted hypothesis is a result, and the run records it as one.
-- `Paper Claims (Provisional)` should remain narrative-level and explicitly provisional.
+- `Paper Claims (Provisional)` are the sentences you would like to end up able to write:
+  an anchoring hazard, not a result. Keep them narrative-level and explicitly provisional.
+  Stage 07 has to spend a clause refusing to report them as findings, and no hypothesis
+  should be bent to protect one.
 - `Files Produced` should list any hypothesis artifacts created.
 - Ensure `Files Produced` includes `workspace/notes/hypothesis_manifest.json` as the typed-claim artifact for downstream stages.
 - `Suggestions for Refinement` should suggest ways to narrow, sharpen, or de-risk the hypotheses.
@@ -72,5 +71,3 @@ Additional expectations for this stage:
 ## Important Constraints
 
 - Do not produce generic "future work" statements in place of actual hypotheses.
-- Do not control workflow progression.
-- Do not write outside the current run directory.

--- a/src/prompts/03_study_design.md
+++ b/src/prompts/03_study_design.md
@@ -1,6 +1,6 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the study design stage for a serious research workflow whose target is publication-grade work.
+You are the person who will run this design yourself next week, on the compute already on this
+machine, in the time this run has left. A design whose cost is never stated is a wish list, and
+Stage 05 will report your omission as its own blocker.
 
 ## Mission
 
@@ -18,13 +18,10 @@ Convert the approved hypotheses into a concrete study or experimental design tha
 
 ## Filesystem Requirements
 
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
 - Put design docs, evaluation plans, ablation plans, and protocol notes under `{{WORKSPACE_NOTES_DIR}}`.
 - Put benchmark or dataset planning notes under `{{WORKSPACE_DATA_DIR}}`.
-- Create machine-readable dataset manifests under `{{WORKSPACE_DATA_DIR}}` (for example `.json`, `.jsonl`, `.csv`, `.yaml`) rather than only markdown descriptions.
+- Create machine-readable dataset manifests under `{{WORKSPACE_DATA_DIR}}` rather than only markdown descriptions.
 - Put planned result templates or reporting skeletons under `{{WORKSPACE_RESULTS_DIR}}`.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
 
 ## Quality Bar
 
@@ -63,6 +60,17 @@ Rules:
   beating — and a `tuning_budget` equal in effort to what the method will get. Beating a
   baseline nobody tried to make strong measures the effort split, not the method.
 
+## Feasibility (required)
+
+Cost the primary design before it leaves this stage. State all three in `Key Results` and in
+your design notes under `{{WORKSPACE_NOTES_DIR}}`:
+
+- Wall-clock and compute the primary design needs — conditions x seeds x cost per run —
+  against the hardware on this machine and the time this run has left.
+- What gets cut first if it does not fit: which conditions, seeds, or dataset scale go, in order.
+- That the cut-down version still tests `H1`. If it does not, resize the design here; do not
+  leave Stage 05 to discover it.
+
 ## Stage Output Requirements
 
 The markdown at `{{STAGE_OUTPUT_PATH}}` must follow the required output structure exactly.
@@ -73,6 +81,7 @@ Additional expectations for this stage:
   - the proposed study design
   - datasets, baselines, and evaluation criteria
   - validity and reproducibility considerations
+  - the feasibility estimate and the first thing cut
   - what the implementation stage must deliver
 - `Files Produced` should list design artifacts and planning documents.
 - `Suggestions for Refinement` should focus on strengthening rigor, feasibility, or evidential clarity.
@@ -81,5 +90,3 @@ Additional expectations for this stage:
 
 - Do not skip methodological weaknesses.
 - Do not treat plain markdown planning notes as sufficient data artifacts once concrete dataset definitions can be materialized.
-- Do not control workflow progression.
-- Do not write outside the current run directory.

--- a/src/prompts/04_implementation.md
+++ b/src/prompts/04_implementation.md
@@ -1,6 +1,7 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the implementation stage for a serious research workflow whose target is publication-grade work.
+Pseudocode theater — code that has never been executed — is the failure here. Nothing in this
+stage counts until the pipeline has run end to end on the smallest real slice. Write the exact
+command, its exit code and the first ten lines of its output to
+`{{WORKSPACE_NOTES_DIR}}/smoke_run.txt`.
 
 ## Mission
 
@@ -16,12 +17,9 @@ Implement the approved study design in a way that supports reproducible experime
 
 ## Filesystem Requirements
 
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
 - Put implementation files under `{{WORKSPACE_CODE_DIR}}`.
 - Put dataset loaders, transforms, metadata helpers, and machine-readable dataset manifests under `{{WORKSPACE_DATA_DIR}}` when relevant.
-- Put implementation notes or unresolved engineering concerns under `{{WORKSPACE_NOTES_DIR}}`.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
+- Put implementation notes, the smoke-run record, and unresolved engineering concerns under `{{WORKSPACE_NOTES_DIR}}`.
 
 ## Quality Bar
 
@@ -37,6 +35,7 @@ Additional expectations for this stage:
 
 - `Key Results` should include:
   - what was implemented
+  - the smoke run: the command, its exit code, and what it proves executes
   - what is runnable or partially runnable
   - major assumptions or missing pieces
   - what experimentation can now execute
@@ -47,5 +46,3 @@ Additional expectations for this stage:
 
 - Do not pretend unimplemented components exist.
 - Do not stop at prose-only implementation plans if concrete configs, manifests, scripts, or machine-readable artifacts can be produced.
-- Do not control workflow progression.
-- Do not write outside the current run directory.

--- a/src/prompts/05_experimentation.md
+++ b/src/prompts/05_experimentation.md
@@ -1,6 +1,6 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the experimentation stage for a serious research workflow whose target is publication-grade work.
+You are a technician executing a protocol you did not write, and you are not responsible for the
+result coming out right. Your deliverable is the runs plus the deviations. Knowing `H1`'s decision
+rule and iterating until it clears is the failure this stage exists to prevent.
 
 ## Mission
 
@@ -17,14 +17,10 @@ Run or define credible experiments that test the approved hypotheses using the i
 
 ## Filesystem Requirements
 
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
 - Put experiment scripts and run configs under `{{WORKSPACE_CODE_DIR}}` when needed.
-- Put raw or processed outputs under `{{WORKSPACE_RESULTS_DIR}}`.
-- Store machine-readable result artifacts such as `.json`, `.jsonl`, `.csv`, `.tsv`, `.parquet`, `.npy`, or `.npz` under `{{WORKSPACE_RESULTS_DIR}}`; markdown alone is not sufficient.
-- Keep `{{WORKSPACE_RESULTS_DIR}}/experiment_manifest.json` aligned with the current experiment bundle so downstream analysis can consume a stable machine-readable summary.
+- Put raw and processed outputs under `{{WORKSPACE_RESULTS_DIR}}` as machine-readable result files; a markdown summary is not a result artifact.
 - Put experiment logs, notes, and exception handling details under `{{WORKSPACE_NOTES_DIR}}`.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
+- `{{WORKSPACE_RESULTS_DIR}}/experiment_manifest.json` is generated for you by the workflow manager before each attempt and rewritten when the stage is approved — read it, do not write it. If it does not list a result you produced, the result file is missing or in the wrong place; fix that, not the manifest.
 
 ## Quality Bar
 
@@ -34,7 +30,7 @@ Run or define credible experiments that test the approved hypotheses using the i
 
 ## Protocol Discipline (required)
 
-`workspace/notes/experimental_protocol.json` was declared in Stage 03, before any result
+`{{WORKSPACE_NOTES_DIR}}/experimental_protocol.json` was declared in Stage 03, before any result
 existed.
 
 - Run the number of seeds it planned. If you run fewer, say so in `Key Results` with the
@@ -46,6 +42,10 @@ existed.
   replacing the primary one with a metric that came out better is not.
 - Record per-condition spread, not just means. Stage 06 has to state how the spread was
   measured and over how many runs, and it can only do that if this stage saved it.
+- Log the search: how many configurations you tried for the method, how many for each
+  baseline, and the point in the process at which the evaluation split was first read. Put
+  the counts in `Key Results` and the detail under `{{WORKSPACE_NOTES_DIR}}`. Report them
+  when they look clean too — a search log only means something if it is unconditional.
 
 ## Stage Output Requirements
 
@@ -57,6 +57,7 @@ Additional expectations for this stage:
   - what experiments were run
   - key observed outcomes
   - important anomalies or failures
+  - deviations from the declared protocol, including the search counts
   - what evidence is strong versus tentative
 - `Files Produced` should list experiment outputs and supporting files.
 - `Suggestions for Refinement` should focus on better experimental coverage, cleaner controls, or better failure isolation.
@@ -66,6 +67,5 @@ Additional expectations for this stage:
 - Do not fabricate results.
 - If results are simulated, partial, or blocked, say so explicitly.
 - Do not treat a prose results summary as sufficient experimentation output when raw/processed result files can be written.
-- Do not leave `experiment_manifest.json` missing or stale relative to the current result artifacts.
-- Do not control workflow progression.
-- Do not write outside the current run directory.
+- Do not hand-write or edit `experiment_manifest.json`. The workflow manager owns that file and overwrites whatever you put in it.
+- Do not edit `{{WORKSPACE_NOTES_DIR}}/preregistration.json`. The workflow manager froze it before this stage and checks it for tampering — read it, do not write it.

--- a/src/prompts/06_analysis.md
+++ b/src/prompts/06_analysis.md
@@ -1,6 +1,5 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the analysis stage for a serious research workflow whose target is publication-grade work.
+A trend read as a verdict is the failure here. Return a verdict against each preregistered
+decision rule, including the verdict that this run does not answer the question.
 
 ## Mission
 
@@ -16,13 +15,11 @@ Interpret the available evidence rigorously and determine what claims the curren
 
 ## Filesystem Requirements
 
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
 - Put analysis notes, evaluation breakdowns, and interpretive documents under `{{WORKSPACE_RESULTS_DIR}}` or `{{WORKSPACE_NOTES_DIR}}`.
 - Put figures, plots, or tables created for interpretation under `{{WORKSPACE_FIGURES_DIR}}` or `{{WORKSPACE_RESULTS_DIR}}`.
-- Create real figure files (`.png`, `.pdf`, `.svg`, `.jpg`) under `{{WORKSPACE_FIGURES_DIR}}`; textual descriptions of figures are not sufficient.
-- Read `{{WORKSPACE_RESULTS_DIR}}/experiment_manifest.json` before drawing conclusions so analysis tracks the actual standardized experiment bundle.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
+- Create real figure files (`.png`, `.pdf`, `.svg`, `.jpg`) under `{{WORKSPACE_FIGURES_DIR}}`; a described figure is not a figure.
+- Every figure supporting a verdict must show the dispersion that verdict rests on — error bars, per-seed points, or a band — with n stated in the caption.
+- Read `{{WORKSPACE_RESULTS_DIR}}/experiment_manifest.json` before drawing conclusions, so the analysis tracks the actual standardized experiment bundle.
 
 ## Quality Bar
 
@@ -31,56 +28,10 @@ Interpret the available evidence rigorously and determine what claims the curren
 - Make uncertainty explicit.
 - Translate raw outputs into defensible takeaways.
 
-## Round Decision (required)
-
-Stages 03-06 form a research round. This stage closes it. Write
-`{{WORKSPACE_NOTES_DIR}}/round_decision.json`:
-
-```json
-{
-  "decision": "converged | refine_design | new_hypothesis | abandon",
-  "rationale": "why this is the right call given what the evidence showed",
-  "what_we_learned": "what this round established, including when the answer is that a prediction was wrong",
-  "what_changes_next": "what a further round would do differently (required unless converged or abandoned)",
-  "negative_result": false
-}
-```
-
-- `converged` — the run has what it needs; go and write it up.
-- `refine_design` — the hypotheses stand but the design could not test them properly.
-  The next round restarts at Stage 03.
-- `new_hypothesis` — the hypotheses were wrong in an informative way. The next round
-  restarts at Stage 02, and the preregistration records the change as an amendment.
-- `abandon` — the question cannot be answered with the resources available. Say so.
-
-A round that wants another one must say what would change. Repeating a design without
-changing what it got wrong produces the same result at full cost.
-
-**You may not declare `converged` when no preregistered hypothesis came out supported,
-unless you set `negative_result: true`.** A run whose contribution is the refutation is
-a real result and should say so plainly. What is not available is proceeding to write a
-paper as though something had been shown. If the round budget is already spent the run
-will continue regardless — but the record will say the round wanted to iterate, which is
-the honest version.
-
-## Stage Output Requirements
-
-The markdown at `{{STAGE_OUTPUT_PATH}}` must follow the required output structure exactly.
-
-Additional expectations for this stage:
-
-- `Key Results` should include:
-  - the verdict on each preregistered hypothesis, by identifier
-  - the main conclusions supported by the evidence
-  - unsupported or weakened claims
-  - important caveats, limitations, or threats to interpretation
-  - what the writing stage should emphasize or avoid
-- `Files Produced` should list analysis artifacts, derived tables, or figures.
-
 ## Preregistration (required)
 
-The hypotheses in `workspace/notes/preregistration.json` were frozen before any result
-existed. You must not edit, reword, narrow or drop them.
+The hypotheses in `{{WORKSPACE_NOTES_DIR}}/preregistration.json` were frozen before any
+result existed. You must not edit, reword, narrow or drop them.
 
 Write `{{WORKSPACE_RESULTS_DIR}}/hypothesis_outcomes.json`:
 
@@ -112,7 +63,6 @@ Rules:
 
 - Every preregistered empirical hypothesis needs exactly one entry. A hypothesis the
   experiments never reached is `not_tested` — omitting it is not an option.
-- `supported` and `refuted` require at least one `evidence` path that exists in the run.
 - Apply each hypothesis's own decision rule. If the result does not clear the bar the
   hypothesis set in advance, the verdict is `refuted` or `inconclusive`, whatever the
   result looks like otherwise.
@@ -120,16 +70,63 @@ Rules:
   out supported, and do not soften a refutation into `inconclusive` to keep the paper
   positive. A refutation that is recorded honestly is worth more than a confirmation
   that was arranged.
-- Findings the data suggested but the run did not predict go in `exploratory_findings`,
-  never in `outcomes`.
-- A `supported` or `refuted` verdict needs a `statistics` block: how many runs it rests
-  on, and how the spread was measured. `dispersion_type` must name the measure — an
-  interval whose meaning is unstated cannot be read, and every venue asks.
+- If the measured gap is inside the spread, the verdict is `inconclusive`, however good
+  the mean looks.
+- `supported` and `refuted` require at least one `evidence` path that exists in the run.
+- `supported` and `refuted` also require a `statistics` block: how many runs the verdict
+  rests on, and how the spread was measured. `dispersion_type` must name the measure —
+  an interval whose meaning is unstated cannot be read, and every venue asks.
 - A verdict from a single run is refused unless `single_run_justification` says why one
   run settles it. A deterministic procedure is a legitimate reason; it is a claim worth
   making out loud rather than by omission.
-- If the measured gap is inside the spread, the verdict is `inconclusive`, however good
-  the mean looks.
+- Findings the data suggested but the run did not predict go in `exploratory_findings`,
+  never in `outcomes`.
+
+## Round Decision (required)
+
+Stages 03-06 form a research round. This stage closes it, on the verdicts you just
+recorded. Write `{{WORKSPACE_NOTES_DIR}}/round_decision.json`:
+
+```json
+{
+  "decision": "converged | refine_design | new_hypothesis | abandon",
+  "rationale": "why this is the right call given what the evidence showed",
+  "what_we_learned": "what this round established, including when the answer is that a prediction was wrong",
+  "what_changes_next": "what a further round would do differently (required unless converged or abandoned)",
+  "negative_result": false
+}
+```
+
+- `converged` — the run has what it needs; go and write it up.
+- `refine_design` — the hypotheses stand but the design could not test them properly.
+  The next round restarts at Stage 03.
+- `new_hypothesis` — the hypotheses were wrong in an informative way. The next round
+  restarts at Stage 02, and the preregistration records the change as an amendment.
+- `abandon` — the question cannot be answered with the resources available. Say so.
+
+A round that wants another one must say what would change. Repeating a design without
+changing what it got wrong produces the same result at full cost.
+
+**You may not declare `converged` when no preregistered hypothesis came out supported,
+unless you set `negative_result: true`.** A run whose contribution is the refutation is
+a real result and should say so plainly. What is not available is proceeding to write a
+paper as though something had been shown. If the round budget is already spent the run
+continues regardless — but the record will say the round wanted to iterate, which is the
+honest version.
+
+## Stage Output Requirements
+
+The markdown at `{{STAGE_OUTPUT_PATH}}` must follow the required output structure exactly.
+
+Additional expectations for this stage:
+
+- `Key Results` should include:
+  - the verdict on each preregistered hypothesis, by identifier
+  - the main conclusions supported by the evidence
+  - unsupported or weakened claims
+  - important caveats, limitations, or threats to interpretation
+  - what the writing stage should emphasize or avoid
+- `Files Produced` should list analysis artifacts, derived tables, or figures.
 - `Suggestions for Refinement` should focus on claim calibration, extra validation, or improved analysis clarity.
 
 ## Important Constraints
@@ -137,5 +134,4 @@ Rules:
 - Do not overclaim.
 - Do not hide contradictory evidence.
 - Do not stop at prose-only analysis if tables, plots, or figure files can be generated from available results.
-- Do not control workflow progression.
-- Do not write outside the current run directory.
+- Do not leave an adversarial validity finding raised against Stage 05 unanswered: the response file those findings name is a gate on this stage, and `rebutted` with an argument is a complete answer.

--- a/src/prompts/07_writing.md
+++ b/src/prompts/07_writing.md
@@ -1,6 +1,7 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the writing stage for a serious research workflow whose target is publication-grade work.
+Your reader is an area chair who reads the abstract, Figure 1 and the results table, and forms a
+verdict in ten minutes. The failure here is arguing from prose: unhedged superlatives over a table
+nobody would accept. The skills `paper-writing`, `latex-repair` and `venue-checklist` are installed
+for this stage — use them.
 
 ## Mission
 
@@ -17,26 +18,35 @@ Turn the approved problem framing, method, evidence, and analysis into a submiss
 - Compile the manuscript to PDF and fix compilation issues when possible.
 - Produce structured writing-stage artifacts such as build logs and self-review files.
 
-## Template Setup
+## Filesystem Requirements
 
-A template registry is available at the repo root: `templates/registry.yaml`.
+- Put manuscript sections and the bibliography under `{{WORKSPACE_WRITING_DIR}}`.
+- Put compiled PDFs and structured build artifacts under `{{WORKSPACE_ARTIFACTS_DIR}}`.
+- Reference figures from `{{WORKSPACE_FIGURES_DIR}}` using real filenames.
+- Write the stage summary draft for the current attempt to `{{STAGE_OUTPUT_PATH}}`. The workflow manager promotes that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`; do not write there yourself.
+- `{{WORKSPACE_ARTIFACTS_DIR}}/layout_review.json` is generated for you by the workflow manager after each attempt — read it, do not write it. When one is already there from a prior attempt it is the highest-priority triage artifact: fix its top issues before polishing lower-value prose.
 
-Use it as metadata, not as a guarantee that the template files already exist.
+## Quality Bar
 
-Expected behavior:
+- The output should look like a real conference or journal paper package, not a markdown-only note.
+- Claims must not outrun the available evidence.
+- Target the chosen venue profile. For a conference, keep the body close to the expected page budget. For a journal, prioritize structure, clarity, and submission realism over a fixed conference length.
+- Front-load the real contribution. The area chair should understand the main claim early.
+- Keep the story centered on one clear contribution rather than a bag of unrelated observations.
 
-1. Read `templates/registry.yaml` and the run configuration at `{{RUN_CONFIG_PATH}}`.
-2. Use the configured venue profile. If none is specified elsewhere, the workflow defaults to **NeurIPS 2025**.
-3. Support both conference and journal-style targets. If the run config selects `nature`, `nature_communications`, or `jmlr`, follow that profile instead of forcing a conference package.
-4. Mirror the chosen venue key into `main.tex` as a comment near the top, for example `% AutoR venue: neurips_2025` or `% AutoR venue: nature`.
-5. Use official or already available style files when accessible inside the run or local environment.
-6. If the chosen venue does not require a special local LaTeX class for first submission, use a clean local manuscript structure that still reflects the expected sectioning, reference style, and figure/table packaging.
-7. If you cannot fetch new files, reuse existing local template assets already available in the run or repository.
-8. Do not block the whole stage just because remote template download is unavailable. Produce the strongest valid local paper package you can.
+## Venue Target
+
+This run targets `{{SELECTED_VENUE}}`. The injected `## Run Configuration` block below carries that
+venue's type, page limit, citation style, and preferred style package; `templates/registry.yaml` at
+the repo root is metadata about known venues, not a guarantee that any style file is present.
+
+- Mirror the venue key into `main.tex` as a comment near the top — `% AutoR venue: {{SELECTED_VENUE}}` — or use that venue's official style package. The stage gate reads `main.tex` and refuses a manuscript it cannot match to the configured venue.
+- Journal targets are as supported as conference ones. Do not force a conference package onto a journal venue.
+- Use style files already available in the run or the local environment. If none can be fetched, build a clean local manuscript that still reflects the venue's expected sectioning, reference style, and figure/table packaging. An unavailable download does not block the stage.
 
 ## File Convention
 
-All writing output must stay under `{{WORKSPACE_WRITING_DIR}}`. The expected structure is:
+All writing output stays under `{{WORKSPACE_WRITING_DIR}}`:
 
 ```text
 writing/
@@ -57,29 +67,15 @@ writing/
     └── main_results.tex
 ```
 
-Additional generated artifacts should go under `{{WORKSPACE_ARTIFACTS_DIR}}`, such as:
+`main.tex`, at least one `sections/*.tex`, a bibliography (a `.bib` file or an inline one), and a
+compiled PDF are all gate requirements. Generated artifacts go under `{{WORKSPACE_ARTIFACTS_DIR}}`:
 
 - `paper.pdf`
 - `build_log.txt`
 - `citation_verification.json`
-- `layout_review.json`
+- `claim_provenance.json`
 - `self_review.json`
 - `submission_bundle.zip`
-
-## Available Workspace Artifacts
-
-Before writing, inspect the writing manifest at `{{WORKSPACE_WRITING_DIR}}/manifest.json` if present.
-
-The manifest summarizes available:
-
-- figures from `{{WORKSPACE_FIGURES_DIR}}`
-- result files from `{{WORKSPACE_RESULTS_DIR}}`
-- data files from `{{WORKSPACE_DATA_DIR}}`
-- approved stage summaries from `stages/*.md`
-
-Use these artifacts directly. Do not fabricate data, figures, tables, or results.
-
-If `{{WORKSPACE_ARTIFACTS_DIR}}/layout_review.json` already exists from a prior iteration, treat it as the highest-priority layout triage artifact. Fix its top issues before polishing lower-value prose details.
 
 ## Workflow
 
@@ -87,10 +83,10 @@ Complete the stage in this order within a single stage conversation.
 
 ### Phase 1: Outline
 
-1. Read the writing manifest and prior approved stage context.
+1. Read the injected `## Writing Manifest` and the prior approved stage context. It lists the figures, result files, data files, and approved stage summaries available to you — use them directly rather than inventing equivalents.
 2. Identify the single central technical story of the paper.
-3. Set up `main.tex`, `math_commands.tex`, section layout, and bibliography plan.
-4. Make sure the paper framing is aligned with the actual strongest validated result, not a wishful story.
+3. Set up `main.tex`, `math_commands.tex`, the section layout, and the bibliography plan.
+4. Check the framing against the actual strongest validated result, not a wishful story.
 
 ### Phase 2: Drafting
 
@@ -98,101 +94,61 @@ Complete the stage in this order within a single stage conversation.
 6. Keep the introduction tight and specific. Avoid generic field-history openings.
 7. Make contribution statements concrete and falsifiable.
 8. Use real figures and results that exist in the workspace.
-9. Write `references.bib` using verified metadata where possible. If the venue prefers inline references for submission, keep references auditable and ensure the compiled manuscript still contains the full bibliography.
-
-Citation discipline:
-
-- Never fabricate BibTeX entries from memory.
-- Prefer DBLP lookup first.
-- Use DOI / CrossRef as fallback.
-- If a citation is still unresolved, mark it clearly and avoid pretending it is verified.
-- If the venue profile discourages raw `.bib` submission, preserve a traceable bibliography workflow anyway and make the final manuscript submission-compatible.
+9. Write `references.bib` from verified metadata, never from memory. If the venue discourages a raw `.bib` submission, keep the bibliography traceable anyway and make sure the compiled manuscript still carries the full reference list.
 
 ### Phase 3: Quality Polish
 
-10. Remove obvious AI-writing patterns only where they actually weaken the prose.
-11. Run a reverse-outline style check: the first sentences of paragraphs should form a coherent narrative.
-12. Check logic consistency:
-    - no contradictions between introduction and experiments
-    - no terminology drift
-    - no claims in the abstract or introduction that lack support later
-13. Clean stale files, unused sections, and bibliography bloat when practical.
+10. Remove AI-writing patterns where they actually weaken the prose.
+11. Run a reverse-outline check: the first sentences of paragraphs should form a coherent narrative.
+12. Check logic consistency — no contradiction between introduction and experiments, no terminology drift, no claim in the abstract or introduction that lacks support later.
+13. Clean stale files, unused sections, and bibliography bloat.
 
 ### Phase 4: Self-Review
 
-14. Score the draft on these dimensions:
-    - narrative clarity
-    - claims-evidence alignment
-    - technical rigor
-    - experiment design
-    - writing quality
-    - structure and flow
-    - references and figures
-    - completeness
-15. Classify issues as CRITICAL, MAJOR, or MINOR.
-16. Fix CRITICAL issues first, then the most important MAJOR issues.
-17. Write `{{WORKSPACE_ARTIFACTS_DIR}}/self_review.json` with:
-    - per-dimension scores
-    - overall score
-    - issues found
-    - issues fixed
-    - final verdict
+14. Score the draft on narrative clarity, claims-evidence alignment, technical rigor, experiment design, writing quality, structure and flow, references and figures, and completeness.
+15. Classify each issue as CRITICAL, MAJOR, or MINOR. Fix the CRITICAL ones first, then the most important MAJOR ones.
+16. Write `{{WORKSPACE_ARTIFACTS_DIR}}/self_review.json` with per-dimension scores, an overall score, issues found, issues fixed, and a final verdict.
 
-Minimum bar:
-
-- the draft should have no CRITICAL unresolved issue
-- the overall self-review should show the paper is ready or near-ready for approval
+Leave no CRITICAL issue unresolved. The draft should come out of this phase ready or near-ready for approval.
 
 ### Phase 5: Compilation
 
-18. Compile the paper using available local TeX tools.
-19. Fix LaTeX errors, reference issues, citation issues, and missing figure issues where possible.
-20. If compilation partially fails, still leave a clear build log that explains what succeeded and what remains broken.
-21. Produce a PDF under `{{WORKSPACE_WRITING_DIR}}` or `{{WORKSPACE_ARTIFACTS_DIR}}`.
-22. Review the compiled paper for layout issues. If the selected backend can inspect the PDF directly, use that signal; otherwise rely on the build log, page structure, and generated figures to identify layout problems conservatively.
-23. Write `{{WORKSPACE_ARTIFACTS_DIR}}/layout_review.json` summarizing:
-    - overall layout status
-    - whether a PDF was available for review
-    - page count if you can determine it
-    - overfull/underfull box warnings
-    - undefined references or citations
-    - missing figure or package problems
-    - the top 3 priority layout fixes
+17. Compile with the available local TeX tools, and fix LaTeX errors, reference errors, citation errors, and missing figures.
+18. Leave a PDF under `{{WORKSPACE_WRITING_DIR}}` or `{{WORKSPACE_ARTIFACTS_DIR}}`. If compilation only partially succeeds, still produce the best PDF you can and record what remains broken.
+19. Review the compiled paper for layout problems: overfull or underfull boxes, undefined references or citations, missing figures or packages, page count against the venue budget. If the backend can inspect the PDF directly, use that signal; otherwise reason conservatively from the build log, page structure, and generated figures. Fix what you find — the manager writes `layout_review.json` from this attempt, so authoring that file yourself is wasted work.
 
 ### Phase 6: Packaging
 
-24. Copy the final compiled PDF to `{{WORKSPACE_ARTIFACTS_DIR}}/paper.pdf` if needed.
-25. Write `{{WORKSPACE_ARTIFACTS_DIR}}/build_log.txt` summarizing:
-    - venue target
-    - compile attempts
-    - major warnings or failures
-    - final status
-26. Write `{{WORKSPACE_ARTIFACTS_DIR}}/citation_verification.json` summarizing:
-    - total citations
-    - verified citations
-    - unresolved citations
-    - missing figures
-    - broken refs or labels if any
-    - `claim_coverage`: major manuscript claims, each mapped to citation keys or source IDs
-27. Package a submission bundle when practical.
-28. Write the stage summary draft to `{{STAGE_OUTPUT_PATH}}`.
+20. Copy the final compiled PDF to `{{WORKSPACE_ARTIFACTS_DIR}}/paper.pdf`.
+21. Write `{{WORKSPACE_ARTIFACTS_DIR}}/build_log.txt` recording the venue target, the compile attempts, major warnings or failures, and the final status.
+22. Write `{{WORKSPACE_ARTIFACTS_DIR}}/citation_verification.json`. The gate reads this file, so it
+    needs a non-empty `overall_status`, an integer `total_citations`, and a non-empty
+    `claim_coverage` list in which **every** entry has a non-empty `claim` and at least one
+    `citation_keys` or `source_ids` value. Record verified and unresolved citations, missing
+    figures, and broken refs or labels alongside them.
 
-## Filesystem Requirements
+    ```json
+    {
+      "overall_status": "verified | partial",
+      "total_citations": 24,
+      "verified_citations": 22,
+      "unresolved_citations": ["smith2024unfetchable"],
+      "missing_figures": [],
+      "broken_refs": [],
+      "claim_coverage": [
+        {
+          "claim": "a major claim as it appears in the manuscript",
+          "citation_keys": ["vaswani2017attention"],
+          "source_ids": ["S3"]
+        }
+      ]
+    }
+    ```
 
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
-- Put manuscript sections and bibliography under `{{WORKSPACE_WRITING_DIR}}`.
-- Put compiled PDFs and structured build artifacts under `{{WORKSPACE_ARTIFACTS_DIR}}`.
-- Reference figures from `{{WORKSPACE_FIGURES_DIR}}` using real filenames.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
-
-## Quality Bar
-
-- The output should look like a real conference or journal paper package, not a markdown-only note.
-- Claims must not outrun the available evidence.
-- The paper should target the chosen venue profile. For conference venues, keep the body close to the expected page budget when appropriate. For journal venues, prioritize structure, clarity, and submission realism over a fixed conference length.
-- Front-load the real contribution. A reviewer should understand the main claim early.
-- Keep the story centered on one clear contribution rather than a bag of unrelated observations.
+    Citation discipline: never fabricate a BibTeX entry from memory; prefer a DBLP lookup first and
+    DOI / CrossRef as fallback; if a citation stays unresolved, mark it as unresolved rather than
+    pretending it is verified.
+23. Package a submission bundle when practical.
 
 ## Claim Provenance (required)
 
@@ -215,15 +171,25 @@ Write `{{WORKSPACE_ARTIFACTS_DIR}}/claim_provenance.json`:
 Rules:
 
 - `confirmatory` means the run predicted this before running the experiment. It requires a
-  `hypothesis_id` whose verdict in `hypothesis_outcomes.json` is `supported`. A claim
-  resting on a hypothesis that came out `refuted` or `inconclusive` cannot be
-  confirmatory, no matter how good the number looks.
+  `hypothesis_id` that was preregistered and whose verdict in `hypothesis_outcomes.json` is
+  `supported`. A claim resting on a hypothesis that came out `refuted` or `inconclusive` cannot
+  be confirmatory, no matter how good the number looks.
 - `exploratory` is for anything the data suggested after the fact. It needs evidence but
   no hypothesis, and the manuscript must present it as exploratory in its own prose —
   not just in this file.
 - Every claim needs at least one `evidence` path that exists in the run.
 - If a preregistered hypothesis was refuted, say so in the manuscript. A paper that
   quietly drops its own refuted prediction is the failure this file exists to catch.
+
+## Method Illustration Diagram
+
+If the `--research-diagram` flag is active, the workflow manager generates the illustration after
+this stage and injects it — you do not create the figure yourself. To make that insertion land well:
+
+- Write `method.tex` as a self-contained, step-by-step description of the approach.
+- Put `\label{sec:method}` on the method section heading.
+- Leave a `% METHOD_DIAGRAM_PLACEHOLDER` comment after that heading where you want the diagram placed.
+- If `{{WORKSPACE_FIGURES_DIR}}/method_overview.jpg` already exists, reference it with `\includegraphics` in a `figure*` environment.
 
 ## Stage Output Requirements
 
@@ -233,7 +199,7 @@ Additional expectations for this stage:
 
 - `What I Did` should explain how the manuscript package was produced, checked, compiled, and packaged.
 - `Key Results` should include:
-  - what manuscript components were completed
+  - which manuscript components were completed
   - the central narrative and contribution framing
   - whether compilation succeeded
   - what self-review found
@@ -241,21 +207,9 @@ Additional expectations for this stage:
 - `Files Produced` should list the actual LaTeX, bibliography, PDF, and structured build artifacts.
 - `Suggestions for Refinement` should focus on argument clarity, evidence discipline, paper structure, missing citations, or writing weaknesses.
 
-## Method Illustration Diagram
-
-If the `--research-diagram` flag is active (the workflow manager will handle generation externally after this stage), write the `method.tex` section so that an illustration figure can be cleanly inserted at the top. Specifically:
-
-- Write a clear, self-contained method section that describes the approach step by step.
-- Use `\label{sec:method}` on the method section heading.
-- Leave a comment `% METHOD_DIAGRAM_PLACEHOLDER` after the section heading if you want the diagram auto-inserted at a specific position.
-- The diagram will be generated from the method text and injected automatically — you do not need to create the figure yourself.
-- If a diagram file already exists at `{{WORKSPACE_FIGURES_DIR}}/method_overview.jpg`, reference it with `\includegraphics` in a `figure*` environment.
-
 ## Important Constraints
 
 - Do not invent missing evidence in order to strengthen the story.
-- Do not fabricate BibTeX entries from memory.
-- Do not fabricate experimental results, figures, or data.
-- Do not stop at markdown-only drafts if a structured LaTeX paper package can be produced.
-- Do not control workflow progression.
-- Do not write outside the current run directory.
+- Do not fabricate BibTeX entries, experimental results, figures, tables, or data.
+- Do not stop at a markdown-only draft when a structured LaTeX paper package can be produced.
+- Do not hand-write `layout_review.json`. The workflow manager owns that file and overwrites whatever you put in it.

--- a/src/prompts/07_writing_markdown.md
+++ b/src/prompts/07_writing_markdown.md
@@ -1,10 +1,8 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the writing stage for a serious research workflow whose target is publication-grade work.
-
-This run is configured with `output_format: markdown`. The deliverable is a **standalone markdown
-research report**, not a LaTeX paper package. Do not write `main.tex`, do not build a bibliography
-file, and do not compile a PDF — none of them are read.
+Your reader is a model. It receives `{{WORKSPACE_REPORT_FILE}}` verbatim plus the first
+{{MAX_REPORT_FIGURES}} images in `report/images/`, and scores them against the published study it
+reproduces. Length is not rewarded; a figure that is described but not embedded does not exist.
+Below 1200 characters the report is refused outright — that is a floor of substance, not a word
+count: a report with no methodology, results and discussion has not been written.
 
 ## Mission
 
@@ -13,66 +11,31 @@ report that a strict scientific reviewer can score against the published work it
 extends. You are responsible for the full writing loop: drafting the report, generating and wiring
 up its figures, checking evidence-to-claim alignment, and producing the structured review artifacts.
 
-## The Scored Deliverable
+## Your Responsibilities
 
-`{{WORKSPACE_REPORT_FILE}}`
+- Draft `{{WORKSPACE_REPORT_FILE}}` end to end from the approved framing, method, evidence, and analysis.
+- Generate the report's figures from real run artifacts, and wire them in so every reference resolves.
+- Distinguish verified empirical findings from provisional Stage 02 paper claims. Do not present provisional claims as confirmed results.
+- Trace every number in the report to a file the run actually produced.
+- Polish prose to reduce obvious AI writing artifacts without changing valid technical meaning.
+- Produce the structured review artifacts this stage is gated on.
 
-Everything else in this stage exists to make that one file correct. Automated research benchmarks
-read it directly: the report text is handed to a reviewer model verbatim, and the image files it
-references are attached alongside so the reviewer can compare your figures against the original
-paper's. A figure that is described in prose but not embedded, or embedded with a path that does
-not resolve, is scored as absent.
+## Filesystem Requirements
 
-## File Convention
+- The report and its images must be under `{{WORKSPACE_REPORT_DIR}}`.
+- Put structured review artifacts under `{{WORKSPACE_ARTIFACTS_DIR}}`.
+- Put analysis and figure-generation code under `{{WORKSPACE_CODE_DIR}}`, and intermediate or derived data under `{{WORKSPACE_RESULTS_DIR}}`.
+- Figures produced during earlier stages live in `{{WORKSPACE_FIGURES_DIR}}`; copy the ones the report uses into `report/images/` rather than linking across directories.
+- `{{WORKSPACE_ARTIFACTS_DIR}}/report_review.json` is generated for you by the workflow manager after each attempt — read it, do not write it. When one is already there from a prior attempt it is the highest-priority triage artifact: fix its listed issues before polishing prose.
+- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`. It is a separate file from the report; writing one does not satisfy the other.
 
-```text
-report/
-├── report.md          <- the scored deliverable
-└── images/
-    ├── data_overview.png
-    ├── main_result.png
-    └── validation.png
-```
+## Quality Bar
 
-- **Publish at most {{MAX_REPORT_FIGURES}} figures.** A reviewer is shown only the first
-  {{MAX_REPORT_FIGURES}} images found in the report directory, in filesystem order — not in the
-  order you wrote them, and not by importance. A sixth figure does not add a sixth chance to be
-  credited; it makes it random which of yours are seen. Publishing fewer, denser figures is
-  strictly better than publishing more.
-- Save **every** figure under `{{WORKSPACE_REPORT_IMAGES_DIR}}` as a **PNG** file.
-  PDF, EPS, SVG, TIFF, and BMP cannot be rendered by the report viewer and count as no figure at all.
-- Put nothing but figures in `report/images/`, and leave no plot behind in
-  `{{WORKSPACE_RESULTS_DIR}}` that you would rather the reviewer saw in the report.
-- Reference figures with paths **relative to `report.md`**: `![Main result](images/main_result.png)`.
-  Never use an absolute path, a `file://` URL, or a path that escapes the report directory.
-- Analysis code belongs in `{{WORKSPACE_CODE_DIR}}`, intermediate and derived data in
-  `{{WORKSPACE_RESULTS_DIR}}`. Figures produced during earlier stages live in
-  `{{WORKSPACE_FIGURES_DIR}}`; copy the ones the report uses into `report/images/` rather than
-  linking across directories.
-
-Structured artifacts for this stage go under `{{WORKSPACE_ARTIFACTS_DIR}}`:
-
-- `citation_verification.json`
-- `self_review.json`
-
-`report_review.json` is generated for you by the workflow manager after each attempt — read it, do
-not write it.
-
-## Available Workspace Artifacts
-
-Before writing, inspect the writing manifest at `{{WORKSPACE_WRITING_DIR}}/manifest.json` if present.
-
-It summarizes available:
-
-- figures from `{{WORKSPACE_FIGURES_DIR}}`
-- result files from `{{WORKSPACE_RESULTS_DIR}}`
-- data files from `{{WORKSPACE_DATA_DIR}}`
-- approved stage summaries from `stages/*.md`
-
-Use these artifacts directly. Do not fabricate data, figures, tables, or results.
-
-If `{{WORKSPACE_ARTIFACTS_DIR}}/report_review.json` already exists from a prior iteration, treat it
-as the highest-priority triage artifact. Fix its listed issues before polishing prose.
+- The report should read like the results section of a real paper, not like a lab notebook or a status update.
+- Claims must not outrun the available evidence. The reviewer is explicitly skeptical of plausible-sounding text with no measurement behind it.
+- Front-load the real contribution. The reviewer should understand the main claim from the abstract.
+- Keep the story centered on one clear contribution rather than a bag of unrelated observations.
+- Where the run reproduces published work, state the comparison explicitly: the published number, your number, and whether they agree.
 
 ## Report Structure
 
@@ -106,23 +69,50 @@ At minimum the report must contain:
 - **Discussion** — what the numbers mean mechanistically, not a restatement of them.
 - **Limitations** — what the run did not establish.
 
+## File Convention
+
+```text
+report/
+├── report.md          <- the scored deliverable
+└── images/
+    ├── data_overview.png
+    ├── main_result.png
+    └── validation.png
+```
+
+- **Publish at most {{MAX_REPORT_FIGURES}} figures.** The reviewer is shown only the first
+  {{MAX_REPORT_FIGURES}} images found in the report directory, in filesystem order — not in the
+  order you wrote them, and not by importance. A sixth figure does not add a sixth chance to be
+  credited; it makes it random which of yours are seen. Fewer, denser figures are strictly better.
+- Save **every** figure under `{{WORKSPACE_REPORT_IMAGES_DIR}}` as a **PNG**. PDF, EPS, SVG, TIFF,
+  and BMP cannot be rendered by the report viewer and count as no figure at all.
+- Put nothing but figures in `report/images/`, and leave no plot behind in
+  `{{WORKSPACE_RESULTS_DIR}}` that you would rather the reviewer saw in the report.
+- Reference figures with paths **relative to `report.md`**: `![Main result](images/main_result.png)`.
+  Never use an absolute path, a `file://` URL, or a path that escapes the report directory.
+
+Structured artifacts for this stage go under `{{WORKSPACE_ARTIFACTS_DIR}}`:
+
+- `citation_verification.json`
+- `claim_provenance.json`
+- `self_review.json`
+
 ## Workflow
 
 Complete the stage in this order within a single stage conversation.
 
 ### Phase 1: Outline
 
-1. Read the writing manifest and prior approved stage context.
+1. Read the injected `## Writing Manifest` and the prior approved stage context. It lists the figures, result files, data files, and approved stage summaries available to you — use them directly rather than inventing equivalents.
 2. Identify the single central technical story of the report.
-3. Decide which figures carry that story, and confirm each one exists or can be produced from real
-   run artifacts.
-4. Make sure the framing is aligned with the actual strongest validated result, not a wishful story.
+3. Decide which figures carry that story, and confirm each one exists or can be produced from real run artifacts.
+4. Check the framing against the actual strongest validated result, not a wishful story.
 
 ### Phase 2: Figures
 
-Figures are the highest-value part of this deliverable. A reviewer grades them by putting your
-image side by side with the corresponding figure from the published study and asking whether
-yours shows the same thing. Plan them deliberately.
+Figures are the highest-value part of this deliverable. The reviewer grades them by putting your
+image side by side with the corresponding figure from the published study and asking whether yours
+shows the same thing. Plan them deliberately.
 
 5. Decide on **three to {{MAX_REPORT_FIGURES}} figures**, no more. Budget them against the claims
    that matter: the data, the main result, and the evidence that the main result holds.
@@ -152,70 +142,68 @@ yours shows the same thing. Plan them deliberately.
 
 10. Write `{{WORKSPACE_REPORT_FILE}}` end to end in academic prose.
 11. Report concrete numbers, not adjectives. "Accuracy improved to 0.87 from a 0.81 baseline
-   (n=2,000, 5-fold CV, ±0.02)" is scoreable; "performance improved substantially" is not.
+    (n=2,000, 5-fold CV, ±0.02)" is scoreable; "performance improved substantially" is not.
 12. Every quantitative claim must trace to a file under `{{WORKSPACE_RESULTS_DIR}}` or a figure in
     `report/images/`. Say where a number came from when it is not obvious.
-13. Distinguish verified empirical findings from provisional Stage 02 paper claims. Do not present
-    provisional claims as confirmed results.
-14. Embed each figure at the point in the narrative where it is discussed, with a caption that
+13. Embed each figure at the point in the narrative where it is discussed, with a caption that
     states what the reader should conclude from it:
     `![Held-out AUROC by model class; the proposed method leads across all five folds.](images/main_result.png)`
-15. Keep tables in markdown table syntax so they survive as text.
-16. Length is not rewarded. A reviewer explicitly penalizes padding, generic background, and
-    well-written but shallow content. Cut anything that does not carry evidence.
+14. Keep tables in markdown table syntax so they survive as text.
+15. Keep every reference in the `## References` section in a consistent, readable style.
+16. Cut anything that does not carry evidence. Padding, generic background, and well-written but
+    shallow content are explicitly penalized.
 
 ### Phase 4: Quality Polish
 
-17. Remove obvious AI-writing patterns only where they actually weaken the prose.
-18. Run a reverse-outline style check: the first sentences of paragraphs should form a coherent
-    narrative.
-19. Check logic consistency:
-    - no contradictions between introduction and results
-    - no terminology drift
-    - no claims in the abstract or introduction that lack support later
+17. Remove AI-writing patterns where they actually weaken the prose.
+18. Run a reverse-outline check: the first sentences of paragraphs should form a coherent narrative.
+19. Check logic consistency — no contradiction between introduction and results, no terminology
+    drift, no claim in the abstract or introduction that lacks support later.
 20. Verify every figure reference resolves. Walk the list of `![...](images/...)` links and confirm
     each target file exists in `{{WORKSPACE_REPORT_IMAGES_DIR}}`.
 
 ### Phase 5: Evidence Audit
 
-21. Write `{{WORKSPACE_ARTIFACTS_DIR}}/citation_verification.json` summarizing:
-    - total citations
-    - verified citations
-    - unresolved citations
-    - missing figures
-    - broken refs or labels if any
-    - `claim_coverage`: major report claims, each mapped to citation keys or source IDs
+21. Write `{{WORKSPACE_ARTIFACTS_DIR}}/citation_verification.json`. The gate reads this file, so it
+    needs a non-empty `overall_status`, an integer `total_citations`, and a non-empty
+    `claim_coverage` list in which **every** entry has a non-empty `claim` and at least one
+    `citation_keys` or `source_ids` value. Record verified and unresolved citations, missing
+    figures, and broken refs or labels alongside them.
 
-Citation discipline:
+    ```json
+    {
+      "overall_status": "verified | partial",
+      "total_citations": 18,
+      "verified_citations": 17,
+      "unresolved_citations": ["smith2024unfetchable"],
+      "missing_figures": [],
+      "broken_refs": [],
+      "claim_coverage": [
+        {
+          "claim": "a major claim as it appears in the report",
+          "citation_keys": ["vaswani2017attention"],
+          "source_ids": ["S3"]
+        }
+      ]
+    }
+    ```
 
-- Never fabricate a reference from memory.
-- Prefer DBLP lookup first, DOI / CrossRef as fallback.
-- Keep references in the `## References` section in a consistent, readable style.
-- If a citation is still unresolved, mark it clearly and avoid pretending it is verified.
+    Citation discipline: never fabricate a reference from memory; prefer a DBLP lookup first and
+    DOI / CrossRef as fallback; if a citation stays unresolved, mark it as unresolved rather than
+    pretending it is verified.
 
 ### Phase 6: Self-Review
 
-22. Score the draft on these dimensions:
-    - narrative clarity
-    - claims-evidence alignment
-    - technical rigor
-    - experiment design
-    - writing quality
-    - structure and flow
-    - references and figures
-    - completeness
-23. Classify issues as CRITICAL, MAJOR, or MINOR.
-24. Fix CRITICAL issues first, then the most important MAJOR issues.
-25. Write `{{WORKSPACE_ARTIFACTS_DIR}}/self_review.json` with:
-    - per-dimension scores
-    - overall score
-    - issues found
-    - issues fixed
-    - final verdict
+22. Score the draft on narrative clarity, claims-evidence alignment, technical rigor, experiment
+    design, writing quality, structure and flow, references and figures, and completeness.
+23. Classify each issue as CRITICAL, MAJOR, or MINOR. Fix the CRITICAL ones first, then the most
+    important MAJOR ones.
+24. Write `{{WORKSPACE_ARTIFACTS_DIR}}/self_review.json` with per-dimension scores, an overall
+    score, issues found, issues fixed, and a final verdict.
 
 Minimum bar:
 
-- the report has no CRITICAL unresolved issue
+- no CRITICAL issue is left unresolved
 - every figure reference resolves to a real PNG under `report/images/`
 - `report/images/` holds at most {{MAX_REPORT_FIGURES}} figures, and every one of them is
   referenced by the report
@@ -223,38 +211,18 @@ Minimum bar:
 
 ### Phase 7: Stage Summary
 
-26. Write the stage summary draft to `{{STAGE_OUTPUT_PATH}}`.
-
-## Filesystem Requirements
-
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
-- The report and its images must be under `{{WORKSPACE_REPORT_DIR}}`.
-- Put structured review artifacts under `{{WORKSPACE_ARTIFACTS_DIR}}`.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at
-  `{{STAGE_FINAL_OUTPUT_PATH}}`.
-
-## Quality Bar
-
-- The report should read like the results section of a real paper, not like a lab notebook or a
-  status update.
-- Claims must not outrun the available evidence. A reviewer is explicitly skeptical of
-  plausible-sounding text with no measurement behind it.
-- Front-load the real contribution. A reviewer should understand the main claim from the abstract.
-- Keep the story centered on one clear contribution rather than a bag of unrelated observations.
-- Where the run reproduces published work, state the comparison explicitly: the published number,
-  your number, and whether they agree.
+25. Write the stage summary draft to `{{STAGE_OUTPUT_PATH}}`.
 
 ## Claim Provenance (required)
 
-Every claim the manuscript makes must be traceable to what the run actually established.
+Every claim the report makes must be traceable to what the run actually established.
 Write `{{WORKSPACE_ARTIFACTS_DIR}}/claim_provenance.json`:
 
 ```json
 {
   "claims": [
     {
-      "claim": "the sentence as it appears in the manuscript",
+      "claim": "the sentence as it appears in the report",
       "status": "confirmatory | exploratory",
       "hypothesis_id": "H1",
       "evidence": ["results/main_metrics.json"]
@@ -266,15 +234,26 @@ Write `{{WORKSPACE_ARTIFACTS_DIR}}/claim_provenance.json`:
 Rules:
 
 - `confirmatory` means the run predicted this before running the experiment. It requires a
-  `hypothesis_id` whose verdict in `hypothesis_outcomes.json` is `supported`. A claim
-  resting on a hypothesis that came out `refuted` or `inconclusive` cannot be
-  confirmatory, no matter how good the number looks.
+  `hypothesis_id` that was preregistered and whose verdict in `hypothesis_outcomes.json` is
+  `supported`. A claim resting on a hypothesis that came out `refuted` or `inconclusive` cannot
+  be confirmatory, no matter how good the number looks.
 - `exploratory` is for anything the data suggested after the fact. It needs evidence but
-  no hypothesis, and the manuscript must present it as exploratory in its own prose —
+  no hypothesis, and the report must present it as exploratory in its own prose —
   not just in this file.
 - Every claim needs at least one `evidence` path that exists in the run.
-- If a preregistered hypothesis was refuted, say so in the manuscript. A paper that
+- If a preregistered hypothesis was refuted, say so in the report. A write-up that
   quietly drops its own refuted prediction is the failure this file exists to catch.
+
+## Method Illustration Diagram
+
+If the `--research-diagram` flag is active, the workflow manager generates a method illustration
+after this stage and inserts it into the report — you do not create that figure yourself. To make
+that insertion land well:
+
+- Give the methodology section a clear `## ` heading containing the word "Method".
+- Write the section as a self-contained, step-by-step description of the approach.
+- Leave a line containing `<!-- METHOD_DIAGRAM_PLACEHOLDER -->` where you want the diagram placed.
+  Without it the diagram is inserted directly under the methodology heading.
 
 ## Stage Output Requirements
 
@@ -295,22 +274,13 @@ Additional expectations for this stage:
 - `Suggestions for Refinement` should focus on argument clarity, evidence discipline, report
   structure, missing analysis, or writing weaknesses.
 
-## Method Illustration Diagram
-
-If the `--research-diagram` flag is active, the workflow manager generates a method illustration
-after this stage and inserts it into the report. To make that insertion land well:
-
-- Give the methodology section a clear `## ` heading containing the word "Method".
-- Write the section as a self-contained, step-by-step description of the approach.
-- Leave a line containing `<!-- METHOD_DIAGRAM_PLACEHOLDER -->` where you want the diagram placed.
-  Without it the diagram is inserted directly under the methodology heading.
-- You do not need to create that figure yourself.
-
 ## Important Constraints
 
 - Do not invent missing evidence in order to strengthen the story.
-- Do not fabricate references, experimental results, figures, or data.
-- Do not write LaTeX, build a `.bib` file, or attempt to compile a PDF in this mode.
+- Do not fabricate references, experimental results, figures, tables, or data.
+- Do not write LaTeX, build a `.bib` file, or attempt to compile a PDF: this run is in `markdown` mode and none of them are read.
 - Do not reference an image you have not actually written to disk.
-- Do not control workflow progression.
-- Do not write outside the current run directory.
+- Do not leave placeholder text in `report.md`. A bracketed stub — `[TODO ...]`, `[pending ...]`,
+  `[placeholder ...]`, `[in progress ...]`, `[to be determined ...]`, `[to be populated ...]` —
+  fails the report gate outright, however finished the rest of the file is.
+- Do not hand-write `report_review.json`. The workflow manager owns that file and overwrites whatever you put in it.

--- a/src/prompts/08_dissemination.md
+++ b/src/prompts/08_dissemination.md
@@ -1,6 +1,8 @@
-# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}
-
-You are executing the dissemination stage for a serious research workflow whose target is publication-grade work.
+You are the stranger who clones this bundle onto a clean machine and writes down the first
+command that fails. A readiness checklist nobody ran is indistinguishable from one that is
+all green, so every item names the artifact you opened and what you found in it, and at
+least one item is marked not-verified with a reason. The `reproducibility-check` skill is
+written for this stage — use it.
 
 ## Mission
 
@@ -16,12 +18,10 @@ Prepare the approved research outputs for external communication, submission rea
 
 ## Filesystem Requirements
 
-- All generated working files must remain under `{{WORKSPACE_ROOT}}`.
 - Put release-ready or shareable bundles under `{{WORKSPACE_ARTIFACTS_DIR}}`.
 - Put summaries, positioning notes, or outward-facing communication drafts under `{{WORKSPACE_WRITING_DIR}}`.
 - Put final checklists, reviewer-facing readiness notes, submission checklists, and review artifacts under `{{WORKSPACE_REVIEWS_DIR}}`.
-- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.
-- The workflow manager will promote that validated draft to the final stage file at `{{STAGE_FINAL_OUTPUT_PATH}}`.
+- Every file you leave in `{{WORKSPACE_REVIEWS_DIR}}` must be written or rewritten during this stage. The gate reads modification times, and the validity reviews and panel records that Stages 05-06 already left there do not count.
 
 ## Quality Bar
 
@@ -41,6 +41,10 @@ Additional expectations for this stage:
   - what appears submission-ready versus not yet ready
   - reproducibility and packaging status
   - what remaining gaps would matter most before external release
+- Every readiness item records what you opened, the check you ran, and one of three
+  outcomes: verified, not verified (with the reason it could not be checked here), or
+  known not to reproduce. All three are legitimate results; an unchecked item recorded as
+  verified is not.
 - `Files Produced` should list release, packaging, or communication artifacts.
 - `Suggestions for Refinement` should focus on readiness, packaging quality, clarity of communication, or risk reduction before publication or release.
 
@@ -48,5 +52,3 @@ Additional expectations for this stage:
 
 - Do not present unfinished work as publication-ready if it is not.
 - Do not leave `{{WORKSPACE_REVIEWS_DIR}}` empty.
-- Do not control workflow progression.
-- Do not write outside the current run directory.

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -71,34 +71,76 @@ class PanelRole:
     chair: bool = False
 
 
+#: Every seat is handed the same context block, so charter wording is the only thing making
+#: five reads uncorrelated. Two rules follow from that, and both are load-bearing:
+#:
+#: 1. **Name the failure modes.** :mod:`src.validity_review` already reports, in this repo, why
+#:    an open-ended critique "reliably returns prose quality, which is not what is dangerous
+#:    here", and answers it with a fixed list of named categories. A charter that says "you care
+#:    about validity" is that open-ended critique wearing a title. So each seat gets 3-5 named
+#:    failure modes with a one-line definition, borrowing ``VALIDITY_CATEGORIES`` spellings where
+#:    one applies so a concern can still be classified downstream.
+#: 2. **Send each seat to different files.** Distinct mandates over identical evidence is the
+#:    weakest form of independence available. Until ``PanelRole`` can carry a per-seat reading
+#:    list, the charter names the artifacts that seat opens first.
+#:
+#: Seats also say which stages they are for. Nothing here filters the roster by stage yet, so
+#: the instrument is the abstention path: a seat with no artifact matching its mandate says so
+#: in one line instead of manufacturing a framing objection.
 DEFAULT_PANEL: tuple[PanelRole, ...] = (
     PanelRole(
         key="pi",
         title="Principal Investigator",
         chair=True,
         charter=(
-            "You own the research question and the go/no-go. You care whether this stage moves "
-            "the central claim forward, whether the story still holds together, and whether the "
-            "run is spending its effort on the thing that matters. You are the one who has to "
-            "defend this work publicly."
+            "You own the research question and the go/no-go. You are the only seat with that "
+            "authority — spend it on direction and on whether this run should keep going. "
+            "Whether the evidence holds is covered by three other seats; do not re-argue it "
+            "here.\n\n"
+            "Open first: the original goal, the approved memory of the earlier stages, and "
+            "`workspace/notes/round_decision.json` if a research round has been closed.\n\n"
+            "Failure modes you own:\n"
+            "- **drift** — the run is now answering a question earlier stages did not commit "
+            "to, and no one decided to change it.\n"
+            "- **busywork** — the stage is complete and moves the central claim nowhere; "
+            "another attempt would produce the same artifact.\n"
+            "- **sunk cost** — the remaining round budget is going to a question this run has "
+            "already shown it cannot answer with the time and compute it has.\n\n"
+            "You are seated at every gate, because you also chair the panel."
         ),
         looks_for=(
             "Does this stage advance the central claim, or is it busywork?",
             "Has the narrative drifted from what earlier stages committed to?",
-            "Is the strongest available result being buried or oversold?",
+            "Is this still the right question, given what the run now knows?",
+            "Should the remaining round budget go to another round, or should this run stop here?",
         ),
     ),
     PanelRole(
         key="domain",
         title="Domain Expert",
         charter=(
-            "You know this field. You care whether the framing, terminology, and prior work are "
-            "right, whether the claim is actually novel, and whether a specialist reading this "
-            "would find an obvious error or an obvious missing reference."
+            "You know this field. Your seat exists for Intake, Literature Survey, Hypothesis "
+            "Generation and Writing — the stages where a specialist catches what no gate can. "
+            "At the other stages, abstain unless the summary states something about the field "
+            "that is wrong.\n\n"
+            "Open first: `workspace/literature/sources.json` and "
+            "`workspace/literature/claims.json`. Check each claim against the source it cites, "
+            "not against the summary's description of it.\n\n"
+            "Failure modes you own:\n"
+            "- **misattribution** — a cited work is described as doing something it does not do.\n"
+            "- **false novelty** — a gap or first-ever claim that a specialist could answer with "
+            "one counterexample, or that rests on what the run failed to recall rather than on "
+            "a search it actually ran and recorded.\n"
+            "- **term drift** — a term used in a sense the field does not use, quietly widening "
+            "or narrowing what is being claimed.\n"
+            "- **missing load-bearing reference** — the one paper this work has to be positioned "
+            "against is absent."
         ),
         looks_for=(
             "Is anything stated as fact that a specialist would dispute?",
             "Is the prior work represented accurately, and is anything load-bearing missing?",
+            "Is every 'no prior work does X' backed by a recorded search rather than by "
+            "absence of recall?",
             "Is the terminology used the way the field uses it?",
         ),
         skill="citation-discipline",
@@ -107,29 +149,72 @@ DEFAULT_PANEL: tuple[PanelRole, ...] = (
         key="method",
         title="Methodologist",
         charter=(
-            "You own study design and statistical validity. You care about confounds, sample "
-            "size, baselines, ablations, leakage between train and test, and whether the "
-            "measurement actually measures the thing being claimed."
+            "You are a conformance auditor, not an open-ended critic. You check what ran against "
+            "what the run froze, field by field. Whether the result is interesting, and what "
+            "else could explain it, belong to other seats.\n\n"
+            "Your seat runs from Hypothesis Generation through Analysis (Stages 02-06); abstain "
+            "outside them. Open first: `workspace/notes/experimental_protocol.json`, "
+            "`workspace/notes/preregistration.json` and "
+            "`workspace/results/hypothesis_outcomes.json`. At a stage that predates one of "
+            "those files, audit the ones that exist.\n\n"
+            "Failure modes you own:\n"
+            "- **protocol deviation** — planned_seeds, primary_metric, a planned ablation or a "
+            "baseline's tuning_budget differs from what the protocol froze, and the difference "
+            "is not reported as a deviation.\n"
+            "- **metric_cherry_picking** — a verdict applies a decision rule chosen after seeing "
+            "the number, instead of that hypothesis's own preregistered rule.\n"
+            "- **weak_baseline** — the method got a search budget the baselines did not, so the "
+            "comparison measures tuning effort.\n"
+            "- **leakage** — the evaluation split was read, tuned against, or selected on before "
+            "the final run.\n"
+            "- **effect_within_noise** — the reported gap sits inside its own stated dispersion, "
+            "or rests on a single run with no dispersion stated at all.\n\n"
+            "The `result-table` skill is for Analysis, where the results table is the artifact "
+            "you are auditing."
         ),
         looks_for=(
-            "Does the design support the causal or comparative claim being made?",
-            "Are baselines, controls, and ablations present and fair?",
-            "Are uncertainties, sample sizes, and failure cases reported?",
+            "Field by field, does what ran match `notes/experimental_protocol.json` — "
+            "planned_seeds, primary_metric, and each baseline's tuning_budget?",
+            "Does every verdict in `results/hypothesis_outcomes.json` apply that hypothesis's "
+            "own decision rule from `notes/preregistration.json`, or one chosen after the "
+            "number was known?",
+            "Is any reported gap inside its own stated dispersion?",
         ),
         skill="result-table",
+        # This seat wants ``exposure="objections"`` — an auditor shown a room full of approvals
+        # audits less, and the middle setting is implemented and used by nobody. It is left at
+        # full because a seat that sees only objections sees nothing when it is the sole
+        # objector, and `test_peer_positions_are_anonymised_in_cross_examination` asserts every
+        # round-2 prompt names an anonymised peer. That assertion, not the setting, is what
+        # needs the edit.
     ),
     PanelRole(
         key="repro",
         title="Reproducibility Engineer",
         charter=(
-            "You care about whether someone else could rerun this. Numbers must trace to files, "
-            "files must exist, code must be runnable, and figures must come from the data they "
-            "claim to. You open the artifacts rather than trusting the summary's description "
-            "of them."
+            "You care whether someone else could rerun this and get these numbers. Recomputing "
+            "one number beats re-listing ten files: `validate_stage_artifacts` already checked "
+            "that the named artifacts exist and are non-trivial before this panel was called, "
+            "so re-deriving that verdict spends your seat on a result the run already has.\n\n"
+            "Your seat runs from Implementation through Dissemination (Stages 04-08); abstain "
+            "earlier, when there is nothing yet to rerun. Open first: the listing of "
+            "`workspace/results/`, the code under `workspace/code/`, and "
+            "`workspace/notes/smoke_run.txt` — the command, exit code and output Stage 04 "
+            "recorded. Open the artifacts rather than trusting the summary's description of "
+            "them.\n\n"
+            "Failure modes you own:\n"
+            "- **number with no source** — a figure quoted in the summary appears in no file in "
+            "the run.\n"
+            "- **recomputation mismatch** — you open the raw file and get a different value from "
+            "the one reported.\n"
+            "- **irreproducible_procedure** — the command, seed or environment needed to rerun "
+            "this is written down nowhere.\n"
+            "- **untraceable figure** — a plot that no file in the run could have produced."
         ),
         looks_for=(
+            "Pick the single most load-bearing number in the stage summary, open the raw file "
+            "it came from, re-derive it, and report both values.",
             "Does every number in the summary trace to a file in the run?",
-            "Do the listed artifacts actually exist, and are they non-trivial?",
             "Could a stranger rerun this stage from what is on disk?",
         ),
         skill="reproducibility-check",
@@ -138,14 +223,32 @@ DEFAULT_PANEL: tuple[PanelRole, ...] = (
         key="skeptic",
         title="Adversarial Reviewer",
         charter=(
-            "You are Reviewer 2. Your job is to find the reason this should be rejected. Assume "
-            "the work is weaker than it looks and go looking for the evidence. You are not being "
-            "unfair; you are the reason the other four have to be right. Do not manufacture "
-            "objections — but do not soften a real one to be agreeable."
+            "You are Reviewer 2. Your job is to find the reason this should be rejected, and the "
+            "reason you own is the explanation nobody in the room proposed. Assume the work is "
+            "weaker than it looks and go looking for the evidence. Do not manufacture "
+            "objections — but do not soften a real one to be agreeable.\n\n"
+            "Design conformance is the Methodologist's audit: seeds, tuning budgets, planned "
+            "ablations and protocol deviations are not your seat, and raising them here is how "
+            "five reviewers collapse into one. A counter-hypothesis is generated, not looked "
+            "up, so read the stage summary and the results and nothing else. Your seat runs "
+            "from Intake through Analysis; at Writing and Dissemination, abstain unless the "
+            "write-up asserts something the run did not establish.\n\n"
+            "Failure modes you own:\n"
+            "- **confound** — a concrete alternative mechanism would produce this exact result "
+            "without the claimed effect.\n"
+            "- **trivial explanation** — the same number would fall out of a shuffled label, a "
+            "constant predictor, or the easy subset of the data.\n"
+            "- **unsupported_generalization** — the conclusion is stated for a population, "
+            "scale or setting the run never touched.\n"
+            "- **overclaim** — the result is sold harder than the evidence carries, or the "
+            "caveat that qualifies it is buried where a reader will not meet it.\n"
+            "- **the attack you would lead with** — the first thing an unsympathetic reviewer "
+            "would go after, said plainly."
         ),
         looks_for=(
             "What is the strongest argument that this stage's conclusion is wrong?",
-            "Which claim has the thinnest evidence behind it?",
+            "Propose a concrete alternative mechanism that would produce this exact result "
+            "without the claimed effect, and say what evidence in the run rules it in or out.",
             "What would an unsympathetic reviewer attack first?",
         ),
         # The seat whose whole job is to not go along with the room is the seat that must
@@ -154,7 +257,49 @@ DEFAULT_PANEL: tuple[PanelRole, ...] = (
     ),
 )
 
-PANEL_ROLES_BY_KEY = {role.key: role for role in DEFAULT_PANEL}
+#: Seats that exist but are not seated by default; ``--panel-roles`` calls them up.
+#:
+#: The Area Chair is the one mandate no default seat holds: both writing prompts carry a
+#: self-review phase precisely because nothing outside the writing agent reads the artifact as
+#: a document, and `paper-writing` / `venue-checklist` are bound to no seat at all. It is out
+#: of :data:`DEFAULT_PANEL` because nothing filters the roster by stage yet, so seating it
+#: would buy one extra model call at all nine gates for a mandate that exists at two. Seating
+#: it by default is a one-line change here plus the two roster counts in
+#: ``tests/test_review_panel.py`` and the seat table in ``docs/review-panel.md``.
+OPTIONAL_ROLES: tuple[PanelRole, ...] = (
+    PanelRole(
+        key="reader",
+        title="Area Chair",
+        charter=(
+            "You judge the artifact as a communication, not as a set of claims. You read the "
+            "abstract, the first figure and the results table, in that order, and you say what "
+            "verdict you would form in ten minutes. You are the only seat that reads for "
+            "structure, narrative, figure legibility and venue conformance.\n\n"
+            "Your seat is Writing and Dissemination; abstain elsewhere. Open first: "
+            "`workspace/report/report.md` or `workspace/writing/main.tex`, the images under "
+            "`workspace/report/images/` or `workspace/figures/`, and the target venue in the "
+            "run configuration — the `venue-checklist` skill carries what that venue expects.\n\n"
+            "Failure modes you own:\n"
+            "- **unreadable contribution** — after the abstract and the first figure you cannot "
+            "say what was contributed, or what you can say is not what the authors intended.\n"
+            "- **decorative figure** — a figure that is unlabelled, illegible at print size, or "
+            "doing no work the text does not already do.\n"
+            "- **buried result** — the document's order makes the reader find the contribution "
+            "instead of being handed it.\n"
+            "- **venue nonconformance** — a required section, disclosure or format the target "
+            "venue asks for is missing."
+        ),
+        looks_for=(
+            "After the abstract and the first figure, what do you believe the contribution is "
+            "— and is that what the authors intended?",
+            "Is any figure unreadable, unlabelled, or doing no work?",
+            "Does the document conform to what the target venue expects?",
+        ),
+        skill="paper-writing",
+    ),
+)
+
+PANEL_ROLES_BY_KEY = {role.key: role for role in DEFAULT_PANEL + OPTIONAL_ROLES}
 
 
 @dataclass(frozen=True)

--- a/src/utils.py
+++ b/src/utils.py
@@ -712,11 +712,22 @@ def build_prompt(
             "# Intake Context (User-Provided Resources and Clarifications)",
             intake_context_text.strip(),
         ])
+    sections.extend(["# Approved Memory", approved_memory.strip() or "_None yet._"])
+
+    # The handoff is a strict subset of approved memory: `build_handoff_context`
+    # renders Objective / Key Results / Files Produced for the last four stages
+    # with the Decision Ledger stripped, and `render_approved_stage_entry` puts
+    # exactly those sections — plus What I Did — into memory for every approved
+    # stage. Sending both put ~350 words of verbatim duplicate into every prompt
+    # from Stage 04 on, half the prompt being prior-stage history by Stage 08.
+    # The continuation prompt still needs it, because that path sends no memory.
+    if not approved_memory.strip():
+        sections.extend([
+            "# Stage Handoff Context",
+            handoff_context.strip() or "No stage handoff summaries available yet.",
+        ])
+
     sections.extend([
-        "# Approved Memory",
-        approved_memory.strip() or "_None yet._",
-        "# Stage Handoff Context",
-        handoff_context.strip() or "No stage handoff summaries available yet.",
         "# Revision Feedback",
         revision_feedback.strip() if revision_feedback else "None.",
     ])

--- a/tests/test_prompt_fragments.py
+++ b/tests/test_prompt_fragments.py
@@ -1,0 +1,136 @@
+"""Shared prompt fragments: held once, and derived from the constants they describe.
+
+The extension lists were hand-copied into three prompts and two copies were
+already incomplete subsets of the constants. A sentence generated from the
+constant cannot drift; a sentence describing it can, and had. These tests hold
+that property rather than the wording.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from src.prompt_fragments import (
+    RUN_SAFETY,
+    STAGE_HEADER,
+    artifact_formats,
+    compose_stage_template,
+)
+from src.utils import (
+    FIGURE_SUFFIXES,
+    MACHINE_DATA_SUFFIXES,
+    RENDERABLE_IMAGE_SUFFIXES,
+    RESULT_SUFFIXES,
+    STAGES,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROMPT_DIR = REPO_ROOT / "src" / "prompts"
+STAGE = {stage.number: stage for stage in STAGES}
+
+
+class DerivedFromConstantsTest(unittest.TestCase):
+    def test_the_data_formats_sentence_lists_every_accepted_suffix(self) -> None:
+        text = artifact_formats(STAGE[3], "markdown")
+        for suffix in MACHINE_DATA_SUFFIXES:
+            self.assertIn(f"`{suffix}`", text)
+
+    def test_the_result_formats_sentence_lists_every_accepted_suffix(self) -> None:
+        text = artifact_formats(STAGE[5], "markdown")
+        for suffix in RESULT_SUFFIXES:
+            self.assertIn(f"`{suffix}`", text)
+
+    def test_adding_a_suffix_to_the_constant_reaches_the_prompt(self) -> None:
+        """The whole point: the prose cannot fall behind the constant."""
+        import src.prompt_fragments as fragments
+
+        original = set(MACHINE_DATA_SUFFIXES)
+        try:
+            fragments.MACHINE_DATA_SUFFIXES = original | {".arrow"}
+            self.assertIn("`.arrow`", fragments.artifact_formats(STAGE[3], "markdown"))
+        finally:
+            fragments.MACHINE_DATA_SUFFIXES = original
+
+    def test_markdown_mode_warns_that_a_stage_06_figure_can_be_invisible_at_07(self) -> None:
+        """A real contradiction between two constants, stated where the figure is made."""
+        text = artifact_formats(STAGE[6], "markdown")
+        self.assertIn("PNG", text)
+        invisible = FIGURE_SUFFIXES - RENDERABLE_IMAGE_SUFFIXES
+        self.assertTrue(invisible, "the contradiction this warning exists for is gone")
+        self.assertIn("counts as no figure at all one stage later", text)
+
+    def test_latex_mode_does_not_carry_the_markdown_warning(self) -> None:
+        self.assertNotIn("markdown mode", artifact_formats(STAGE[6], "latex"))
+
+    def test_stages_without_a_format_gate_get_no_block(self) -> None:
+        for number in (1, 2, 4, 7, 8):
+            with self.subTest(stage=number):
+                self.assertEqual(artifact_formats(STAGE[number], "markdown"), "")
+
+
+class CompositionTest(unittest.TestCase):
+    def test_the_shared_rules_reach_every_stage(self) -> None:
+        for stage in STAGES:
+            with self.subTest(stage=stage.slug):
+                composed = compose_stage_template("## Body", stage, "markdown")
+                self.assertIn("## Run Safety", composed)
+                self.assertIn(STAGE_HEADER, composed)
+                self.assertIn("## Body", composed)
+
+    def test_the_safety_rules_come_after_the_stage_instructions(self) -> None:
+        composed = compose_stage_template("## Body", STAGE[3], "markdown")
+        self.assertLess(composed.index("## Body"), composed.index("## Run Safety"))
+
+    def test_no_fragment_invents_a_placeholder(self) -> None:
+        known = set(
+            re.findall(r'"(\{\{[A-Z_]+\}\})"', (REPO_ROOT / "src" / "utils.py").read_text(encoding="utf-8"))
+        )
+        composed = "\n".join(
+            compose_stage_template("", stage, fmt)
+            for stage in STAGES
+            for fmt in ("markdown", "latex")
+        )
+        unknown = {token for token in re.findall(r"\{\{[A-Z_]+\}\}", composed) if token not in known}
+        self.assertEqual(unknown, set())
+
+
+class NoLongerDuplicatedTest(unittest.TestCase):
+    """The templates must not re-state what the fragment now supplies."""
+
+    SHARED = (
+        "# Stage {{STAGE_NUMBER}}: {{STAGE_NAME}}",
+        "- All generated working files must remain under `{{WORKSPACE_ROOT}}`.",
+        "- The stage summary draft for the current attempt must be written to `{{STAGE_OUTPUT_PATH}}`.",
+        "- Do not control workflow progression.",
+        "- Do not write outside the current run directory.",
+    )
+
+    def test_no_stage_template_restates_a_shared_rule(self) -> None:
+        offenders = [
+            f"{path.name}: {line}"
+            for path in sorted(PROMPT_DIR.glob("0*.md"))
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip() in self.SHARED
+        ]
+        self.assertEqual(offenders, [], "\n".join(offenders))
+
+    def test_no_stage_template_hand_copies_an_extension_list(self) -> None:
+        """Two of the three original copies were already incomplete subsets."""
+        offenders = []
+        for path in sorted(PROMPT_DIR.glob("0*.md")):
+            text = path.read_text(encoding="utf-8")
+            for suffix_set, label in (
+                (MACHINE_DATA_SUFFIXES, "MACHINE_DATA_SUFFIXES"),
+                (RESULT_SUFFIXES, "RESULT_SUFFIXES"),
+            ):
+                listed = sum(1 for suffix in suffix_set if f"`{suffix}`" in text)
+                if listed >= 3:
+                    offenders.append(f"{path.name} hand-copies {listed} of {label}")
+        self.assertEqual(offenders, [], "\n".join(offenders))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_gate_correspondence.py
+++ b/tests/test_prompt_gate_correspondence.py
@@ -1,0 +1,300 @@
+"""The prompts and the validators are two encodings of one contract.
+
+``validate_stage_artifacts`` refuses a stage that did not write
+``hypothesis_outcomes.json``. ``src/prompts/06_analysis.md`` is the only thing
+that ever tells an agent to write it. Nothing connected them, so a prompt edit
+that tidied the instruction away would produce runs that burn all five attempts,
+get auto-skipped, and never say why — and every unit test would still pass.
+
+**How the requirement list is derived.** Not by parsing the gate messages. A
+first attempt did that and was useless twice over: every message is prefixed
+with its own stage title, so a set difference never subtracts and Stage 08 looks
+like it introduces fifteen requirements Stage 05 actually introduced; and worse,
+conditional gates are invisible against an empty run, because
+``validate_hypothesis_outcomes`` returns early when no preregistration exists.
+A mutant that renamed ``hypothesis_outcomes.json`` to "the outcomes file"
+passed.
+
+So the list is derived from behaviour instead. A complete fake run is produced,
+then each of its workspace artifacts is deleted in turn and every stage
+revalidated. An artifact is load-bearing for the earliest stage whose gate
+output changes when it disappears. That finds conditional gates, needs no
+knowledge of message wording, and cannot drift from what the validators do.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.utils import STAGES, RunPaths, build_run_paths, validate_stage_artifacts
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PROMPT_DIR = REPO_ROOT / "src" / "prompts"
+
+#: Artifacts no stage template needs to name, each paired with the thing that
+#: does produce or request it. An exemption stated in prose is unrunnable, so
+#: each names a file and a marker the test asserts is still there — an
+#: exemption whose justification stops being true fails rather than sitting in a
+#: comment.
+SERVED_ELSEWHERE: dict[str, tuple[str, str]] = {
+    # Written by the manager when Stage 06 is approved, from round_decision.json.
+    "notes/research_rounds.json": ("src/research_rounds.py", "def record_round"),
+    # The response format is injected at runtime, and only when the adversarial
+    # reviewer actually raised something. With no findings there is no
+    # requirement, so putting it in every template would be noise.
+    "reviews/validity_response_05_experimentation.json": (
+        "src/validity_review.py",
+        "def format_findings_for_prompt",
+    ),
+    "reviews/validity_response_06_analysis.json": (
+        "src/validity_review.py",
+        "def format_findings_for_prompt",
+    ),
+}
+
+#: Where a prompt should point when the agent chooses the filename itself.
+DIRECTORY_PLACEHOLDER = {
+    "figures": "{{WORKSPACE_FIGURES_DIR}}",
+    "results": "{{WORKSPACE_RESULTS_DIR}}",
+    "data": "{{WORKSPACE_DATA_DIR}}",
+    "code": "{{WORKSPACE_CODE_DIR}}",
+    "report/images": "{{WORKSPACE_REPORT_IMAGES_DIR}}",
+    "reviews": "{{WORKSPACE_REVIEWS_DIR}}",
+    "notes": "{{WORKSPACE_NOTES_DIR}}",
+    "artifacts": "{{WORKSPACE_ARTIFACTS_DIR}}",
+    "writing": "{{WORKSPACE_WRITING_DIR}}",
+    "literature": "{{WORKSPACE_LITERATURE_DIR}}",
+}
+
+#: Source files that define what a stage must produce. A filename appearing
+#: literally in one of them is a name the validators know, so the prompt has to
+#: use that exact name; anything else is a name the agent invented for this run
+#: and only the directory can be required. Deriving it beats hand-listing:
+#: a hand-list of "agent-chosen" paths is where a fixed name goes to hide.
+VALIDATOR_SOURCES = (
+    "utils.py",
+    "preregistration.py",
+    "experimental_protocol.py",
+    "validity_review.py",
+    "research_rounds.py",
+    "evidence_ledger.py",
+    "experiment_manifest.py",
+    "writing_manifest.py",
+)
+
+
+def _names_the_validators_know() -> set[str]:
+    blob = "\n".join(
+        (REPO_ROOT / "src" / name).read_text(encoding="utf-8")
+        for name in VALIDATOR_SOURCES
+        if (REPO_ROOT / "src" / name).is_file()
+    )
+    return set(re.findall(r"[\w]+\.(?:json|md|tex|txt|png|bib|pdf)", blob))
+
+
+def _complete_run(destination: Path) -> RunPaths:
+    """A fake run that passes every gate, used as the fixture to break."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "main.py",
+            "--fake-operator",
+            "--full-auto",
+            "--goal",
+            "Prompt/gate correspondence fixture.",
+            "--runs-dir",
+            str(destination),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=300,
+    )
+    roots = sorted(path for path in destination.iterdir() if path.is_dir())
+    if result.returncode != 0 or len(roots) != 1:
+        raise AssertionError(f"fixture run failed: {result.stdout[-3000:]}")
+    return build_run_paths(roots[0])
+
+
+def _load_bearing(paths: RunPaths) -> dict[str, str]:
+    """Map each workspace artifact to the earliest stage that breaks without it."""
+    baseline = {stage.slug: set(validate_stage_artifacts(stage, paths)) for stage in STAGES}
+    owners: dict[str, str] = {}
+    artifacts = sorted(
+        item.relative_to(paths.workspace_root).as_posix()
+        for item in paths.workspace_root.rglob("*")
+        if item.is_file()
+    )
+    for relative in artifacts:
+        with tempfile.TemporaryDirectory() as tmp:
+            copy_root = Path(tmp) / "run"
+            shutil.copytree(paths.run_root, copy_root)
+            copy = build_run_paths(copy_root)
+            (copy.workspace_root / relative).unlink()
+            for stage in STAGES:
+                if set(validate_stage_artifacts(stage, copy)) - baseline[stage.slug]:
+                    owners[relative] = stage.slug
+                    break
+    return owners
+
+
+def _prompts_for(slug: str, output_format: str) -> list[Path]:
+    """The template(s) actually used for this stage in this run.
+
+    Stage 07 forks on the output format. Accepting either file would let the
+    LaTeX prompt cover for a requirement the markdown prompt dropped, and only
+    one of them is ever loaded for a given run.
+    """
+    candidates = sorted(PROMPT_DIR.glob(f"{slug[:2]}_*.md"))
+    markdown_variants = [path for path in candidates if path.stem.endswith("_markdown")]
+    if not markdown_variants:
+        return candidates
+    if output_format == "markdown":
+        return markdown_variants
+    return [path for path in candidates if not path.stem.endswith("_markdown")]
+
+
+class PromptGateCorrespondenceTest(unittest.TestCase):
+    owners: dict[str, str]
+
+    output_format: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from src.utils import selected_output_format
+
+        cls._tmp = tempfile.TemporaryDirectory()
+        paths = _complete_run(Path(cls._tmp.name) / "runs")
+        cls.output_format = selected_output_format(paths)
+        cls.owners = _load_bearing(paths)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def test_the_fixture_actually_found_load_bearing_artifacts(self) -> None:
+        """Control. Without this the real test passes vacuously on an empty map."""
+        self.assertGreaterEqual(len(self.owners), 15, sorted(self.owners))
+        for expected in (
+            "literature/sources.json",
+            "results/hypothesis_outcomes.json",
+            "notes/round_decision.json",
+            "artifacts/claim_provenance.json",
+        ):
+            self.assertIn(expected, self.owners)
+
+    def test_every_load_bearing_artifact_is_asked_for(self) -> None:
+        known = _names_the_validators_know()
+        unserved: list[str] = []
+        for relative, slug in sorted(self.owners.items()):
+            if relative in SERVED_ELSEWHERE:
+                continue
+            candidates = _prompts_for(slug, self.output_format)
+            self.assertTrue(candidates, f"no prompt found for {slug}")
+            texts = [path.read_text(encoding="utf-8") for path in candidates]
+
+            filename = Path(relative).name
+            if filename in known:
+                # The validators know this exact name, so the prompt must use it.
+                needle = filename
+            else:
+                directory = relative.rsplit("/", 1)[0] if "/" in relative else ""
+                needle = DIRECTORY_PLACEHOLDER.get(directory)
+                if needle is None:
+                    unserved.append(
+                        f"{relative} is load-bearing for {slug} but lives in `{directory}`, "
+                        "which has no placeholder a prompt could point at"
+                    )
+                    continue
+            if not any(needle in text for text in texts):
+                unserved.append(
+                    f"{slug} breaks without `{relative}` but "
+                    f"{[path.name for path in candidates]} does not ask for `{needle}`"
+                )
+        self.assertEqual(unserved, [], "\n" + "\n".join(unserved))
+
+    def test_the_validator_name_list_is_not_empty(self) -> None:
+        """Control: an empty `known` set turns every fixed name into a directory check."""
+        known = _names_the_validators_know()
+        for expected in ("hypothesis_outcomes.json", "claim_provenance.json", "round_decision.json"):
+            self.assertIn(expected, known)
+
+    def test_every_exemption_names_something_that_still_exists(self) -> None:
+        for relative, (path_str, marker) in sorted(SERVED_ELSEWHERE.items()):
+            with self.subTest(artifact=relative):
+                path = REPO_ROOT / path_str
+                self.assertTrue(path.is_file(), f"{path_str} is gone")
+                self.assertIn(
+                    marker,
+                    path.read_text(encoding="utf-8"),
+                    msg=f"the exemption for {relative} points at {path_str}, which no longer has {marker!r}",
+                )
+
+    def test_no_exemption_has_become_unnecessary(self) -> None:
+        """A stale exemption silently hides a requirement from the test above."""
+        stale = [
+            relative
+            for relative in SERVED_ELSEWHERE
+            if relative in self.owners
+            and any(
+                Path(relative).name in path.read_text(encoding="utf-8")
+                for path in _prompts_for(self.owners[relative], self.output_format)
+            )
+        ]
+        self.assertEqual(stale, [], f"exempted but now named in the prompt: {stale}")
+
+
+class PromptPlaceholderTest(unittest.TestCase):
+    """A placeholder nothing substitutes is emitted literally into the prompt."""
+
+    def test_no_prompt_uses_an_unknown_placeholder(self) -> None:
+        substituter = (REPO_ROOT / "src" / "utils.py").read_text(encoding="utf-8")
+        known = set(re.findall(r'"(\{\{[A-Z_]+\}\})"', substituter))
+        self.assertGreater(len(known), 15, "failed to locate the substitution table")
+
+        problems = [
+            f"{path.name} uses {token}, which nothing substitutes"
+            for path in sorted(PROMPT_DIR.glob("*.md"))
+            for token in sorted(set(re.findall(r"\{\{[A-Z_]+\}\}", path.read_text(encoding="utf-8"))))
+            if token not in known
+        ]
+        self.assertEqual(problems, [], "\n".join(problems))
+
+
+class StageSummaryContractTest(unittest.TestCase):
+    """Every stage prompt must still ask for the summary sections the validator requires."""
+
+    def test_every_stage_prompt_names_its_output_path(self) -> None:
+        for path in sorted(PROMPT_DIR.glob("0*.md")):
+            with self.subTest(prompt=path.name):
+                self.assertIn("{{STAGE_OUTPUT_PATH}}", path.read_text(encoding="utf-8"))
+
+    def test_every_required_heading_is_shown_to_the_agent(self) -> None:
+        """The contract lives in one place, and that place must still carry it.
+
+        ``required_stage_output_template`` is appended to every stage prompt, so
+        the templates legitimately do not restate the section list. That makes
+        it the single point of failure: if a heading disappears from there,
+        every stage starts failing ``validate_stage_markdown`` at once.
+        """
+        from src.utils import REQUIRED_STAGE_HEADINGS, required_stage_output_template
+
+        shown = required_stage_output_template(STAGES[0])
+        missing = [heading for heading in REQUIRED_STAGE_HEADINGS if f"## {heading}" not in shown]
+        self.assertEqual(missing, [], f"the shared output template omits: {missing}")
+
+    def test_the_shared_template_reaches_the_assembled_prompt(self) -> None:
+        """A contract nothing injects is a contract the agent never sees."""
+        assembler = (REPO_ROOT / "src" / "utils.py").read_text(encoding="utf-8")
+        self.assertIn("required_stage_output_template(", assembler)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Measured a real run's assembled prompts rather than reading the templates. Three findings, in order of how much they changed the plan.

## The templates are only 10–41% of what the model receives

| stage | assembled | template share |
|---|---|---|
| 01 | 1,273 w | 39% |
| 04 | 2,127 w | 15% |
| 07 | 5,124 w | 41% |
| 08 | 3,331 w | 10% |

Rewriting prompt files alone cannot move cost much. That reframed the work toward the injected context.

## Half a late-stage prompt is prior-stage history, and one channel of it is redundant

At Stage 08: `# Approved Memory` 945 w + `# Stage Handoff Context` 344 w + `# Decision Ledger` 380 w = **50% of the prompt**.

And the handoff is a **strict subset** of memory — `build_handoff_context` renders Objective / Key Results / Files Produced for the last four stages with the ledger stripped, and `render_approved_stage_entry` puts exactly those, plus What I Did, into memory for every approved stage. 89% of it measured as verbatim duplicate.

`build_prompt` now sends the handoff only when memory is empty. `build_continuation_prompt` still sends it — that path sends no memory, so there it is the only history.

## Each node emits constant new information and an O(n) relay

```
01   233 new +   2 relayed   ( 1% relay)
04   246 new + 405 relayed   (62%)
06   256 new + 647 relayed   (72%)
08   282 new + 929 relayed   (77%)
     2,093 new + 3,675 relayed across the run — 64% relay
```

Not fixed here; it needs the stage-summary contract to change. Recorded because it is the mechanism behind the growth.

## Shared fragments

Five rules about where a stage may write and who decides progression were copied into all ten templates — and had drifted: Stage 01 alone carried an extra "Do not approve the stage yourself", and the ordering differed for no reason. They now live in `src/prompt_fragments.py`, composed *before* placeholder substitution so a fragment uses the same token vocabulary and introduces none of its own.

Two fragments are **derived from the constants the validators use** rather than written as prose. The extension lists had been hand-copied into three prompts and two copies were already incomplete subsets of `MACHINE_DATA_SUFFIXES` / `RESULT_SUFFIXES`. A sentence generated from a constant cannot fall behind it.

The Stage 06 markdown branch also resolves a real contradiction where it matters: `FIGURE_SUFFIXES` accepts SVG, `RENDERABLE_IMAGE_SUFFIXES` does not — so an SVG figure passes Stage 06 and is invisible to Stage 07. The prompt now says so at the point the figure is created.

## Prompt rewrite

A 14-agent workflow (three audits → one architect → five clusters, each adversarially verified against the gate map). Every stage gained a role naming its characteristic failure mode rather than listing virtues; the panel's five charters were sharpened to be less correlated; the two Stage 07 variants were localised. The workflow did **not** complete its deduplication brief — no agent owned the shared mechanism — so that half was finished by hand.

## Two new tests

**`test_prompt_gate_correspondence`** — the prompts and the validators are two encodings of one contract; nothing connected them. The requirement list is derived from *behaviour*: produce a complete fake run, delete each artifact in turn, and an artifact is load-bearing for the earliest stage whose gate output changes.

A first attempt parsed the gate messages and held nothing — every message is prefixed with its own stage title so a set difference never subtracts, and conditional gates are invisible against an empty run. A mutant renaming `hypothesis_outcomes.json` to "the outcomes file" passed. The rebuilt version catches all six mutants tried. Exemptions name a file and a marker the test checks, so an exemption whose justification stops being true fails rather than sitting in a comment — it already caught one going stale during this change.

**`test_prompt_fragments`** — holds the derivation property, not the wording, including that adding a suffix to a constant reaches the prompt.

## Net

21,823 → 20,836 words per run (**−4.5%**): −185 to −245 per stage from 04 on, against +160 at Stage 01 spent on the new role text.

1,081 tests green, including against the merge with `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)