### PR TITLE
Spend effort where the research needs it, not evenly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,136 @@
 </p>
 
 <p align="center">
+<<<<<<< HEAD
+=======
+  <img src="assets/examples/example_fig6_two_layer.png" alt="AutoR example figure" width="92%" />
+</p>
+
+---
+
+> AutoR is not a chat demo, not a generic agent framework, and not a markdown-only research toy.
+>
+> It is a structured research harness over a coding agent execution layer:
+> **AI handles execution, humans own the direction, and every run becomes an inspectable research artifact on disk.**
+
+> New users should start with the step-by-step guides:
+> [English Guide](docs/tutorial_en.md) or [中文教程](docs/tutorial_zh.md).
+
+## 📖 Overview
+
+Most autoresearch systems optimize for autonomy.
+
+AutoR takes a different position: research is too important to hand over as a blind end-to-end loop. The goal is not to remove humans from research. The goal is to give them a stronger execution system.
+
+### ✨ At a Glance
+
+| Dimension | AutoR |
+| --- | --- |
+| Execution model | A coding agent as the execution layer, AutoR as the research control loop |
+| Control model | Human approval by default, with an optional strict reviewer-agent gate for unattended runs |
+| Research unit | A reproducible run under `runs/<run_id>/` |
+| Workflow shape | Nine stages as a **directed graph** the run navigates; the linear sequence is one path through it |
+| Improvement | On by default: drafts are measured and ratcheted, so a stage can only get better — and the score is blind to what the run concluded |
+| Quality bar | Artifact-backed outputs, not markdown-only summaries |
+| Recovery | Resume, redo-stage, rollback-stage, stage-local continuation |
+
+### 🔦 Highlights
+
+| Layer | Highlight | What AutoR actually does |
+| --- | --- | --- |
+| Big idea | **Human-centered research execution** | AutoR is not an autonomous scientist. AI handles execution; humans retain approval and direction at every stage boundary. |
+| Big idea | **The stages are a graph, not a list** | Analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it. AutoR computes which moves are open by checking artifacts on disk; the agent chooses among those and says why. [Details](docs/self-improvement.md) |
+| Big idea | **Improvement that is measured, not hoped for** | A refinement round is scored against a rigour rubric read off disk. The best-scoring draft is what gets promoted; a round that scores worse is reverted. A stage can only improve. |
+| Big idea | **Self-improvement that cannot p-hack** | The fitness function is blind to what the run concluded — a refuted hypothesis with clean evidence outscores a supported one resting on an assertion — and any round that moves a hypothesis verdict is rejected outright. |
+| Big idea | **The harness learns across runs** | An optional archive compares each graph edge against runs that reached the same node and did not take it, and reorders which move is preferred. It can never open a guarded edge. |
+| Big idea | **Research loop over agent loop** | The system manages stage progression, validation, repair, recovery, and human checkpoints above the lower-level agent execution loop. |
+| Big idea | **Every run is a reproducible research artifact** | Each run leaves behind prompts, logs, approved summaries, code, data, figures, writing sources, and packaged outputs under `runs/<run_id>/`. |
+| Big idea | **Verifiable outputs, not paper-shaped theater** | The workflow is judged by inspectable artifacts and human approval, not by whether a generated document merely looks polished. |
+| Useful feature | **Structured literature organization** | Survey notes, bibliographies, related-work tables, and reading artifacts stay under `workspace/literature/` instead of disappearing into chat history. |
+| Useful feature | **Automated experiment manifests** | Machine-readable experiment and result files make runs inspectable, comparable, and reusable downstream. |
+| Useful feature | **Citation verification and writing checks** | Writing expects citation verification, figure-link checks, and self-review artifacts before Stage 07 is considered complete. |
+| Useful feature | **Artifact indexing across stages** | `artifact_index.json` and related manifests help later stages find data, results, and figures without guessing from filenames. |
+| Useful feature | **Obligations carried forward** | An approving reviewer records what a later stage still owes; the debt is injected into that stage and its review, and only a reviewer can discharge it. |
+| Useful feature | **Cross-model review veto** | When the reviewer approves, a different model family audits that approval and can send the stage back. A veto, never an override, so it can only tighten the gate. |
+| Useful feature | **Self-improving review policy** | Every correction the reviewer demands becomes a standing rule checked on all later stages, recorded in an auditable `review_policy.json` with the stage and attempt that produced it. |
+| Useful feature | **Resume, redo, and rollback controls** | Long research runs can continue in place, retry a stage, or roll downstream state back without starting over. |
+| Useful feature | **Deliberating review panel** | Instead of one reviewer agent at the approval gate, `--review-panel` seats a PI, domain expert, methodologist, reproducibility engineer and adversarial reviewer who review independently, cross-examine, then converge — and a blocking objection cannot be approved over. Each run measures the panel against its own single-pass baseline and reports when it did not earn its cost. |
+| Useful feature | **Divergent ideation panel** | `--ideation-panel` widens Stage 02 with proposers working from distinct lenses - mechanism, contrarian, adjacent field, null/artifact, regime - deduplicated and scored into a candidate pool the stage chooses from. It decides nothing, and reports when the extra proposers added nothing. |
+| Useful feature | **Anchored review comments** | A reviewer can quote the passage it objects to instead of refusing the whole stage. The revision is told to change only those spans, and is then diffed against them — so "preserve the correct parts" is measured rather than hoped for. |
+| Useful feature | **Selective deep thinking** | Most steps are execution. With `--deliberation` a stage that hits a genuine crux can stop, name the question, and pull in a panel of theorist / empiricist / critic / pragmatist plus an expert brief — then carry on with an answer that names its own falsifier. Budgeted, and measured against what the agent already believed. |
+| Useful feature | **Effort tiers** | `--effort-tiers` runs each stage as routine or deliberative rather than treating them alike — a lean prompt and a single reviewer where the decisions are already made, the full apparatus where something is genuinely undecided. Each stage sets the next one's tier, and a routine stage that keeps failing is promoted automatically. |
+| Useful feature | **Two output formats** | Stage 07 writes a benchmark-ready markdown report (`report/report.md` + PNG figures) by default, or a venue-aware LaTeX paper package with a compiled PDF via `--output-format latex`. |
+
+In practice, that means AutoR is useful not only because of the high-level framing, but also because it handles real research chores: literature organization, experiment manifests, citation verification, artifact indexing, manuscript packaging, and recoverable long-running workflows.
+
+### ✅ What AutoR Guarantees
+
+- By default, human approval is required before the workflow advances.
+- An optional reviewer agent can simulate that gate for unattended runs, but the human-centered default remains manual review.
+- Approved summaries become the only cross-stage memory.
+- Every run is isolated, resumable, and auditable.
+- Later stages must produce real artifacts, not only prose.
+- A coding agent is the execution layer; AutoR is the research control loop above it.
+
+### 🤔 Why AutoR?
+
+Many systems aim to generate research outputs that *look* ready.
+
+AutoR takes a harder path:
+
+- it requires real experiments
+- it enforces artifact validation
+- it keeps humans in control
+
+So the question is not:
+
+> Does it look ready?
+
+It is:
+
+> Can you verify every part of it?
+
+## 📰 News
+
+Latest mainline updates:
+
+- **2026-08-06**: **Recursive self-improvement is now the default.** The nine stages are a **directed graph** the run navigates: an analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it, and the move into Stage 07 stays closed until every hypothesis carries a verdict. The stage that just ran chooses the next move, among the ones AutoR's guards leave open. Every valid draft is scored against a rigour rubric read off disk and held to a champion ratchet, so the draft that gets promoted is the best one the run produced rather than the last one — that half costs nothing, because the rubric never calls a backend. Two improvement rounds per stage are budgeted on top, and a stage the rubric has nothing to say about spends none of them. A round that scores worse is reverted; a round that changes a hypothesis verdict is rejected outright. Each finished run records its route and measured fitness in a cross-run archive, which compares every graph edge against runs that reached the same node and did not take it. Opt out with `--stage-graph linear`, `--routing off`, `--no-evolve`, `--no-archive`. See [Recursive Self-Improvement](docs/self-improvement.md).
+- **2026-06-02**: Added a configurable Codex sandbox mode. Codex-backed runs still default to `workspace-write`, but users who intentionally need remote GPU or SSH execution can now opt into `--codex-sandbox danger-full-access`; the setting is persisted in `run_config.json` and preserved on resume.
+- **2026-05-10**: Refined the terminal-first run experience. Stage 00 now uses a dedicated clarification flow: the first intake pass asks the user questions one by one with selectable options, custom answers, and skip; the revised intake brief then uses a compact refine / approve / abort menu instead of showing the normal suggestion template. The terminal UI also keeps colored frames on wrapped body rows, handles long lines and wide characters more reliably, and the Codex backend now uses the current `--sandbox workspace-write` execution flag instead of the deprecated Codex CLI `--full-auto` flag.
+- **2026-04-20**: Added an optional `--full-auto` approval mode. The execution loop is unchanged, but the manual approval gate can now be replaced by a strict simulated reviewer agent backed by Claude or Codex, with reviewer settings persisted in `run_config.json`.
+- **2026-04-19**: Merged **AutoR Studio** into main: a local browser workspace for the same run-based workflow, with live stage monitoring, human review, restart-safe recovery, paper preview, version history, and a Notebook view. The browser UI shares the same run directories and artifact model as the terminal workflow and is currently Claude-backed.
+- **2026-04-18**: Fixed a stage-summary recovery bug so local normalization now restores the required `Decision Ledger` section and validates draft outputs against the correct `.tmp.md` path. Added stage recovery controls that let operators `/skip` the current stage, `/back <stage>` to an earlier stage, or choose skip / roll back directly after retry exhaustion.
+- **2026-04-15**: Added minimal `--operator codex` support alongside Claude, persisted the selected execution backend in `run_config.json`, and improved terminal rendering for backend JSON streams.
+- **2026-04-13**: Added literature evidence ledgers and citation verification outputs, introduced typed hypothesis manifests, hardened experiment manifest parsing, and added regression coverage for research diagram injection.
+- **2026-04-10**: Added a decision ledger for human approvals and refined the public showcase gallery so research artifacts are presented more clearly.
+- **2026-04-08**: Documented optional `--research-diagram` dependencies and tightened the README positioning around human-centered, artifact-backed research execution.
+
+## 🌟 Showcase
+
+AutoR already has a full example run used throughout the repository: `runs/20260330_101222`.
+
+### 🧪 Example Run Snapshot
+
+| What the run produced | What it demonstrates |
+| --- | --- |
+| [example_paper.pdf](assets/examples/example_paper.pdf) | A compiled manuscript artifact within a broader research package |
+| Executable research code | The run is not just a writing pipeline |
+| Machine-readable datasets and result files | Claims are backed by inspectable experiment outputs |
+| Real figures used in the research package | The run produces publication-style visuals, not placeholders |
+| Review and dissemination materials | The workflow continues past writing into release readiness |
+
+Highlighted outcomes from that run:
+
+- `AGSNv2` reached **36.21 ± 1.08** on Actor.
+- The system produced a full research package with real figures, writing sources, and auditable artifacts.
+- The final run preserved the full human-in-the-loop approval trail.
+
+### 🖥️ Terminal Experience
+
+AutoR is designed for terminal-first execution, but the interaction layer is not limited to raw logs and plain prompts. The current UI supports banner-style startup, colored stage panels, parsed backend event streams, display-width-aware markdown wrapping, keyboard-selectable menus, and a Stage 00 clarification flow suitable for demos and recordings.
+
+<p align="center">
+>>>>>>> dd3d62c (Spend effort where the research needs it, not evenly)
   <img src="assets/terminal.png" alt="AutoR terminal UI" width="92%" />
 </p>
 
