### PR TITLE
Give an abandoned round somewhere to go, and stop the run talking itself out of it

### DIFF
--- a/src/archive.py
+++ b/src/archive.py
@@ -684,8 +684,25 @@ class Archive:
         # closed, or the node is never reached — and nudging it changes nothing.
         # So exploration only has something to offer edges that lost the ordering.
         by_priority = {f"{e.source}->{e.target}": e.priority for e in base_graph.edges}
+
+        # An edge with no rival is not explorable. Preferring it changes nothing: a
+        # run reaching that node was going to take it anyway. `linear` is the case
+        # that makes this concrete — every node has exactly one way onward, so no
+        # reordering there can send a run anywhere it was not already going, and a
+        # proposal saying otherwise would buy a variant for a trial that cannot run.
+        #
+        # Terminals do not count as rivals. `06_analysis->finish` is live only when
+        # the round concluded the question cannot be answered, and in that case it is
+        # the only live forward move, so its priority relative to the writing edge
+        # decides nothing either.
+        rivals: dict[str, int] = {}
+        for edge in base_graph.edges:
+            if edge.kind in {"advance", "revisit"}:
+                rivals[edge.source] = rivals.get(edge.source, 0) + 1
         candidates = [
-            edge for edge in self.unexplored_edges(base_graph) if by_priority.get(edge, 0) > 0
+            edge
+            for edge in self.unexplored_edges(base_graph)
+            if by_priority.get(edge, 0) > 0 and rivals.get(edge.split("->", 1)[0], 0) > 1
         ]
         if not candidates:
             return None

