### PR TITLE
Fix five interaction bugs the hunt confirmed

### DIFF
--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -330,6 +330,13 @@ thing.
 
 Three further refusals hold this together:
 
+- **A run that did not finish is not recorded at all.** A halted or aborted run
+  measured some stages and stopped, so its mean sits on an easier composition than a
+  run that finished.
+- **A move the run did not make is not recorded either.** A resume that starts
+  somewhere other than where the last closed visit was heading is an operator
+  overruling that move; it went off the router with no choice set, so it is marked
+  bypassed rather than counted as a traversal.
 - **Below `min_observations` on each side, nothing is acted on.** A variant that
   beat the incumbent once beat it once. Be aware this bound is a guard rather than
   a derivation: a two-sided permutation test over *n* per side attains at best

--- a/main.py
+++ b/main.py
@@ -621,6 +621,7 @@ def create_reviewer(
             stage_timeout=stage_timeout,
             persona_text=persona_text,
             deliberation_rounds=deliberation_rounds,
+            unattended=unattended,
         )
     return AutomatedReviewer(
         backend_name,

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -503,6 +503,10 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
             stage_timeout=args.stage_timeout,
             persona_text=load_persona(args.persona),
             deliberation_rounds=args.panel_rounds,
+            # The benchmark adapter is unattended by construction. `docs/review-panel.md`
+            # documents `rcb_agent.py --review-panel`, which is the exact context the
+            # unreadable-verdict fallback was found in.
+            unattended=True,
         )
     else:
         reviewer = AutomatedReviewer(

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -5,7 +5,7 @@ import re
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from .operator import ClaudeOperator
 from .obligations import format_for_review_prompt, load_ledger
@@ -182,7 +182,38 @@ class AutomatedReviewer:
                 raw_response=stdout_text or stderr_text,
             )
 
-        decision = self._parse_decision(stdout_text, markdown=stage_markdown)
+        return self.parse_with_retry(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            raw_response=stdout_text,
+            markdown=stage_markdown,
+        )
+
+    def parse_with_retry(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        raw_response: str,
+        markdown: str = "",
+        label: str = "review_verdict",
+        on_unreadable: "Callable[[str], ReviewDecision] | None" = None,
+    ) -> ReviewDecision:
+        """Read a verdict, re-ask once if it cannot be read, then fall back.
+
+        Split out of :meth:`review_stage` so a deliberating panel's chair goes through
+        the same path. It did not: the chair's reply was parsed with a bare
+        `parse_decision`, so one unparseable synthesis cancelled the whole run —
+        `run_status: cancelled`, Stage 01 stuck in review — where the solo reviewer on
+        the identical reply retries and continues.
+
+        ``on_unreadable`` lets a caller supply a better fallback than this one. The
+        panel has an obvious one: the seats already stated their objections, so their
+        dissent is a more informative answer than a generic re-run request.
+        """
+        decision = self._parse_decision(raw_response, markdown=markdown)
         if not self._is_unreadable(decision):
             return decision
 
@@ -194,15 +225,17 @@ class AutomatedReviewer:
             paths=paths,
             stage=stage,
             attempt_no=attempt_no,
-            prompt=self._build_verdict_only_prompt(stage=stage, previous=stdout_text),
-            label="review_verdict",
+            prompt=self._build_verdict_only_prompt(stage=stage, previous=raw_response),
+            label=label,
         )
         if retry[0] == 0:
-            retried = self._parse_decision(retry[1], markdown=stage_markdown)
+            retried = self._parse_decision(retry[1], markdown=markdown)
             if not self._is_unreadable(retried):
                 return retried
 
-        return self._unreadable_verdict(stdout_text)
+        if on_unreadable is not None and self.unattended:
+            return on_unreadable(raw_response)
+        return self._unreadable_verdict(raw_response)
 
     @staticmethod
     def _is_unreadable(decision: ReviewDecision) -> bool:

--- a/src/artifact_index.py
+++ b/src/artifact_index.py
@@ -76,6 +76,34 @@ class ArtifactIndex:
         )
 
 
