### PR TITLE
Concentrate the expensive knob on the few steps that repay it

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Useful feature | **Divergent ideation panel** | `--ideation-panel` widens Stage 02 with proposers working from distinct lenses - mechanism, contrarian, adjacent field, null/artifact, regime - deduplicated and scored into a candidate pool the stage chooses from. It decides nothing, and reports when the extra proposers added nothing. |
 | Useful feature | **Anchored review comments** | A reviewer can quote the passage it objects to instead of refusing the whole stage. The revision is told to change only those spans, and is then diffed against them — so "preserve the correct parts" is measured rather than hoped for. |
 | Useful feature | **Selective deep thinking** | Most steps are execution. With `--deliberation` a stage that hits a genuine crux can stop, name the question, and pull in a panel of theorist / empiricist / critic / pragmatist plus an expert brief — then carry on with an answer that names its own falsifier. Budgeted, and measured against what the agent already believed. |
-| Useful feature | **Effort tiers** | `--effort-tiers` runs each stage as routine or deliberative rather than treating them alike — a lean prompt and a single reviewer where the decisions are already made, the full apparatus where something is genuinely undecided. Each stage sets the next one's tier, and a routine stage that keeps failing is promoted automatically. |
+| Useful feature | **Effort tiers** | `--effort-tiers` runs each stage as routine or deliberative rather than treating them alike — a lean prompt and a single reviewer where the decisions are already made, the full apparatus where something is genuinely undecided. Each stage sets the next one's tier, and a routine stage that keeps failing is promoted automatically. Polish rounds and the strong model are then concentrated on the deliberative steps rather than spread evenly. |
 | Useful feature | **Two output formats** | Stage 07 writes a benchmark-ready markdown report (`report/report.md` + PNG figures) by default, or a venue-aware LaTeX paper package with a compiled PDF via `--output-format latex`. |
 
 In practice, that means AutoR is useful not only because of the high-level framing, but also because it handles real research chores: literature organization, experiment manifests, citation verification, artifact indexing, manuscript packaging, and recoverable long-running workflows.
@@ -344,6 +344,7 @@ scope. "Make each one refutable" is advice about a gate that now exists.
 | Choose the execution backend and model | `python main.py --operator claude --model opus` or `python main.py --operator codex --model default` |
 =======
 | Spend effort unevenly across the loop | `python main.py --effort-tiers --goal "..."` |