--- a/src/manager.py
+++ b/src/manager.py
@@ -56,6 +56,8 @@ from .prompt_fragments import compose_stage_template
 from .validity_review import ValidityReviewer, format_findings_for_prompt
 from .research_rounds import (
     ROUND_CLOSING_STAGE_NUMBER,
+    Round,
+    latest_round,
     read_round_decision,
     format_round_status,
     format_rounds_for_prompt,
@@ -498,8 +500,44 @@ class ResearchManager:
         save_graph_state(paths, state)
         return self._complete_run(paths, state=state)
 
+    def _run_was_abandoned(self, paths: RunPaths) -> "Round | None":
+        """The closed round that concluded the question cannot be answered, if any."""
+        final = latest_round(paths)
+        return final if final is not None and final.decision == "abandon" else None
+
     def _complete_run(self, paths: RunPaths, state: "GraphState | None" = None) -> bool:
         route = format_route(state) if state is not None else ""
+
+        # A run that concluded it cannot answer its question reached the end of the
+        # graph legitimately, and it did not produce what it set out to produce.
+        # `completed` and `cancelled` are both wrong, and `cancelled` is the worse
+        # of the two: it is what an abort writes, so the honest outcome would be
+        # indistinguishable from a crash in every downstream reader.
+        abandoned = self._run_was_abandoned(paths)
+        if abandoned is not None:
+            append_log_entry(
+                paths.logs,
+                "run_abandoned",
+                f"Round {abandoned.number} concluded `abandon`: {abandoned.rationale}"
+                + (f"\nRoute: {route}" if route else ""),
+            )
+            update_manifest_run_status(
+                paths,
+                run_status="abandoned",
+                last_event="run.abandoned",
+                current_stage_slug=None,
+                completed_at=datetime.now().isoformat(timespec="seconds"),
+            )
+            self.ui.show_status(
+                f"Run abandoned after round {abandoned.number}: {abandoned.rationale}",
+                level="warn",
+            )
+            self._print(
+                "Run stopped: the question cannot be answered with the resources available. "
+                "That conclusion is recorded in workspace/notes/research_rounds.json."
+            )
+            return True
+
         append_log_entry(
             paths.logs,
             "run_complete",

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -195,6 +195,29 @@ def _guard_report_exists(paths: RunPaths, state: "GraphState") -> GuardResult:
     return GuardResult(False, "no report or manuscript source has been written")
 
 
+def _guard_round_abandoned(paths: RunPaths, state: "GraphState") -> GuardResult:
+    """Open only when the closed round concluded the question cannot be answered.
+
+    :mod:`src.research_rounds` lets a round end in ``abandon`` — the resources
+    available cannot settle the question — and until this edge existed the decision
+    had nowhere to go. `resume_stage_slug_for("abandon")` returns None, so the walk
+    advanced to Stage 07, `validate_round_decision` refused it there, and the stage
+    burned its whole retry budget. Measured on a scripted run: **10 operator calls
+    at Stage 07**, all discarded, and the run recorded as `cancelled` —
+    indistinguishable from a crash. The most scientifically honest outcome a run can
+    reach was its most expensive and its worst-labelled.
+    """
+    from .research_rounds import latest_round
+
+    final = latest_round(paths)
+    if final is not None and final.decision == "abandon":
+        return GuardResult(
+            True,
+            f"round {final.number} concluded the question cannot be answered: {final.rationale}",
+        )
+    return GuardResult(False, "no closed round has concluded `abandon`")
+
+
 def _guard_has_hypotheses(paths: RunPaths, state: "GraphState") -> GuardResult:
     manifest = _load_json(paths.hypothesis_manifest)
     if isinstance(manifest, dict) and manifest.get("empirical_hypotheses"):
@@ -210,6 +233,7 @@ GUARDS: dict[str, GuardFn] = {
     "validity_chain": _guard_validity_chain,
     "report_exists": _guard_report_exists,
     "has_hypotheses": _guard_has_hypotheses,
+    "round_abandoned": _guard_round_abandoned,
 }
 
 
@@ -273,6 +297,21 @@ _ADVANCE_GUARDS = {
 }
 
 
+#: Forward edges are priority 0 everywhere except out of Stage 06, where the
+#: abandonment terminal sits at 0 and writing up sits behind it. Priority only
+#: separates *live* forward moves, so on every ordinary run — where the terminal's
+#: guard is shut — Stage 06 still advances to writing exactly as before. It matters
+#: in the one case it exists for: a round that concluded the question cannot be
+#: answered stops, rather than writing up the answer it does not have.
+_ADVANCE_PRIORITIES = {"07_writing": 1}
+
+#: Terminals other than "the run produced what it set out to produce". Carried by
+#: both topologies: refusing to write up an abandoned round is a correctness
+#: property, not a routing preference, and `--stage-graph linear` asks for a strict
+#: sequence of *stages*, not for the run to keep going after it has said it cannot.
+TERMINAL_EDGES: tuple["Edge", ...] = ()  # populated below, after Edge is defined
+
+
 def _advance_edges(*, guarded: bool) -> list[Edge]:
     edges: list[Edge] = []
     guards = _ADVANCE_GUARDS if guarded else {}
@@ -289,10 +328,21 @@ def _advance_edges(*, guarded: bool) -> list[Edge]:
                     else "The run has produced everything it set out to produce."
                 ),
                 guard=guards.get(target, "always"),
-                priority=0,
+                priority=_ADVANCE_PRIORITIES.get(target, 0),
             )
         )
     return edges
+
+
+TERMINAL_EDGES = (
+    Edge(
+        "06_analysis", FINISH, "finish",
+        "The round concluded that the question cannot be answered with the resources "
+        "available. Recording that and stopping is the result; writing up a manuscript "
+        "for a question the run just said it could not settle is not.",
+        guard="round_abandoned", priority=0,
+    ),
+)
 
 
 #: The moves a linear list cannot express. Each one exists because a specific
@@ -515,7 +565,9 @@ def save_graph_state(paths: RunPaths, state: GraphState) -> None:
 #: Why a move is unavailable. The distinction decides whether the walk may fall
 #: through it: a guard is a statement about the *research* and can be overridden as
 #: a last resort, while a budget is a statement about the *run* and cannot.