+def is_autor_own_record(paths: RunPaths, path: Path) -> bool:
+    """Whether a workspace file is AutoR's own bookkeeping rather than research output.
+
+    One rule with two readers. `write_experiment_manifest` runs on the way *into*
+    every stage from 05 on — `information_flow` declares the manifest as an inbound
+    channel — so it is rewritten inside the stage's own execution window on every
+    run. Counted as output, a Stage 05 that produced literally nothing scored a third
+    of `artifact_breadth` off a file whose own body reads `result_artifact_count: 0`.
+    At Stages 03 and 04 it was worse than wrong, it was *noisy*: the manifest write
+    and the next stage's start marker land in the same clock tick often enough to
+    make the score flicker on byte-identical inputs.
+
+    `src.rubric` and this module both had to know the rule and only this one did.
+    `RECORD_ARTIFACTS` is the list `experiment_manifest` already keeps of the files
+    it excludes from its own result set, so there is no third spelling.
+    """
+    from .experiment_manifest import RECORD_ARTIFACTS
+
+    if path.name.endswith(".schema.json"):
+        return True
+    try:
+        relative = path.relative_to(paths.workspace_root).as_posix()
+    except ValueError:
+        return False
+    return relative in RECORD_ARTIFACTS
+
+
+
 def write_artifact_index(paths: RunPaths) -> ArtifactIndex:
     artifacts = _scan_artifacts(paths)
     counts_by_category = {
@@ -160,9 +188,7 @@ def _scan_artifacts(paths: RunPaths) -> list[ArtifactRecord]:
         for path in sorted(directory.rglob("*")):
             if not path.is_file() or path.suffix.lower() not in suffixes:
                 continue
-            if path.name.endswith(".schema.json"):
-                continue
-            if category == "results" and path.name == "experiment_manifest.json":
+            if is_autor_own_record(paths, path):
                 continue
             stat = path.stat()
             records.append(

--- a/src/manager.py
+++ b/src/manager.py
@@ -476,6 +476,20 @@ class ResearchManager:
         # stopped survives into this one, and the run that recovers from a halt is
         # reported as the run that halted.
         state.halted_because, state.halted_kind = "", ""
+
+        # A resume that starts somewhere other than where the last closed visit said
+        # the run was going is an operator overruling that move. It was made off the
+        # router with no choice set, so it is not an edge observation — the same rule
+        # as `/back` and a round's own jump.
+        #
+        # Without this the archive learns a move the run did not make. Measured after
+        # `--final-stage 06` then a plain resume: the record claims
+        # `06_analysis->finish` *and* a route reading `06 -> 07 -> 08`, while the
+        # advance into Stage 07 is missing entirely. One row, two contradictory
+        # claims, and `EdgePayoff.believable` counts both.
+        if state.path and state.path[-1].chose and state.path[-1].chose != entry.slug:
+            state.path[-1].bypassed = True
+            save_graph_state(paths, state)
         stage: StageSpec | None = entry
 
         while stage is not None:
@@ -564,10 +578,10 @@ class ResearchManager:
         last = state.path[-1]
         if last.chose != GRAPH_FINISH or not last.closed_round:
             return None
-        final = latest_round(paths)
-        if final is not None and final.number == last.closed_round and final.decision == "abandon":
-            return final
-        return None
+        # Same widening as the graph guard: a later `converged` round does not erase
+        # an abandonment, it launders one. `unreopened_abandonment` is the reader
+        # that knows the difference, because overruling has its own spelling.
+        return unreopened_abandonment(paths)
 
     def _complete_run(self, paths: RunPaths, state: "GraphState | None" = None) -> bool:
         route = format_route(state) if state is not None else ""
@@ -964,15 +978,40 @@ class ResearchManager:
         )
 
     def _settle_effort(
-        self, paths: RunPaths, stage: StageSpec, attempt_no: int, stage_markdown: str
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        stage_markdown: str,
+        polish_rounds: int = 0,
     ) -> None:
-        """Record what this stage cost, and let it set the next stage's tier."""
+        """Record what this stage cost, and let it set the next stage's tier.
+
+        Two corrections to what the raw attempt number says, both because a polish
+        round is not a contest on this code's own terms: it happens before
+        `mark_stage_human_review_manifest` and before `_collect_review_decision`, so
+        it never reaches the gate at all.
+
+        Charged as one, the ledger contradicted itself inside a single artifact —
+        `failures: 0` beside `contested: true` for the same stage, and `attempts: 3`
+        where the manifest said `1`. Measured on shipped defaults, four of eight
+        stages. And because polish is tier-independent, routine stages recorded it
+        too, so it destroyed the measure rather than biasing it:
+        `deliberative_but_uncontested` needs `attempts == 1 and not contested`, which
+        under defaults could only fire for a stage evolution declined to polish.
+        """
         try:
             self.effort_plan.note_outcome(
                 stage,
-                attempts=attempt_no,
-                # Uncontested means it cleared its gate without anyone asking for a change.
-                contested=attempt_no > 1,
+                # The same subtraction the manifest already gets.
+                attempts=max(attempt_no - polish_rounds, 1),
+                # Uncontested means it cleared its gate without anyone asking for a
+                # change. Read off the failures the gate actually recorded rather
+                # than off an attempt counter that also counts work nobody asked for.
+                # `_note_effort_failure` runs before any approval, so this is settled
+                # by the time we get here — and it is right on a second visit too,
+                # where the attempt number is run-wide.
+                contested=self.effort_plan.decision_for(stage).failures > 0,
             )
             following = self._stage_after(stage)
             declaration = parse_declaration(stage_markdown)
@@ -2305,7 +2344,9 @@ class ResearchManager:
                     self._stage_file_paths(stage_markdown),
                 )
                 if self.effort_plan.enabled:
