### PR TITLE
Let a stage stop and think hard where thinking hard pays

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Useful feature | **Deliberating review panel** | Instead of one reviewer agent at the approval gate, `--review-panel` seats a PI, domain expert, methodologist, reproducibility engineer and adversarial reviewer who review independently, cross-examine, then converge — and a blocking objection cannot be approved over. Each run measures the panel against its own single-pass baseline and reports when it did not earn its cost. |
 | Useful feature | **Divergent ideation panel** | `--ideation-panel` widens Stage 02 with proposers working from distinct lenses - mechanism, contrarian, adjacent field, null/artifact, regime - deduplicated and scored into a candidate pool the stage chooses from. It decides nothing, and reports when the extra proposers added nothing. |
 | Useful feature | **Anchored review comments** | A reviewer can quote the passage it objects to instead of refusing the whole stage. The revision is told to change only those spans, and is then diffed against them — so "preserve the correct parts" is measured rather than hoped for. |
+| Useful feature | **Selective deep thinking** | Most steps are execution. With `--deliberation` a stage that hits a genuine crux can stop, name the question, and pull in a panel of theorist / empiricist / critic / pragmatist plus an expert brief — then carry on with an answer that names its own falsifier. Budgeted, and measured against what the agent already believed. |
 | Useful feature | **Two output formats** | Stage 07 writes a benchmark-ready markdown report (`report/report.md` + PNG figures) by default, or a venue-aware LaTeX paper package with a compiled PDF via `--output-format latex`. |
 
 In practice, that means AutoR is useful not only because of the high-level framing, but also because it handles real research chores: literature organization, experiment manifests, citation verification, artifact indexing, manuscript packaging, and recoverable long-running workflows.
@@ -303,6 +304,7 @@ AI handles execution load; humans steer the research when direction actually mat
 | Give the panel a researcher persona to stand in for | `python main.py --review-panel --persona docs/persona-example.md --goal "..."` |
 | Seat the panel across different models | `python main.py --review-panel --panel-models pi=opus skeptic=codex:default --goal "..."` |
 | Widen Stage 02's hypotheses with a proposer panel | `python main.py --ideation-panel --goal "..."` |
+| Let a stage stop and think hard at a crux | `python main.py --deliberation --goal "..."` |
 | Choose the execution backend | `python main.py --operator claude` or `python main.py --operator codex` |
 | Choose the reviewer backend separately | `python main.py --full-auto --review-operator claude --review-model opus` |
 | Choose a Claude model | `python main.py --operator claude --model sonnet` or `python main.py --operator claude --model opus` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ detail behind it.
 | Replace the reviewer agent with a panel that argues before it decides | [Review Panel](review-panel.md) |
 | Send back one passage instead of the whole stage | [Anchored Review Comments](stage-comments.md) |
 | Widen Stage 02's hypotheses with a panel that proposes instead of deciding | [Ideation Panel](ideation-panel.md) |
+| Let a stage stop and think hard when it hits a genuine crux | [Raising a Crux](deliberation.md) |
 | Configure venues, backends, sandboxes, or API keys | [Configuration](configuration.md) |
 | Use or script the browser UI | [Studio Guide & HTTP API](studio.md) |
 | Understand how the code is organized | [Architecture](architecture.md) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -196,6 +196,18 @@ converted to a refinement in code. Each run also writes
 baseline so it can report that it did not earn its cost. Full description, including the
 pre-registered evidence against multi-agent deliberation, in [Review Panel](review-panel.md).
 