-BLOCK_KINDS = ("guard", "visits", "steps")
+#: ``concluded`` is neither — the run has already decided to stop, and the move is
+#: not unavailable so much as moot.
+BLOCK_KINDS = ("guard", "visits", "steps", "concluded")
 
 
 @dataclass(frozen=True)
@@ -565,12 +617,12 @@ class StageGraph:
         which is the only way the default path stays trustworthy once it stops being
         the only path.
         """
-        return cls(_advance_edges(guarded=False), name="linear")
+        return cls([*_advance_edges(guarded=False), *TERMINAL_EDGES], name="linear")
 
     @classmethod
     def adaptive(cls) -> "StageGraph":
         """The advance edges plus every backward move that has a research meaning."""
-        return cls([*_advance_edges(guarded=True), *REVISIT_EDGES], name="adaptive")
+        return cls([*_advance_edges(guarded=True), *TERMINAL_EDGES, *REVISIT_EDGES], name="adaptive")
 
     @classmethod
     def named(cls, name: str) -> "StageGraph":
@@ -615,7 +667,8 @@ class StageGraph:
                     "steps",
                 )
             results.append(Move(edge, guard, blocked, kind))
-        return results
+
+        return _preempted_by_a_conclusion(results)
 
     def admissible_moves(self, paths: RunPaths, slug: str, state: GraphState, **kwargs: Any) -> list[Move]:
         return [move for move in self.moves(paths, slug, state, **kwargs) if move.admissible]
@@ -674,8 +727,15 @@ class StageGraph:
         # still refusing a Stage 07 that writes up unadjudicated hypotheses — be the
         # correctness gate it always was. A guard is a routing preference; the gate
         # is the gate.
-        if forward:
-            return replace(min(forward, key=by_rank), last_resort=True)
+        # Only an `advance` may be taken as a last resort. A `finish` edge is a
+        # *conclusion* — "the run produced what it set out to produce", or "the
+        # question cannot be answered" — and a conclusion reached because nothing
+        # else was available is not one the run is entitled to. Without this, a node
+        # whose every forward move is shut could fall through to the abandonment
+        # terminal and record that the run had decided to give up, which it had not.
+        fallback = [move for move in forward if move.edge.kind == "advance"]
+        if fallback:
+            return replace(min(fallback, key=by_rank), last_resort=True)
 
         # No forward edge is declared here at all. Only reachable on a hand-built
         # topology; the shipped ones give every node one.
@@ -704,6 +764,49 @@ class StageGraph:
                 f"{move.edge.rationale} |"
             )
         return "\n".join(lines)
+
+
+def _preempted_by_a_conclusion(moves: list[Move]) -> list[Move]:
+    """A live conditional terminal is the only move at its node.
+
+    A terminal whose guard is not ``always`` is not an exit that happens to be
+    available — it is a conclusion the run reached and recorded, and a conclusion is
+    not one option among several. Without this the abandonment terminal is merely
+    the *default*, and the default is only what happens when nobody is asked.
+    Measured on the shipped defaults (`adaptive` + `routing auto`): a run whose
+    round concluded the question cannot be answered still offers five live moves at
+    Stage 06, so the backend is consulted, and a backend answering
+    ``{"target": "07_writing", "reason": "the refutation is the contribution"}``
+    gets it — `agent_directed=True`, no refusal. The run talks itself out of its own
+    finding.
+
+    A person may still overrule it. `/back` and `--rollback-stage` do not go through
+    the router at all, which is the right place for "the operator disagrees with the
+    run's own conclusion" to live.
+    """
+    conclusion = next(
+        (
+            move
+            for move in moves
+            if move.edge.kind == "finish" and move.edge.guard != "always" and move.admissible
+        ),
+        None,
+    )
+    if conclusion is None:
+        return moves
+    return [
+        move
+        if move is conclusion
+        else replace(
+            move,
+            blocked_because=(
+                f"the run has concluded: {conclusion.guard.reason}. Recording that and stopping "
+                "is the result; continuing would contradict the run's own record."
+            ),
+            blocked_kind="concluded",
+        )
+        for move in moves
+    ]
 
 
 def stage_for_slug(slug: str) -> StageSpec | None:

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -23,7 +23,7 @@ from src.manifest import load_run_manifest
 from src.router import RoutingDecision
 from src.rubric import score_stage
 from src.stage_graph import FINISH, GUARDS, GraphState, StageGraph, load_graph_state
-from src.utils import STAGES, build_run_paths, load_run_config, read_text
+from src.utils import STAGES, build_run_paths, load_run_config, read_text, write_text
 from tests.test_manager_smoke import REPO_ROOT, ScriptedSmokeOperator
 
 
@@ -281,12 +281,26 @@ class GraphWalkTests(unittest.TestCase):
         self.assertTrue(self.drive(manager))
         paths = self.only_run()
 
+        # `round_abandoned` is exempt and must be: it opens the edge a run takes
+        # when it concludes the question cannot be answered, so a run that answered
+        # it is precisely the run that should not satisfy it. The exemption is a
+        # claim, so it is run as a control — `test_the_abandonment_guard_opens_on_a
+        # _run_that_abandons` below is the other half, and without it this exemption
+        # would be indistinguishable from the two broken guards this gate was
+        # written to catch.
+        outcome_specific = {"round_abandoned"}
         failing = {
             name: fn(paths, GraphState()).reason
             for name, fn in sorted(GUARDS.items())
-            if not fn(paths, GraphState()).ok
+            if name not in outcome_specific and not fn(paths, GraphState()).ok
         }
         self.assertEqual(failing, {}, msg=f"guards unsatisfiable by a completed run: {failing}")
+        for name in outcome_specific:
+            self.assertIn(name, GUARDS, msg=f"{name} is exempted but no longer exists")
+            self.assertFalse(
+                GUARDS[name](paths, GraphState()).ok,
+                msg=f"{name} is exempted as outcome-specific but passes on an ordinary run",
+            )
 
     def test_every_reproducibility_check_passes_on_a_completed_run(self) -> None:
         """The same trap on the rubric side: a criterion that can never reach 1.00