-                    self._settle_effort(paths, stage, attempt_no, stage_markdown)
+                    self._settle_effort(
+                        paths, stage, attempt_no, stage_markdown, polish_rounds=polish_rounds
+                    )
                 if stage.slug == "02_hypothesis_generation":
                     self._measure_pool_adoption(paths, stage, stage_markdown)
                 if stage.slug == "04_implementation":

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -511,6 +511,7 @@ class ReviewPanel:
         stage_timeout: int = 14400,
         persona_text: str = "",
         deliberation_rounds: int = 2,
+        unattended: bool = False,
     ) -> None:
         if not roles:
             raise ValueError("A review panel needs at least one role.")
@@ -521,6 +522,12 @@ class ReviewPanel:
         self.ui = ui or TerminalUI()
         self.persona_text = persona_text.strip()
         self.deliberation_rounds = max(1, deliberation_rounds)
+        # Passed down, and it was not. `create_reviewer` takes `unattended` and the
+        # panel branch discarded it, so every seat was built attended — while
+        # `--review-panel` alone makes `resolve_unattended` true and puts the manager
+        # in unattended mode. The gate was holding reviewers configured for a human
+        # who was not there.
+        self.unattended = unattended
         self._members: dict[str, AutomatedReviewer] = {
             role.key: AutomatedReviewer(
                 role.backend or backend_name,
@@ -528,6 +535,7 @@ class ReviewPanel:
                 fake_mode=fake_mode,
                 ui=self.ui,
                 stage_timeout=stage_timeout,
+                unattended=unattended,
             )
             for role in roles
         }