@@ -210,7 +340,12 @@ scope. "Make each one refutable" is advice about a gate that now exists.
 | Seat the panel across different models | `python main.py --review-panel --panel-models pi=opus skeptic=codex:default --goal "..."` |
 | Widen Stage 02's hypotheses with a proposer panel | `python main.py --ideation-panel --goal "..."` |
 | Let a stage stop and think hard at a crux | `python main.py --deliberation --goal "..."` |
+<<<<<<< HEAD
 | Choose the execution backend and model | `python main.py --operator claude --model opus` or `python main.py --operator codex --model default` |
+=======
+| Spend effort unevenly across the loop | `python main.py --effort-tiers --goal "..."` |
+| Choose the execution backend | `python main.py --operator claude` or `python main.py --operator codex` |
+>>>>>>> dd3d62c (Spend effort where the research needs it, not evenly)
 | Choose the reviewer backend separately | `python main.py --full-auto --review-operator claude --review-model opus` |
 | Allow Codex-backed SSH / remote GPU execution | `python main.py --operator codex --codex-sandbox danger-full-access --goal "Your research goal here"` |
 | Produce a LaTeX paper package instead of a markdown report | `python main.py --output-format latex --goal "..."` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ detail behind it.
 | Send back one passage instead of the whole stage | [Anchored Review Comments](stage-comments.md) |
 | Widen Stage 02's hypotheses with a panel that proposes instead of deciding | [Ideation Panel](ideation-panel.md) |
 | Let a stage stop and think hard when it hits a genuine crux | [Raising a Crux](deliberation.md) |
+| Spend effort where the research needs it instead of evenly | [Effort Tiers](effort-tiers.md) |
 | Configure venues, backends, sandboxes, or API keys | [Configuration](configuration.md) |
 | Use or script the browser UI | [Studio Guide & HTTP API](studio.md) |
 | Understand how the code is organized | [Architecture](architecture.md) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -198,6 +198,15 @@ converted to a refinement in code. Each run also writes
 baseline so it can report that it did not earn its cost. Full description, including the
 pre-registered evidence against multi-agent deliberation, in [Review Panel](review-panel.md).
 