@@ -308,6 +322,89 @@ class GraphWalkTests(unittest.TestCase):
         self.assertEqual(
             shortfalls, {}, msg=f"validity-chain checks unsatisfiable by a completed run: {shortfalls}"
         )
+
+    # -- abandonment is an outcome, not a failure ----------------------------
+
+    def _abandon_at_analysis(self, manager) -> None:
+        """Make Stage 06 declare that the question cannot be answered."""
+        original = manager.operator.run_stage
+
+        def run_stage(stage, prompt, run_paths, attempt_no, continue_session=False):
+            result = original(stage, prompt, run_paths, attempt_no, continue_session)
+            if stage.number == 6:
+                write_text(
+                    run_paths.round_decision,
+                    json.dumps(
+                        {
+                            "decision": "abandon",
+                            "rationale": "The effect cannot be separated from tuning noise "
+                            "with the compute available.",
+                            "what_we_learned": "Every arm we can afford sits within noise of "
+                            "the baseline on this split.",
+                            "what_changes_next": "",
+                            "negative_result": False,
+                        }
+                    ),
+                )
+            return result
+
+        manager.operator.run_stage = run_stage
+
+    def test_an_abandoned_run_stops_instead_of_writing_up(self) -> None:
+        """The defect this closes, measured before and after.
+
+        `resume_stage_slug_for("abandon")` returns None, so the round decision had
+        nowhere to go: the walk advanced to Stage 07, `validate_round_decision`
+        refused it there, and the stage burned its entire retry budget. Measured on
+        this fixture beforehand: **10 operator calls at Stage 07**, every one
+        discarded, and the run recorded `cancelled` — the same status an abort
+        writes, so the most scientifically honest outcome a run can reach was
+        indistinguishable from a crash and was its most expensive.
+        """
+        operator, manager = self.build()
+        self._abandon_at_analysis(manager)
+        completed = self.drive(manager)
+
+        paths = self.only_run()
+        self.assertEqual(operator.invocations.get("07_writing", 0), 0)
+        self.assertEqual(operator.invocations.get("08_dissemination", 0), 0)
+
+        manifest = load_run_manifest(paths.run_manifest)
+        self.assertEqual(manifest.run_status, "abandoned")
+        self.assertTrue(
+            completed,
+            msg="a run that concluded its question cannot be answered did what it should; "
+            "reporting that as failure would make the honest outcome look like a crash",
+        )
+
+        route = load_graph_state(paths).path
+        self.assertEqual(route[-1].stage, STAGE_06.slug)
+        self.assertEqual(route[-1].chose, FINISH)
+
+    def test_abandonment_is_only_reachable_by_declaring_it(self) -> None:
+        """A conclusion reached because nothing else was available is not one the run
+        is entitled to. Every forward move out of Stage 06 is shut here, and the walk
+        must still not record that the run gave up."""
+        _operator, manager = self.build()
+        self.assertTrue(self.drive(manager))
+        paths = self.only_run()
+        self.assertEqual(load_run_manifest(paths.run_manifest).run_status, "completed")
+        self.assertNotIn(
+            FINISH,
+            [visit.chose for visit in load_graph_state(paths).path[:-1]],
+        )
+
+    def test_the_abandonment_guard_opens_on_a_run_that_abandons(self) -> None:
+        """The control for the exemption in `test_every_guard_passes_on_a_completed_run`.
+
+        Without this, exempting a guard from the satisfiability gate would be
+        indistinguishable from the two broken guards that gate was written to catch.
+        """
+        _operator, manager = self.build()
+        self._abandon_at_analysis(manager)
+        self.drive(manager)
+        paths = self.only_run()
+        self.assertTrue(GUARDS["round_abandoned"](paths, GraphState()).ok)
 
     # -- settings survive a resume -------------------------------------------
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -227,6 +227,60 @@ class RouterTests(unittest.TestCase):
         self.assertEqual(rows[-1]["stage"], STAGE_06.slug)
         self.assertTrue(rows[-1]["fell_back_to"])
 