@@ -641,6 +649,9 @@ class ReviewPanel:
             self._calls += 1
             verdicts.append(
                 self._verdict_from_output(
+                    paths=paths,
+                    stage=stage,
+                    attempt_no=attempt_no,
                     role=role,
                     stage_markdown=stage_markdown,
                     member=member,
@@ -654,6 +665,9 @@ class ReviewPanel:
     def _verdict_from_output(
         self,
         *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
         role: PanelRole,
         stage_markdown: str = "",
         member: AutomatedReviewer,
@@ -691,7 +705,14 @@ class ReviewPanel:
                 abstained=True,
             )
 
-        decision = member.parse_decision(stdout_text, markdown=stage_markdown)
+        decision = member.parse_with_retry(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            raw_response=stdout_text,
+            markdown=stage_markdown,
+            label=f"panel_{role.key}_verdict",
+        )
         blocking = bool(payload.get("blocking")) if isinstance(payload, dict) else False
         concerns: tuple[str, ...] = ()
         if isinstance(payload, dict) and isinstance(payload.get("concerns"), list):
@@ -780,7 +801,25 @@ class ReviewPanel:
                 reason=f"Panel chair could not be reached (exit code {exit_code}); "
                 "falling back to the panel's own objections.",
             )
-        return chair.parse_decision(stdout_text, markdown=stage_markdown)
+        # Through the same read-retry-fall-back path a solo reviewer uses. A bare
+        # parse here meant one unparseable synthesis cancelled the run, while an
+        # *unreachable* chair fell back to the panel's own objections — the softer
+        # failure got the harsher outcome, and the panel already encodes the rule it
+        # was breaking: `_round` marks an unreadable seat non-blocking precisely so
+        # one bad answer cannot veto.
+        return chair.parse_with_retry(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            raw_response=stdout_text,
+            markdown=stage_markdown,
+            label="panel_chair_verdict",
+            on_unreadable=lambda _raw: self._decision_from_dissent(
+                verdicts,
+                reason="The panel chair's verdict could not be read; falling back to the "
+                "panel's own objections.",
+            ),
+        )
 
     def _enforce_blocking_objections(self, deliberation: PanelDeliberation) -> ReviewDecision:
         """Refuse approval while a blocking objection stands.

--- a/src/rubric.py
+++ b/src/rubric.py
@@ -43,6 +43,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from .artifact_index import is_autor_own_record
 from .utils import (
     FIGURE_SUFFIXES,
     MACHINE_DATA_SUFFIXES,
@@ -62,7 +63,11 @@ from .utils import (
 #: changed. Scores carrying different versions are not comparable, and every
 #: consumer that ranks two scores has to refuse to rank across a version change:
 #: a reweight would otherwise read as a run that got better or worse overnight.
-RUBRIC_VERSION = "1"
+#: ``2`` excludes AutoR's own record files from ``artifact_breadth``. A v1 score and
+#: a v2 score are not two measurements of one thing, and every consumer refuses to
+#: rank across the change rather than quietly treating the correction as a run
+#: having got worse.
+RUBRIC_VERSION = "2"
 
 #: The keys the rubric refuses to read out of an adjudication artifact.
 #:
@@ -448,6 +453,11 @@ def _fresh_artifact_kinds(
         for directory in directories:
             for path in _existing_files(directory):
                 if path.suffix.lower() not in allowed:
+                    continue
+                # AutoR's own bookkeeping is not the stage's output. Per-file rather
+                # than by pruning the directory, because `artifact_dirs` are
+                # operator-declared and may point anywhere.
+                if is_autor_own_record(paths, path):
                     continue
                 try:
                     stat = path.stat()

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -207,7 +207,7 @@ def _guard_round_abandoned(paths: RunPaths, state: "GraphState") -> GuardResult:
     indistinguishable from a crash. The most scientifically honest outcome a run can
     reach was its most expensive and its worst-labelled.
     """
-    from .research_rounds import latest_round
+    from .research_rounds import unreopened_abandonment
 
     # Scoped to *this visit*, not to the run.
     #
@@ -229,13 +229,25 @@ def _guard_round_abandoned(paths: RunPaths, state: "GraphState") -> GuardResult:
     if not closed:
         return GuardResult(False, "this visit closed no research round")
 
-    final = latest_round(paths)
-    if final is not None and final.number == closed and final.decision == "abandon":
+    # The *ledger* question is "does an abandonment still stand", not "was the last
+    # round an abandonment". Asking the narrower one let the rollback the tool itself
+    # recommends launder it: abandon at round 1, `--resume-run --rollback-stage 03`,
+    # round 2 closes `converged`, and the terminal shuts because round 2 is not an
+    # abandonment. Measured: Stage 07 then burned 10 operator calls against a gate
+    # refusing it 20 times, and the run produced nothing.
+    #
+    # The *visit* gate stays. It exists so a visit that closed no round cannot be
+    # governed by the ledger at all; it was never meant to let a closing visit
+    # overrule a standing abandonment silently. Overruling one is legitimate and has
+    # its own spelling — `reopens_round` — which this reader honours.
+    standing = unreopened_abandonment(paths)
+    if standing is not None:
         return GuardResult(
             True,
-            f"round {final.number} concluded the question cannot be answered: {final.rationale}",
+            f"round {standing.number} concluded the question cannot be answered: "
+            f"{standing.rationale}",
         )
-    return GuardResult(False, f"round {closed} did not conclude `abandon`")
+    return GuardResult(False, "no abandonment stands")
 
 
 def _guard_has_hypotheses(paths: RunPaths, state: "GraphState") -> GuardResult:

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -235,6 +235,40 @@ class ManagerIntegrationTests(unittest.TestCase):
         manager.effort_plan = EffortPlan(enabled=enabled)
         return manager, paths
 
+    def test_a_polish_round_is_not_a_contest(self) -> None:
+        """The ledger contradicted itself inside one artifact.
+
+        `EvolutionConfig.rounds` defaults to 2 and polish rounds increment
+        `attempt_no`, which `_settle_effort` passed straight through — so
+        `effort.json` recorded `failures: 0` beside `contested: true` for the same
+        stage, and `attempts: 3` where the manifest said `1`. Four of eight stages on
+        shipped defaults.
+
+        A polish round is not a contest on this code's own terms: the `continue` that
+        starts one happens before `mark_stage_human_review_manifest` and before
+        `_collect_review_decision`, so it never reaches the gate at all. And because
+        polish is tier-independent it hit routine stages too, which destroyed the
+        measure rather than biasing it — `deliberative_but_uncontested` needs
+        `attempts == 1 and not contested`, so under defaults it could only ever fire
+        for a stage evolution declined to polish.
+        """
+        manager, _paths = self._manager_and_paths()
+        manager._settle_effort(_paths, STAGE_04, attempt_no=3, stage_markdown="", polish_rounds=2)
+
+        decision = manager.effort_plan.decision_for(STAGE_04)
+        self.assertEqual(decision.attempts, 1)
+        self.assertFalse(decision.contested)
+
+    def test_a_stage_that_failed_its_gate_is_still_contested(self) -> None:
+        """The control. `contested` now comes from the failures the gate recorded, so
+        a real refusal has to survive the change."""
+        manager, _paths = self._manager_and_paths()
+        manager.effort_plan.note_failure(STAGE_04)
+        manager._settle_effort(_paths, STAGE_04, attempt_no=3, stage_markdown="", polish_rounds=2)
+
+        decision = manager.effort_plan.decision_for(STAGE_04)
+        self.assertTrue(decision.contested)
+
     def test_a_routine_stage_prompt_is_told_it_is_routine(self) -> None:
         manager, paths = self._manager_and_paths()
         prompt = manager._build_stage_prompt(paths, STAGE_04, None, False)

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -20,9 +20,16 @@ from unittest.mock import patch
 from src.evolution import EvolutionConfig
 from src.manager import ResearchManager
 from src.manifest import load_run_manifest
-from src.router import RoutingDecision
+from src.router import RoutingDecision, routing_summary
 from src.rubric import score_stage
-from src.stage_graph import FINISH, GUARDS, GraphState, StageGraph, load_graph_state
+from src.stage_graph import (
+    FINISH,
+    GUARDS,
+    GraphState,
+    StageGraph,
+    load_graph_state,
+    save_graph_state,
+)
 from src.utils import STAGES, build_run_paths, load_run_config, read_text, write_text
 from tests.test_manager_smoke import REPO_ROOT, ScriptedSmokeOperator
 
@@ -360,6 +367,121 @@ class GraphWalkTests(unittest.TestCase):
         self.assertTrue(resumed.resume_run(paths.run_root))
         self.assertEqual(load_run_manifest(paths.run_manifest).run_status, "completed")
 
+    def test_a_standing_abandonment_is_not_laundered_by_a_rollback_resume(self) -> None:
+        """The rollback the tool itself recommends was the way around the terminal.
+
+        A bare resume of an abandoned run prints "To continue anyway, roll back
+        explicitly, or record a round that reopens it." Take the first suggestion:
+        `--rollback-stage 03`, round 2 closes `converged`, and the guard shut because
+        round 2 was not an abandonment. Measured: Stage 07 burned 10 operator calls
+        against a gate refusing it 20 times, and the run produced nothing.
+
+        The ledger question is "does an abandonment still stand", not "was the last
+        round one". The visit gate stays — it stops a visit that closed nothing being
+        governed by the ledger at all — and the companion below is what holds it.
+        """
+        _operator, manager = self.build()
+        self._abandon_at_analysis(manager)
+        self.drive(manager)
+        paths = self.only_run()
+        self.assertEqual(load_run_manifest(paths.run_manifest).run_status, "abandoned")
+
+        operator, resumed = self.build()
+        self._declare_at_analysis(resumed, "converged")
+        stage_03 = next(stage for stage in STAGES if stage.number == 3)
+        self.drive_resume(resumed, paths.run_root, rollback_stage=stage_03)
+
+        self.assertEqual(operator.invocations.get("07_writing", 0), 0)
+        self.assertEqual(operator.invocations.get("08_dissemination", 0), 0)
+        # The Stage-07 refusal specifically. The log legitimately records the round's
+        # own decision; what must be absent is the gate rejecting a write-up 20 times.
+        self.assertNotIn("cannot run: round", read_text(paths.logs))
+        self.assertEqual(load_run_manifest(paths.run_manifest).run_status, "abandoned")
+
+    def test_a_round_that_says_it_reopens_the_abandonment_may_continue(self) -> None:
+        """The companion, so the fix cannot be satisfied by nailing the terminal shut.
+
+        Overruling an abandonment is legitimate. It has a spelling, and a round that
+        uses it gets through to writing.
+        """
+        _operator, manager = self.build()
+        self._abandon_at_analysis(manager)
+        self.drive(manager)
+        paths = self.only_run()
+
+        operator, resumed = self.build()
+        self._declare_at_analysis(resumed, "converged", reopens_round=1)
+        stage_03 = next(stage for stage in STAGES if stage.number == 3)
+        self.drive_resume(resumed, paths.run_root, rollback_stage=stage_03)
+
+        self.assertGreater(operator.invocations.get("07_writing", 0), 0)
+        self.assertEqual(load_run_manifest(paths.run_manifest).run_status, "completed")
+
+    def test_a_resume_that_starts_elsewhere_does_not_archive_the_move_it_overruled(self) -> None:
+        """The halted walk closed Stage 06 with `chose='finish'`. The resume starts at
+        Stage 07 and never re-enters 06, so that visit is never reconciled — and the
+        archived row claimed `06_analysis->finish` while its own route read
+        `06 -> 07 -> 08`. One record, two contradictory claims, and the real advance
+        into Stage 07 missing entirely.
+        """
+        stage_06 = next(stage for stage in STAGES if stage.number == 6)
+        _operator, manager = self.build()
+        self.assertTrue(self.drive(manager, final_stage=stage_06))
+        paths = self.only_run()
+        self.assertIn("06_analysis->finish", routing_summary(paths)["edges"])
+
+        _op2, resumed = self.build()
+        self.drive_resume(resumed, paths.run_root)
+
+        summary = routing_summary(paths)
+        self.assertNotIn("06_analysis->finish", summary["edges"])
+        self.assertIn("07_writing->08_dissemination", summary["edges"])
+        self.assertEqual(summary["bypassed"], 1)
+        self.assertIn("07_writing", summary["route"])
+
+    def test_a_resume_that_continues_where_it_was_heading_keeps_its_edge(self) -> None:
+        """The control for the `!= entry.slug` half.
+
+        Dropping that condition would mark *every* resumed run's last move bypassed,
+        including one that simply picked up where it left off, and quietly delete a
+        traversal the run genuinely made. Staged directly rather than through a real
+        interruption, because the two natural ways to stop a walk — a budget halt and
+        an abort — both leave a last visit that was not heading to the entry stage.
+        """
+        _operator, manager = self.build(graph_max_steps=4)
+        self.drive(manager)
+        paths = self.only_run()
+
+        # Rewrite the halt as "it was on its way to Stage 05 and stopped", which is
+        # what an interruption between stages looks like.
+        state = load_graph_state(paths)
+        state.path[-1].chose = STAGE_05.slug
+        state.path[-1].kind = "advance"
+        save_graph_state(paths, state)
+        before = dict(routing_summary(paths)["edges"])
+        self.assertIn("04_implementation->05_experimentation", before)
+
+        _op2, resumed = self.build(graph_max_steps=40)
+        self.drive_resume(resumed, paths.run_root)
+
+        after = routing_summary(paths)["edges"]
+        self.assertIn("04_implementation->05_experimentation", after)
+        self.assertEqual(routing_summary(paths)["bypassed"], 0)
+
+    def test_an_unfinished_visit_is_left_alone(self) -> None:
+        """A visit with no recorded move was never a traversal, so there is nothing to
+        reconcile and nothing to mark. An abort leaves one."""
+        _operator, manager = self.build()
+        self.drive(manager)
+        paths = self.only_run()
+        state = load_graph_state(paths)
+        state.path[-1].chose = ""
+        save_graph_state(paths, state)
+
+        _op2, resumed = self.build()
+        self.drive_resume(resumed, paths.run_root)
+        self.assertEqual(routing_summary(paths)["bypassed"], 0)
+
     # -- the checks have to be satisfiable -----------------------------------
 
     def test_every_guard_passes_on_a_completed_run(self) -> None:
@@ -423,6 +545,35 @@ class GraphWalkTests(unittest.TestCase):
         self.assertEqual(
             shortfalls, {}, msg=f"validity-chain checks unsatisfiable by a completed run: {shortfalls}"
         )
+
+    def _declare_at_analysis(self, manager, decision: str, **extra) -> None:
+        """Make Stage 06 close its round with `decision`."""
+        original = manager.operator.run_stage
+
+        def run_stage(stage, prompt, run_paths, attempt_no, continue_session=False):
+            result = original(stage, prompt, run_paths, attempt_no, continue_session)
+            if stage.number == 6:
+                payload = {
+                    "decision": decision,
+                    "rationale": "The second design separates the effect cleanly enough.",
+                    "what_we_learned": "Tuning on a development split removes the confound.",
+                    "what_changes_next": "",
+                    "negative_result": True,
+                }
+                payload.update(extra)
+                write_text(run_paths.round_decision, json.dumps(payload))
+            return result
+
+        manager.operator.run_stage = run_stage
+
+    def drive_resume(self, manager: ResearchManager, run_root, **kwargs) -> bool:
+        stack = ExitStack()
+        stack.enter_context(patch.object(manager.ui, "choose_intake_clarification_answer", return_value=None))
+        stack.enter_context(patch.object(manager.ui, "read_optional_multiline_feedback", return_value=None))
+        stack.enter_context(patch.object(manager.ui, "choose_intake_final_action", return_value="5"))
+        stack.enter_context(patch.object(manager, "_ask_choice", return_value="5"))
+        with stack:
+            return manager.resume_run(run_root, **kwargs)
 
     # -- abandonment is an outcome, not a failure ----------------------------
 

--- a/tests/test_review_panel.py
+++ b/tests/test_review_panel.py
@@ -96,7 +96,9 @@ class _ScriptedPanel:
         member_run = chair_member.run_prompt
 
         def chair_aware_run(*, paths, stage, attempt_no, prompt, label):
-            if label == "panel_chair":
+            # `panel_chair_verdict` is the chair's verdict-only re-ask, so it draws
+            # from the chair's script rather than a seat's.
+            if label.startswith("panel_chair"):
                 self.calls.append(("__chair__", label))
                 if not chair_queue:
                     raise AssertionError("No scripted chair response left")
@@ -547,6 +549,74 @@ class DropInContractTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class UnreadableChairTests(unittest.TestCase):
+    """One unparseable synthesis must not cancel the run.
+
+    `#147` gave the solo reviewer a verdict-only re-ask and, unattended, a
+    send-back-for-another-pass instead of an abort. The panel bypassed both: the
+    chair's reply went through a bare `parse_decision`, so an unreadable synthesis
+    aborted — `run_status: cancelled`, Stage 01 stuck in review — where the solo
+    reviewer on the identical reply continues.
+
+    Two things rule out intent. `_round` already marks an unreadable *seat*
+    non-blocking, so the panel encodes the rule the chair path was breaking. And an
+    *unreachable* chair falls back to the panel's own objections, so the softer
+    failure got the harsher outcome.
+    """
+
+    def _panel(self, *, unattended: bool):
+        """Readable, split seats; only the chair's synthesis is prose.
+
+        Split so a second round and a chair synthesis both happen, and so the
+        fallback has real objections to fall back *to* — the point is that the seats'
+        actual complaints survive rather than being replaced by a generic re-run
+        request.
+        """
+        script = {
+            "pi": [_verdict_json("approve"), _verdict_json("approve")],
+            "domain": [_verdict_json("approve"), _verdict_json("approve")],
+            "method": [
+                _verdict_json("custom_feedback", feedback="Add a competent baseline."),
+                _verdict_json("custom_feedback", feedback="Add a competent baseline."),
+            ],
+            "repro": [_verdict_json("approve"), _verdict_json("approve")],
+            "skeptic": [_verdict_json("approve"), _verdict_json("approve")],
+            "__chair__": [
+                "I have read the draft and I have some thoughts about it.",
+                "Still prose, I am afraid.",
+            ],
+        }
+        return _ScriptedPanel(self, script, unattended=unattended)
+
+    def test_unattended_an_unreadable_chair_falls_back_to_the_panel_s_objections(self) -> None:
+        harness = self._panel(unattended=True)
+        decision = harness.review()
+
+        self.assertNotEqual(decision.decision_token, "abort")
+        self.assertEqual(decision.choice, "4")
+        self.assertIn("panel", decision.reason.lower())
+        # The verdict-only re-ask happened, and got its own prompt_cache label.
+        self.assertIn(
+            "panel_chair_verdict", [label for _key, label in harness.calls]
+        )
+
+    def test_attended_an_unreadable_chair_still_aborts(self) -> None:
+        """The control against an over-broad fix. With a human there, guessing at a
+        verdict is the one thing the approval gate exists to prevent."""
+        harness = self._panel(unattended=False)
+        self.assertEqual(harness.review().decision_token, "abort")
+
+    def test_the_seats_are_built_with_the_panel_s_own_unattended_setting(self) -> None:
+        """`create_reviewer` takes `unattended` and the panel branch discarded it, so
+        every seat was attended — while `--review-panel` alone puts the manager in
+        unattended mode."""
+        panel = ReviewPanel(DEFAULT_PANEL, backend_name="claude", model="sonnet", unattended=True)
+        self.assertTrue(all(member.unattended for member in panel._members.values()))
+
+        attended = ReviewPanel(DEFAULT_PANEL, backend_name="claude", model="sonnet")
+        self.assertFalse(any(member.unattended for member in attended._members.values()))
 
 
 class PanelEffectTests(unittest.TestCase):

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -23,7 +24,14 @@ from src.rubric import (
     score_stage,
     verdict_digest,
 )
-from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_layout,
+    mark_stage_execution_started,
+    read_text,
+    write_text,
+)
 from tests import prereg_support
 
 
