### PR TITLE
Do not recover a multi-hour run as a free one

### DIFF
--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -325,7 +325,36 @@ def _recorded_duration(workspace: Path, started_at: float) -> int:
             existing = {}
         if isinstance(existing, dict) and existing.get("duration_seconds"):
             return int(existing["duration_seconds"])
+
+    # A run killed by a signal never recorded its own duration, so fall back to how
+    # long the run tree was being written for. Reporting this export's few seconds
+    # instead would put a multi-hour run on the leaderboard at zero cost, since cost
+    # per task is derived from duration.
+    measured = _run_tree_duration(workspace)
+    if measured is not None:
+        return measured
     return round(time.monotonic() - started_at)
+
+
+def _run_tree_duration(workspace: Path) -> int | None:
+    """Wall-clock span of the AutoR run tree, from oldest to newest file.
+
+    An estimate, and deliberately a conservative one: it cannot see time spent before
+    the first file was written or after the last. Better than zero, and never larger
+    than the truth.
+    """
+    runs_root = runs_dir_for(workspace)
+    if not runs_root.exists():
+        return None
+    stamps = [
+        path.stat().st_mtime
+        for path in runs_root.rglob("*")
+        if path.is_file()
+    ]
+    if len(stamps) < 2:
+        return None
+    span = round(max(stamps) - min(stamps))
+    return span if span > 0 else None
 
 
 def run(args: argparse.Namespace) -> BenchmarkResult:

--- a/tests/test_rcb_adapter.py
+++ b/tests/test_rcb_adapter.py
@@ -638,3 +638,52 @@ class ExportOnlyMetadataTest(unittest.TestCase):
         for key in ("task_id", "run_id", "timestamp", "status", "duration_seconds"):
             self.assertIn(key, meta, key)
         self.assertEqual(meta["status"], "completed")
+
+
+class RecoveredDurationTest(unittest.TestCase):
+    """A run killed by a signal never recorded its duration; zero is the wrong answer.
+
+    The leaderboard derives cost per task from duration, so a multi-hour run recovered
+    as `duration_seconds: 0` is published as having cost nothing.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.workspace = Path(self._tmp.name) / "Physics_003_20260806_052405"
+        self.workspace.mkdir()
+        ensure_workspace_layout(self.workspace)
+        self.paths = build_run_paths(runs_dir_for(self.workspace) / "20260806_052441")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.memory, "# Memory\n")
+        write_text(self.paths.stages_dir / "06_analysis.md", "# Stage 06\n\n" + ("Analysis. " * 200))
+
+    def _age_run_tree(self, seconds: int) -> None:
+        import os
+
+        first = self.paths.user_input
+        now = os.path.getmtime(first)
+        os.utime(first, (now - seconds, now - seconds))
+
+    def _meta(self) -> dict:
+        return json.loads((self.workspace / "_meta.json").read_text(encoding="utf-8"))
+
+    def test_duration_is_recovered_from_the_run_tree_span(self) -> None:
+        self._age_run_tree(4000)
+        rcb_agent.main(["--workspace", str(self.workspace), "--export-only", "--no-synthesis"])
+        self.assertGreater(self._meta()["duration_seconds"], 3000)
+
+    def test_a_recorded_duration_still_wins_over_the_estimate(self) -> None:
+        self._age_run_tree(4000)
+        (self.workspace / "_meta.json").write_text(
+            json.dumps({"task_id": "Physics_003", "status": "running", "duration_seconds": 777}),
+            encoding="utf-8",
+        )
+        rcb_agent.main(["--workspace", str(self.workspace), "--export-only", "--no-synthesis"])
+        self.assertEqual(self._meta()["duration_seconds"], 777)
+
+    def test_a_recovered_run_is_never_reported_as_free(self) -> None:
+        self._age_run_tree(4000)
+        rcb_agent.main(["--workspace", str(self.workspace), "--export-only", "--no-synthesis"])
+        self.assertNotEqual(self._meta()["duration_seconds"], 0)


### PR DESCRIPTION
#139 kept an existing `duration_seconds` through recovery — but a run killed by a signal never wrote one, so the fallback recorded how long the **export** took. Both recovered pilot runs came back as `duration_seconds: 0` after roughly an hour of work each.

The leaderboard derives **cost per task from duration**. Zero seconds is zero dollars, so those runs would have been published as having cost nothing: the most flattering number available, produced by a bug rather than by efficiency.

## Fix

When nothing is on record, the duration comes from the span of the run tree's own file timestamps. Deliberately conservative — it cannot see time before the first file was written or after the last, so it **under-reports rather than over-reports**.

A recorded duration still wins over the estimate.

## Tests

Three, one of which states the failure directly:

```python
def test_a_recovered_run_is_never_reported_as_free(self):
    ...
    self.assertNotEqual(self._meta()["duration_seconds"], 0)
```

1068 tests, 3 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)