+    def test_the_agent_cannot_decline_the_run_s_own_abandonment(self) -> None:
+        """Making the terminal the *default* is not enough, and this is why.
+
+        The default is only what happens when nobody is asked, and `auto` — the
+        shipped default — asks wherever more than one move is live. Measured before
+        this rule existed: a run whose round concluded the question cannot be
+        answered still offered five live moves at Stage 06, so the backend was
+        consulted, and a backend answering "the refutation is the contribution" got
+        `07_writing` with `agent_directed=True` and no refusal. The run talked itself
+        out of its own finding.
+
+        A person may still overrule it — `/back` and `--rollback-stage` do not go
+        through the router at all.
+        """
+        self.adjudicate()
+        self.abandon()
+        operator = FakeRoutingOperator(
+            json.dumps({"target": "07_writing", "reason": "The refutation is the contribution."})
+        )
+        decision = StageRouter(operator, mode="auto").choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+        )
+        self.assertEqual(decision.target, FINISH)
+        self.assertFalse(decision.agent_directed)
+        self.assertEqual(operator.prompts, [], msg="the backend was asked about a settled question")
+
+    def test_every_other_move_is_recorded_as_moot_rather_than_guard_blocked(self) -> None:
+        """An estimator must be able to tell "this was shut by a research condition"
+        from "the run had already stopped"."""
+        self.adjudicate()
+        self.abandon()
+        decision = StageRouter(None, mode="off").choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+        )
+        self.assertEqual(set(decision.blocked.values()), {"concluded"})
+        self.assertIn("07_writing", decision.blocked)
+
+    def abandon(self) -> None:
+        from src.research_rounds import record_round
+
+        write_text(
+            self.paths.round_decision,
+            json.dumps(
+                {
+                    "decision": "abandon",
+                    "rationale": "The effect cannot be separated from tuning noise here.",
+                    "what_we_learned": "Every arm we can afford sits within noise of baseline.",
+                    "what_changes_next": "",
+                    "negative_result": False,
+                }
+            ),
+        )
+        record_round(self.paths, acted_on=True)
+
     # -- when to ask ---------------------------------------------------------
 
     def test_off_never_asks(self) -> None:
