### PR TITLE
Scope an abandonment to the visit that made it, and stop --final-stage walking backwards

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -58,6 +58,7 @@ from .research_rounds import (
     ROUND_CLOSING_STAGE_NUMBER,
     Round,
     latest_round,
+    unreopened_abandonment,
     read_round_decision,
     format_round_status,
     format_rounds_for_prompt,
@@ -224,6 +225,11 @@ class ResearchManager:
         self.review_model = review_model or getattr(reviewer, "model", getattr(operator, "model", "unknown"))
         self.last_run_paths: RunPaths | None = None
         self._jump_reason: str = ""
+        #: The round `_close_round` just closed, carried from `_run_stage` to
+        #: `_advance_from` so it can be stamped on the visit. The abandonment guard
+        #: reads the visit rather than the run-global ledger, so this is what scopes
+        #: it to the traversal that actually made the decision.
+        self._closed_round: int = 0
         self._redo_start_stage: StageSpec | None = None
         self._research_diagram: bool = False
         self._final_stage: StageSpec | None = None
@@ -463,6 +469,7 @@ class ResearchManager:
             graph_enter(paths, state, stage)
             self._jump_target_stage = None
             self._jump_reason = ""
+            self._closed_round = 0
             approved = self._run_stage(paths, stage)
 
             # Three things reach this seam: `/back <stage>`, a rollback after retry
@@ -510,10 +517,25 @@ class ResearchManager:
         save_graph_state(paths, state)
         return self._complete_run(paths, state=state)
 
-    def _run_was_abandoned(self, paths: RunPaths) -> "Round | None":
-        """The closed round that concluded the question cannot be answered, if any."""
+    def _run_was_abandoned(
+        self, paths: RunPaths, state: "GraphState | None" = None
+    ) -> "Round | None":
+        """The round this walk stopped on, if it stopped because of an abandonment.
+
+        Asks the walk rather than the ledger. A run whose first round abandoned and
+        which an operator then rolled back and finished has an abandonment in its
+        history and is not an abandoned run, and the status it ends with decides how
+        every downstream reader treats it.
+        """
+        if state is None or not state.path:
+            return None
+        last = state.path[-1]
+        if last.chose != GRAPH_FINISH or not last.closed_round:
+            return None
         final = latest_round(paths)
-        return final if final is not None and final.decision == "abandon" else None
+        if final is not None and final.number == last.closed_round and final.decision == "abandon":
+            return final
+        return None
 
     def _complete_run(self, paths: RunPaths, state: "GraphState | None" = None) -> bool:
         route = format_route(state) if state is not None else ""
@@ -523,7 +545,7 @@ class ResearchManager:
         # `completed` and `cancelled` are both wrong, and `cancelled` is the worse
         # of the two: it is what an abort writes, so the honest outcome would be
         # indistinguishable from a crash in every downstream reader.
-        abandoned = self._run_was_abandoned(paths)
+        abandoned = self._run_was_abandoned(paths, state)
         if abandoned is not None:
             append_log_entry(
                 paths.logs,
@@ -566,7 +588,23 @@ class ResearchManager:
         return True
 
     def _graph_entry_stage(self, paths: RunPaths, start_stage: StageSpec | None) -> StageSpec | None:
-        """Where the walk starts: the requested stage, or the first unsettled one."""
+        """Where the walk starts: the requested stage, or the first unsettled one.
+
+        An abandoned run has no entry. It stopped at Stage 06 by design, so Stages 07
+        and 08 are unsettled and would otherwise be picked as the resume point —
+        `--resume-run` would drive straight into the stage the terminal exists to
+        avoid, and burn its whole retry budget against a gate that refuses it. The
+        abandonment has to be overruled on the record before the run continues.
+        """
+        standing = unreopened_abandonment(paths)
+        if standing is not None and start_stage is None:
+            self.ui.show_status(
+                f"Round {standing.number} concluded the question cannot be answered: "
+                f"{standing.rationale} Nothing to resume. To continue anyway, roll back "
+                "explicitly, or record a round that reopens it.",
+                level="warn",
+            )
+            return None
         pending = self._select_stages_for_run(paths, start_stage)
         return pending[0] if pending else None
 
@@ -580,6 +618,11 @@ class ResearchManager:
         score = None
         if self.evolution is not None:
             score = self.evolution.finalize_stage(paths, stage)
+
+        # Before the guards are evaluated: the abandonment terminal asks the visit,
+        # not the ledger.
+        if state.path:
+            state.path[-1].closed_round = self._closed_round
 
         decision = self.router.choose(
             paths=paths,
@@ -3089,6 +3132,7 @@ class ResearchManager:
         )
         if entry is None:
             return
+        self._closed_round = entry.number
 
         append_log_entry(
             paths.logs,

--- a/src/research_rounds.py
+++ b/src/research_rounds.py
@@ -83,6 +83,8 @@ class Round:
     recorded_at: str
     acted_on: bool = True
     budget_note: str = ""
+    #: The abandoned round this one overrules, if any. Zero otherwise.
+    reopens_round: int = 0
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -96,6 +98,7 @@ class Round:
             "recorded_at": self.recorded_at,
             "acted_on": self.acted_on,
             "budget_note": self.budget_note,
+            "reopens_round": self.reopens_round,
         }
 
 
@@ -124,6 +127,7 @@ def load_rounds(paths: RunPaths) -> list[Round]:
                 recorded_at=str(entry.get("recorded_at") or ""),
                 acted_on=bool(entry.get("acted_on", True)),
                 budget_note=str(entry.get("budget_note") or ""),
+                reopens_round=int(entry.get("reopens_round") or 0),
             )
         )
     return rounds
