### PR TITLE
Do not discard a run because the reviewer's verdict was unreadable

### DIFF
--- a/main.py
+++ b/main.py
@@ -558,6 +558,7 @@ def create_reviewer(
     fake_mode: bool,
     ui: TerminalUI,
     stage_timeout: int,
+    unattended: bool = False,
     panel_roles: list[str] | None = None,
     panel_models: list[str] | None = None,
     use_panel: bool = False,
@@ -585,6 +586,7 @@ def create_reviewer(
         fake_mode=fake_mode,
         ui=ui,
         stage_timeout=stage_timeout,
+        unattended=unattended,
     )
 
 
@@ -890,6 +892,7 @@ def main() -> int:
                 fake_mode=args.fake_operator,
                 ui=ui,
                 stage_timeout=args.stage_timeout,
+                unattended=unattended,
                 use_panel=args.review_panel,
                 panel_roles=args.panel_roles,
                 panel_models=args.panel_models,
@@ -975,6 +978,7 @@ def main() -> int:
             fake_mode=args.fake_operator,
             ui=ui,
             stage_timeout=args.stage_timeout,
+            unattended=unattended,
             use_panel=args.review_panel,
             panel_roles=args.panel_roles,
             panel_models=args.panel_models,

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -504,6 +504,9 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
             fake_mode=args.fake_operator,
             ui=ui,
             stage_timeout=args.stage_timeout,
+            # The benchmark run has no human to interpret an unreadable verdict, and
+            # aborting at Stage 01 forfeits the task outright.
+            unattended=True,
         )
     manager = ResearchManager(
         project_root=REPO_ROOT,

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -45,6 +45,11 @@ DECISION_TO_CHOICE = {
 }
 
 
+#: Prefix that marks "the reviewer answered but we could not read it", as distinct from
+#: "the reviewer refused". The two are told apart by `AutomatedReviewer._is_unreadable`.
+UNREADABLE_REASON = "Automated reviewer did not return valid JSON."
+
+
 def _try_load_json(text: str) -> dict[str, Any] | None:
     try:
         payload = json.loads(text)
@@ -117,7 +122,12 @@ class AutomatedReviewer:
         fake_mode: bool = False,
         ui: TerminalUI | None = None,
         stage_timeout: int = 14400,
+        unattended: bool = False,
     ) -> None:
+        # Unattended runs cannot ask a human what the reviewer meant, and aborting a
+        # multi-hour run because a verdict was unreadable throws away work the reviewer
+        # may well have been about to approve. See _unreadable_verdict.
+        self.unattended = unattended
         normalized_backend = backend_name.strip().lower() if backend_name.strip() else "claude"
         if normalized_backend == "codex":
             self._operator = CodexOperator(model=model, fake_mode=fake_mode, ui=ui, stage_timeout=stage_timeout)
@@ -172,7 +182,78 @@ class AutomatedReviewer:
                 raw_response=stdout_text or stderr_text,
             )
 