@@ -286,7 +340,11 @@ class RouterTests(unittest.TestCase):
         )
         self.assertIn("05_experimentation", decision.offered)
         self.assertIn("07_writing", decision.offered)
-        self.assertEqual(decision.blocked, {})
+        # The abandonment terminal is on the record as shut. That is the useful
+        # state to capture: an estimator has to be able to tell "the run could have
+        # stopped and did not" from "stopping was never on the table".
+        self.assertEqual(decision.blocked, {"finish": "guard"})
+        self.assertNotIn("finish", decision.offered)
 
     def test_the_choice_set_is_recorded_on_the_refusal_path_too(self) -> None:
         """A refusal is still an observation of what was on the table. Recording it

--- a/tests/test_stage_graph.py
+++ b/tests/test_stage_graph.py
@@ -55,12 +55,35 @@ class LinearTopologyTests(unittest.TestCase):
             current = move.target
         self.assertEqual(route, [stage.slug for stage in STAGES])
 
-    def test_no_forward_move_on_the_linear_graph_is_guarded(self) -> None:
-        """A guard on the only edge out of a node could only ever halt the run, and
-        the condition it would halt on is already a stage validation error with a
-        better message. Two gates over one condition is one too many."""
+    def test_no_advance_on_the_linear_graph_is_guarded(self) -> None:
+        """A guard on the only way *onward* from a node could only ever halt the run,
+        and the condition it would halt on is already a stage validation error with a
+        better message. Two gates over one condition is one too many.
+
+        The abandonment terminal is exempt and has to be: it is not the way onward,
+        it is a second exit whose guard is the entire point of it. A shut guard there
+        removes the edge rather than halting anything — which is the case on every
+        run that did not abandon, i.e. almost all of them.
+        """
         for edge in StageGraph.linear().edges:
-            self.assertEqual(edge.guard, "always", msg=f"{edge.source}->{edge.target} is guarded")
+            if edge.kind == "finish" and edge.guard != "always":
+                continue
+            self.assertEqual(
+                edge.guard, "always", msg=f"{edge.source}->{edge.target} is guarded"
+            )
+
+    def test_the_linear_graph_still_has_exactly_one_way_onward_from_each_node(self) -> None:
+        """The exemption above is only safe if it is narrow. `linear` may gain
+        terminals; it may not gain a choice of direction."""
+        graph = StageGraph.linear()
+        for stage in STAGES:
+            onward = [e for e in graph.out_edges(stage.slug) if e.kind == "advance"]
+            self.assertLessEqual(len(onward), 1, msg=f"{stage.slug} has {len(onward)} advances")
+            self.assertEqual(
+                [e for e in graph.out_edges(stage.slug) if e.kind == "revisit"],
+                [],
+                msg=f"{stage.slug} has a backward edge on the linear topology",
+            )
 
     def test_every_registered_guard_is_wired_to_an_edge(self) -> None:
         """A guard nobody wired is a check nobody runs.