@@ -249,6 +257,42 @@ class RubricTestCase(unittest.TestCase):
             ),
         )
         self.assertLess(planned.by_key["commitment"].score, done.by_key["commitment"].score)
+
+    def test_autors_own_bookkeeping_is_not_the_stages_output(self) -> None:
+        """`write_experiment_manifest` runs on the way *into* every stage from 05 on —
+        `information_flow` declares the manifest as an inbound channel — so it is
+        rewritten inside the stage's own execution window on every run. Counted as
+        output, a Stage 05 that produced literally nothing scored a third of
+        `artifact_breadth` off a file whose own body reads `result_artifact_count: 0`.
+
+        `_score_reproducibility` already read the same file's empty `result_artifacts`
+        and penalised the stage for it, so the rubric was crediting and debiting one
+        artifact at once.
+        """
+        from src.experiment_manifest import write_experiment_manifest
+
+        mark_stage_execution_started(self.paths, STAGE_05)
+        time.sleep(0.02)
+        write_experiment_manifest(self.paths)
+
+        manifest = json.loads(read_text(self.paths.experiment_manifest))
+        self.assertEqual(manifest.get("result_artifacts"), [])
+        score = score_stage(paths=self.paths, stage=STAGE_05, markdown=stage_markdown(STAGE_05))
+        self.assertEqual(score.by_key["artifact_breadth"].score, 0.0)
+
+    def test_a_real_result_beside_the_bookkeeping_still_counts(self) -> None:
+        """The control, so the exclusion cannot over-broaden into dropping output."""
+        from src.experiment_manifest import write_experiment_manifest
+
+        mark_stage_execution_started(self.paths, STAGE_05)
+        time.sleep(0.02)
+        write_experiment_manifest(self.paths)
+        write_text(
+            self.paths.results_dir / "metrics.json",
+            json.dumps({"baseline": 0.58, "treatment": 0.74, "seeds": [1, 2, 3, 4, 5]}),
+        )
+        score = score_stage(paths=self.paths, stage=STAGE_05, markdown=stage_markdown(STAGE_05))
+        self.assertGreater(score.by_key["artifact_breadth"].score, 0.0)
 
     # -- structure -----------------------------------------------------------
 