@@ -178,11 +182,13 @@ def validate_round_decision(paths: RunPaths, stage: StageSpec) -> list[str]:
                 "requires at least one closed research round. Stage 06 records the round's "
                 "conclusion in workspace/notes/research_rounds.json when it is approved."
             ]
-        if final.decision == "abandon":
+        standing = unreopened_abandonment(paths)
+        if standing is not None:
             return [
-                f"cannot run: round {final.number} concluded `abandon` — {final.rationale}. "
+                f"cannot run: round {standing.number} concluded `abandon` — {standing.rationale}. "
                 "Writing up a run that decided the question could not be answered would "
-                "contradict its own record."
+                "contradict its own record. A later round may overrule it, but has to say so: "
+                f"set `reopens_round: {standing.number}` in round_decision.json."
             ]
         return []
 
@@ -258,6 +264,7 @@ def record_round(
         recorded_at=_now(),
         acted_on=acted_on,
         budget_note=budget_note,
+        reopens_round=int(payload.get("reopens_round") or 0),
     )
     rounds.append(entry)
     _write_rounds(paths, rounds)
@@ -265,6 +272,32 @@ def record_round(
     # next round inherit the previous round's conclusion.
     paths.round_decision.unlink(missing_ok=True)
     return entry
+
+
+def unreopened_abandonment(paths: RunPaths) -> Round | None:
+    """The abandonment that still stands, if there is one.
+
+    Not ``latest_round``. An abandonment is a conclusion about the whole run, and
+    reading only the last entry let it be laundered: close round 1 as ``abandon``,
+    go back through any route that does not consult it — `/back`,
+    `--rollback-stage`, or the graph's own revisit edges — re-approve Stage 06 and
+    declare ``converged``, and the ledger reads ``[abandon, converged]`` while every
+    downstream check sees only the second. The run then writes up the question it
+    had recorded that it could not answer.
+
+    Overruling one is legitimate and often right — a person who disagrees is exactly
+    who should be able to. It has to be on the record, which is what
+    ``reopens_round`` is: a later round naming the abandoned round it supersedes.
+    The difference between "we reconsidered and said so" and "we reconsidered" is
+    the whole of the thing, which is the same rule
+    :func:`src.preregistration.amend_preregistration` already applies to hypotheses.
+    """
+    rounds = load_rounds(paths)
+    reopened = {item.reopens_round for item in rounds if item.reopens_round}
+    standing = [
+        item for item in rounds if item.decision == "abandon" and item.number not in reopened
+    ]
+    return standing[-1] if standing else None
 
 
 def resume_stage_slug_for(decision: str) -> str | None:

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -209,13 +209,33 @@ def _guard_round_abandoned(paths: RunPaths, state: "GraphState") -> GuardResult:
     """
     from .research_rounds import latest_round
 
+    # Scoped to *this visit*, not to the run.
+    #
+    # `research_rounds.json` is run-global and nothing invalidates it — a rollback
+    # does not touch it, and `_skip_stage` never closes a round at all. Read
+    # globally, an abandonment recorded once would govern every later arrival at
+    # Stage 06 forever: an operator who disagreed, rolled back to Stage 03 and
+    # re-ran into a Stage 06 that exhausted its retries would find the walk
+    # terminating on a decision that visit never made — and, because a live
+    # conditional terminal preempts every other move, with no way for the agent to
+    # go anywhere else either.
+    #
+    # Every other guard here reads stage artifacts, which a rollback invalidates.
+    # This one reads a ledger, so the scoping has to be explicit: the closing round
+    # is stamped on the `Visit`, and the guard asks whether *this* traversal closed
+    # a round that concluded abandon.
+    visit = state.path[-1] if state.path else None
+    closed = visit.closed_round if visit is not None else 0
+    if not closed:
+        return GuardResult(False, "this visit closed no research round")
+
     final = latest_round(paths)
-    if final is not None and final.decision == "abandon":
+    if final is not None and final.number == closed and final.decision == "abandon":
         return GuardResult(
             True,
             f"round {final.number} concluded the question cannot be answered: {final.rationale}",
         )
-    return GuardResult(False, "no closed round has concluded `abandon`")
+    return GuardResult(False, f"round {closed} did not conclude `abandon`")
 
 
 def _guard_has_hypotheses(paths: RunPaths, state: "GraphState") -> GuardResult:
@@ -297,13 +317,12 @@ _ADVANCE_GUARDS = {
 }
 
 
-#: Forward edges are priority 0 everywhere except out of Stage 06, where the
-#: abandonment terminal sits at 0 and writing up sits behind it. Priority only
-#: separates *live* forward moves, so on every ordinary run — where the terminal's
-#: guard is shut — Stage 06 still advances to writing exactly as before. It matters
-#: in the one case it exists for: a round that concluded the question cannot be
-#: answered stops, rather than writing up the answer it does not have.
-_ADVANCE_PRIORITIES = {"07_writing": 1}
+#: Per-target overrides for the forward priority. Empty, and it should stay that
+#: way unless something can be shown to depend on it: a live conditional terminal
+#: preempts every other move at its node, so priority never decides between a
+#: terminal and an advance, and every node has exactly one advance. An entry here
+#: that changes no behaviour is a constant a reader will assume is load-bearing.
+_ADVANCE_PRIORITIES: dict[str, int] = {}
 
 #: Terminals other than "the run produced what it set out to produce". Carried by
 #: both topologies: refusing to write up an abandoned round is a correctness
@@ -443,6 +462,10 @@ class Visit:
     #: and an estimator that counted them as decisions where nothing else was on
     #: offer would be reading an operator's intervention as evidence about an edge.
     bypassed: bool = False
+    #: The research round this visit closed, if it closed one. Zero otherwise.
+    #: What makes the abandonment guard a statement about this traversal rather than
+    #: about the run's whole history.
+    closed_round: int = 0
     #: Filled in when the run leaves. An unfinished visit is the record of where a
     #: run was interrupted, which is what a resume needs.
     left_at: str = ""
@@ -471,6 +494,7 @@ class Visit:
             "offered": list(self.offered),
             "blocked": dict(self.blocked),
             "bypassed": self.bypassed,
+            "closed_round": self.closed_round,
         }
 
     @classmethod
@@ -494,6 +518,7 @@ class Visit:
                 str(k): str(v) for k, v in (payload.get("blocked") or {}).items() if str(k)
             },
             bypassed=bool(payload.get("bypassed")),
+            closed_round=int(payload.get("closed_round") or 0),
         )
 
 
@@ -566,8 +591,10 @@ def save_graph_state(paths: RunPaths, state: GraphState) -> None:
 #: through it: a guard is a statement about the *research* and can be overridden as
 #: a last resort, while a budget is a statement about the *run* and cannot.
 #: ``concluded`` is neither — the run has already decided to stop, and the move is
-#: not unavailable so much as moot.
-BLOCK_KINDS = ("guard", "visits", "steps", "concluded")
+#: not unavailable so much as moot. ``pruned`` is the caller's own ``--final-stage``:
+#: not a fact about the research at all, and the one kind that means the walk is
+#: finished rather than stuck.
+BLOCK_KINDS = ("guard", "visits", "steps", "concluded", "pruned")
 
 
 @dataclass(frozen=True)
@@ -646,9 +673,26 @@ class StageGraph:
         """
         results: list[Move] = []
         for edge in self.out_edges(slug):
+            # `--final-stage` used to drop the edge from the list entirely. That made
+            # the node look like one with no forward move at all, and `default_move`
+            # fell through to the backward edges — so on the adaptive topology, which
+            # is the default, `--final-stage 07` sent the run back to Stage 06 and
+            # kept going until a budget stopped it. Measured at every final stage:
+            # 05 -> 04, 06 -> 05, 07 -> 06, all revisits. Recorded as a block instead,
+            # the node still has its forward move and the walk can see that the
+            # reason it cannot be taken is the caller's, not the research's.
             if final_stage is not None and edge.target != FINISH:
                 target_stage = stage_for_slug(edge.target)
                 if target_stage is not None and target_stage.number > final_stage.number:
+                    results.append(
+                        Move(
+                            edge,
+                            GuardResult(True, "not evaluated"),
+                            f"`{edge.target}` is past the requested final stage "
+                            f"`{final_stage.slug}`",
+                            "pruned",
+                        )
+                    )
                     continue
 
             guard = edge.guard_fn()(paths, state)
@@ -704,9 +748,9 @@ class StageGraph:
         if live_forward:
             return min(live_forward, key=by_rank)
 
-        # A budget said stop. Unlike a guard, that is not a statement about the
-        # research and there is nothing to route around.
-        if any(move.blocked_kind in {"steps", "visits"} for move in forward):
+        # A budget said stop, or the caller did. Unlike a guard, neither is a
+        # statement about the research, and there is nothing to route around.
+        if any(move.blocked_kind in {"steps", "visits", "pruned"} for move in forward):
             return None
 
         # Forward is shut by a guard, and the default does **not** go back.

--- a/tests/test_archive_exploration.py
+++ b/tests/test_archive_exploration.py
@@ -10,7 +10,7 @@ from src.archive import (
     RunRecord,
     edge_payoffs,
 )
-from src.stage_graph import StageGraph
+from src.stage_graph import Edge, StageGraph
 from src.utils import append_jsonl
 
 
@@ -29,6 +29,63 @@ def _record(run_id: str, edges: list[str], fitness: float = 0.5) -> RunRecord:
         agent_directed=0,
         recorded_at="2026-08-06T00:00:00",
     )