### PR DESCRIPTION
The first half of unifying `research_rounds.py` (#127) with the stage graph. It lands the correctness payload; the speculative half is cut, with reasons.

## The defect

`research_rounds.py` lets a round conclude `abandon` — the resources available cannot settle the question. That decision had nowhere to go. `resume_stage_slug_for("abandon")` returns None, so `_close_round` recorded the round and returned, the walk advanced to Stage 07, and `validate_round_decision` refused it *there*.

Measured on a scripted run:

| | before | after |
| --- | --- | --- |
| Stage 07 operator calls | **10** (all discarded) | **0** |
| Stage 07 status | `failed` | never entered |
| `run_status` | `cancelled` — same as an abort | `abandoned` |
| walk result | `False` | `True` |

The most scientifically honest outcome a run can reach was its most expensive, and downstream it was indistinguishable from a crash. Existing tests covered only the *validation* ("writing is refused after an abandoned round"); nothing tested what the run does.

## The fix

Abandonment becomes a terminal edge out of Stage 06, guarded on the closed round. Carried by **both** topologies — refusing to write up an abandoned round is a correctness property, not a routing preference, and `--stage-graph linear` asks for a strict sequence of stages, not for the run to keep going after it has said it cannot.

Forward priority out of Stage 06 puts the terminal ahead of writing. Priority only separates *live* forward moves, so an ordinary run advances to Stage 07 exactly as before.

## A conclusion is not one option among several

Making the terminal the default was **not enough**, and three independent reviews caught why: the default is only what happens when nobody is asked, and `routing auto` — the shipped default — asks wherever more than one move is live.

Verified before the fix:

```
live moves after abandon: ['finish', '05_experimentation', '07_writing',
                           '03_study_design', '02_hypothesis_generation']
default_move            : finish
agent asked, chose      : 07_writing | agent_directed: True | refusal: none
```

The run talked itself out of its own finding. A live **conditional** terminal now preempts every other move at its node, and the rest are recorded blocked with a new kind, `concluded` — an estimator has to be able to tell "shut by a research condition" from "the run had already stopped". After: one live move, and `auto` does not even ask.

A person may still overrule it. `/back` and `--rollback-stage` do not go through the router, which is exactly where "the operator disagrees with the run's own conclusion" belongs.

## Two bugs the change surfaced, both caught by tests already in the tree

- **The last resort could choose to give up.** With two forward edges out of Stage 06, a node whose every forward move was shut could fall through to the abandonment terminal and record that the run had decided to stop, which it had not. Only an `advance` may be a last resort. Caught by `test_priority_never_changes_what_the_run_does_by_default` going 0/400 → 31/400.
- **The exploration proposer offered a trial that cannot run.** An edge with no rival at its source is not explorable — a run reaching that node was going to take it anyway. `linear` makes it concrete: one way onward from every node.

## The first exemption, run as a control

`test_every_guard_passes_on_a_completed_run` gains an exemption: `round_abandoned` is the guard a completed run *should not* satisfy. The gate now asserts both halves — that it fails on an ordinary run, and that it opens on a run that abandons. Without the second, exempting a guard would be indistinguishable from the two broken guards that gate was written to catch (#134).

## What is cut, and why

**Expressing `--max-rounds` as a guard — cut outright.** A guard sees only `(RunPaths, GraphState)` and could not read it; `--max-rounds` is not persisted in `run_config`, so it silently reverts to 1 on resume; and blocking `06→03` on a spent round budget would stop an analysis that exposed a confound from routing back to design in a default run. Three reviewers found this independently.

**Routing `refine_design`/`new_hypothesis` through the router — deferred.** Worth doing (those decisions currently reach the archive as `bypassed` with no choice set), but not here: `_rollback_and_jump` also plants a `record_correction` the reviewer reads, `_close_round` computes `acted_on` before the router could refuse the intent, and `_skip_stage` closes no round at all. Each is fixable; none is a one-liner.

## Testing

1143 pass. New: an abandoned run stops instead of writing up (asserting the 0-invocation and `abandoned` status directly), abandonment is only reachable by declaring it, the guard opens on a run that abandons, the agent cannot decline the abandonment, and other moves are recorded `concluded` rather than `guard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)