### PR DESCRIPTION
The five remaining findings from the interaction hunt in #150. Each verified by running the harness before being touched, and each mutation-checked after: **removing any one of the five fails exactly one test.**

## 1. A standing abandonment survived the rollback the tool itself recommends

A bare resume of an abandoned run prints *"To continue anyway, roll back explicitly, or record a round that reopens it."* Take the first suggestion:

```
--rollback-stage 03  →  round 2 closes `converged`
                     →  the terminal shuts (round 2 is not an abandonment)
                     →  Stage 07: 10 operator calls, 20 refusals logged, nothing produced
```

The ledger question is *"does an abandonment still stand"*, not *"was the last round one"*. Both readers now ask `unreopened_abandonment`.

The **visit gate stays** — it exists so a visit that closed no round cannot be governed by the ledger at all. A companion test asserts a round declaring `reopens_round: 1` still reaches writing, so the fix cannot be satisfied by nailing the terminal shut.

## 2. Resuming past `--final-stage` archived a move the run did not make

The halted walk closed Stage 06 with `chose='finish'`. The resume starts at 07 and never re-enters 06, so the archived row claimed `06_analysis->finish` while its own route read `06 → 07 → 08` — and the real advance into Stage 07 was missing entirely. One record, two contradictory claims, and `EdgePayoff.believable` counts both.