+| Keep the strong model for the steps that matter | `python main.py --effort-tiers --model opus --routine-model sonnet --goal "..."` |
 | Choose the execution backend | `python main.py --operator claude` or `python main.py --operator codex` |
 >>>>>>> dd3d62c (Spend effort where the research needs it, not evenly)
 | Choose the reviewer backend separately | `python main.py --full-auto --review-operator claude --review-model opus` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -202,9 +202,10 @@ pre-registered evidence against multi-agent deliberation, in [Review Panel](revi
 
 | Flag | Default | Description |
 | --- | --- | --- |
+| `--routine-model MODEL` | - | Model for routine-tier stages, keeping the strong model for the few steps whose output the rest of the run inherits. Requires `--effort-tiers`. |
 | `--effort-tiers` | off | Run each stage as `routine` or `deliberative` instead of treating them alike. Routine gets a lean prompt, a single reviewer, and no escalation offer. Each stage declares what the next needs; a routine stage that fails twice is promoted automatically. |
 
-Off means exactly the previous behaviour. Both directions of mis-spending are recorded in
+Under tiering, polish rounds — the run's most expensive setting — are withheld from routine stages entirely, so the same rounds land only where something is still undecided. Off means exactly the previous behaviour. Both directions of mis-spending are recorded in
 `workspace/reviews/effort.json`. Full description in [Effort Tiers](effort-tiers.md).
 
 ### Crux deliberation

--- a/docs/effort-tiers.md
+++ b/docs/effort-tiers.md
@@ -61,6 +61,50 @@ And a routine stage is told explicitly that if it discovers something is *not* s
 should say so under Open Questions rather than quietly deciding it alone. Running cheap is a
 claim about the work, and the stage doing the work is allowed to contradict it.
 
+## Concentrating the expensive knob
+
+Tiering by itself only *labels* the steps that matter. This is the part that acts on the label.
+
+The polish loop is the run's most expensive setting — [`src/evolution.py`](../src/evolution.py)
+says so itself: *"each one is a full stage execution, so this is where the money goes"* — and
+it was being spread across all eight stages regardless of whether a stage had anything left to
+decide. Cost on every step, benefit on a few.
+
+Under `--effort-tiers`:
+
+| Resource | routine | deliberative |
+| --- | --- | --- |
+| Polish rounds | **none** | all the configured rounds |
+| Model | `--routine-model` if given | the run's model |
+
+This is a **reallocation, not an increase**. The same rounds, aimed only at the stages that
+still have something to decide; the cheaper model handed to the ones that do not.
+
+```bash
+python main.py --effort-tiers --model opus --routine-model sonnet --goal "..."
+```
+
+A promotion moves the resources with it: a routine stage promoted after failing twice regains
+its polish rounds, because promotion is a statement that the work is harder than expected and
+a label that does not change what the stage gets is not worth making.
+
+### Did the concentration actually happen?
+
+`workspace/reviews/effort.json` gains a `concentration` block:
+
+```json
+{
+  "polish_withheld_from_routine": true,
+  "polish_rounds_spent": {"routine": 0, "deliberative": 5},
+  "share_on_deliberative": 1.0,
+  "stages_on_the_cheaper_model": ["04_implementation", "05_experimentation"],
+  "verdict": "All 5 polish round(s) went to deliberative stages; routine stages spent none."
+}
+```
+
+Spending nothing is not success either — a run with no polish rounds at all reports that
+nothing was concentrated, rather than claiming a perfect share of zero.
+
 ## Both directions of waste are recorded
 
 `workspace/reviews/effort.json`:

--- a/main.py
+++ b/main.py
@@ -174,6 +174,13 @@ def parse_args() -> argparse.Namespace:
              "needs, and a routine stage that keeps failing is promoted automatically.",
     )
     parser.add_argument(
+        "--routine-model",
+        metavar="MODEL",
+        help="Model for stages running in the routine tier, so the strong model is kept for "
+             "the few steps whose output the rest of the run inherits. Requires "
+             "--effort-tiers; without it every stage is deliberative and this does nothing.",
+    )
+    parser.add_argument(
         "--deliberation",
         action="store_true",
         help="Let a stage stop and pull in a panel when it hits a genuine crux. The agent "
@@ -761,6 +768,17 @@ def configure_effort(manager, args, *, backend_name: str, model: str, ui: Termin
     if not getattr(args, "effort_tiers", False):
         return
     manager.effort_plan = EffortPlan(enabled=True)
+    if getattr(args, "routine_model", None):
+        manager.routine_operator = create_operator(
+            # The execution backend, not the reviewer's: this operator runs stages.
+            getattr(manager.operator, "backend_name", "claude"),
+            model=args.routine_model,
+            fake_mode=fake_mode,
+            ui=ui,
+            codex_sandbox=getattr(args, "codex_sandbox", None) or DEFAULT_CODEX_SANDBOX,
+            stage_timeout=stage_timeout,
+        )
+        manager.concentration.routine_model = args.routine_model
     if isinstance(manager.reviewer, AutomatedReviewer):
         manager.solo_reviewer = manager.reviewer
     elif manager.reviewer is not None:

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -192,6 +192,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
              "needs, and a routine stage that keeps failing is promoted automatically.",
     )
     parser.add_argument(
+        "--routine-model",
+        metavar="MODEL",
+        help="Model for stages running in the routine tier, so the strong model is kept for "
+             "the few steps whose output the rest of the run inherits. Requires "
+             "--effort-tiers; without it every stage is deliberative and this does nothing.",
+    )
+    parser.add_argument(
         "--deliberation",
         action="store_true",
         help="Let a stage stop and pull in a panel when it hits a genuine crux. The agent "

--- a/src/effort.py
+++ b/src/effort.py
@@ -52,6 +52,65 @@ PROMOTE_AFTER_FAILURES = 2
 
 LEDGER_FILENAME = "effort.json"
 
+
+@dataclass
+class Concentration:
+    """What each tier is actually given, once the tiers are known.
+
+    Tiering by itself only *labels* the steps that matter. This is the part that acts on the
+    label. The polish loop is the run's most expensive knob — :mod:`src.evolution` says so
+    itself, "each one is a full stage execution, so this is where the money goes" — and it was
+    being spread across all eight stages regardless. Cost on every step, benefit on a few.
+
+    Concentration is a reallocation rather than an increase: the same rounds, aimed only at the
+    stages that still have something to decide, and the cheaper model handed to the ones that
+    do not.
+    """
+
+    #: Polish rounds are withheld from routine stages entirely.
+    polish_routine: bool = False
+    #: Rounds actually spent, per tier, so the reallocation can be checked rather than assumed.
+    rounds_spent: dict[str, int] = field(default_factory=lambda: {ROUTINE: 0, DELIBERATIVE: 0})
+    #: Stages that ran on the cheaper model.
+    cheap_model_stages: list[str] = field(default_factory=list)
+    routine_model: str = ""
+
+    def note_round(self, tier: str) -> None:
+        self.rounds_spent[tier] = self.rounds_spent.get(tier, 0) + 1
+
+    def note_cheap_model(self, stage_slug: str) -> None:
+        if stage_slug not in self.cheap_model_stages:
+            self.cheap_model_stages.append(stage_slug)
+
+    def to_dict(self) -> dict[str, Any]:
+        spent = dict(self.rounds_spent)
+        total = sum(spent.values())
+        return {
+            "polish_withheld_from_routine": not self.polish_routine,
+            "polish_rounds_spent": spent,
+            "share_on_deliberative": (
+                round(spent.get(DELIBERATIVE, 0) / total, 2) if total else None
+            ),
+            "routine_model": self.routine_model,
+            "stages_on_the_cheaper_model": list(self.cheap_model_stages),
+            "verdict": self._verdict(spent, total),
+        }
+
+    @staticmethod
+    def _verdict(spent: dict[str, int], total: int) -> str:
+        if total == 0:
+            return "No polish rounds were spent, so nothing was concentrated."
+        leaked = spent.get(ROUTINE, 0)
+        if leaked:
+            return (
+                f"{total} polish round(s) spent, but {leaked} of them went to routine stages. "
+                "The expensive knob is still landing where the benefit does not."
+            )
+        return (
+            f"All {total} polish round(s) went to deliberative stages; routine stages spent "
+            "none."
+        )
+
 #: Where each stage starts when nothing has said otherwise.
 #:
 #: These are starting guesses about the *shape* of the work, not claims about any particular
@@ -226,9 +285,17 @@ def tier_notice(stage: StageSpec, tier: str, next_stage: StageSpec | None) -> st
 # ---------------------------------------------------------------------------
 
 
-def record_plan(paths: RunPaths, plan: EffortPlan) -> dict[str, Any]:
+def record_plan(
+    paths: RunPaths, plan: EffortPlan, concentration: "Concentration | None" = None
+) -> dict[str, Any]:
     decisions = [decision.to_dict() for decision in plan.decisions.values()]
-    payload = {"enabled": plan.enabled, "stages": decisions, "summary": summarize(plan)}
+    payload: dict[str, Any] = {
+        "enabled": plan.enabled,
+        "stages": decisions,
+        "summary": summarize(plan),
+    }
+    if concentration is not None:
+        payload["concentration"] = concentration.to_dict()
     paths.reviews_dir.mkdir(parents=True, exist_ok=True)
     write_text(paths.reviews_dir / LEDGER_FILENAME, json.dumps(payload, indent=2, ensure_ascii=False))
     return payload

--- a/src/manager.py
+++ b/src/manager.py
@@ -122,6 +122,7 @@ from .deliberation import (
     record_resolution,
 )
 from .effort import (
+    Concentration,
     DELIBERATIVE,
     EffortPlan,
     parse_declaration,
@@ -244,6 +245,10 @@ class ResearchManager:
         self.ideation_panel: IdeationPanel | None = None
         self.crux_panel: CruxPanel | None = None
         self.effort_plan = EffortPlan(enabled=False)
+        self.concentration = Concentration()
+        #: A cheaper operator for routine stages. The strong model stays for the few steps
+        #: whose output the rest of the run inherits.
+        self.routine_operator: OperatorProtocol | None = None
         #: A plain reviewer kept alongside a panel, so a routine stage can be gated cheaply.
         self.solo_reviewer: AutomatedReviewer | None = None
         self._crux_resolutions: list[Any] = []
@@ -808,6 +813,27 @@ class ResearchManager:
         except Exception as exc:  # noqa: BLE001 - measurement must not derail the stage
             append_log_entry(paths.logs, f"{stage.slug} anchored_revision_failed", str(exc))
 
+    def _evolution_applies(self, stage: StageSpec) -> bool:
+        """Whether this stage may spend polish rounds.
+
+        A polish round is a full stage execution — the most expensive thing the loop does. A
+        stage whose decisions are already made has nothing to polish toward, so withholding
+        the rounds there is what turns tiering from a label into a reallocation.
+        """
+        assert self.evolution is not None
+        if not self.evolution.config.applies_to(stage):
+            return False
+        if self.effort_plan.enabled and not self.concentration.polish_routine:
+            return not self.effort_plan.is_routine(stage)
+        return True
+
+    def _operator_for(self, stage: StageSpec) -> OperatorProtocol:
+        """The cheaper backend for routine work, the configured one for everything else."""
+        if self.routine_operator is not None and self.effort_plan.is_routine(stage):
+            self.concentration.note_cheap_model(stage.slug)
+            return self.routine_operator
+        return self.operator
+
     def _stage_after(self, stage: StageSpec) -> StageSpec | None:
         """The next stage in the fixed order, for the tier declaration to name."""
         return next((later for later in STAGES if later.number == stage.number + 1), None)
@@ -889,7 +915,7 @@ class ResearchManager:
                     f"{stage.slug} effort_declaration",
                     f"{following.slug}: {tier}" + (f" — {reason}" if reason else ""),
                 )
-            record_plan(paths, self.effort_plan)
+            record_plan(paths, self.effort_plan, self.concentration)
         except Exception as exc:  # noqa: BLE001 - tiering must never disturb an approval
             append_log_entry(paths.logs, f"{stage.slug} effort_failed", str(exc))
 
@@ -909,7 +935,7 @@ class ResearchManager:
                     f"{stage.slug} effort_promoted",
                     self.effort_plan.decision_for(stage).reason,
                 )
-            record_plan(paths, self.effort_plan)
+            record_plan(paths, self.effort_plan, self.concentration)
         except Exception as exc:  # noqa: BLE001
             append_log_entry(paths.logs, f"{stage.slug} effort_failed", str(exc))
 
@@ -1045,7 +1071,7 @@ class ResearchManager:
             prompt = self._build_stage_prompt(paths, stage, revision_feedback, continue_session)
             append_log_entry(paths.logs, f"{stage.slug} attempt {attempt_no} prompt", prompt)
 
-            result = self.operator.run_stage(stage, prompt, paths, attempt_no, continue_session=continue_session)
+            result = self._operator_for(stage).run_stage(stage, prompt, paths, attempt_no, continue_session=continue_session)
             append_log_entry(
                 paths.logs,
                 f"{stage.slug} attempt {attempt_no} result",
@@ -1329,7 +1355,7 @@ class ResearchManager:
             )
             append_log_entry(paths.logs, f"project_bootstrap attempt {attempt_no} prompt", prompt)
 
-            result = self.operator.run_stage(stage, prompt, paths, attempt_no, continue_session=continue_session)
+            result = self._operator_for(stage).run_stage(stage, prompt, paths, attempt_no, continue_session=continue_session)
             append_log_entry(
                 paths.logs,
                 f"project_bootstrap attempt {attempt_no} result",
@@ -1488,7 +1514,7 @@ class ResearchManager:
             prompt = self._build_bootstrap_prompt(paths, stage, corpus_prompt_section, revision_feedback, continue_session)
             append_log_entry(paths.logs, f"bootstrap attempt {attempt_no} prompt", prompt)
 
-            result = self.operator.run_stage(stage, prompt, paths, attempt_no, continue_session=continue_session)
+            result = self._operator_for(stage).run_stage(stage, prompt, paths, attempt_no, continue_session=continue_session)
             append_log_entry(
                 paths.logs,
                 f"bootstrap attempt {attempt_no} result",
@@ -1858,7 +1884,7 @@ class ResearchManager:
                 prompt,
             )
 
-            result = self.operator.run_stage(
+            result = self._operator_for(stage).run_stage(
                 stage,
                 prompt,
                 paths,
@@ -2071,7 +2097,8 @@ class ResearchManager:
                 continue
 
             # The draft is valid. Measure it, and decide whether it may stand.
-            if self.evolution is not None and self.evolution.config.applies_to(stage):
+            if self.evolution is not None and self._evolution_applies(stage):
+                self.concentration.note_round(self.effort_plan.tier_for(stage))
                 outcome = self.evolution.consider(
                     paths=paths,
                     stage=stage,

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -344,3 +344,114 @@ class ManagerIntegrationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ConcentrationTests(unittest.TestCase):
+    """Tiering labels the steps that matter; this is the part that acts on the label."""
+
+    def test_all_polish_on_deliberative_reads_as_concentrated(self) -> None:
+        from src.effort import Concentration
+
+        concentration = Concentration()
+        for _ in range(4):
+            concentration.note_round(DELIBERATIVE)
+        payload = concentration.to_dict()
+        self.assertEqual(payload["share_on_deliberative"], 1.0)
+        self.assertIn("routine stages spent none", payload["verdict"])
+
+    def test_polish_leaking_to_routine_is_called_out(self) -> None:
+        from src.effort import Concentration
+
+        concentration = Concentration()
+        concentration.note_round(DELIBERATIVE)
+        concentration.note_round(ROUTINE)
+        payload = concentration.to_dict()
+        self.assertEqual(payload["share_on_deliberative"], 0.5)
+        self.assertIn("landing where the benefit does not", payload["verdict"])
+
+    def test_no_rounds_at_all_is_not_reported_as_success(self) -> None:
+        from src.effort import Concentration
+
+        # Concentrating nothing is not the same as concentrating well.
+        self.assertIn("nothing was concentrated", Concentration().to_dict()["verdict"])
+
+    def test_cheap_model_stages_are_recorded_once_each(self) -> None:
+        from src.effort import Concentration
+
+        concentration = Concentration(routine_model="haiku")
+        concentration.note_cheap_model("04_implementation")
+        concentration.note_cheap_model("04_implementation")
+        payload = concentration.to_dict()
+        self.assertEqual(payload["stages_on_the_cheaper_model"], ["04_implementation"])
+        self.assertEqual(payload["routine_model"], "haiku")
+
+
+class ConcentrationIntegrationTests(unittest.TestCase):
+    def _manager_and_paths(self, *, enabled: bool = True):
+        from unittest.mock import MagicMock
+        from src.evolution import EvolutionConfig
+        from src.manager import ResearchManager
+
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        runs_dir = Path(tmp_dir.name) / "runs"
+        runs_dir.mkdir()
+        paths = build_run_paths(runs_dir / "20260101_000000")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Goal")
+        write_text(paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025")
+
+        operator = MagicMock()
+        operator.model = "sonnet"
+        operator.backend_name = "claude"
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=runs_dir,
+            operator=operator,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+            evolution=EvolutionConfig(measure=True, rounds=2),
+        )
+        manager.effort_plan = EffortPlan(enabled=enabled)
+        return manager, paths
+
+    def test_a_routine_stage_is_denied_the_polish_rounds(self) -> None:
+        manager, _paths = self._manager_and_paths()
+        # A polish round is a full stage execution — the most expensive thing the loop does.
+        self.assertFalse(manager._evolution_applies(STAGE_04))
+        self.assertTrue(manager._evolution_applies(STAGE_03))
+
+    def test_tiering_off_leaves_polish_on_every_stage(self) -> None:
+        manager, _paths = self._manager_and_paths(enabled=False)
+        self.assertTrue(manager._evolution_applies(STAGE_04))
+        self.assertTrue(manager._evolution_applies(STAGE_03))
+
+    def test_a_promoted_stage_regains_its_polish_rounds(self) -> None:
+        manager, _paths = self._manager_and_paths()
+        self.assertFalse(manager._evolution_applies(STAGE_04))
+        for _ in range(PROMOTE_AFTER_FAILURES):
+            manager.effort_plan.note_failure(STAGE_04)
+        # Promotion is not just a label: the resources follow it.
+        self.assertTrue(manager._evolution_applies(STAGE_04))
+
+    def test_a_routine_stage_runs_on_the_cheaper_operator(self) -> None:
+        manager, _paths = self._manager_and_paths()
+        cheap = object()
+        manager.routine_operator = cheap
+
+        self.assertIs(manager._operator_for(STAGE_04), cheap)
+        self.assertIs(manager._operator_for(STAGE_03), manager.operator)
+        self.assertEqual(manager.concentration.cheap_model_stages, [STAGE_04.slug])
+
+    def test_without_a_routine_operator_everything_uses_the_configured_one(self) -> None:
+        manager, _paths = self._manager_and_paths()
+        self.assertIs(manager._operator_for(STAGE_04), manager.operator)
+        self.assertEqual(manager.concentration.cheap_model_stages, [])
+
+    def test_the_reallocation_reaches_the_ledger(self) -> None:
+        manager, paths = self._manager_and_paths()
+        manager.concentration.note_round(DELIBERATIVE)
+        manager._settle_effort(paths, STAGE_03, 1, "# Stage 03\n")
+        payload = json.loads(read_text(paths.reviews_dir / LEDGER_FILENAME))
+        self.assertIn("concentration", payload)
+        self.assertEqual(payload["concentration"]["polish_rounds_spent"][DELIBERATIVE], 1)


### PR DESCRIPTION
#145 tiered the stages but only **labelled** them. A deliberative stage got exactly what it had always got, and the run's most expensive setting stayed spread evenly across all eight — which is the thing tiering was supposed to fix.

## The setting

The polish loop, and `src/evolution.py` says so itself:

> each one is a full stage execution, so this is where the money goes

`applies_to` with an empty `stages` tuple meant **every** stage — including the ones whose decisions were already made and which therefore had nothing to polish toward.

## What changed

Under `--effort-tiers`:

| Resource | routine | deliberative |
|:---|:---|:---|
| Polish rounds | **none** | all the configured rounds |
| Model | `--routine-model` if given | the run's model |

```bash
python main.py --effort-tiers --model opus --routine-model sonnet --goal "..."
```

A **reallocation, not an increase**: the same rounds, aimed only where something is still undecided.

## Promotion moves the resources with it

A routine stage promoted after failing twice **regains its polish rounds**. Promotion is a statement that the work is harder than expected, and a label that does not change what a stage gets is not worth making.

## Did the concentration actually happen?

```json
{
  "polish_withheld_from_routine": true,
  "polish_rounds_spent": {"routine": 0, "deliberative": 5},
  "share_on_deliberative": 1.0,
  "stages_on_the_cheaper_model": ["04_implementation", "05_experimentation"],
  "verdict": "All 5 polish round(s) went to deliberative stages; routine stages spent none."
}
```

Two things it refuses to do:

- **A null result does not pass as a good one.** A run with no polish rounds at all reports *"nothing was concentrated"* rather than claiming a perfect share of zero.
- **A leak is named.** *"5 polish round(s) spent, but 1 of them went to routine stages. The expensive knob is still landing where the benefit does not."*

## Verification

1,254 tests, 12 new. Mutation-verified:

| Mutant | Tests killed |
|:---|:---|
| give routine stages polish after all | 2 |
| never use the cheap operator | 1 |
| stop reporting leaked rounds | 1 |

Control passes.

One thing worth noting from integration: `_operator_for` takes the execution backend from the manager's own operator rather than the reviewer's, which was what the surrounding helper happened to have to hand — the two are configurably different and this operator runs stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)