+
+
+class ExplorableOnlyWithARivalTest(unittest.TestCase):
+    """An edge with no rival at its source is not explorable.
+
+    Preferring it changes nothing — a run reaching that node was going to take it
+    anyway — so a proposal naming it buys a variant for a trial that cannot run.
+    Held by its own test rather than as a side effect of the `linear` case, which
+    only exercises it while `linear` happens to have a non-zero priority somewhere.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.archive = Archive(Path(self._tmp.name) / "archive")
+        for index in range(5):
+            append_jsonl(
+                self.archive.runs_file,
+                _record(f"r{index}", ["01_literature_survey->02_hypothesis_generation"]).to_dict(),
+            )
+
+    def _graph(self, edges):
+        return StageGraph(edges, name="adaptive")
+
+    def test_a_lone_untaken_advance_is_not_offered_for_exploration(self) -> None:
+        graph = self._graph(
+            [
+                Edge("01_literature_survey", "02_hypothesis_generation", "advance", "on", priority=0),
+                Edge("02_hypothesis_generation", "03_study_design", "advance", "on", priority=2),
+            ]
+        )
+        self.assertIsNone(self.archive.propose_exploration(graph=graph))
+
+    def test_an_untaken_edge_with_a_rival_is_offered(self) -> None:
+        graph = self._graph(
+            [
+                Edge("01_literature_survey", "02_hypothesis_generation", "advance", "on", priority=0),
+                Edge("02_hypothesis_generation", "03_study_design", "advance", "on", priority=0),
+                Edge("02_hypothesis_generation", "01_literature_survey", "revisit", "back", priority=2),
+            ]
+        )
+        variant = self.archive.propose_exploration(graph=graph)
+        self.assertIsNotNone(variant)
+        self.assertIn("02_hypothesis_generation->01_literature_survey", variant.edge_priority)
+
+    def test_a_terminal_does_not_count_as_a_rival(self) -> None:
+        """`06_analysis->finish` is live only when the round concluded the question
+        cannot be answered, and in that case it is the only live forward move — so
+        its priority relative to the writing edge decides nothing either."""
+        graph = self._graph(
+            [
+                Edge("01_literature_survey", "02_hypothesis_generation", "advance", "on", priority=0),
+                Edge("02_hypothesis_generation", "03_study_design", "advance", "on", priority=2),
+                Edge("02_hypothesis_generation", "finish", "finish", "stop", guard="round_abandoned"),
+            ]
+        )
+        self.assertIsNone(self.archive.propose_exploration(graph=graph))
 
 
 class EdgeVisibilityTest(unittest.TestCase):

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -404,7 +404,17 @@ class GraphWalkTests(unittest.TestCase):
         self._abandon_at_analysis(manager)
         self.drive(manager)
         paths = self.only_run()
-        self.assertTrue(GUARDS["round_abandoned"](paths, GraphState()).ok)
+
+        # Against the state the run actually persisted, not a synthetic one: the
+        # guard is scoped to the visit that closed the round, so a bare GraphState
+        # is a Stage 06 that closed nothing, and asserting on one would prove the
+        # opposite of what this test is for.
+        state = load_graph_state(paths)
+        self.assertTrue(GUARDS["round_abandoned"](paths, state).ok)
+        self.assertEqual(state.path[-1].closed_round, 1)
+
+        # And the same ledger does not govern a visit that closed no round.
+        self.assertFalse(GUARDS["round_abandoned"](paths, GraphState()).ok)
 
     # -- settings survive a resume -------------------------------------------
 

--- a/tests/test_research_rounds.py
+++ b/tests/test_research_rounds.py
@@ -32,6 +32,7 @@ from src.research_rounds import (
     read_round_decision,
     record_round,
     resume_stage_slug_for,
+    unreopened_abandonment,
     validate_round_decision,
 )
 from src.utils import STAGES, build_run_paths, ensure_run_layout, validate_stage_artifacts, write_text
@@ -221,6 +222,73 @@ class Stage07GateTest(RoundTestCase):
     def test_the_stage_gate_calls_this(self) -> None:
         problems = validate_stage_artifacts(STAGE_07, self.paths)
         self.assertTrue(any("closed research round" in problem for problem in problems), problems)
+
+
+class AbandonmentStandsUntilOverruledTest(RoundTestCase):
+    """An abandonment is a conclusion about the run, not about the last round.
+
+    Reading only the last entry let it be laundered: abandon, go back through any
+    route that does not consult it, re-approve Stage 06, declare converged — the
+    ledger reads `[abandon, converged]` and every downstream check saw only the
+    second. The run then wrote up the question it had recorded it could not answer.
+    """
+
+    def _abandon(self) -> None:
+        write_validity_chain(self.paths, close_first_round=False)
+        self.refute_everything()
+        write_round_decision(
+            self.paths,
+            decision="abandon",
+            rationale="The effect cannot be separated from tuning noise at this budget.",
+            what_we_learned="Every arm we can afford sits within noise of the baseline.",
+            what_changes_next="",
+        )
+        record_round(self.paths, acted_on=True)
+
+    def test_a_later_converged_round_does_not_erase_it(self) -> None:
+        self._abandon()
+        write_round_decision(
+            self.paths,
+            decision="converged",
+            rationale="On reflection the second design does separate the effect cleanly.",
+            what_we_learned="The development split removes the confound entirely.",
+            what_changes_next="",
+            negative_result=True,
+        )
+        record_round(self.paths, acted_on=True)
+
+        self.assertEqual(
+            [item.decision for item in load_rounds(self.paths)], ["abandon", "converged"]
+        )
+        problems = validate_round_decision(self.paths, STAGE_07)
+        self.assertTrue(any("concluded `abandon`" in problem for problem in problems), problems)
+        self.assertTrue(any("reopens_round: 1" in problem for problem in problems), problems)
+
+    def test_a_round_that_says_it_reopens_the_abandonment_is_allowed_through(self) -> None:
+        """Overruling one is legitimate and often right. It has to be on the record —
+        the same rule preregistration already applies to a revised hypothesis."""
+        self._abandon()
+        write_round_decision(
+            self.paths,
+            decision="converged",
+            rationale="The second design separates the effect, so the earlier call was wrong.",
+            what_we_learned="Tuning on a development split removes the confound entirely.",
+            what_changes_next="",
+            negative_result=True,
+        )
+        payload = json.loads(self.paths.round_decision.read_text(encoding="utf-8"))
+        payload["reopens_round"] = 1
+        write_text(self.paths.round_decision, json.dumps(payload))
+        record_round(self.paths, acted_on=True)
+
+        self.assertEqual(unreopened_abandonment(self.paths), None)
+        self.assertEqual(validate_round_decision(self.paths, STAGE_07), [])
+
+    def test_an_abandonment_with_nothing_after_it_still_stands(self) -> None:
+        self._abandon()
+        standing = unreopened_abandonment(self.paths)
+        self.assertIsNotNone(standing)
+        self.assertEqual(standing.number, 1)
 
 
 class PromptCarryForwardTest(RoundTestCase):

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -247,7 +247,7 @@ class RouterTests(unittest.TestCase):
             json.dumps({"target": "07_writing", "reason": "The refutation is the contribution."})
         )
         decision = StageRouter(operator, mode="auto").choose(
-            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=self.abandoned_state()
         )
         self.assertEqual(decision.target, FINISH)
         self.assertFalse(decision.agent_directed)
@@ -259,10 +259,40 @@ class RouterTests(unittest.TestCase):
         self.adjudicate()
         self.abandon()
         decision = StageRouter(None, mode="off").choose(
-            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=self.abandoned_state()
         )
         self.assertEqual(set(decision.blocked.values()), {"concluded"})
         self.assertIn("07_writing", decision.blocked)
+
+    def abandoned_state(self) -> GraphState:
+        """A graph state whose current visit is the one that closed the round.
+
+        The guard is scoped to the traversal, not to the run, so a bare
+        `GraphState()` is a Stage 06 that closed nothing — which is the whole point
+        of the scoping and is asserted directly in
+        `test_a_stale_abandonment_does_not_govern_a_later_visit`.
+        """
+        from src.research_rounds import latest_round
+
+        state = GraphState()
+        state.path.append(Visit(stage=STAGE_06.slug, entered_at="t"))
+        final = latest_round(self.paths)
+        state.path[-1].closed_round = final.number if final else 0
+        return state
+
+    def test_a_stale_abandonment_does_not_govern_a_later_visit(self) -> None:
+        """`research_rounds.json` is run-global and nothing invalidates it — not a
+        rollback, and not an auto-skipped Stage 06, which closes no round at all. Read
+        globally, one abandonment would terminate every later arrival at Stage 06 for
+        the rest of the run, and preemption would leave the agent nowhere else to go.
+        """
+        self.adjudicate()
+        self.abandon()
+        decision = StageRouter(None, mode="off").choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+        )
+        self.assertNotEqual(decision.target, FINISH)
+        self.assertNotIn("concluded", decision.blocked.values())
 
     def abandon(self) -> None:
         from src.research_rounds import record_round

--- a/tests/test_stage_graph.py
+++ b/tests/test_stage_graph.py
@@ -267,17 +267,38 @@ class AdaptiveTopologyTests(unittest.TestCase):
             )
         )
 
-    def test_final_stage_prunes_moves_past_it(self) -> None:
-        """`--final-stage 07` means the run does not owe a dissemination package, so
-        the edge into one must not be on the menu."""
+    def test_final_stage_takes_the_move_past_it_off_the_menu(self) -> None:
+        """`--final-stage 07` means the run does not owe a dissemination package."""
         stage_07 = stage_for_slug("07_writing")
-        targets = {
-            move.target
-            for move in self.graph.moves(
-                self.paths, "07_writing", GraphState(), final_stage=stage_07
-            )
-        }
-        self.assertNotIn("08_dissemination", targets)
+        moves = self.graph.moves(
+            self.paths, "07_writing", GraphState(), final_stage=stage_07
+        )
+        pruned = next(move for move in moves if move.target == "08_dissemination")
+        self.assertFalse(pruned.admissible)
+        self.assertEqual(pruned.blocked_kind, "pruned")
+
+    def test_final_stage_ends_the_walk_instead_of_sending_it_backwards(self) -> None:
+        """The bug that dropping the edge caused, at every final stage.
+
+        `moves()` used to omit a pruned edge entirely, so the node looked like one
+        with no forward move at all and `default_move` fell through to the backward
+        edges. On the adaptive topology — the default — `--final-stage 07` therefore
+        sent the run back to Stage 06 and kept going until a budget stopped it.
+        Measured before the fix: final-stage 05 went to 04, 06 went to 05, 07 went to
+        06, all revisits, on the graph a default run walks.
+
+        A pruned edge is the caller's own instruction. It is not a fact about the
+        research, and unlike a guard there is nothing to route around.
+        """
+        for number in (5, 6, 7):
+            final = next(stage for stage in STAGES if stage.number == number)
+            with self.subTest(final_stage=final.slug):
+                self.assertIsNone(
+                    self.graph.default_move(
+                        self.paths, final.slug, GraphState(), final_stage=final
+                    ),
+                    msg=f"--final-stage {final.slug} did not end the walk",
+                )
 
     # -- what the graph allows ----------------------------------------------
 


### PR DESCRIPTION
Follow-up to #143, from an adversarial review of what it landed (4 reviewers × distinct angles, then adjudication). Four verified defects — three of them introduced or made reachable by that change.

## 1. A stale abandonment governed every later visit to Stage 06

`research_rounds.json` is run-global and **nothing invalidates it**: a rollback does not touch it, and `_skip_stage` never closes a round at all. Read globally — which is how #143's guard read it — one abandonment terminated every later arrival at Stage 06 for the rest of the run.

Preemption made it worse than a default: it was the *only* live move, so the agent could not go anywhere else either. Verified with a fresh `GraphState`:

```
default_move("06_analysis") -> finish      # a visit that closed no round
```

Scenario: an operator disagrees with the abandonment, runs `--rollback-stage 03`, the redo reaches Stage 06 and is auto-skipped after retry exhaustion — no round recorded — and the walk stops on a decision that visit never made, relabelling the run `abandoned`.

Every other guard reads stage artifacts, which a rollback invalidates. This one reads a ledger, so the scoping has to be explicit: `_close_round` stamps the closing round on the `Visit`, and the guard asks whether **this traversal** closed a round that concluded abandon. `_run_was_abandoned` asks the walk too — a run whose first round abandoned and which an operator then finished has an abandonment in its history and is not an abandoned run.

## 2. `--final-stage` never stopped the walk on the default topology

`moves()` **dropped** a pruned edge, so the node looked like one with no forward move and `default_move` fell through to the backward edges. Measured on adaptive — the default:

| | `default_move` at the final stage |
| --- | --- |
| `--final-stage 05` | → `04_implementation` (revisit) |
| `--final-stage 06` | → `05_experimentation` (revisit) |
| `--final-stage 07` | → `06_analysis` (revisit) |
| linear, for comparison | `None` (walk ends) |

`--final-stage 07` — the documented way to get a manuscript without a dissemination package — sent the run back into analysis and looped until a budget intervened.

A pruned edge is now recorded blocked with its own kind rather than dropped. It is the caller's own instruction, not a fact about the research, and unlike a guard there is nothing to route around.

## 3. An abandonment could be laundered

`validate_round_decision` read `latest_round`, so `[abandon, converged]` passed and the run wrote up the question it had recorded it could not answer. The graph route is closed while the abandonment stands, but `/back`, `--rollback-stage` and `--resume-run` do not consult the router at all.

It now reads the whole ledger. Overruling an abandonment is legitimate and often right — a person who disagrees is exactly who should be able to — but it goes **on the record** as `reopens_round: N`, the same rule `amend_preregistration` already applies to a revised hypothesis.

And a resume of a standing abandonment no longer has an entry stage: it would otherwise drive straight into the stage the terminal exists to avoid and burn its whole retry budget against a gate that refuses it.

## 4. A dead constant propping up an untested rule

`_ADVANCE_PRIORITIES = {"07_writing": 1}` changed nothing — a live conditional terminal preempts every other move at its node, so priority never decides between a terminal and an advance, and every node has exactly one advance. Mutating it to `{}` killed no test.

It was also the only thing making the archive's `rivals` filter observable, so that sound rule was resting on a dead constant. The entry is cut; `rivals` has three tests of its own.

## Mutation-checked

Each new rule, removed in turn:

| Rule removed | Tests that die |
| --- | --- |
| visit scoping on the abandonment guard | 2 |
| pruned-edge halt | 1 |
| `rivals` filter | 2 |

## Testing

1191 pass (up from 1143).

One correction to #143's PR body while I'm here: "0 calls at Stage 07" was true of walks that pass through Stage 06, not of every path — `--resume-run` entered Stage 07 directly and burned the budget as before. That is what item 3 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)