+### Effort tiers
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--effort-tiers` | off | Run each stage as `routine` or `deliberative` instead of treating them alike. Routine gets a lean prompt, a single reviewer, and no escalation offer. Each stage declares what the next needs; a routine stage that fails twice is promoted automatically. |
+
+Off means exactly the previous behaviour. Both directions of mis-spending are recorded in
+`workspace/reviews/effort.json`. Full description in [Effort Tiers](effort-tiers.md).
+
 ### Crux deliberation
 
 | Flag | Default | Description |

--- a/docs/effort-tiers.md
+++ b/docs/effort-tiers.md
@@ -1,0 +1,97 @@
+# Effort tiers
+
+[Raising a crux](deliberation.md) gave a stage a way to stop and think hard. This is the other
+half, and without it the first half is only a sentence in a prompt: **nothing in AutoR ever ran
+cheaper on routine work.** Every stage carried the full prompt assembly, the full gate, and
+every panel that happened to be switched on — whether it was choosing an identification
+strategy or writing a CSV loader.
+
+```bash
+python main.py --effort-tiers --goal "..."
+python main.py --effort-tiers --review-panel --deliberation --goal "..."
+```
+
+---
+
+## Why uneven spending
+
+That uniformity is the mistake the multi-agent feedback literature made and measured: applying
+the expensive configuration everywhere is how the expensive configuration loses on average.
+The cost lands on every step; the benefit lands on a few.
+
+| | `routine` | `deliberative` |
+| --- | --- | --- |
+| Prompt | lean, plus a "do not re-open settled questions" notice | full |
+| Gate | single reviewer, even when a panel is seated | whatever is configured |
+| Crux escalation offered | no | yes |
+| Ideation panel (Stage 02) | no | yes |
+
+## Who chooses
+
+**The stage that just finished declares what the next one needs**, because it is the thing
+that just learned whether the hard part is over. It ends its `Decision Ledger` with one line:
+
+```
+Next stage effort: routine — the design is settled; this is engineering.
+Next stage effort: deliberative — the identification strategy is still open.
+```
+
+A per-stage default applies when nothing says otherwise:
+
+| Deliberative by default | Routine by default |
+| --- | --- |
+| 01 literature, 02 hypotheses, 03 design, 06 analysis, 07 writing | 04 implementation, 05 experimentation, 08 dissemination |
+
+Those are guesses about the *shape* of the work, not claims about any particular research
+question — which is exactly why a stage can override the next one's.
+
+## What stops a wrong guess costing anything
+
+**A routine stage that fails its gate twice is promoted to deliberative** and re-run with the
+full apparatus. Cheap is a bet; this is what happens when the bet loses, and the run recovers
+by itself rather than thrashing at low power.
+
+Two, not one: a single failed gate is ordinary and often a formatting problem. Twice means the
+work is harder than the previous stage thought.
+
+A promotion also **outranks a later declaration** — evidence beats a guess. A stage cannot talk
+a promoted successor back down to routine.
+
+And a routine stage is told explicitly that if it discovers something is *not* settled, it
+should say so under Open Questions rather than quietly deciding it alone. Running cheap is a
+claim about the work, and the stage doing the work is allowed to contradict it.
+
+## Both directions of waste are recorded
+
+`workspace/reviews/effort.json`:
+
+```json
+{
+  "summary": {
+    "stages_planned": 8,
+    "run_as_routine": 3,
+    "declared_by_a_prior_stage": 5,
+    "promoted_after_failing": 1,
+    "deliberative_but_uncontested": 2,
+    "verdict": "3 of 8 stage(s) ran routine; 1 had to be promoted after failing, so that call was wrong; 2 ran deliberative but passed first time uncontested, so that effort bought nothing."
+  }
+}
+```
+
+- **`promoted_after_failing`** — ran cheap and should not have.
+- **`deliberative_but_uncontested`** — passed first time with nobody asking for a change, so
+  the ceremony was paid for and unused.
+
+A tiering scheme that can only report one direction is measuring whether it was brave, not
+whether it was right. A run where `run_as_routine` is 0 is called out too: nothing was treated
+as routine, which is the thing tiering exists to avoid.
+
+## Limits worth knowing
+
+- **The promotion rule catches running too cheap; nothing catches running too rich.**
+  `deliberative_but_uncontested` is a hint, not proof — a stage can be genuinely hard and still
+  pass first time because it was done well.
+- **The declaring stage is guessing about work it has not done.** It knows whether *its own*
+  decisions are settled, which is a good proxy and not the same thing.
+- **Tiering is off by default, and off means exactly the previous behaviour** — every stage
+  deliberative, nothing gated more cheaply by accident.

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -826,6 +826,14 @@ Required: non-empty string `overall_status`; booleans `pdf_available` and
 Validated by `validate_layout_review` in
 [`src/writing_manifest.py`](../src/writing_manifest.py).
 
+### `workspace/reviews/effort.json`
+
+Written under `--effort-tiers`. Which tier each stage ran in, who chose it, why, and both
+directions of mis-spending: `promoted_after_failing` (ran cheap and should not have) and
+`deliberative_but_uncontested` (paid for ceremony nobody used).
+
+See [Effort Tiers](effort-tiers.md).
+
 ### `workspace/reviews/deliberations.json`
 
 Written when a stage raises a crux under `--deliberation`. Every question escalated, the

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from src.approval_agent import AutomatedReviewer
 from src.deliberation import DEFAULT_MAX_DELIBERATIONS
+from src.effort import EffortPlan
 from src.review_panel import (
     DEFAULT_PANEL,
     ReviewPanel,
@@ -163,6 +164,14 @@ def parse_args() -> argparse.Namespace:
              "(for example: pi=opus skeptic=codex:default). Seats left unassigned use the "
              "reviewer default. Heterogeneity is the lever with the best evidence behind it: "
              "five prompts against one model are five correlated reads wearing five hats.",
+    )
+    parser.add_argument(
+        "--effort-tiers",
+        action="store_true",
+        help="Run each stage as routine or deliberative rather than treating them alike. A "
+             "routine stage gets a lean prompt, a single reviewer, and no escalation offer; a "
+             "deliberative one gets everything configured. Each stage declares what the next "
+             "needs, and a routine stage that keeps failing is promoted automatically.",
     )
     parser.add_argument(
         "--deliberation",
@@ -745,6 +754,21 @@ def resolve_search_context(ui: TerminalUI, *, mode: str, operator: str, codex_sa
 
 
 
+
+def configure_effort(manager, args, *, backend_name: str, model: str, ui: TerminalUI, fake_mode: bool,
+                     stage_timeout: int) -> None:
+    """Turn on effort tiering, and give routine stages a cheap gate to use."""
+    if not getattr(args, "effort_tiers", False):
+        return
+    manager.effort_plan = EffortPlan(enabled=True)
+    if isinstance(manager.reviewer, AutomatedReviewer):
+        manager.solo_reviewer = manager.reviewer
+    elif manager.reviewer is not None:
+        # A panel is seated, so build the plain reviewer a routine stage falls back to.
+        manager.solo_reviewer = AutomatedReviewer(
+            backend_name, model=model, fake_mode=fake_mode, ui=ui, stage_timeout=stage_timeout
+        )
+
 def create_crux_panel(args, *, backend_name: str, model: str, ui: TerminalUI):
     """Build the crux deliberation panel, or None when it is not requested."""
     if not getattr(args, "deliberation", False):
@@ -900,6 +924,10 @@ def main() -> int:
         manager.crux_panel = create_crux_panel(
             args, backend_name=review_operator, model=review_model, ui=ui
         )
+        configure_effort(
+            manager, args, backend_name=review_operator, model=review_model, ui=ui,
+            fake_mode=args.fake_operator, stage_timeout=args.stage_timeout,
+        )
         completed = manager.resume_run(
             run_root,
             start_stage=start_stage or rollback_stage,
@@ -981,6 +1009,10 @@ def main() -> int:
     )
     manager.crux_panel = create_crux_panel(
         args, backend_name=review_operator, model=review_model, ui=ui
+    )
+    configure_effort(
+        manager, args, backend_name=review_operator, model=review_model, ui=ui,
+        fake_mode=args.fake_operator, stage_timeout=args.stage_timeout,
     )
 
     goal = resolve_goal(args, unattended=unattended)

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -184,6 +184,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
              "five prompts against one model are five correlated reads wearing five hats.",
     )
     parser.add_argument(
+        "--effort-tiers",
+        action="store_true",
+        help="Run each stage as routine or deliberative rather than treating them alike. A "
+             "routine stage gets a lean prompt, a single reviewer, and no escalation offer; a "
+             "deliberative one gets everything configured. Each stage declares what the next "
+             "needs, and a routine stage that keeps failing is promoted automatically.",
+    )
+    parser.add_argument(
         "--deliberation",
         action="store_true",
         help="Let a stage stop and pull in a panel when it hits a genuine crux. The agent "
@@ -541,6 +549,17 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
             ui=ui,
             stage_timeout=args.stage_timeout,
             max_deliberations=args.max_deliberations,
+        )
+
+    if args.effort_tiers:
+        from src.effort import EffortPlan
+
+        manager.effort_plan = EffortPlan(enabled=True)
+        manager.solo_reviewer = (
+            reviewer if isinstance(reviewer, AutomatedReviewer)
+            else AutomatedReviewer(review_backend, model=review_model,
+                                   fake_mode=args.fake_operator, ui=ui,
+                                   stage_timeout=args.stage_timeout)
         )
 
     pipeline_completed = False

--- a/src/effort.py
+++ b/src/effort.py
@@ -1,0 +1,282 @@
+"""Spend effort where the research needs it, not evenly.
+
+:mod:`src.deliberation` gave a stage a way to stop and think hard. This is the other half, and
+without it the first half is only a sentence in a prompt: **nothing in AutoR ever ran cheaper
+on routine work.** Every stage carries the full prompt assembly, the full gate, and every panel
+that happens to be switched on — whether it is choosing an identification strategy or writing a
+CSV loader.
+
+That uniformity is the same mistake the multi-agent feedback literature made and measured.
+Applying the expensive configuration everywhere is how the expensive configuration loses on
+average: the cost lands on every step and the benefit lands on a few.
+
+So a stage runs in one of two tiers:
+
+``routine``
+    The decisions are already made and this is execution. Lean prompt, single reviewer at the
+    gate, no crux escalation offered, no ideation panel.
+``deliberative``
+    Something genuinely undecided is at stake. Everything configured is available.
+
+**Who chooses.** The stage that just finished declares what the next one needs, because it is
+the thing that just learned whether the hard part is over. A default per stage applies when
+nothing says otherwise.
+
+**What stops a wrong guess being costly.** A routine stage that fails its gate twice is
+*promoted* to deliberative and re-run with the full apparatus. Cheap is a bet, and this is what
+happens when the bet loses — the run recovers by itself rather than thrashing at low power.
+
+Both directions of waste are recorded. A routine stage that had to be promoted was
+under-resourced; a deliberative stage that passed on its first attempt with nothing contested
+was over-resourced. A tiering scheme that cannot report either is not measuring anything.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from .utils import RunPaths, StageSpec, append_log_entry, read_text, write_text
+
+
+ROUTINE = "routine"
+DELIBERATIVE = "deliberative"
+TIERS = (ROUTINE, DELIBERATIVE)
+
+#: Failures at which a routine stage is promoted. Two rather than one: a single failed gate is
+#: ordinary and often a formatting problem, while twice means the work itself is harder than
+#: the previous stage thought.
+PROMOTE_AFTER_FAILURES = 2
+
+LEDGER_FILENAME = "effort.json"
+
+#: Where each stage starts when nothing has said otherwise.
+#:
+#: These are starting guesses about the *shape* of the work, not claims about any particular
+#: research question — which is exactly why a stage can override the next one's tier. Framing,
+#: hypotheses, design, and interpretation are where a wrong call is expensive and hard to
+#: reverse. Implementation and execution are where the decisions have already been made and
+#: the work is to carry them out correctly.
+DEFAULT_TIERS: dict[str, str] = {
+    "01_literature_survey": DELIBERATIVE,
+    "02_hypothesis_generation": DELIBERATIVE,
+    "03_study_design": DELIBERATIVE,
+    "04_implementation": ROUTINE,
+    "05_experimentation": ROUTINE,
+    "06_analysis": DELIBERATIVE,
+    "07_writing": DELIBERATIVE,
+    "08_dissemination": ROUTINE,
+}
+
+_DECLARATION = re.compile(
+    r"next\s+stage\s+effort\s*:\s*(routine|deliberative)\b(?:\s*[-—:]\s*(.*))?",
+    flags=re.IGNORECASE,
+)
+
+
+@dataclass
+class TierDecision:
+    stage_slug: str
+    tier: str
+    chosen_by: str = "default"
+    reason: str = ""
+    promoted_from: str = ""
+    failures: int = 0
+    attempts: int = 0
+    contested: bool | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def normalize_tier(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    lowered = value.strip().lower()
+    return lowered if lowered in TIERS else None
+
+
+def parse_declaration(stage_markdown: str) -> tuple[str, str] | None:
+    """Read a ``Next stage effort: routine — the design is settled`` line from a summary.
+
+    A line rather than a JSON block: this is written into a stage summary a human reads, and
+    the required output format is already crowded. Anything the stage says after the tier is
+    kept as the reason, because a tier with no reason is a guess nobody can audit later.
+    """
+    match = _DECLARATION.search(stage_markdown or "")
+    if match is None:
+        return None
+    tier = normalize_tier(match.group(1))
+    if tier is None:
+        return None
+    return tier, (match.group(2) or "").strip()
+
+
+@dataclass
+class EffortPlan:
+    """Which tier each stage runs in, and why."""
+
+    decisions: dict[str, TierDecision] = field(default_factory=dict)
+    enabled: bool = True
+
+    def tier_for(self, stage: StageSpec) -> str:
+        if not self.enabled:
+            return DELIBERATIVE
+        decision = self.decisions.get(stage.slug)
+        return decision.tier if decision else DEFAULT_TIERS.get(stage.slug, DELIBERATIVE)
+
+    def decision_for(self, stage: StageSpec) -> TierDecision:
+        if stage.slug not in self.decisions:
+            self.decisions[stage.slug] = TierDecision(
+                stage_slug=stage.slug,
+                tier=DEFAULT_TIERS.get(stage.slug, DELIBERATIVE),
+                chosen_by="default",
+                reason="No prior stage declared an effort tier for this one.",
+            )
+        return self.decisions[stage.slug]
+
+    def is_routine(self, stage: StageSpec) -> bool:
+        # No `enabled` check here on purpose: `tier_for` already answers deliberative when the
+        # plan is off, and guarding the same thing twice means neither guard is the one being
+        # tested.
+        return self.tier_for(stage) == ROUTINE
+
+    def declare(self, stage_slug: str, tier: str, reason: str, *, chosen_by: str = "prior stage") -> None:
+        """Record what a stage said the next one needs."""
+        existing = self.decisions.get(stage_slug)
+        if existing is not None and existing.chosen_by == "promotion":
+            # A promotion is evidence; a declaration is a guess. Evidence wins.
+            return
+        self.decisions[stage_slug] = TierDecision(
+            stage_slug=stage_slug, tier=tier, chosen_by=chosen_by, reason=reason
+        )
+
+    def note_failure(self, stage: StageSpec) -> bool:
+        """Count a failed gate. Returns True when this promotes the stage."""
+        decision = self.decision_for(stage)
+        decision.failures += 1
+        if (
+            self.enabled
+            and decision.tier == ROUTINE
+            and decision.failures >= PROMOTE_AFTER_FAILURES
+        ):
+            decision.promoted_from = ROUTINE
+            decision.tier = DELIBERATIVE
+            decision.chosen_by = "promotion"
+            decision.reason = (
+                f"Ran as routine and failed its gate {decision.failures} times; the work is "
+                "harder than the previous stage expected."
+            )
+            return True
+        return False
+
+    def note_outcome(self, stage: StageSpec, *, attempts: int, contested: bool | None) -> None:
+        decision = self.decision_for(stage)
+        decision.attempts = attempts
+        decision.contested = contested
+
+
+# ---------------------------------------------------------------------------
+# Prompt block
+# ---------------------------------------------------------------------------
+
+
+def tier_notice(stage: StageSpec, tier: str, next_stage: StageSpec | None) -> str:
+    """Tell a stage how much ceremony it is running with, and ask it to set the next one."""
+    if tier == ROUTINE:
+        head = (
+            "# Effort Tier: routine\n\n"
+            "The decisions this stage depends on are already made. This is execution: carry "
+            "them out correctly and completely, and do not re-open settled questions. You are "
+            "running with a lighter review than a deliberative stage, so the bar is that the "
+            "work is *right*, not that it is *argued for*.\n\n"
+            "If you discover that something genuinely is not settled, say so plainly in "
+            "`Decision Ledger` under Open Questions rather than quietly deciding it yourself."
+        )
+    else:
+        head = (
+            "# Effort Tier: deliberative\n\n"
+            "Something genuinely undecided is at stake here. Take the time. Consider more than "
+            "one way the question could be answered, say why you chose the one you chose, and "
+            "record what would have changed your mind. Work that is complete and unargued is "
+            "not what this stage is for."
+        )
+
+    if next_stage is None:
+        return head
+    return (
+        head
+        + "\n\n## Set the next stage's effort\n\n"
+        + f"End your `Decision Ledger` with one line saying what **{next_stage.stage_title}** "
+        "needs:\n\n"
+        + "```\nNext stage effort: routine — the design is settled; this is engineering.\n```\n\n"
+        + "or\n\n"
+        + "```\nNext stage effort: deliberative — the identification strategy is still open.\n```\n\n"
+        + "Choose `routine` when the decisions that stage depends on are already made, and "
+        "`deliberative` when it still has to decide something that would be expensive to get "
+        "wrong. Guessing routine is not punished — a routine stage that fails twice is promoted "
+        "automatically — but guessing it every time defeats the point."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+
+
+def record_plan(paths: RunPaths, plan: EffortPlan) -> dict[str, Any]:
+    decisions = [decision.to_dict() for decision in plan.decisions.values()]
+    payload = {"enabled": plan.enabled, "stages": decisions, "summary": summarize(plan)}
+    paths.reviews_dir.mkdir(parents=True, exist_ok=True)
+    write_text(paths.reviews_dir / LEDGER_FILENAME, json.dumps(payload, indent=2, ensure_ascii=False))
+    return payload
+
+
+def summarize(plan: EffortPlan) -> dict[str, Any]:
+    decisions = list(plan.decisions.values())
+    routine = [d for d in decisions if d.tier == ROUTINE]
+    deliberative = [d for d in decisions if d.tier == DELIBERATIVE]
+    promoted = [d for d in decisions if d.promoted_from]
+    # A deliberative stage that passed first time with nothing contested paid for an argument
+    # nobody had.
+    overspent = [
+        d for d in deliberative
+        if not d.promoted_from and d.attempts == 1 and d.contested is False
+    ]
+    declared = [d for d in decisions if d.chosen_by == "prior stage"]
+    return {
+        "stages_planned": len(decisions),
+        "run_as_routine": len(routine),
+        "run_as_deliberative": len(deliberative),
+        "declared_by_a_prior_stage": len(declared),
+        "promoted_after_failing": len(promoted),
+        "deliberative_but_uncontested": len(overspent),
+        "verdict": _verdict(len(decisions), len(routine), len(promoted), len(overspent)),
+    }
+
+
+def _verdict(planned: int, routine: int, promoted: int, overspent: int) -> str:
+    """Both directions of waste, said plainly."""
+    if planned == 0:
+        return "No stages were tiered."
+    if routine == 0:
+        return (
+            f"Every one of {planned} stage(s) ran deliberative. Nothing was treated as routine, "
+            "so this run spent the expensive configuration everywhere — which is the thing "
+            "tiering exists to avoid."
+        )
+    parts = [f"{routine} of {planned} stage(s) ran routine"]
+    if promoted:
+        parts.append(
+            f"{promoted} had to be promoted after failing, so that call was wrong"
+        )
+    if overspent:
+        parts.append(
+            f"{overspent} ran deliberative but passed first time uncontested, so that effort "
+            "bought nothing"
+        )
+    if not promoted and not overspent:
+        parts.append("no stage was mis-tiered in either direction")
+    return "; ".join(parts) + "."

--- a/src/information_flow.py
+++ b/src/information_flow.py
@@ -185,6 +185,12 @@ def _idea_pool(context: ChannelContext) -> str | None:
     manager = context.manager
     if manager is None or getattr(manager, "ideation_panel", None) is None:
         return None
+    # Widening the candidate pool is for a stage that still has to choose. A stage running
+    # routine has already been told its decisions are made, so paying a proposer panel to
+    # re-open them is the expensive configuration landing where its benefit does not.
+    plan = getattr(manager, "effort_plan", None)
+    if plan is not None and plan.is_routine(context.stage):
+        return None
     return manager._build_idea_pool(context.paths, context.stage, context.attempt_no)  # noqa: SLF001
 
 

--- a/src/manager.py
+++ b/src/manager.py
@@ -120,6 +120,13 @@ from .deliberation import (
     read_requests,
     record_resolution,
 )
+from .effort import (
+    DELIBERATIVE,
+    EffortPlan,
+    parse_declaration,
+    record_plan,
+    tier_notice,
+)
 from .ideation_panel import (
     IdeationPanel,
     format_pool_for_prompt,
@@ -230,6 +237,9 @@ class ResearchManager:
         self._final_stage: StageSpec | None = None
         self.ideation_panel: IdeationPanel | None = None
         self.crux_panel: CruxPanel | None = None
+        self.effort_plan = EffortPlan(enabled=False)
+        #: A plain reviewer kept alongside a panel, so a routine stage can be gated cheaply.
+        self.solo_reviewer: AutomatedReviewer | None = None
         self._crux_resolutions: list[Any] = []
         self._pending_comments: list[Any] = []
         self._open_comments: list[Any] = []
@@ -755,6 +765,10 @@ class ResearchManager:
         except Exception as exc:  # noqa: BLE001 - measurement must not derail the stage
             append_log_entry(paths.logs, f"{stage.slug} anchored_revision_failed", str(exc))
 
+    def _stage_after(self, stage: StageSpec) -> StageSpec | None:
+        """The next stage in the fixed order, for the tier declaration to name."""
+        return next((later for later in STAGES if later.number == stage.number + 1), None)
+
     def _settle_cruxes(self, paths: RunPaths, stage: StageSpec, attempt_no: int) -> str | None:
         """Deliberate any crux the agent raised, and send the stage back with the answers.
 
@@ -806,6 +820,55 @@ class ResearchManager:
             "the answers are below under `Resolved Cruxes`. Apply them and revise the parts of "
             "the stage that depended on your working answer, leaving the rest alone."
         )
+
+    def _settle_effort(
+        self, paths: RunPaths, stage: StageSpec, attempt_no: int, stage_markdown: str
+    ) -> None:
+        """Record what this stage cost, and let it set the next stage's tier."""
+        try:
+            self.effort_plan.note_outcome(
+                stage,
+                attempts=attempt_no,
+                # Uncontested means it cleared its gate without anyone asking for a change.
+                contested=attempt_no > 1,
+            )
+            following = self._stage_after(stage)
+            declaration = parse_declaration(stage_markdown)
+            if following is not None and declaration is not None:
+                tier, reason = declaration
+                self.effort_plan.declare(
+                    following.slug,
+                    tier,
+                    reason or f"Declared by {stage.stage_title}.",
+                )
+                append_log_entry(
+                    paths.logs,
+                    f"{stage.slug} effort_declaration",
+                    f"{following.slug}: {tier}" + (f" — {reason}" if reason else ""),
+                )
+            record_plan(paths, self.effort_plan)
+        except Exception as exc:  # noqa: BLE001 - tiering must never disturb an approval
+            append_log_entry(paths.logs, f"{stage.slug} effort_failed", str(exc))
+
+    def _note_effort_failure(self, paths: RunPaths, stage: StageSpec) -> None:
+        """A failed gate. Promote a routine stage that keeps failing."""
+        if not self.effort_plan.enabled:
+            return
+        try:
+            if self.effort_plan.note_failure(stage):
+                self.ui.show_status(
+                    f"{stage.stage_title} was running as routine and keeps failing; "
+                    "promoting it to deliberative.",
+                    level="warn",
+                )
+                append_log_entry(
+                    paths.logs,
+                    f"{stage.slug} effort_promoted",
+                    self.effort_plan.decision_for(stage).reason,
+                )
+            record_plan(paths, self.effort_plan)
+        except Exception as exc:  # noqa: BLE001
+            append_log_entry(paths.logs, f"{stage.slug} effort_failed", str(exc))
 
     def _generate_writing_review(self, paths: RunPaths) -> dict[str, object]:
         """Produce the Stage 07 triage artifact that matches this run's output format.
@@ -2024,6 +2087,11 @@ class ResearchManager:
                 suggestions=suggestions,
             )
 
+            # A refusal is the signal that this stage is harder than the previous one
+            # expected; enough of them promote a routine stage to deliberative.
+            if choice not in {"5", "6"}:
+                self._note_effort_failure(paths, stage)
+
             if choice in {"1", "2", "3"}:
                 selected = suggestions[int(choice) - 1]
                 revision_feedback = (
@@ -2093,6 +2161,8 @@ class ResearchManager:
                     attempt_no - polish_rounds,
                     self._stage_file_paths(stage_markdown),
                 )
+                if self.effort_plan.enabled:
+                    self._settle_effort(paths, stage, attempt_no, stage_markdown)
                 if stage.slug == "02_hypothesis_generation":
                     self._measure_pool_adoption(paths, stage, stage_markdown)
                 if stage.slug == "04_implementation":
@@ -2241,13 +2311,22 @@ class ResearchManager:
             stage_template = stage_template.rstrip() + "\n\n" + inbound + "\n"
         self._record_inbound_channels(paths, stage, delivered)
 
+        routine = self.effort_plan.is_routine(stage)
+        if self.effort_plan.enabled:
+            stage_template = (
+                stage_template.rstrip()
+                + "\n\n"
+                + tier_notice(stage, self.effort_plan.tier_for(stage), self._stage_after(stage))
+                + "\n"
+            )
+
         # The crux-panel blocks stay outside the channel registry on purpose.
         # `escalation_offer` carries no heading of its own, and the resolutions
         # block consumes one-shot state — it clears `_crux_resolutions` after
         # rendering. A registry entry declares who reads what; a builder that
         # mutates the manager is a different kind of thing, and filing it as a
         # channel would make the registry mean less than it does.
-        if self.crux_panel is not None:
+        if self.crux_panel is not None and not routine:
             stage_template = (
                 stage_template.rstrip()
                 + "\n\n"
@@ -2332,7 +2411,12 @@ class ResearchManager:
             f"Automated reviewer is auditing {stage.stage_title}...",
             level="info",
         )
-        decision = self.reviewer.review_stage(
+        reviewer = self.reviewer
+        if self.effort_plan.is_routine(stage) and self.solo_reviewer is not None:
+            # A panel deliberating over execution work is the expensive configuration landing
+            # where its benefit does not.
+            reviewer = self.solo_reviewer
+        decision = reviewer.review_stage(
             paths=paths,
             stage=stage,
             attempt_no=attempt_no,

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -1,0 +1,346 @@
+"""Spending effort unevenly, and admitting when the spend was wrong.
+
+Tiering is a bet made per stage. The tests that matter are the ones about losing the bet:
+does a routine stage that keeps failing recover, and does the ledger say so afterwards.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.effort import (
+    DEFAULT_TIERS,
+    DELIBERATIVE,
+    LEDGER_FILENAME,
+    PROMOTE_AFTER_FAILURES,
+    ROUTINE,
+    EffortPlan,
+    normalize_tier,
+    parse_declaration,
+    record_plan,
+    summarize,
+    tier_notice,
+)
+from src.terminal_ui import TerminalUI
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    read_text,
+    write_text,
+)
+
+
+STAGE_03 = next(s for s in STAGES if s.slug == "03_study_design")
+STAGE_04 = next(s for s in STAGES if s.slug == "04_implementation")
+STAGE_08 = next(s for s in STAGES if s.slug == "08_dissemination")
+
+
+class TierBasicsTests(unittest.TestCase):
+    def test_the_defaults_split_deciding_from_carrying_out(self) -> None:
+        # Framing, hypotheses, design and interpretation decide things; implementation,
+        # execution and packaging carry decisions out.
+        self.assertEqual(DEFAULT_TIERS["03_study_design"], DELIBERATIVE)
+        self.assertEqual(DEFAULT_TIERS["06_analysis"], DELIBERATIVE)
+        self.assertEqual(DEFAULT_TIERS["04_implementation"], ROUTINE)
+        self.assertEqual(DEFAULT_TIERS["08_dissemination"], ROUTINE)
+        self.assertEqual(set(DEFAULT_TIERS), {stage.slug for stage in STAGES})
+
+    def test_normalize_accepts_only_real_tiers(self) -> None:
+        self.assertEqual(normalize_tier(" Routine "), ROUTINE)
+        self.assertIsNone(normalize_tier("medium"))
+        self.assertIsNone(normalize_tier(None))
+
+    def test_a_disabled_plan_treats_everything_as_deliberative(self) -> None:
+        # Off means the old behaviour exactly: nothing gets a cheaper path by accident.
+        plan = EffortPlan(enabled=False)
+        self.assertEqual(plan.tier_for(STAGE_04), DELIBERATIVE)
+        self.assertFalse(plan.is_routine(STAGE_04))
+
+    def test_an_enabled_plan_uses_the_defaults(self) -> None:
+        plan = EffortPlan(enabled=True)
+        self.assertTrue(plan.is_routine(STAGE_04))
+        self.assertFalse(plan.is_routine(STAGE_03))
+
+
+class DeclarationTests(unittest.TestCase):
+    def test_a_stage_can_set_the_next_stages_tier(self) -> None:
+        parsed = parse_declaration(
+            "## Decision Ledger\n- Locked: ...\n\nNext stage effort: routine — the design is settled.\n"
+        )
+        self.assertEqual(parsed, (ROUTINE, "the design is settled."))
+
+    def test_the_declaration_is_case_insensitive_and_reason_optional(self) -> None:
+        self.assertEqual(parse_declaration("NEXT STAGE EFFORT: Deliberative"), (DELIBERATIVE, ""))
+
+    def test_an_unknown_tier_is_not_a_declaration(self) -> None:
+        self.assertIsNone(parse_declaration("Next stage effort: whenever"))
+
+    def test_a_summary_with_no_declaration_parses_as_none(self) -> None:
+        self.assertIsNone(parse_declaration("# Stage 03\n\n## Key Results\n\nDone.\n"))
+        self.assertIsNone(parse_declaration(""))
+
+    def test_a_declaration_overrides_the_default(self) -> None:
+        plan = EffortPlan(enabled=True)
+        self.assertTrue(plan.is_routine(STAGE_04))
+        plan.declare(STAGE_04.slug, DELIBERATIVE, "the loader design is still open")
+        self.assertFalse(plan.is_routine(STAGE_04))
+        self.assertEqual(plan.decision_for(STAGE_04).chosen_by, "prior stage")
+
+
+class PromotionTests(unittest.TestCase):
+    """Cheap is a bet; this is what happens when the bet loses."""
+
+    def test_a_routine_stage_that_keeps_failing_is_promoted(self) -> None:
+        plan = EffortPlan(enabled=True)
+        self.assertTrue(plan.is_routine(STAGE_04))
+        for _ in range(PROMOTE_AFTER_FAILURES - 1):
+            self.assertFalse(plan.note_failure(STAGE_04))
+        self.assertTrue(plan.note_failure(STAGE_04))
+        self.assertFalse(plan.is_routine(STAGE_04))
+
+    def test_one_failure_is_not_enough(self) -> None:
+        # A single failed gate is ordinary and often a formatting problem.
+        plan = EffortPlan(enabled=True)
+        plan.note_failure(STAGE_04)
+        self.assertTrue(plan.is_routine(STAGE_04))
+
+    def test_the_promotion_records_what_it_came_from_and_why(self) -> None:
+        plan = EffortPlan(enabled=True)
+        for _ in range(PROMOTE_AFTER_FAILURES):
+            plan.note_failure(STAGE_04)
+        decision = plan.decision_for(STAGE_04)
+        self.assertEqual(decision.promoted_from, ROUTINE)
+        self.assertEqual(decision.chosen_by, "promotion")
+        self.assertIn("harder than the previous stage expected", decision.reason)
+
+    def test_a_deliberative_stage_is_never_promoted(self) -> None:
+        plan = EffortPlan(enabled=True)
+        for _ in range(PROMOTE_AFTER_FAILURES + 2):
+            self.assertFalse(plan.note_failure(STAGE_03))
+        self.assertEqual(plan.decision_for(STAGE_03).promoted_from, "")
+
+    def test_a_promotion_outranks_a_later_declaration(self) -> None:
+        plan = EffortPlan(enabled=True)
+        for _ in range(PROMOTE_AFTER_FAILURES):
+            plan.note_failure(STAGE_04)
+        plan.declare(STAGE_04.slug, ROUTINE, "still think it is easy")
+        # Evidence beats a guess.
+        self.assertFalse(plan.is_routine(STAGE_04))
+
+    def test_a_disabled_plan_never_promotes(self) -> None:
+        plan = EffortPlan(enabled=False)
+        for _ in range(PROMOTE_AFTER_FAILURES + 1):
+            self.assertFalse(plan.note_failure(STAGE_04))
+
+
+class NoticeTests(unittest.TestCase):
+    def test_a_routine_stage_is_told_not_to_re_open_settled_questions(self) -> None:
+        notice = tier_notice(STAGE_04, ROUTINE, STAGE_08)
+        self.assertIn("Effort Tier: routine", notice)
+        self.assertIn("do not re-open settled questions", notice)
+        # …but it must be able to say the premise was wrong.
+        self.assertIn("Open Questions", notice)
+
+    def test_a_deliberative_stage_is_told_to_take_the_time(self) -> None:
+        notice = tier_notice(STAGE_03, DELIBERATIVE, STAGE_04)
+        self.assertIn("Effort Tier: deliberative", notice)
+        self.assertIn("Take the time", notice)
+
+    def test_the_notice_asks_for_the_next_stages_tier_by_name(self) -> None:
+        notice = tier_notice(STAGE_03, DELIBERATIVE, STAGE_04)
+        self.assertIn(STAGE_04.stage_title, notice)
+        self.assertIn("Next stage effort:", notice)
+
+    def test_the_last_stage_is_not_asked_to_set_a_successor(self) -> None:
+        self.assertNotIn("Next stage effort:", tier_notice(STAGE_08, ROUTINE, None))
+
+
+class LedgerTests(unittest.TestCase):
+    def _paths(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(paths)
+        return paths
+
+    def test_both_directions_of_waste_are_reported(self) -> None:
+        plan = EffortPlan(enabled=True)
+        plan.decision_for(STAGE_04)                 # routine, fine
+        for _ in range(PROMOTE_AFTER_FAILURES):     # routine, mis-called
+            plan.note_failure(STAGE_08)
+        plan.note_outcome(STAGE_03, attempts=1, contested=False)  # deliberative, over-spent
+
+        summary = summarize(plan)
+        self.assertEqual(summary["promoted_after_failing"], 1)
+        self.assertEqual(summary["deliberative_but_uncontested"], 1)
+        self.assertIn("that call was wrong", summary["verdict"])
+        self.assertIn("bought nothing", summary["verdict"])
+
+    def test_a_run_that_tiered_nothing_routine_is_called_out(self) -> None:
+        plan = EffortPlan(enabled=True)
+        plan.note_outcome(STAGE_03, attempts=2, contested=True)
+        summary = summarize(plan)
+        self.assertEqual(summary["run_as_routine"], 0)
+        self.assertIn("which is the thing tiering exists to avoid", summary["verdict"])
+
+    def test_a_clean_run_says_nothing_was_mis_tiered(self) -> None:
+        plan = EffortPlan(enabled=True)
+        plan.note_outcome(STAGE_04, attempts=1, contested=False)   # routine, cheap, passed
+        plan.note_outcome(STAGE_03, attempts=2, contested=True)    # deliberative, contested
+        self.assertIn("no stage was mis-tiered", summarize(plan)["verdict"])
+
+    def test_the_plan_is_written_where_stage_08_reads_reviews(self) -> None:
+        paths = self._paths()
+        plan = EffortPlan(enabled=True)
+        plan.declare(STAGE_04.slug, ROUTINE, "engineering only")
+        payload = record_plan(paths, plan)
+        on_disk = json.loads(read_text(paths.reviews_dir / LEDGER_FILENAME))
+        self.assertEqual(on_disk["summary"], payload["summary"])
+        self.assertEqual(on_disk["stages"][0]["reason"], "engineering only")
+
+    def test_an_empty_plan_does_not_divide_by_zero(self) -> None:
+        self.assertIn("No stages were tiered", summarize(EffortPlan(enabled=True))["verdict"])
+
+
+class ManagerIntegrationTests(unittest.TestCase):
+    def _manager_and_paths(self, *, enabled: bool = True):
+        from unittest.mock import MagicMock
+        from src.manager import ResearchManager
+
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        runs_dir = Path(tmp_dir.name) / "runs"
+        runs_dir.mkdir()
+        paths = build_run_paths(runs_dir / "20260101_000000")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Goal")
+        write_text(paths.memory, "# Approved Run Memory\n\n## Approved Stage Summaries\n\n_None yet._\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025")
+
+        operator = MagicMock()
+        operator.model = "sonnet"
+        operator.backend_name = "claude"
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=runs_dir,
+            operator=operator,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        manager.effort_plan = EffortPlan(enabled=enabled)
+        return manager, paths
+
+    def test_a_routine_stage_prompt_is_told_it_is_routine(self) -> None:
+        manager, paths = self._manager_and_paths()
+        prompt = manager._build_stage_prompt(paths, STAGE_04, None, False)
+        self.assertIn("Effort Tier: routine", prompt)
+
+    def test_a_routine_stage_is_not_offered_the_crux_escalation(self) -> None:
+        from src.deliberation import CruxPanel, DEFAULT_VOICES
+
+        manager, paths = self._manager_and_paths()
+        manager.crux_panel = CruxPanel(
+            DEFAULT_VOICES, backend_name="claude", model="sonnet",
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        routine = manager._build_stage_prompt(paths, STAGE_04, None, False)
+        deliberative = manager._build_stage_prompt(paths, STAGE_03, None, False)
+
+        # A stage whose decisions are made has nothing to escalate; offering it the option is
+        # how a routine stage stops being one.
+        self.assertNotIn("Raising A Crux", routine)
+        self.assertIn("Raising A Crux", deliberative)
+
+    def test_tiering_off_leaves_the_prompt_exactly_as_before(self) -> None:
+        manager, paths = self._manager_and_paths(enabled=False)
+        prompt = manager._build_stage_prompt(paths, STAGE_04, None, False)
+        self.assertNotIn("Effort Tier", prompt)
+
+    def test_a_declaration_in_an_approved_summary_sets_the_next_stage(self) -> None:
+        manager, paths = self._manager_and_paths()
+        manager._settle_effort(
+            paths, STAGE_03, 1,
+            "# Stage 03\n\n## Decision Ledger\n\nNext stage effort: deliberative — the loader "
+            "design is still open.\n",
+        )
+        self.assertFalse(manager.effort_plan.is_routine(STAGE_04))
+        self.assertIn("effort_declaration", read_text(paths.logs))
+
+    def test_repeated_refusals_promote_a_routine_stage(self) -> None:
+        manager, paths = self._manager_and_paths()
+        for _ in range(PROMOTE_AFTER_FAILURES):
+            manager._note_effort_failure(paths, STAGE_04)
+        self.assertFalse(manager.effort_plan.is_routine(STAGE_04))
+        self.assertIn("effort_promoted", read_text(paths.logs))
+
+    def test_a_broken_plan_cannot_disturb_an_approval(self) -> None:
+        manager, paths = self._manager_and_paths()
+
+        def explode(*_args, **_kwargs):
+            raise RuntimeError("plan blew up")
+
+        manager.effort_plan.note_outcome = explode
+        manager._settle_effort(paths, STAGE_03, 1, "# Stage 03\n")
+        self.assertIn("plan blew up", read_text(paths.logs))
+
+    def test_a_routine_stage_does_not_pay_for_the_ideation_pool(self) -> None:
+        from src.information_flow import ChannelContext
+        from src.information_flow import _idea_pool  # noqa: PLC2701
+
+        manager, paths = self._manager_and_paths()
+        built: list[str] = []
+        manager.ideation_panel = object()  # presence is all the channel checks
+        manager._build_idea_pool = lambda p, st, a: built.append(st.slug) or "pool"
+
+        stage_02 = next(s for s in STAGES if s.slug == "02_hypothesis_generation")
+        manager.effort_plan.declare(stage_02.slug, ROUTINE, "hypotheses were settled upstream")
+        self.assertIsNone(
+            _idea_pool(ChannelContext(paths=paths, stage=stage_02, attempt_no=1, manager=manager))
+        )
+        self.assertEqual(built, [])
+
+        manager.effort_plan.declare(stage_02.slug, DELIBERATIVE, "still open")
+        self.assertEqual(
+            _idea_pool(ChannelContext(paths=paths, stage=stage_02, attempt_no=1, manager=manager)),
+            "pool",
+        )
+
+    def test_a_routine_stage_gates_with_the_solo_reviewer(self) -> None:
+        from src.approval_agent import AutomatedReviewer, ReviewDecision
+
+        manager, paths = self._manager_and_paths()
+        calls: list[str] = []
+
+        class Recorder(AutomatedReviewer):
+            def __init__(self, tag):
+                super().__init__("claude", model="sonnet", fake_mode=True)
+                self.tag = tag
+
+            def review_stage(self, **_kwargs):
+                calls.append(self.tag)
+                return ReviewDecision(choice="5", decision_token="approve")
+
+        manager.reviewer = Recorder("panel")
+        manager.solo_reviewer = Recorder("solo")
+        manager._display_stage_output = lambda *a, **k: None
+
+        manager._collect_review_decision(
+            paths=paths, stage=STAGE_04, attempt_no=1,
+            stage_markdown="# Stage 04\n", suggestions=["a", "b", "c"],
+        )
+        manager._collect_review_decision(
+            paths=paths, stage=STAGE_03, attempt_no=1,
+            stage_markdown="# Stage 03\n", suggestions=["a", "b", "c"],
+        )
+
+        # Routine goes to the cheap gate; deliberative keeps the configured one.
+        self.assertEqual(calls, ["solo", "panel"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#142 gave a stage a way to stop and think hard. This is the other half — and without it the first half was only a sentence in a prompt.

**Nothing in AutoR ever ran *cheaper* on routine work.** Every stage carried the full prompt assembly, the full gate, and every panel that happened to be switched on — whether it was choosing an identification strategy or writing a CSV loader.

That uniformity is the mistake the multi-agent feedback literature made and measured: applying the expensive configuration everywhere is how it loses on average. The cost lands on every step; the benefit lands on a few.

## Two tiers

| | `routine` | `deliberative` |
|:---|:---|:---|
| Prompt | lean, plus "do not re-open settled questions" | full |
| Gate | single reviewer, even when a panel is seated | whatever is configured |
| Crux escalation offered | no | yes |
| Ideation panel (Stage 02) | no | yes |

## The stage that just finished chooses the next one's tier

Because it is the thing that just learned whether the hard part is over. One line in its Decision Ledger, with a reason:

```
Next stage effort: routine — the design is settled; this is engineering.
```

Per-stage defaults apply otherwise. Those defaults are guesses about the *shape* of the work, not claims about any particular research question — which is exactly why a stage can override them.

## What stops a wrong guess costing anything

**A routine stage that fails its gate twice is promoted** and re-run with the full apparatus. Cheap is a bet; this is what happens when the bet loses, and the run recovers by itself rather than thrashing at low power.

Two, not one — a single failed gate is ordinary and often a formatting problem.

A promotion **outranks a later declaration**: evidence beats a guess. And a routine stage is told that if it discovers something is *not* settled it must say so under Open Questions rather than quietly deciding alone — running cheap is a claim about the work, and the stage doing the work may contradict it.

## Both directions of waste

```json
"verdict": "3 of 8 stage(s) ran routine; 1 had to be promoted after failing, so that call was wrong; 2 ran deliberative but passed first time uncontested, so that effort bought nothing."
```

- `promoted_after_failing` — ran cheap and should not have
- `deliberative_but_uncontested` — paid for ceremony nobody used

A scheme that can only report one direction is measuring whether it was brave, not whether it was right. A run that tiered *nothing* routine is called out too.

## A guard that held nothing, found by mutation

`is_routine` checked `self.enabled` and then called `tier_for`, which **already** answers deliberative when the plan is off. Removing the second check killed no test — because it was genuinely redundant. Two guards over one rule mean neither is the one being tested.

Dropped it rather than leaving decoration, and confirmed the single remaining guard now dies under mutation. Third time in this series that the mutation pass found something real instead of confirming what I believed.

## Verification

1,214 tests, 31 new. Mutation-verified:

| Mutant | Tests killed |
|:---|:---|
| never promote a routine stage | 5 |
| promote on the first failure | 1 |
| let a declaration override a promotion | 1 |
| disable the one remaining enabled-check | 1 |

Control passes.

## Limits, in the doc

- **The promotion rule catches running too cheap; nothing catches running too rich.** `deliberative_but_uncontested` is a hint, not proof — a stage can be genuinely hard and still pass first time because it was done well.
- **The declaring stage is guessing about work it has not done.** It knows whether *its own* decisions are settled, which is a good proxy and not the same thing.
- Off by default, and off means exactly the previous behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)