+### Crux deliberation
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--deliberation` | off | Let a stage stop and pull in a panel when it hits a genuine crux. The agent names the question, finishes with its working answer, and the resolution reaches the next pass. |
+| `--max-deliberations N` | `3` | Cruxes a run may escalate. Scarcity is what makes "think hard here" mean anything. |
+| `--deliberation-voices VOICE...` | all four | `theorist`, `empiricist`, `critic`, `pragmatist`. |
+| `--deliberation-models VOICE=MODEL...` | - | Assign a model per voice. |
+
+The ledger records whether the panel changed the agent's answer or merely confirmed it. Full
+description in [Raising a Crux](deliberation.md).
+
 ### Ideation panel
 
 | Flag | Default | Description |

--- a/docs/deliberation.md
+++ b/docs/deliberation.md
@@ -1,0 +1,126 @@
+# Raising a crux
+
+AutoR spends the same effort on every step. Most steps deserve that — copying a dataset,
+writing a plotting script, filling in a section. A few do not. The choice of identification
+strategy, the reading of an anomalous result, the decision about what the central claim is:
+those are the places a human researcher stops, argues with colleagues, reads for a day, and
+sits with it.
+
+Doing those at the same tempo as the mechanical steps is how a run produces work that is
+complete and shallow.
+
+```bash
+python main.py --deliberation --goal "..."
+python main.py --deliberation --max-deliberations 5 --goal "..."
+python main.py --deliberation --deliberation-models critic=opus --goal "..."
+```
+
+---
+
+## Why selective, when uniform deliberation lost
+
+The pre-registered comparison in [arXiv:2607.14713](https://arxiv.org/abs/2607.14713) found
+multi-agent deliberation **losing** to a single pass when applied uniformly to every paper.
+Its authors close by naming the open question exactly:
+
+> this design does not identify the occasions on which the more elaborate tools would pay
+
+That is what this answers. Deliberation is expensive, so it is spent only where the agent
+doing the work says it is stuck — and then measured, to see whether stopping was worth it.
+
+## The agent decides
+
+Every stage prompt carries the offer:
+
+> Most of this stage is execution: do it. But if you hit a question where the right answer is
+> genuinely unclear and getting it wrong would invalidate work downstream, you may stop and
+> pull in help rather than guessing and moving on.
+
+The agent writes `workspace/notes/deliberation_request.json`:
+
+```json
+{"question": "Should identification rely on the 2019 policy discontinuity or on household fixed effects?",
+ "why_it_matters": "Every downstream estimate inherits this choice.",
+ "already_considered": ["Matching on pre-period covariates, rejected for lack of overlap."],
+ "working_answer": "Use household fixed effects, because the discontinuity sample is too small.",
+ "help_wanted": "perspectives | expertise | both"}
+```
+
+…then **finishes the stage with its working answer**. It is never blocked. The panel convenes
+on that question, and the resolution reaches the next attempt.
+
+`working_answer` is required in spirit rather than in schema: it is what lets the run measure
+whether the panel changed anything, and a crux raised without one can only be recorded as
+unmeasured.
+
+## Why a third panel
+
+| Panel | Takes | Produces |
+| --- | --- | --- |
+| [Review](review-panel.md) | a finished draft | a gate decision (converges) |
+| [Ideation](ideation-panel.md) | a research goal | a candidate pool (stays diverged) |
+| **Crux** | **a question** | **an answer that names its own falsifier** |
+
+Neither existing panel answers a question. Four voices — **theorist**, **empiricist**,
+**critic**, **pragmatist** — each commit to an answer and are then required to *argue against
+themselves*, because the strongest objection to a position is the most useful thing its holder
+can contribute, and a position with no stated weakness has not been thought about.
+
+When `help_wanted` includes expertise, an **expert brief** is assembled first from the run's
+literature and installed skills. Opinions arrive faster than evidence, so the evidence goes
+first — a panel that argues before reading is a panel arguing from priors.
+
+## The resolution must name its own falsifier
+
+The synthesis returns four fields, and `falsifier` may not be empty:
+
+- **answer** — what to do, concretely enough to act on today
+- **reason** — why, in terms of evidence rather than vote count
+- **falsifier** — what observation would change this answer
+- **dissent** — the strongest surviving objection, kept rather than smoothed away
+
+An answer nothing could overturn is an opinion, and the point of stopping to think was to get
+past opinions.
+
+The stage receives it as a conclusion with reasons attached, **not an order**: it may depart
+from the answer by saying so in `Decision Ledger`. A resolution the stage cannot argue with is
+a manager, not a colleague.
+
+## The budget
+
+`--max-deliberations` defaults to **3**. Scarcity is what makes "think hard here" mean
+anything; an agent that can escalate everything has prioritised nothing. When the budget is
+spent the offer is withdrawn from the prompt rather than silently ignored, and a further
+request is refused with a log line.
+
+Questions shorter than 25 characters are dropped — "what about the data?" has no answer, and a
+panel asked it writes essays.
+
+## Was stopping worth it?
+
+`workspace/reviews/deliberations.json`, same discipline as the other panels:
+
+```json
+{
+  "summary": {
+    "cruxes_raised": 2,
+    "changed_the_agents_answer": 0,
+    "confirmed_the_agents_answer": 2,
+    "voice_calls": 10,
+    "verdict": "2 crux(es) escalated at 10 calls, and the panel confirmed the agent's own answer every time. On this run stopping to think changed nothing — the agent was escalating questions it had already settled."
+  }
+}
+```
+
+Every position from every voice is kept, including the ones the resolution rejected.
+
+## Limits worth knowing
+
+- **The agent chooses what is hard, and it may choose badly.** It can escalate a question it
+  had already settled, or fail to escalate the one that mattered. The `confirmed` count catches
+  the first; nothing catches the second.
+- **A resolved crux is not a correct crux.** Four voices agreeing says they share a prior, not
+  that they are right — which is why the falsifier is mandatory and the dissent is kept.
+- **Cost is real**: `voices + 2` calls per crux with a brief, six by default, times the budget.
+- If `confirmed_the_agents_answer` dominates across your runs, the honest reading is that this
+  agent does not need the help it is asking for, and the flag should be off.

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -826,6 +826,17 @@ Required: non-empty string `overall_status`; booleans `pdf_available` and
 Validated by `validate_layout_review` in
 [`src/writing_manifest.py`](../src/writing_manifest.py).
 
+### `workspace/reviews/deliberations.json`
+
+Written when a stage raises a crux under `--deliberation`. Every question escalated, the
+expert brief, each voice's position and self-objection, and the resolution with its falsifier
+and surviving dissent.
+
+`summary.confirmed_the_agents_answer` is the one to read: escalations where the panel simply
+agreed with what the agent already had are escalations that were not needed.
+
+See [Raising a Crux](deliberation.md).
+
 ### `workspace/reviews/comment_ledger.json`
 
 Written when a reviewer anchors its objections to quoted passages. One entry per review round,

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 from src.approval_agent import AutomatedReviewer
+from src.deliberation import DEFAULT_MAX_DELIBERATIONS
 from src.review_panel import (
     DEFAULT_PANEL,
     ReviewPanel,
@@ -162,6 +163,33 @@ def parse_args() -> argparse.Namespace:
              "(for example: pi=opus skeptic=codex:default). Seats left unassigned use the "
              "reviewer default. Heterogeneity is the lever with the best evidence behind it: "
              "five prompts against one model are five correlated reads wearing five hats.",
+    )
+    parser.add_argument(
+        "--deliberation",
+        action="store_true",
+        help="Let a stage stop and pull in a panel when it hits a genuine crux. The agent "
+             "names the question, finishes with its working answer, and a focused panel "
+             "resolves it for the next pass. Most steps are execution; this is for the few "
+             "that are not.",
+    )
+    parser.add_argument(
+        "--max-deliberations",
+        type=int,
+        default=DEFAULT_MAX_DELIBERATIONS,
+        help="Cruxes a run may escalate before the budget is refused. Scarcity is what makes "
+             f"'think hard here' mean anything. Defaults to {DEFAULT_MAX_DELIBERATIONS}.",
+    )
+    parser.add_argument(
+        "--deliberation-voices",
+        nargs="+",
+        metavar="VOICE",
+        help="Seat only these voices: theorist, empiricist, critic, pragmatist.",
+    )
+    parser.add_argument(
+        "--deliberation-models",
+        nargs="+",
+        metavar="VOICE=MODEL",
+        help="Assign a model per voice, as voice=model or voice=backend:model.",
     )
     parser.add_argument(
         "--ideation-panel",
@@ -716,6 +744,23 @@ def resolve_search_context(ui: TerminalUI, *, mode: str, operator: str, codex_sa
 
 
 
+
+def create_crux_panel(args, *, backend_name: str, model: str, ui: TerminalUI):
+    """Build the crux deliberation panel, or None when it is not requested."""
+    if not getattr(args, "deliberation", False):
+        return None
+    from src.deliberation import CruxPanel, apply_voice_models, resolve_voices
+
+    return CruxPanel(
+        apply_voice_models(resolve_voices(args.deliberation_voices), args.deliberation_models),
+        backend_name=backend_name,
+        model=model,
+        fake_mode=args.fake_operator,
+        ui=ui,
+        stage_timeout=args.stage_timeout,
+        max_deliberations=args.max_deliberations,
+    )
+
 def create_ideation_panel(args, *, backend_name: str, model: str, ui: TerminalUI):
     """Build the Stage 02 proposer panel, or None when it is not requested."""
     if not getattr(args, "ideation_panel", False):
@@ -852,6 +897,9 @@ def main() -> int:
         manager.ideation_panel = create_ideation_panel(
             args, backend_name=review_operator, model=review_model, ui=ui
         )
+        manager.crux_panel = create_crux_panel(
+            args, backend_name=review_operator, model=review_model, ui=ui
+        )
         completed = manager.resume_run(
             run_root,
             start_stage=start_stage or rollback_stage,
@@ -929,6 +977,9 @@ def main() -> int:
     )
 
     manager.ideation_panel = create_ideation_panel(
+        args, backend_name=review_operator, model=review_model, ui=ui
+    )
+    manager.crux_panel = create_crux_panel(
         args, backend_name=review_operator, model=review_model, ui=ui
     )
 

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -58,6 +58,7 @@ from src.rcb import (  # noqa: E402
     runs_dir_for,
 )
 from src.terminal_ui import TerminalUI  # noqa: E402
+from src.deliberation import DEFAULT_MAX_DELIBERATIONS  # noqa: E402
 from src.utils import (  # noqa: E402
     DEFAULT_OUTPUT_FORMAT,
     DEFAULT_VENUE,
@@ -181,6 +182,33 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
              "(for example: pi=opus skeptic=codex:default). Seats left unassigned use the "
              "reviewer default. Heterogeneity is the lever with the best evidence behind it: "
              "five prompts against one model are five correlated reads wearing five hats.",
+    )
+    parser.add_argument(
+        "--deliberation",
+        action="store_true",
+        help="Let a stage stop and pull in a panel when it hits a genuine crux. The agent "
+             "names the question, finishes with its working answer, and a focused panel "
+             "resolves it for the next pass. Most steps are execution; this is for the few "
+             "that are not.",
+    )
+    parser.add_argument(
+        "--max-deliberations",
+        type=int,
+        default=DEFAULT_MAX_DELIBERATIONS,
+        help="Cruxes a run may escalate before the budget is refused. Scarcity is what makes "
+             f"'think hard here' mean anything. Defaults to {DEFAULT_MAX_DELIBERATIONS}.",
+    )
+    parser.add_argument(
+        "--deliberation-voices",
+        nargs="+",
+        metavar="VOICE",
+        help="Seat only these voices: theorist, empiricist, critic, pragmatist.",
+    )
+    parser.add_argument(
+        "--deliberation-models",
+        nargs="+",
+        metavar="VOICE=MODEL",
+        help="Assign a model per voice, as voice=model or voice=backend:model.",
     )
     parser.add_argument(
         "--ideation-panel",
@@ -500,6 +528,19 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
             ui=ui,
             stage_timeout=args.stage_timeout,
             ideas_per_proposer=args.ideas_per_proposer,
+        )
+
+    if args.deliberation:
+        from src.deliberation import CruxPanel, apply_voice_models, resolve_voices
+
+        manager.crux_panel = CruxPanel(
+            apply_voice_models(resolve_voices(args.deliberation_voices), args.deliberation_models),
+            backend_name=review_backend,
+            model=review_model,
+            fake_mode=args.fake_operator,
+            ui=ui,
+            stage_timeout=args.stage_timeout,
+            max_deliberations=args.max_deliberations,
         )
 
     pipeline_completed = False

--- a/src/deliberation.py
+++ b/src/deliberation.py
@@ -1,0 +1,640 @@
+"""Think hard, but only where thinking hard pays.
+
+AutoR spends the same effort on every step. Most steps deserve that: copying a dataset,
+writing a plotting script, filling in a section. A few do not. The choice of identification
+strategy, the reading of an anomalous result, the decision about what the central claim is —
+those are the places a human researcher stops, argues with colleagues, reads for a day, and
+sits with it. Doing them at the same tempo as the mechanical steps is how a run produces work
+that is complete and shallow.
+
+So this module lets the executing agent **raise a crux**: name a specific question it is stuck
+on, say what breaks if it gets it wrong, and ask for either more perspectives, expert
+grounding, or both. AutoR convenes a focused deliberation on that one question and hands back
+a resolution the next attempt can use.
+
+**Why selective and not uniform.** The pre-registered comparison in
+`arXiv:2607.14713 <https://arxiv.org/abs/2607.14713>`_ found multi-agent deliberation losing
+to a single pass when applied uniformly to every paper — and its authors close by saying the
+design "does not identify the occasions on which the more elaborate tools would pay". That is
+the open question, and it is the one this answers: deliberation is expensive, so spend it only
+where the agent doing the work says it is stuck, and then measure whether it changed anything.
+
+**What makes this different from the two existing panels.** :mod:`src.review_panel` judges a
+finished draft and converges on a gate decision. :mod:`src.ideation_panel` generates candidates
+and stays diverged. Neither answers a *question*. A crux deliberation takes a proposition,
+collects positions that must argue against themselves, and resolves to an answer that names
+its own falsifier — the thing that would change it. An answer with no stated falsifier is an
+opinion, and the point of stopping to think was to get past opinions.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .approval_agent import AutomatedReviewer
+from .terminal_ui import TerminalUI
+from .utils import (
+    RunPaths,
+    StageSpec,
+    append_log_entry,
+    read_text,
+    truncate_text,
+    write_text,
+)
+
+
+#: Where the executing agent raises a crux. A file rather than a prompt convention: the
+#: operator is a coding agent with file tools, and a file is unambiguous and inspectable.
+REQUEST_FILENAME = "deliberation_request.json"
+
+#: Where resolutions accumulate, one per crux, for the run and for later stages to read.
+LEDGER_FILENAME = "deliberations.json"
+
+#: How many cruxes a run may escalate by default. "Think hard here" is only meaningful if it
+#: is scarce; an agent that can escalate everything has not prioritised anything.
+DEFAULT_MAX_DELIBERATIONS = 3
+
+#: Below this a question is too vague to deliberate — "what should we do about the data?" has
+#: no answer, and a panel asked it will produce five essays.
+MIN_QUESTION_CHARS = 25
+
+HELP_KINDS = ("perspectives", "expertise", "both")
+
+
+@dataclass(frozen=True)
+class Voice:
+    """One participant in a crux deliberation."""
+
+    key: str
+    title: str
+    charter: str
+    backend: str | None = None
+    model: str | None = None
+
+
+DEFAULT_VOICES: tuple[Voice, ...] = (
+    Voice(
+        key="theorist",
+        title="Theorist",
+        charter=(
+            "Answer from what the theory requires. Which option is consistent with the "
+            "mechanism the run has committed to, and which one quietly assumes something the "
+            "theory does not license?"
+        ),
+    ),
+    Voice(
+        key="empiricist",
+        title="Empiricist",
+        charter=(
+            "Answer from what the data can actually support. Which option can be estimated "
+            "with the data in this run, at a precision that would let anyone distinguish the "
+            "answers? An option that is right in principle and unidentified in practice is the "
+            "wrong answer here."
+        ),
+    ),
+    Voice(
+        key="critic",
+        title="Critic",
+        charter=(
+            "Answer by finding the failure. For each option, name the way it goes wrong and how "
+            "a referee would attack it. You are allowed to conclude that both options are wrong "
+            "and the question is mis-posed — say so if it is true."
+        ),
+    ),
+    Voice(
+        key="pragmatist",
+        title="Pragmatist",
+        charter=(
+            "Answer from what this run can finish. Weigh the cost of each option against the "
+            "time and artifacts available, and say plainly when the more rigorous option is out "
+            "of reach — but never dress up the cheap option as the correct one."
+        ),
+    ),
+)
+
+VOICES_BY_KEY = {voice.key: voice for voice in DEFAULT_VOICES}
+
+
+def resolve_voices(keys: list[str] | None) -> tuple[Voice, ...]:
+    if not keys:
+        return DEFAULT_VOICES
+    voices: list[Voice] = []
+    for key in keys:
+        normalized = key.strip().lower()
+        if normalized not in VOICES_BY_KEY:
+            known = ", ".join(sorted(VOICES_BY_KEY))
+            raise ValueError(f"Unknown deliberation voice: {key}. Known voices: {known}.")
+        voice = VOICES_BY_KEY[normalized]
+        if voice not in voices:
+            voices.append(voice)
+    return tuple(voices)
+
+
+def apply_voice_models(voices: tuple[Voice, ...], assignments: list[str] | None) -> tuple[Voice, ...]:
+    """Assign a backend and model per voice from ``voice=[backend:]model`` strings."""
+    if not assignments:
+        return voices
+    by_key = {voice.key: voice for voice in voices}
+    updated = dict(by_key)
+    for raw in assignments:
+        if "=" not in raw:
+            raise ValueError(
+                f"Bad deliberation model assignment: {raw!r}. Expected voice=model or voice=backend:model."
+            )
+        key, _, spec = raw.partition("=")
+        key, spec = key.strip().lower(), spec.strip()
+        if key not in by_key:
+            known = ", ".join(sorted(by_key))
+            raise ValueError(f"Unknown deliberation voice in model assignment: {key}. Seated: {known}.")
+        if not spec:
+            raise ValueError(f"Bad deliberation model assignment: {raw!r}. No model given.")
+        backend, _, model = spec.partition(":") if ":" in spec else (None, "", spec)
+        model = model.strip()
+        if not model:
+            raise ValueError(f"Bad deliberation model assignment: {raw!r}. No model given.")
+        current = updated[key]
+        updated[key] = Voice(**{**current.__dict__, "backend": backend or current.backend, "model": model})
+    return tuple(updated[voice.key] for voice in voices)
+
+
+# ---------------------------------------------------------------------------
+# The request
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CruxRequest:
+    question: str
+    why_it_matters: str = ""
+    already_considered: tuple[str, ...] = ()
+    working_answer: str = ""
+    help_wanted: str = "both"
+    stage_slug: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def parse_requests(payload: Any, *, stage: StageSpec) -> list[CruxRequest]:
+    """Read crux requests the executing agent left behind.
+
+    Tolerant of shape — a single object or a list — because this file is written by a model
+    mid-stage, and a malformed escalation should cost the escalation, not the stage.
+    """
+    entries = payload if isinstance(payload, list) else [payload]
+    requests: list[CruxRequest] = []
+    for raw in entries:
+        if not isinstance(raw, dict):
+            continue
+        question = str(raw.get("question") or "").strip()
+        if len(question) < MIN_QUESTION_CHARS:
+            continue
+        considered = raw.get("already_considered")
+        help_wanted = str(raw.get("help_wanted") or "both").strip().lower()
+        requests.append(
+            CruxRequest(
+                question=question,
+                why_it_matters=str(raw.get("why_it_matters") or "").strip(),
+                already_considered=tuple(
+                    str(item).strip() for item in considered if str(item).strip()
+                ) if isinstance(considered, list) else (),
+                working_answer=str(raw.get("working_answer") or raw.get("current_answer") or "").strip(),
+                help_wanted=help_wanted if help_wanted in HELP_KINDS else "both",
+                stage_slug=stage.slug,
+            )
+        )
+    return requests
+
+
+def read_requests(paths: RunPaths, stage: StageSpec) -> list[CruxRequest]:
+    path = paths.notes_dir / REQUEST_FILENAME
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(read_text(path))
+    except (OSError, json.JSONDecodeError):
+        return []
+    return parse_requests(payload, stage=stage)
+
+
+def clear_requests(paths: RunPaths) -> None:
+    """Consume the request file so one crux is not deliberated twice."""
+    path = paths.notes_dir / REQUEST_FILENAME
+    if path.exists():
+        path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# The result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Position:
+    voice: str
+    title: str
+    backend: str
+    model: str
+    answer: str
+    argument: str = ""
+    against_self: str = ""
+    failed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Resolution:
+    request: CruxRequest
+    positions: list[Position] = field(default_factory=list)
+    brief: str = ""
+    answer: str = ""
+    reason: str = ""
+    falsifier: str = ""
+    dissent: str = ""
+    voice_calls: int = 0
+    changed_the_answer: bool | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "request": self.request.to_dict(),
+            "brief": self.brief,
+            "positions": [position.to_dict() for position in self.positions],
+            "answer": self.answer,
+            "reason": self.reason,
+            "falsifier": self.falsifier,
+            "dissent": self.dissent,
+            "voice_calls": self.voice_calls,
+            "distinct_answers": self.distinct_answers,
+            "changed_the_answer": self.changed_the_answer,
+            "verdict": self.verdict(),
+        }
+
+    @property
+    def distinct_answers(self) -> int:
+        from .ideation_panel import similarity
+
+        answers = [position.answer for position in self.positions if position.answer and not position.failed]
+        distinct: list[str] = []
+        for answer in answers:
+            if not any(similarity(answer, kept) >= 0.5 for kept in distinct):
+                distinct.append(answer)
+        return len(distinct)
+
+    def verdict(self) -> str:
+        """Whether stopping to think was worth the calls it cost."""
+        if not self.answer:
+            return "The deliberation produced no answer; the stage keeps its own."
+        if self.changed_the_answer is False:
+            return (
+                f"The panel reached the same answer the agent already had, at {self.voice_calls} "
+                "calls. This crux did not need escalating."
+            )
+        if self.changed_the_answer is True:
+            return (
+                f"The panel reached a different answer than the agent's working one, at "
+                f"{self.voice_calls} calls, from {self.distinct_answers} distinct position(s)."
+            )
+        return (
+            f"Resolved from {self.distinct_answers} distinct position(s) at {self.voice_calls} "
+            "calls; the agent had no working answer to compare against."
+        )
+
+
+# ---------------------------------------------------------------------------
+# The deliberation
+# ---------------------------------------------------------------------------
+
+
+class CruxPanel:
+    """Convene a focused deliberation on one question the agent got stuck on."""
+
+    def __init__(
+        self,
+        voices: tuple[Voice, ...] = DEFAULT_VOICES,
+        *,
+        backend_name: str,
+        model: str,
+        fake_mode: bool = False,
+        ui: TerminalUI | None = None,
+        stage_timeout: int = 14400,
+        max_deliberations: int = DEFAULT_MAX_DELIBERATIONS,
+    ) -> None:
+        if not voices:
+            raise ValueError("A crux deliberation needs at least one voice.")
+        self.voices = voices
+        self.backend_name = backend_name
+        self.model = model
+        self.fake_mode = fake_mode
+        self.ui = ui or TerminalUI()
+        self.max_deliberations = max(0, max_deliberations)
+        self.spent = 0
+        self._members = {
+            voice.key: AutomatedReviewer(
+                voice.backend or backend_name,
+                model=voice.model or model,
+                fake_mode=fake_mode,
+                ui=self.ui,
+                stage_timeout=stage_timeout,
+            )
+            for voice in voices
+        }
+
+    @property
+    def budget_left(self) -> int:
+        return max(0, self.max_deliberations - self.spent)
+
+    def deliberate(
+        self, *, paths: RunPaths, stage: StageSpec, attempt_no: int, request: CruxRequest
+    ) -> Resolution | None:
+        """Run one crux to a resolution, or None when the budget is spent."""
+        if self.fake_mode or self.budget_left == 0:
+            return None
+        self.spent += 1
+        resolution = Resolution(request=request)
+
+        if request.help_wanted in ("expertise", "both"):
+            resolution.brief = self._expert_brief(paths, stage, attempt_no, request)
+
+        for voice in self.voices:
+            member = self._members[voice.key]
+            self.ui.show_status(f"Crux deliberation: {voice.title} is thinking...", level="info")
+            exit_code, stdout_text, _stderr = member.run_prompt(
+                paths=paths,
+                stage=stage,
+                attempt_no=attempt_no,
+                prompt=self._position_prompt(paths, request, voice, resolution.brief),
+                label=f"crux_{voice.key}",
+            )
+            resolution.voice_calls += 1
+            payload = member._extract_json_payload(stdout_text) if exit_code == 0 else None  # noqa: SLF001
+            if not isinstance(payload, dict) or not str(payload.get("answer") or "").strip():
+                resolution.positions.append(
+                    Position(voice=voice.key, title=voice.title, backend=member.backend_name,
+                             model=member.model, answer="", failed=True)
+                )
+                continue
+            resolution.positions.append(
+                Position(
+                    voice=voice.key,
+                    title=voice.title,
+                    backend=member.backend_name,
+                    model=member.model,
+                    answer=str(payload["answer"]).strip(),
+                    argument=str(payload.get("argument") or "").strip(),
+                    against_self=str(payload.get("against_self") or payload.get("strongest_objection") or "").strip(),
+                )
+            )
+
+        self._resolve(paths, stage, attempt_no, resolution)
+        return resolution
+
+    def _expert_brief(
+        self, paths: RunPaths, stage: StageSpec, attempt_no: int, request: CruxRequest
+    ) -> str:
+        """Ground the question in what the run already knows before anyone opines.
+
+        Opinions arrive faster than evidence, so the evidence goes first. A panel that argues
+        before reading is a panel arguing from priors.
+        """
+        member = self._members[self.voices[0].key]
+        self.ui.show_status("Crux deliberation: assembling the expert brief...", level="info")
+        exit_code, stdout_text, _stderr = member.run_prompt(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            prompt=(
+                "# AutoR Crux: Expert Brief\n\n"
+                "Before a panel argues about the question below, establish what is already "
+                "known. You are not answering the question — you are giving the panel the "
+                "ground truth it should argue from.\n\n"
+                "Read the run's literature directory and any relevant installed skill. Report:\n\n"
+                "- what the field's standard practice is on this question, and where it is contested\n"
+                "- what this run's own artifacts already settle or rule out\n"
+                "- the specific facts a wrong answer here would contradict\n\n"
+                "Prose, under 400 words, no recommendation. Say plainly where you found nothing.\n\n"
+                f"# Question\n\n{request.question}\n\n"
+                f"# Why It Matters\n\n{request.why_it_matters or '(not stated)'}\n\n"
+                f"# Literature\n\n`{paths.literature_dir.resolve()}`\n\n"
+                f"# Workspace\n\n`{paths.workspace_root.resolve()}`\n\n"
+                "# Approved Memory\n\n"
+                f"{truncate_text(_excerpt(paths.memory), max_chars=8000)}\n"
+            ),
+            label="crux_brief",
+        )
+        return stdout_text.strip() if exit_code == 0 else ""
+
+    def _position_prompt(self, paths: RunPaths, request: CruxRequest, voice: Voice, brief: str) -> str:
+        considered = (
+            "\n".join(f"- {item}" for item in request.already_considered)
+            if request.already_considered
+            else "- (the agent did not say)"
+        )
+        return (
+            f"# AutoR Crux Deliberation: {voice.title}\n\n"
+            "The agent doing this research stopped and said it is stuck on one question. You are "
+            "one of several people it pulled in. Answer the question — do not review the stage, "
+            "do not broaden the scope, and do not hedge into 'it depends' without saying what it "
+            f"depends on.\n\n## Your Angle\n\n{voice.charter}\n\n"
+            "## Discipline\n\n"
+            "- Commit to an answer. A panel of maybes resolves nothing.\n"
+            "- Then argue **against your own answer** as hard as you can. The strongest objection "
+            "to your position is the most useful thing you can contribute, and a position with no "
+            "stated weakness has not been thought about.\n"
+            "- Ground claims in the run's artifacts and literature, not in general knowledge.\n"
+            "- If the question is mis-posed, say what the right question is instead of answering "
+            "the wrong one.\n\n"
+            "## Return Format\n\n"
+            "Return JSON only:\n"
+            '{"answer":"","argument":"","against_self":""}\n\n'
+            f"# The Question\n\n{request.question}\n\n"
+            f"# Why It Matters\n\n{request.why_it_matters or '(not stated)'}\n\n"
+            f"# What The Agent Already Considered\n\n{considered}\n\n"
+            + (f"# The Agent's Working Answer\n\n{request.working_answer}\n\n" if request.working_answer else "")
+            + (f"# Expert Brief\n\n{brief}\n\n" if brief else "")
+            + "# Research Goal\n\n"
+            f"{truncate_text(_excerpt(paths.user_input), max_chars=3000)}\n\n"
+            "# Approved Memory\n\n"
+            f"{truncate_text(_excerpt(paths.memory), max_chars=8000)}\n"
+        )
+
+    def _resolve(
+        self, paths: RunPaths, stage: StageSpec, attempt_no: int, resolution: Resolution
+    ) -> None:
+        live = [position for position in resolution.positions if not position.failed]
+        if not live:
+            return
+
+        member = self._members[self.voices[0].key]
+        self.ui.show_status("Crux deliberation: resolving...", level="info")
+        positions = "\n\n".join(
+            f"**Voice {chr(ord('A') + index)}**\nAnswer: {position.answer}"
+            + (f"\nArgument: {position.argument}" if position.argument else "")
+            + (f"\nStrongest objection to their own answer: {position.against_self}" if position.against_self else "")
+            for index, position in enumerate(live)
+        )
+        exit_code, stdout_text, _stderr = member.run_prompt(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            prompt=(
+                "# AutoR Crux: Resolution\n\n"
+                "Several people answered the question below, each having also argued against "
+                "themselves. Turn that into one answer the research can act on. Their identities "
+                "are withheld so you weigh each on its argument.\n\n"
+                "## What The Answer Must Contain\n\n"
+                "- **answer** — what the research should do, concretely enough to act on today.\n"
+                "- **reason** — why, in terms of the evidence, not the vote count. One well-argued "
+                "position outranks three assertions.\n"
+                "- **falsifier** — what observation or check would change this answer. An answer "
+                "that nothing could overturn is an opinion, and the point of stopping to think "
+                "was to get past opinions. This field may not be empty.\n"
+                "- **dissent** — the strongest surviving objection, kept rather than smoothed away.\n\n"
+                "Return JSON only:\n"
+                '{"answer":"","reason":"","falsifier":"","dissent":""}\n\n'
+                f"# The Question\n\n{resolution.request.question}\n\n"
+                + (f"# Expert Brief\n\n{resolution.brief}\n\n" if resolution.brief else "")
+                + f"# Positions\n\n{positions}\n"
+            ),
+            label="crux_resolve",
+        )
+        resolution.voice_calls += 1
+        if exit_code != 0:
+            return
+        payload = member._extract_json_payload(stdout_text)  # noqa: SLF001
+        if not isinstance(payload, dict):
+            return
+        resolution.answer = str(payload.get("answer") or "").strip()
+        resolution.reason = str(payload.get("reason") or "").strip()
+        resolution.falsifier = str(payload.get("falsifier") or "").strip()
+        resolution.dissent = str(payload.get("dissent") or "").strip()
+
+        if resolution.request.working_answer and resolution.answer:
+            from .ideation_panel import similarity
+
+            resolution.changed_the_answer = (
+                similarity(resolution.answer, resolution.request.working_answer) < 0.5
+            )
+
+
+def _excerpt(path) -> str:
+    return read_text(path).strip() if path.exists() else "(missing)"
+
+
+# ---------------------------------------------------------------------------
+# Prompt blocks and records
+# ---------------------------------------------------------------------------
+
+
+def escalation_offer(paths: RunPaths, budget_left: int) -> str:
+    """The block that tells a stage it is allowed to stop and think."""
+    if budget_left <= 0:
+        return (
+            "# Raising A Crux\n\n"
+            "This run has spent its deliberation budget. Work through remaining difficulties "
+            "yourself and record the ones you are least sure about in `Decision Ledger`."
+        )
+    return (
+        "# Raising A Crux\n\n"
+        "Most of this stage is execution: do it. But if you hit a question where the right "
+        "answer is genuinely unclear and getting it wrong would invalidate work downstream, you "
+        "may stop and pull in help rather than guessing and moving on.\n\n"
+        f"Write `{(paths.notes_dir / REQUEST_FILENAME).resolve()}`:\n\n"
+        "```json\n"
+        '{"question": "the specific question, answerable and decidable",\n'
+        ' "why_it_matters": "what breaks downstream if this is wrong",\n'
+        ' "already_considered": ["what you have already ruled out, and why"],\n'
+        ' "working_answer": "your best answer right now, so the panel can disagree with it",\n'
+        ' "help_wanted": "perspectives | expertise | both"}\n'
+        "```\n\n"
+        "Then **finish the stage with your working answer**. A panel will be convened on that "
+        "question and its resolution handed to you on the next pass; you are not blocked.\n\n"
+        f"You may raise {budget_left} more this run. Spend them on the questions a reviewer would "
+        "attack first, not on things you can settle by reading a file. An escalation that turns "
+        "out to have had an obvious answer costs the run a round it needed elsewhere."
+    )
+
+
+def format_resolution_for_prompt(resolutions: list[Resolution]) -> str:
+    """Hand the resolutions back to the stage that asked for them."""
+    if not resolutions:
+        return ""
+    lines = [
+        "You raised the following as cruxes. A panel deliberated on each and resolved it. "
+        "Apply the answer, or say in `Decision Ledger` why you are departing from it — these "
+        "are conclusions with reasons attached, not orders, and the dissent is included so you "
+        "can weigh it yourself.",
+        "",
+    ]
+    for index, resolution in enumerate(resolutions, start=1):
+        lines.extend([f"### Crux {index}: {resolution.request.question}", ""])
+        if resolution.answer:
+            lines.extend([f"**Answer.** {resolution.answer}", ""])
+        if resolution.reason:
+            lines.extend([f"**Why.** {resolution.reason}", ""])
+        if resolution.falsifier:
+            lines.extend([f"**What would change this.** {resolution.falsifier}", ""])
+        if resolution.dissent:
+            lines.extend([f"**Surviving dissent.** {resolution.dissent}", ""])
+        if not resolution.answer:
+            lines.extend(["The panel did not reach an answer; keep your own and note the uncertainty.", ""])
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def record_resolution(paths: RunPaths, stage: StageSpec, resolution: Resolution) -> dict[str, Any]:
+    """Persist the crux, every position, and whether escalating changed anything."""
+    path = paths.reviews_dir / LEDGER_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    ledger: dict[str, Any] = {"deliberations": []}
+    if path.exists():
+        try:
+            existing = json.loads(read_text(path))
+            if isinstance(existing, dict) and isinstance(existing.get("deliberations"), list):
+                ledger = existing
+        except (OSError, json.JSONDecodeError):
+            ledger = {"deliberations": []}
+
+    ledger["deliberations"].append({"stage": stage.slug, **resolution.to_dict()})
+    ledger["summary"] = _summary(ledger["deliberations"])
+    write_text(path, json.dumps(ledger, indent=2, ensure_ascii=False))
+
+    append_log_entry(
+        paths.logs,
+        f"{stage.slug} crux_deliberation",
+        f"question: {resolution.request.question}\n{resolution.verdict()}",
+    )
+    return ledger
+
+
+def _summary(entries: list[dict[str, Any]]) -> dict[str, Any]:
+    calls = sum(int(entry.get("voice_calls") or 0) for entry in entries)
+    changed = sum(1 for entry in entries if entry.get("changed_the_answer") is True)
+    unchanged = sum(1 for entry in entries if entry.get("changed_the_answer") is False)
+    return {
+        "cruxes_raised": len(entries),
+        "changed_the_agents_answer": changed,
+        "confirmed_the_agents_answer": unchanged,
+        "voice_calls": calls,
+        "verdict": _summary_verdict(len(entries), changed, unchanged, calls),
+    }
+
+
+def _summary_verdict(total: int, changed: int, unchanged: int, calls: int) -> str:
+    if total == 0:
+        return "No cruxes were raised."
+    if unchanged and not changed:
+        return (
+            f"{total} crux(es) escalated at {calls} calls, and the panel confirmed the agent's "
+            "own answer every time. On this run stopping to think changed nothing — the agent "
+            "was escalating questions it had already settled."
+        )
+    if changed:
+        return (
+            f"{total} crux(es) escalated at {calls} calls; the panel changed the answer on "
+            f"{changed} of them."
+        )
+    return f"{total} crux(es) escalated at {calls} calls; no working answer was offered to compare against."