A resume that starts somewhere other than where the last closed visit was heading is an operator overruling that move: off the router, no choice set, so it is marked `bypassed` — the same rule as `/back`.

The control is staged directly rather than end-to-end, because both natural ways to stop a walk (budget halt, abort) leave a last visit that was *not* heading to the entry stage, so an end-to-end control would pass with the condition removed.

## 3. `--effort-tiers` charged polish rounds as contests

`effort.json` recorded `failures: 0` beside `contested: true` for the same stage, and `attempts: 3` where the manifest said `1` — **four of eight stages on shipped defaults**.

A polish round is not a contest on this code's own terms: it happens before `mark_stage_human_review_manifest` and before `_collect_review_decision`, so it never reaches the gate. Attempts get the subtraction the manifest already gets; `contested` now comes from the failures the gate recorded.

Because polish is tier-independent it hit routine stages too, so this **destroyed the measure rather than biasing it**: `deliberative_but_uncontested` went 1 → 5 on an otherwise identical run.

## 4. `artifact_breadth` counted AutoR's own bookkeeping as output

`write_experiment_manifest` runs on the way **into** every stage from 05 on — `information_flow` declares it as an inbound channel — so it is rewritten inside the stage's own execution window every run.

```
Stage 05, produced nothing:  artifact_breadth = 0.3333
  "1 artifact kind(s) written during this stage (results)"
  manifest body:  result_artifact_count: 0
```