-        return self._parse_decision(stdout_text, markdown=stage_markdown)
+        decision = self._parse_decision(stdout_text, markdown=stage_markdown)
+        if not self._is_unreadable(decision):
+            return decision
+
+        # The reviewer answered, we just could not read it. Ask once more for the verdict
+        # alone: a reviewer that has already inspected the artifacts and then narrated its
+        # findings in prose is one re-ask away from a usable answer, and that is far
+        # cheaper than discarding the stage.
+        retry = self.run_prompt(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            prompt=self._build_verdict_only_prompt(stage=stage, previous=stdout_text),
+            label="review_verdict",
+        )
+        if retry[0] == 0:
+            retried = self._parse_decision(retry[1], markdown=stage_markdown)
+            if not self._is_unreadable(retried):
+                return retried
+
+        return self._unreadable_verdict(stdout_text)
+
+    @staticmethod
+    def _is_unreadable(decision: ReviewDecision) -> bool:
+        return decision.decision_token == "abort" and decision.reason.startswith(UNREADABLE_REASON)
+
+    def _unreadable_verdict(self, raw_response: str) -> ReviewDecision:
+        """What to do when the reviewer's answer cannot be read, twice.
+
+        Attended: abort, unchanged -- a human is there, and guessing at a verdict is the
+        one thing the approval gate exists to prevent.
+
+        Unattended: send the stage back for another pass instead. An unreadable verdict is
+        not a refusal to approve, it is a failure to read the answer, and the two deserve
+        different outcomes. Revising is bounded by the stage's own attempt budget, so this
+        cannot loop; aborting, by contrast, discards the entire run at whatever stage the
+        parse happened to fail -- in practice Stage 01, hours of real work gone over a
+        formatting slip.
+        """
+        if not self.unattended:
+            return ReviewDecision(
+                choice="6",
+                decision_token="abort",
+                reason=UNREADABLE_REASON + " AutoR stopped instead of approving blindly.",
+                raw_response=raw_response,
+            )
+        return ReviewDecision(
+            choice="4",
+            decision_token="revise",
+            reason=(
+                UNREADABLE_REASON
+                + " Unattended, so the stage was sent back for another pass rather than "
+                "approved or aborted."
+            ),
+            feedback=(
+                "The automated reviewer's verdict could not be parsed, so this stage was "
+                "not approved. Re-examine the draft against the stage contract and the "
+                "artifacts it claims, fix whatever is weakest, and restate the summary."
+            ),
+            raw_response=raw_response,
+        )
+
+    def _build_verdict_only_prompt(self, *, stage: StageSpec, previous: str) -> str:
+        return (
+            f"You were asked to review {stage.stage_title} and your reply could not be "
+            "parsed as a decision.\n\n"
+            "Do not inspect anything further. Do not call any tool. Reply with a single "
+            "JSON object and nothing else, on one line:\n\n"
+            '{"decision": "approve" | "revise" | "abort", "reason": "<one sentence>"}\n\n'
+            "Use the same judgement you already reached. Your previous reply ended:\n\n"
+            + previous.strip()[-2000:]
+        )
 
     def run_prompt(
         self,
@@ -363,7 +444,7 @@ class AutomatedReviewer:
             return ReviewDecision(
                 choice="6",
                 decision_token="abort",
-                reason="Automated reviewer did not return valid JSON. AutoR stopped instead of approving blindly.",
+                reason=UNREADABLE_REASON + " AutoR stopped instead of approving blindly.",
                 raw_response=raw_response,
             )
 

--- a/tests/test_reviewer_unreadable_verdict.py
+++ b/tests/test_reviewer_unreadable_verdict.py
@@ -1,0 +1,168 @@
+"""What happens when the reviewer answers but AutoR cannot read the answer.
+
+Observed on a real ResearchClawBench run: Stage 01 produced a strong, validated draft
+after 40 minutes and two attempts; the reviewer inspected it for 21 turns and then
+narrated its findings in prose instead of emitting the verdict JSON. AutoR aborted the
+whole run. An unreadable verdict is not a refusal to approve -- it is a failure to read
+the answer -- and unattended those deserve different outcomes.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.approval_agent import UNREADABLE_REASON, AutomatedReviewer, ReviewDecision
+from src.utils import STAGES, build_run_paths, ensure_run_layout
+
+GOOD = '{"decision": "approve", "reason": "Artifacts check out."}'
+PROSE = "I reviewed the draft and the artifacts. Everything looks broadly reasonable."
+
+
+class _Harness(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        self.stage = STAGES[0]
+
+    def _reviewer(self, *, unattended: bool) -> AutomatedReviewer:
+        with patch("src.approval_agent.ClaudeOperator"):
+            return AutomatedReviewer("claude", model="opus", unattended=unattended)
+
+    def _review(self, replies, *, unattended: bool):
+        """Drive one review, with `replies` consumed one per backend call."""
+        seen: list[str] = []
+        reviewer = self._reviewer(unattended=unattended)
+
+        def run_prompt(*, paths, stage, attempt_no, prompt, label):
+            seen.append(label)
+            return (0, replies[len(seen) - 1], "")
+
+        with patch.object(reviewer, "run_prompt", side_effect=run_prompt), \
+             patch.object(reviewer, "_build_review_prompt", return_value="prompt"):
+            decision = reviewer.review_stage(
+                paths=self.paths, stage=self.stage, attempt_no=1,
+                stage_markdown="# Stage 01: Literature Survey", suggestions=["a", "b", "c"],
+            )
+        return decision, seen
+
+
+class ReadableVerdictTest(_Harness):
+    def test_a_parseable_verdict_is_used_and_nothing_is_re_asked(self) -> None:
+        decision, calls = self._review([GOOD], unattended=True)
+        self.assertEqual(decision.decision_token, "approve")
+        self.assertEqual(calls, ["review"])
+
+    def test_a_refusal_is_still_a_refusal(self) -> None:
+        """The fix must not turn a reviewer that genuinely says abort into a retry."""
+        reply = '{"decision": "abort", "reason": "The results are fabricated."}'
+        decision, calls = self._review([reply], unattended=True)
+        self.assertEqual(decision.decision_token, "abort")
+        self.assertIn("fabricated", decision.reason)
+        self.assertEqual(calls, ["review"])
+
+
+class ReAskTest(_Harness):
+    def test_an_unreadable_verdict_is_re_asked_once(self) -> None:
+        decision, calls = self._review([PROSE, GOOD], unattended=False)
+        self.assertEqual(decision.decision_token, "approve")
+        self.assertEqual(calls, ["review", "review_verdict"])
+
+    def test_the_re_ask_demands_the_verdict_alone(self) -> None:
+        reviewer = self._reviewer(unattended=True)
+        prompt = reviewer._build_verdict_only_prompt(stage=self.stage, previous=PROSE)
+        self.assertIn("Do not call any tool", prompt)
+        self.assertIn('"decision"', prompt)
+        self.assertIn(PROSE, prompt)
+
+    def test_the_re_ask_carries_a_distinct_label_so_it_is_auditable(self) -> None:
+        """It writes its own prompt_cache entry rather than overwriting the first."""
+        _, calls = self._review([PROSE, GOOD], unattended=True)
+        self.assertEqual(calls[1], "review_verdict")
+
+
+class UnreadableTwiceTest(_Harness):
+    def test_attended_still_aborts(self) -> None:
+        """A human is there; guessing at a verdict is what the gate exists to prevent."""
+        decision, calls = self._review([PROSE, PROSE], unattended=False)
+        self.assertEqual(decision.choice, "6")
+        self.assertEqual(decision.decision_token, "abort")
+        self.assertEqual(calls, ["review", "review_verdict"])
+
+    def test_unattended_revises_instead_of_discarding_the_run(self) -> None:
+        decision, _ = self._review([PROSE, PROSE], unattended=True)
+        self.assertEqual(decision.choice, "4")
+        self.assertEqual(decision.decision_token, "revise")
+
+    def test_unattended_never_approves_what_it_could_not_read(self) -> None:
+        """Revising is the middle path; approving blindly is still forbidden."""
+        decision, _ = self._review([PROSE, PROSE], unattended=True)
+        self.assertNotEqual(decision.decision_token, "approve")
+        self.assertNotEqual(decision.choice, "5")
+
+    def test_the_revision_carries_actionable_feedback(self) -> None:
+        decision, _ = self._review([PROSE, PROSE], unattended=True)
+        self.assertTrue(decision.feedback.strip())
+        self.assertIn("not approved", decision.feedback)
+
+    def test_both_outcomes_say_the_verdict_was_unreadable(self) -> None:
+        for unattended in (True, False):
+            with self.subTest(unattended=unattended):
+                decision, _ = self._review([PROSE, PROSE], unattended=unattended)
+                self.assertIn(UNREADABLE_REASON, decision.reason)
+
+    def test_the_raw_response_is_kept_for_diagnosis(self) -> None:
+        decision, _ = self._review([PROSE, PROSE], unattended=True)
+        self.assertIn(PROSE, decision.raw_response)
+
+
+class ReAskFailureTest(_Harness):
+    def test_a_failed_re_ask_falls_back_rather_than_raising(self) -> None:
+        reviewer = self._reviewer(unattended=True)
+        calls: list[str] = []
+
+        def run_prompt(*, paths, stage, attempt_no, prompt, label):
+            calls.append(label)
+            return (0, PROSE, "") if label == "review" else (1, "", "boom")
+
+        with patch.object(reviewer, "run_prompt", side_effect=run_prompt), \
+             patch.object(reviewer, "_build_review_prompt", return_value="p"):
+            decision = reviewer.review_stage(
+                paths=self.paths, stage=self.stage, attempt_no=1,
+                stage_markdown="# Stage 01: Literature Survey", suggestions=["a", "b", "c"],
+            )
+        self.assertEqual(decision.choice, "4")
+        self.assertEqual(calls, ["review", "review_verdict"])
+
+    def test_a_nonzero_first_call_still_aborts_without_a_re_ask(self) -> None:
+        """A backend that failed to run is a different thing from one that answered
+        unreadably, and must not be re-asked into a false decision."""
+        reviewer = self._reviewer(unattended=True)
+        calls: list[str] = []
+
+        def run_prompt(*, paths, stage, attempt_no, prompt, label):
+            calls.append(label)
+            return (2, "", "backend exploded")
+
+        with patch.object(reviewer, "run_prompt", side_effect=run_prompt), \
+             patch.object(reviewer, "_build_review_prompt", return_value="p"):
+            decision = reviewer.review_stage(
+                paths=self.paths, stage=self.stage, attempt_no=1,
+                stage_markdown="# Stage 01", suggestions=["a", "b", "c"],
+            )
+        self.assertEqual(decision.decision_token, "abort")
+        self.assertIn("exit code 2", decision.reason)
+        self.assertEqual(calls, ["review"])
+
+
+class RcbAgentIsUnattendedTest(unittest.TestCase):
+    def test_the_benchmark_adapter_builds_an_unattended_reviewer(self) -> None:
+        """The benchmark has no human, and aborting at Stage 01 forfeits the task."""
+        source = Path(__file__).resolve().parent.parent / "rcb_agent.py"
+        text = source.read_text()
+        block = text[text.index("reviewer = AutomatedReviewer("):]
+        self.assertIn("unattended=True", block[: block.index(")\n")])


### PR DESCRIPTION
Found by running AutoR on a real ResearchClawBench task, not by reading.

## What happened

`Astronomy_000`, opus, unattended. Stage 01 spent **40 minutes and two attempts** and produced a genuinely strong draft: 26 sources, 38 claims, DOIs cross-checked against CrossRef, twelve closed-form physics checks, a reproducible characterisation script, and **two real numerical bugs caught along the way** (`np.nan_to_num` collapsing `±inf` sentinels, and a validation check passing only because numpy's default `atol=1e-8` swamped values of order 1e-33). Its own evolution score was `1.000` across all five criteria.

The reviewer then inspected it for 21 turns and **narrated its findings in prose instead of emitting the verdict JSON**. AutoR aborted the entire run:

```
decision_token: abort
reason: Automated reviewer did not return valid JSON.
        AutoR stopped instead of approving blindly.
```

## Why that is the wrong failure mode

Refusing to approve blindly is right. **Aborting is not the same thing.** An unreadable verdict is not a refusal to approve — it is a failure to *read* the answer, and the two deserve different outcomes.

Unattended there is no human to ask what the reviewer meant, and the abort forfeits the whole task at whatever stage the parse happened to fail. Here that was Stage 01, so forty minutes of correct work was discarded over a formatting slip.

## The fix

**1. Re-ask once.** A reviewer that has already examined the artifacts and then narrated its findings is one re-ask away from a usable answer, and that is far cheaper than discarding the stage. The re-ask forbids further tool calls, asks for the verdict alone, and quotes the tail of the previous reply so the reviewer restates the judgement it already reached. It runs under its own `review_verdict` label, so it gets its own `prompt_cache` entry instead of overwriting the first.

**2. Unattended, fall back to revise rather than abort.** Sending the stage back for another pass is bounded by the stage's own attempt budget, so it cannot loop.

| | Attended | Unattended |
|---|---|---|
| Readable verdict | used as given | used as given |
| Genuine `abort` | abort | abort |
| Unreadable twice | **abort** (unchanged) | **revise** |

Unattended **never approves what it could not read** — revise is the middle path, and a test pins that it is neither approve nor abort.

`rcb_agent.py` builds its reviewer with `unattended=True`, and a test asserts that at the source rather than trusting the wiring.

## Verification

- **1258 tests green** (+14), `py_compile` clean.
- **Mutation swept with a control run: 12 mutants, all killed** — removing the re-ask, aborting unattended anyway, approving instead of revising, revising when attended, treating a genuine abort as unreadable, reusing the `review` label, letting the re-ask call tools, emptying the feedback, and flipping `rcb_agent` back to attended.

The genuine-abort case matters most: the fix must not turn a reviewer that actually says "the results are fabricated" into a retry. `_is_unreadable` keys on the specific reason prefix, and a test drives a real abort through to confirm it survives untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)