--- a/src/manager.py
+++ b/src/manager.py
@@ -109,6 +109,14 @@ from .stage_graph import (
 from .diagram_gen import post_writing_diagram_hook
 from .terminal_ui import TerminalUI
 from .platform.foundry import generate_paper_package, generate_release_package
+from .deliberation import (
+    CruxPanel,
+    clear_requests,
+    escalation_offer,
+    format_resolution_for_prompt,
+    read_requests,
+    record_resolution,
+)
 from .ideation_panel import (
     IdeationPanel,
     format_pool_for_prompt,
@@ -218,6 +226,8 @@ class ResearchManager:
         self._research_diagram: bool = False
         self._final_stage: StageSpec | None = None
         self.ideation_panel: IdeationPanel | None = None
+        self.crux_panel: CruxPanel | None = None
+        self._crux_resolutions: list[Any] = []
         self._pending_comments: list[Any] = []
         self._open_comments: list[Any] = []
         self._commented_draft: str = ""
@@ -705,6 +715,58 @@ class ResearchManager:
                 )
         except Exception as exc:  # noqa: BLE001 - measurement must not derail the stage
             append_log_entry(paths.logs, f"{stage.slug} anchored_revision_failed", str(exc))
+
+    def _settle_cruxes(self, paths: RunPaths, stage: StageSpec, attempt_no: int) -> str | None:
+        """Deliberate any crux the agent raised, and send the stage back with the answers.
+
+        Returns the revision instruction when a deliberation ran, or None to let the stage
+        proceed to its gate untouched. Best-effort: a panel that cannot be reached must not
+        strand a stage that already produced a usable draft.
+        """
+        if self.crux_panel is None:
+            return None
+        try:
+            requests = read_requests(paths, stage)
+        except Exception:  # noqa: BLE001 - a malformed escalation costs the escalation only
+            requests = []
+        if not requests:
+            return None
+        clear_requests(paths)
+
+        resolutions = []
+        for request in requests:
+            if self.crux_panel.budget_left == 0:
+                append_log_entry(
+                    paths.logs,
+                    f"{stage.slug} crux_budget_spent",
+                    f"Refused to deliberate: {request.question}",
+                )
+                self.ui.show_status(
+                    "Deliberation budget is spent; the remaining crux was not escalated.",
+                    level="warn",
+                )
+                break
+            self.ui.show_status(f"{stage.stage_title} raised a crux: {request.question}", level="info")
+            try:
+                resolution = self.crux_panel.deliberate(
+                    paths=paths, stage=stage, attempt_no=attempt_no, request=request
+                )
+            except Exception as exc:  # noqa: BLE001 - never strand a usable draft
+                append_log_entry(paths.logs, f"{stage.slug} crux_failed", str(exc))
+                continue
+            if resolution is None:
+                continue
+            record_resolution(paths, stage, resolution)
+            resolutions.append(resolution)
+
+        if not resolutions:
+            return None
+        self._crux_resolutions = resolutions
+        return (
+            "Continue the current stage conversation. A panel resolved the crux(es) you raised; "
+            "the answers are below under `Resolved Cruxes`. Apply them and revise the parts of "
+            "the stage that depended on your working answer, leaving the rest alone."
+        )
 
     def _generate_writing_review(self, paths: RunPaths) -> dict[str, object]:
         """Produce the Stage 07 triage artifact that matches this run's output format.
@@ -1857,6 +1919,14 @@ class ResearchManager:
             # them before anyone decides anything.
             self._close_comment_round(paths, stage, attempt_no, stage_markdown)
 
+            # The agent may have stopped and asked for help on a specific question.
+            crux_feedback = self._settle_cruxes(paths, stage, attempt_no)
+            if crux_feedback is not None:
+                revision_feedback = crux_feedback
+                continue_session = True
+                attempt_no += 1
+                continue
+
             # The draft is valid. Measure it, and decide whether it may stand.
             if self.evolution is not None and self.evolution.config.applies_to(stage):
                 outcome = self.evolution.consider(
@@ -2154,6 +2224,21 @@ class ResearchManager:
                     + format_resources_for_intake_prompt(ctx.resources)
                     + "\n"
                 )
+        if self.crux_panel is not None:
+            stage_template = (
+                stage_template.rstrip()
+                + "\n\n"
+                + escalation_offer(paths, self.crux_panel.budget_left)
+                + "\n"
+            )
+        if self._crux_resolutions:
+            stage_template = (
+                stage_template.rstrip()
+                + "\n\n## Resolved Cruxes\n\n"
+                + format_resolution_for_prompt(self._crux_resolutions)
+                + "\n"
+            )
+            self._crux_resolutions = []
         if stage.slug == "02_hypothesis_generation" and self.ideation_panel is not None:
             stage_template = (
                 stage_template.rstrip()

--- a/tests/test_deliberation.py
+++ b/tests/test_deliberation.py
@@ -1,0 +1,457 @@
+"""Stopping to think, and checking whether it was worth stopping.
+
+Uniform deliberation lost to a single pass in the pre-registered comparison. The bet here is
+that *selective* deliberation is different — so the tests that matter are the ones about
+selection: can a crux be raised, is the budget real, and does the ledger admit when escalating
+confirmed what the agent already believed.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.deliberation import (
+    DEFAULT_MAX_DELIBERATIONS,
+    DEFAULT_VOICES,
+    LEDGER_FILENAME,
+    MIN_QUESTION_CHARS,
+    REQUEST_FILENAME,
+    CruxPanel,
+    CruxRequest,
+    Position,
+    Resolution,
+    apply_voice_models,
+    clear_requests,
+    escalation_offer,
+    format_resolution_for_prompt,
+    parse_requests,
+    read_requests,
+    record_resolution,
+    resolve_voices,
+)
+from src.terminal_ui import TerminalUI
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    read_text,
+    write_text,
+)
+
+
+STAGE_03 = next(stage for stage in STAGES if stage.slug == "03_study_design")
+
+_QUESTION = (
+    "Should identification rely on the 2019 policy discontinuity or on household fixed effects?"
+)
+_WORKING = "Use household fixed effects, because the discontinuity sample is too small."
+_DIFFERENT = "Use the 2019 discontinuity and report fixed effects only as a robustness check."
+
+
+def _request(**overrides) -> dict:
+    base = {
+        "question": _QUESTION,
+        "why_it_matters": "Every downstream estimate inherits this choice.",
+        "already_considered": ["Matching on pre-period covariates, rejected for lack of overlap."],
+        "working_answer": _WORKING,
+        "help_wanted": "both",
+    }
+    base.update(overrides)
+    return base
+
+
+class RequestTests(unittest.TestCase):
+    def test_a_well_formed_request_parses(self) -> None:
+        requests = parse_requests(_request(), stage=STAGE_03)
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].stage_slug, STAGE_03.slug)
+        self.assertEqual(requests[0].help_wanted, "both")
+        self.assertEqual(len(requests[0].already_considered), 1)
+
+    def test_a_list_of_requests_parses(self) -> None:
+        self.assertEqual(len(parse_requests([_request(), _request()], stage=STAGE_03)), 2)
+
+    def test_a_question_too_vague_to_answer_is_dropped(self) -> None:
+        # "What should we do about the data?" has no answer; a panel asked it writes essays.
+        self.assertLess(len("what about the data?"), MIN_QUESTION_CHARS)
+        self.assertEqual(parse_requests(_request(question="what about the data?"), stage=STAGE_03), [])
+
+    def test_an_unknown_help_kind_falls_back_to_both(self) -> None:
+        self.assertEqual(parse_requests(_request(help_wanted="telepathy"), stage=STAGE_03)[0].help_wanted, "both")
+
+    def test_malformed_input_costs_the_escalation_not_the_stage(self) -> None:
+        self.assertEqual(parse_requests(None, stage=STAGE_03), [])
+        self.assertEqual(parse_requests(["not a dict"], stage=STAGE_03), [])
+        self.assertEqual(parse_requests({}, stage=STAGE_03), [])
+
+    def test_requests_round_trip_through_the_file(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.notes_dir / REQUEST_FILENAME, json.dumps(_request()))
+
+        self.assertEqual(len(read_requests(paths, STAGE_03)), 1)
+        clear_requests(paths)
+        # Consumed, so the same crux is never deliberated twice.
+        self.assertEqual(read_requests(paths, STAGE_03), [])
+
+    def test_a_corrupt_request_file_reads_as_no_request(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.notes_dir / REQUEST_FILENAME, "{ not json")
+        self.assertEqual(read_requests(paths, STAGE_03), [])
+
+
+class OfferTests(unittest.TestCase):
+    def _paths(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(paths)
+        return paths
+
+    def test_the_offer_says_most_steps_are_just_execution(self) -> None:
+        offer = escalation_offer(self._paths(), budget_left=3)
+        self.assertIn("Most of this stage is execution", offer)
+        self.assertIn(REQUEST_FILENAME, offer)
+        self.assertIn("you are not blocked", offer)
+
+    def test_the_offer_states_the_remaining_budget(self) -> None:
+        self.assertIn("2 more", escalation_offer(self._paths(), budget_left=2))
+
+    def test_a_spent_budget_withdraws_the_offer(self) -> None:
+        offer = escalation_offer(self._paths(), budget_left=0)
+        self.assertIn("spent its deliberation budget", offer)
+        self.assertNotIn(REQUEST_FILENAME, offer)
+
+
+class VoiceTests(unittest.TestCase):
+    def test_the_default_voices_have_distinct_angles(self) -> None:
+        self.assertEqual(len(DEFAULT_VOICES), 4)
+        self.assertEqual(len({voice.charter for voice in DEFAULT_VOICES}), 4)
+
+    def test_a_subset_keeps_order_and_an_unknown_voice_is_refused(self) -> None:
+        self.assertEqual([v.key for v in resolve_voices(["critic", "theorist"])], ["critic", "theorist"])
+        with self.assertRaises(ValueError):
+            resolve_voices(["oracle"])
+
+    def test_models_can_be_assigned_per_voice(self) -> None:
+        voices = apply_voice_models(DEFAULT_VOICES, ["critic=opus", "theorist=codex:default"])
+        by_key = {voice.key: voice for voice in voices}
+        self.assertEqual(by_key["critic"].model, "opus")
+        self.assertEqual((by_key["theorist"].backend, by_key["theorist"].model), ("codex", "default"))
+
+    def test_a_malformed_assignment_is_refused(self) -> None:
+        for bad in ("critic", "critic=", "nobody=opus"):
+            with self.assertRaises(ValueError, msg=bad):
+                apply_voice_models(DEFAULT_VOICES, [bad])
+
+
+class _ScriptedPanel:
+    """A crux panel whose voices answer from a script."""
+
+    def __init__(self, testcase: unittest.TestCase, script: dict[str, object], **kwargs):
+        tmp_dir = tempfile.TemporaryDirectory()
+        testcase.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "Goal")
+        write_text(self.paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(self.paths, model="sonnet", venue="neurips_2025")
+        self.labels: list[str] = []
+
+        self.panel = CruxPanel(
+            kwargs.pop("voices", DEFAULT_VOICES),
+            backend_name="claude", model="sonnet",
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+            **kwargs,
+        )
+
+        def make(key):
+            def run_prompt(*, paths, stage, attempt_no, prompt, label):
+                self.labels.append(label)
+                if label == "crux_brief":
+                    return 0, str(script.get("__brief__", "Standard practice is contested.")), ""
+                if label == "crux_resolve":
+                    response = script.get("__resolve__")
+                    if response == "__FAIL__":
+                        return 1, "", "boom"
+                    return 0, json.dumps(response), ""
+                response = script.get(key)
+                if response == "__FAIL__":
+                    return 1, "", "boom"
+                return 0, json.dumps(response if response is not None else {"answer": f"{key} says X"}), ""
+            return run_prompt
+
+        for voice in self.panel.voices:
+            self.panel._members[voice.key].run_prompt = make(voice.key)
+
+    def run(self, **overrides) -> Resolution | None:
+        return self.panel.deliberate(
+            paths=self.paths, stage=STAGE_03, attempt_no=1,
+            request=parse_requests(_request(**overrides), stage=STAGE_03)[0],
+        )
+
+
+class DeliberationTests(unittest.TestCase):
+    def _script(self, resolve_answer: str = _DIFFERENT) -> dict[str, object]:
+        return {
+            "theorist": {"answer": _DIFFERENT, "argument": "The discontinuity identifies the estimand.",
+                         "against_self": "The bandwidth choice is arbitrary."},
+            "empiricist": {"answer": _WORKING, "argument": "n is too small at the cutoff."},
+            "critic": {"answer": _DIFFERENT, "argument": "Fixed effects leave time-varying confounds."},
+            "pragmatist": {"answer": _DIFFERENT, "argument": "Both are affordable."},
+            "__resolve__": {"answer": resolve_answer, "reason": "Weight of argument.",
+                            "falsifier": "If the cutoff sample is under 200, revert.",
+                            "dissent": "The empiricist's precision objection stands."},
+        }
+
+    def test_every_voice_is_heard_and_the_crux_resolves(self) -> None:
+        harness = _ScriptedPanel(self, self._script())
+        resolution = harness.run()
+        assert resolution is not None
+        self.assertEqual(len(resolution.positions), 4)
+        self.assertEqual(resolution.answer, _DIFFERENT)
+        self.assertEqual(resolution.falsifier, "If the cutoff sample is under 200, revert.")
+        self.assertEqual(resolution.dissent, "The empiricist's precision objection stands.")
+
+    def test_expertise_is_gathered_before_anyone_opines(self) -> None:
+        harness = _ScriptedPanel(self, self._script())
+        harness.run(help_wanted="both")
+        # Opinions arrive faster than evidence, so the brief goes first.
+        self.assertEqual(harness.labels[0], "crux_brief")
+
+    def test_asking_only_for_perspectives_skips_the_brief(self) -> None:
+        harness = _ScriptedPanel(self, self._script())
+        harness.run(help_wanted="perspectives")
+        self.assertNotIn("crux_brief", harness.labels)
+
+    def test_a_resolution_that_differs_from_the_agent_is_flagged(self) -> None:
+        resolution = _ScriptedPanel(self, self._script(_DIFFERENT)).run()
+        assert resolution is not None
+        self.assertIs(resolution.changed_the_answer, True)
+        self.assertIn("different answer", resolution.verdict())
+
+    def test_a_resolution_that_confirms_the_agent_says_so(self) -> None:
+        resolution = _ScriptedPanel(self, self._script(_WORKING)).run()
+        assert resolution is not None
+        self.assertIs(resolution.changed_the_answer, False)
+        self.assertIn("did not need escalating", resolution.verdict())
+
+    def test_distinct_positions_are_counted_not_just_voices(self) -> None:
+        script = self._script()
+        # Three voices give the same answer; that is one position, not three.
+        script["pragmatist"] = {"answer": _DIFFERENT}
+        script["critic"] = {"answer": _DIFFERENT}
+        resolution = _ScriptedPanel(self, script).run()
+        assert resolution is not None
+        self.assertEqual(resolution.distinct_answers, 2)
+
+    def test_an_unreachable_voice_does_not_stop_the_deliberation(self) -> None:
+        script = self._script()
+        script["critic"] = "__FAIL__"
+        resolution = _ScriptedPanel(self, script).run()
+        assert resolution is not None
+        self.assertTrue(any(position.failed for position in resolution.positions))
+        self.assertEqual(resolution.answer, _DIFFERENT)
+
+    def test_a_failed_resolution_leaves_no_answer(self) -> None:
+        script = self._script()
+        script["__resolve__"] = "__FAIL__"
+        resolution = _ScriptedPanel(self, script).run()
+        assert resolution is not None
+        self.assertEqual(resolution.answer, "")
+        self.assertIn("no answer", resolution.verdict())
+
+    def test_fake_mode_never_deliberates(self) -> None:
+        self.assertIsNone(_ScriptedPanel(self, {}, fake_mode=True).run())
+
+    def test_an_empty_roster_is_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            CruxPanel((), backend_name="claude", model="sonnet")
+
+
+class BudgetTests(unittest.TestCase):
+    """Scarcity is what makes 'think hard here' mean anything."""
+
+    def _script(self) -> dict[str, object]:
+        return {"__resolve__": {"answer": _DIFFERENT, "reason": "r", "falsifier": "f", "dissent": "d"}}
+
+    def test_the_budget_is_spent_down_and_then_refuses(self) -> None:
+        harness = _ScriptedPanel(self, self._script(), max_deliberations=2)
+        self.assertEqual(harness.panel.budget_left, 2)
+        self.assertIsNotNone(harness.run())
+        self.assertIsNotNone(harness.run())
+        self.assertEqual(harness.panel.budget_left, 0)
+        # An agent that can escalate everything has prioritised nothing.
+        self.assertIsNone(harness.run())
+
+    def test_a_zero_budget_never_deliberates(self) -> None:
+        harness = _ScriptedPanel(self, self._script(), max_deliberations=0)
+        self.assertIsNone(harness.run())
+        self.assertEqual(harness.labels, [])
+
+    def test_the_default_budget_is_small(self) -> None:
+        self.assertLessEqual(DEFAULT_MAX_DELIBERATIONS, 5)
+
+
+class LedgerTests(unittest.TestCase):
+    def _paths(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(paths)
+        return paths
+
+    def _resolution(self, changed: bool | None) -> Resolution:
+        return Resolution(
+            request=parse_requests(_request(), stage=STAGE_03)[0],
+            positions=[Position(voice="theorist", title="Theorist", backend="claude",
+                                model="sonnet", answer=_DIFFERENT)],
+            answer=_DIFFERENT, reason="r", falsifier="f", dissent="d",
+            voice_calls=5, changed_the_answer=changed,
+        )
+
+    def test_a_resolution_is_recorded_with_its_positions(self) -> None:
+        paths = self._paths()
+        record_resolution(paths, STAGE_03, self._resolution(True))
+        payload = json.loads(read_text(paths.reviews_dir / LEDGER_FILENAME))
+        self.assertEqual(payload["summary"]["cruxes_raised"], 1)
+        self.assertEqual(payload["summary"]["changed_the_agents_answer"], 1)
+        self.assertEqual(len(payload["deliberations"][0]["positions"]), 1)
+
+    def test_escalations_that_only_confirmed_the_agent_are_called_out(self) -> None:
+        paths = self._paths()
+        record_resolution(paths, STAGE_03, self._resolution(False))
+        record_resolution(paths, STAGE_03, self._resolution(False))
+        summary = json.loads(read_text(paths.reviews_dir / LEDGER_FILENAME))["summary"]
+        self.assertEqual(summary["confirmed_the_agents_answer"], 2)
+        self.assertIn("stopping to think changed nothing", summary["verdict"])
+
+    def test_the_verdict_reaches_the_run_log(self) -> None:
+        paths = self._paths()
+        record_resolution(paths, STAGE_03, self._resolution(True))
+        self.assertIn("crux_deliberation", read_text(paths.logs))
+
+    def test_a_corrupt_ledger_is_replaced_rather_than_crashing(self) -> None:
+        paths = self._paths()
+        paths.reviews_dir.mkdir(parents=True, exist_ok=True)
+        write_text(paths.reviews_dir / LEDGER_FILENAME, "{ not json")
+        record_resolution(paths, STAGE_03, self._resolution(True))
+        self.assertEqual(len(json.loads(read_text(paths.reviews_dir / LEDGER_FILENAME))["deliberations"]), 1)
+
+
+class HandbackTests(unittest.TestCase):
+    def _resolution(self) -> Resolution:
+        return Resolution(
+            request=parse_requests(_request(), stage=STAGE_03)[0],
+            answer=_DIFFERENT, reason="Weight of argument.",
+            falsifier="If the cutoff sample is under 200, revert.",
+            dissent="The precision objection stands.",
+        )
+
+    def test_the_stage_gets_the_answer_its_reason_and_its_falsifier(self) -> None:
+        rendered = format_resolution_for_prompt([self._resolution()])
+        self.assertIn(_QUESTION, rendered)
+        self.assertIn(_DIFFERENT, rendered)
+        self.assertIn("What would change this", rendered)
+        self.assertIn("Surviving dissent", rendered)
+
+    def test_the_answer_is_a_conclusion_not_an_order(self) -> None:
+        # A resolution the stage cannot argue with is a manager, not a colleague.
+        self.assertIn("not orders", format_resolution_for_prompt([self._resolution()]))
+
+    def test_no_resolutions_render_nothing(self) -> None:
+        self.assertEqual(format_resolution_for_prompt([]), "")
+
+    def test_an_unresolved_crux_tells_the_stage_to_keep_its_own(self) -> None:
+        unresolved = Resolution(request=parse_requests(_request(), stage=STAGE_03)[0])
+        self.assertIn("keep your own", format_resolution_for_prompt([unresolved]))
+
+
+class ManagerIntegrationTests(unittest.TestCase):
+    def _manager_and_paths(self, **panel_kwargs):
+        from unittest.mock import MagicMock
+        from src.manager import ResearchManager
+
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        runs_dir = Path(tmp_dir.name) / "runs"
+        runs_dir.mkdir()
+        paths = build_run_paths(runs_dir / "20260101_000000")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Goal")
+        write_text(paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025")
+
+        operator = MagicMock()
+        operator.model = "sonnet"
+        operator.backend_name = "claude"
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=runs_dir,
+            operator=operator,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        harness = _ScriptedPanel(self, {
+            "__resolve__": {"answer": _DIFFERENT, "reason": "r", "falsifier": "f", "dissent": "d"},
+        }, **panel_kwargs)
+        harness.paths = paths
+        manager.crux_panel = harness.panel
+        return manager, paths
+
+    def test_a_raised_crux_sends_the_stage_back_with_the_answer(self) -> None:
+        manager, paths = self._manager_and_paths()
+        write_text(paths.notes_dir / REQUEST_FILENAME, json.dumps(_request()))
+
+        feedback = manager._settle_cruxes(paths, STAGE_03, 1)
+
+        self.assertIsNotNone(feedback)
+        assert feedback is not None
+        self.assertIn("Resolved Cruxes", feedback)
+        self.assertEqual(len(manager._crux_resolutions), 1)
+        # Consumed, so the next attempt does not re-deliberate the same crux.
+        self.assertFalse((paths.notes_dir / REQUEST_FILENAME).exists())
+        self.assertTrue((paths.reviews_dir / LEDGER_FILENAME).exists())
+
+    def test_no_request_means_the_stage_proceeds_untouched(self) -> None:
+        manager, paths = self._manager_and_paths()
+        self.assertIsNone(manager._settle_cruxes(paths, STAGE_03, 1))
+
+    def test_no_panel_means_the_feature_is_absent(self) -> None:
+        manager, paths = self._manager_and_paths()
+        manager.crux_panel = None
+        write_text(paths.notes_dir / REQUEST_FILENAME, json.dumps(_request()))
+        self.assertIsNone(manager._settle_cruxes(paths, STAGE_03, 1))
+        # The request is left alone rather than silently eaten.
+        self.assertTrue((paths.notes_dir / REQUEST_FILENAME).exists())
+
+    def test_a_spent_budget_refuses_rather_than_stranding_the_stage(self) -> None:
+        manager, paths = self._manager_and_paths(max_deliberations=0)
+        write_text(paths.notes_dir / REQUEST_FILENAME, json.dumps(_request()))
+        self.assertIsNone(manager._settle_cruxes(paths, STAGE_03, 1))
+        self.assertIn("crux_budget_spent", read_text(paths.logs))
+
+    def test_a_panel_that_throws_cannot_strand_a_usable_draft(self) -> None:
+        manager, paths = self._manager_and_paths()
+
+        def explode(**_kwargs):
+            raise RuntimeError("panel is down")
+
+        manager.crux_panel.deliberate = explode
+        write_text(paths.notes_dir / REQUEST_FILENAME, json.dumps(_request()))
+
+        self.assertIsNone(manager._settle_cruxes(paths, STAGE_03, 1))
+        self.assertIn("panel is down", read_text(paths.logs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
AutoR spends the same effort on every step. Most steps deserve that — copying a dataset, writing a plotting script, filling in a section. A few do not: the choice of identification strategy, the reading of an anomalous result, what the central claim is. Those are where a researcher stops, argues with colleagues, reads for a day, and sits with it.

Doing them at the tempo of the mechanical steps is how a run produces work that is complete and shallow.

## Why *selective*, when uniform deliberation lost

The pre-registered comparison in [arXiv:2607.14713](https://arxiv.org/abs/2607.14713) found multi-agent deliberation **losing** to a single pass when applied uniformly — and closes by naming the open question exactly:

> this design does not identify the occasions on which the more elaborate tools would pay

Spending deliberation only where the agent doing the work says it is stuck is a candidate answer to that, and the ledger measures whether it was one.

## The agent decides, and is never blocked

Every stage prompt carries the offer. The agent writes `workspace/notes/deliberation_request.json` — question, why it matters, what it already ruled out, **its working answer** — then finishes the stage with that answer. The panel convenes; the resolution reaches the next attempt.

The working answer is what makes the whole thing measurable: it is the baseline the resolution is compared against.

## Why a third panel rather than reusing one

| Panel | Takes | Produces |
|:---|:---|:---|
| Review | a finished draft | a gate decision (converges) |
| Ideation | a research goal | a candidate pool (stays diverged) |
| **Crux** | **a question** | **an answer that names its own falsifier** |

Four voices — theorist, empiricist, critic, pragmatist — each commit to an answer and are then required to **argue against themselves**, because the strongest objection to a position is the most useful thing its holder can contribute.

When expertise is requested, an **expert brief** is assembled from the run's literature and skills *before* any voice speaks. Opinions arrive faster than evidence, so the evidence goes first.

## The resolution must name its own falsifier

`answer`, `reason`, **`falsifier`** (may not be empty), `dissent`. An answer nothing could overturn is an opinion, and the point of stopping to think was to get past opinions.

The stage receives it as a conclusion with reasons, **not an order** — it may depart by saying so in `Decision Ledger`. A resolution the stage cannot argue with is a manager, not a colleague.

## Budget

Defaults to **3**. Scarcity is what makes "think hard here" mean anything; an agent that can escalate everything has prioritised nothing. A spent budget **withdraws the offer from the prompt** rather than ignoring requests silently. Questions under 25 characters are refused — *"what about the data?"* has no answer, and a panel asked it writes essays.

## Was stopping worth it?

Same discipline as the other panels:

> 2 crux(es) escalated at 10 calls, and the panel confirmed the agent's own answer every time. On this run stopping to think changed nothing — the agent was escalating questions it had already settled.

## Verification

1,177 tests, 40 new. Mutation-verified:

| Mutant | Tests killed |
|:---|:---|
| budget never runs out | 3 |
| never admit the panel merely agreed | 1 |
| request not consumed (same crux twice) | 2 |
| accept a vague question | 1 |

Control passes. Also driven live end to end: crux raised → brief → 4 distinct positions → resolution with falsifier and dissent → next attempt receives it, budget 3→2, ledger records `changed_the_answer: true`.

## Limits, in the doc

- **The agent chooses what is hard, and may choose badly.** The `confirmed` count catches escalating a settled question; **nothing catches failing to escalate the one that mattered.**
- **A resolved crux is not a correct crux.** Four voices agreeing says they share a prior — which is why the falsifier is mandatory and the dissent is kept.
- Off by default. A missing panel leaves a raised request untouched rather than eating it; a panel that throws cannot strand a usable draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)