Meanwhile `_score_reproducibility` read the same empty `result_artifacts` and *penalised* the stage. The rubric was crediting and debiting one file at once.

One rule now, shared with `artifact_index`, keyed off the `RECORD_ARTIFACTS` list `experiment_manifest` already keeps. Verified a real result still counts (0 → 0.33 → 1.0 as data, code and a figure appear).

This changes measurement, so **`RUBRIC_VERSION` goes to 2** rather than letting old archive rows silently compare across the correction.

## 5. `--review-panel` dropped #147's unattended unreadable-verdict fallback

One unparseable chair synthesis cancelled the whole run — `run_status: cancelled`, Stage 01 stuck in review — where the solo reviewer on the identical reply retries and continues.

`ReviewPanel.__init__` had **no `unattended` parameter at all**, so `create_reviewer(unattended=...)` discarded it on the panel branch — while `--review-panel` alone makes `resolve_unattended` true, leaving the manager in unattended mode holding reviewers built attended.

The retry-and-fall-back tail is factored out of `review_stage` into `parse_with_retry` and used by the chair and by each seat. Unattended, the chair falls back to the panel's own objections, which is more informative than a generic re-run request and is what an *unreachable* chair already did.

Two things ruled out intent: `_round` already marks an unreadable **seat** non-blocking, so the panel encodes the rule the chair path was breaking; and the softer failure was getting the harsher outcome. `rcb_agent.py` is wired `unattended=True` — it is unattended by construction, and `docs/review-panel.md` documents `rcb_agent.py --review-panel`, which is the exact context #147 was found in.

## Mutation check

| Fix reverted | Tests that die |
| --- | --- |
| ledger question widened | `test_a_standing_abandonment_is_not_laundered_by_a_rollback_resume` |
| resume reconciliation | `test_a_resume_that_starts_elsewhere_does_not_archive_the_move_it_overruled` |
| effort attempt/contested | `test_a_polish_round_is_not_a_contest` |
| bookkeeping exclusion | `test_autors_own_bookkeeping_is_not_the_stages_output` |
| chair parse retry | `test_unattended_an_unreadable_chair_falls_back_to_the_panel_s_objections` |

## Testing

1356 pass (from 1344). Every fix has a control alongside it: `reopens_round` still gets through, a resume that continues where it was heading keeps its edge, a genuinely failed gate is still contested, a real result still counts, and an attended panel still aborts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)