### PR TITLE
Collapse four switches into one dial

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Useful feature | **Anchored review comments** | A reviewer can quote the passage it objects to instead of refusing the whole stage. The revision is told to change only those spans, and is then diffed against them — so "preserve the correct parts" is measured rather than hoped for. |
 | Useful feature | **Selective deep thinking** | Most steps are execution. With `--deliberation` a stage that hits a genuine crux can stop, name the question, and pull in a panel of theorist / empiricist / critic / pragmatist plus an expert brief — then carry on with an answer that names its own falsifier. Budgeted, and measured against what the agent already believed. |
 | Useful feature | **Effort tiers** | `--effort-tiers` runs each stage as routine or deliberative rather than treating them alike — a lean prompt and a single reviewer where the decisions are already made, the full apparatus where something is genuinely undecided. Each stage sets the next one's tier, and a routine stage that keeps failing is promoted automatically. Polish rounds and the strong model are then concentrated on the deliberative steps rather than spread evenly. |
+| Useful feature | **One dial** | `--rigor {fast,standard,thorough,max}` decides how much optional machinery a run uses, ordered by what each costs and what evidence there is for it. Individual switches remain as overrides in both directions. |
 | Useful feature | **Run scorecard** | Every optional feature measures itself; at the end of a run `workspace/reviews/scorecard.md` reads all of those ledgers together and says which ones earned their cost and which flags to turn off — keeping "could not be measured" separate from "changed nothing". |
 | Useful feature | **Two output formats** | Stage 07 writes a benchmark-ready markdown report (`report/report.md` + PNG figures) by default, or a venue-aware LaTeX paper package with a compiled PDF via `--output-format latex`. |
 
@@ -336,15 +337,12 @@ scope. "Make each one refutable" is advice about a gate that now exists.
 | Start with preloaded resources | `python main.py --goal "Your research goal here" --resources paper.pdf refs.bib data.csv` |
 | Run a local smoke test without a real agent backend | `python main.py --fake-operator --goal "Smoke test"` |
 | Run with the automated reviewer gate | `python main.py --full-auto --goal "Your research goal here"` |
-| Replace the single reviewer with a deliberating panel | `python main.py --review-panel --goal "..."` |
+| Choose how much optional machinery to run | `python main.py --rigor thorough --goal "..."` |
 | Give the panel a researcher persona to stand in for | `python main.py --review-panel --persona docs/persona-example.md --goal "..."` |
 | Seat the panel across different models | `python main.py --review-panel --panel-models pi=opus skeptic=codex:default --goal "..."` |
-| Widen Stage 02's hypotheses with a proposer panel | `python main.py --ideation-panel --goal "..."` |
-| Let a stage stop and think hard at a crux | `python main.py --deliberation --goal "..."` |
 <<<<<<< HEAD
 | Choose the execution backend and model | `python main.py --operator claude --model opus` or `python main.py --operator codex --model default` |
 =======
-| Spend effort unevenly across the loop | `python main.py --effort-tiers --goal "..."` |
 | Keep the strong model for the steps that matter | `python main.py --effort-tiers --model opus --routine-model sonnet --goal "..."` |
 | Choose the execution backend | `python main.py --operator claude` or `python main.py --operator codex` |
 >>>>>>> dd3d62c (Spend effort where the research needs it, not evenly)

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ detail behind it.
 | Run AutoR unattended, or benchmark it on ResearchClawBench | [ResearchClawBench](researchclawbench.md) |
 | Understand what a run leaves on disk | [Run Artifacts](run-artifacts.md) |
 | Know exactly what a stage must produce to be accepted | [Stage Contract](stage-contract.md) |
+| Choose how much optional machinery a run uses | [Rigor](rigor.md) |
 | Replace the reviewer agent with a panel that argues before it decides | [Review Panel](review-panel.md) |
 | Send back one passage instead of the whole stage | [Anchored Review Comments](stage-comments.md) |
 | Widen Stage 02's hypotheses with a panel that proposes instead of deciding | [Ideation Panel](ideation-panel.md) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -198,6 +198,17 @@ converted to a refinement in code. Each run also writes
 baseline so it can report that it did not earn its cost. Full description, including the
 pre-registered evidence against multi-agent deliberation, in [Review Panel](review-panel.md).
 
+### Rigor
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--rigor {fast,standard,thorough,max}` | `standard` | How much optional machinery to run. One dial in place of four switches. |
+
+`fast` nothing · `standard` effort tiers · `thorough` + crux deliberation and the ideation
+panel · `max` + the review panel. The levels nest, and every individual switch below still
+works as an override in both directions (`--no-ideation-panel`, `--review-panel`). Full
+description in [Rigor](rigor.md).
+
 ### Effort tiers
 
 | Flag | Default | Description |

--- a/docs/rigor.md
+++ b/docs/rigor.md
@@ -1,0 +1,77 @@
+# One dial: `--rigor`
+
+AutoR's optional machinery arrived one feature at a time, and each arrival made the same
+locally correct argument: *this is unproven, so do not impose it — default it off behind its
+own flag.*
+
+Four features later that aggregate was indefensible. You had to know four switches to get any
+of it, and AutoR then wrote you a scorecard whose entire purpose is to say **which of those
+four you should have picked**. An instrument that says "you cannot know this up front" sitting
+behind an interface that demands you know it up front is a contradiction, not a design.
+
+So there is one dial.
+
+```bash
+python main.py --goal "..."                    # standard, the default
+python main.py --rigor fast --goal "..."
+python main.py --rigor thorough --goal "..."
+python main.py --rigor max --goal "..."
+```
+
+| Level | Turns on | Why here |
+| --- | --- | --- |
+| `fast` | nothing optional | What AutoR did before any of this existed. |
+| **`standard`** | effort tiers | The only switch that *lowers* a run's cost, so it costs nothing to default on. |
+| `thorough` | + crux deliberation, ideation panel | Budgeted and one-off respectively. |
+| `max` | + review panel | Bills per *gate* rather than per run, and is the one with direct evidence against it. |
+
+The levels nest: a higher level never turns off something a lower one turned on.
+
+## The ordering is not a taste
+
+It follows the two things that decide whether a feature belongs in a default — what it costs
+per run, and what evidence there is that it helps.
+
+- **Effort tiers** withholds polish rounds from stages whose decisions are already made. It is
+  the only one of the four that makes a run cheaper.
+- **Crux deliberation** is budgeted at three escalations and only fires when a stage says it
+  is stuck.
+- **The ideation panel** is one extra round of proposers, once, at Stage 02.
+- **The review panel** costs 5–11 calls *per gate*, and the pre-registered comparison in
+  [arXiv:2607.14713](https://arxiv.org/abs/2607.14713) found uniform multi-agent deliberation
+  losing to a single pass.
+
+Worth saying plainly: **the feature built first here, and most elaborately, is the one that
+belongs furthest from the default.**
+
+## Individual switches still work
+
+They are escape hatches now, not the interface. Each takes a negative form:
+
+```bash
+python main.py --rigor thorough --no-ideation-panel --goal "..."
+python main.py --rigor fast --review-panel --goal "..."
+```
+
+An explicit flag wins in **both** directions. That is why the switches are declared with
+`BooleanOptionalAction` and no default: a plain `store_true` cannot tell *"off because they
+asked"* from *"off because nobody mentioned it"*, and that difference is the whole reason an
+override can beat a level.
+
+The per-feature knobs — `--panel-roles`, `--ideation-lenses`, `--deliberation-voices`,
+`--panel-models` and friends — are untouched. They were never the problem; needing four
+booleans to get any behaviour at all was.
+
+## Reading the dial back
+
+The chosen level is printed at startup and recorded on the run's
+[scorecard](scorecard.md), so the card can be read against what was asked for:
+
+```
+Run at `--rigor thorough`.
+4 optional feature(s) ran, costing about 58 extra model call(s); 2 changed an
+outcome; 1 changed nothing and can be turned off; 1 could not be measured.
+```
+
+The intended loop is: run at a level, read the card, move the dial. Not: read four docs and
+guess.

--- a/main.py
+++ b/main.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 from src.approval_agent import AutomatedReviewer
 from src.deliberation import DEFAULT_MAX_DELIBERATIONS
+from src.rigor import DEFAULT_LEVEL, LEVELS, describe as describe_rigor
+from src.rigor import help_text as rigor_help_text
+from src.rigor import feature_flags, resolve as resolve_rigor
 from src.effort import EffortPlan
 from src.review_panel import (
     DEFAULT_PANEL,
@@ -141,8 +144,15 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--rigor",
+        choices=list(LEVELS),
+        default=DEFAULT_LEVEL,
+        help=rigor_help_text(),
+    )
+    parser.add_argument(
         "--review-panel",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Replace the single reviewer agent with a deliberating panel of role-differentiated "
              "reviewers (PI, domain expert, methodologist, reproducibility engineer, adversarial "
              "reviewer). They review independently, then cross-examine, then a chair synthesizes "
@@ -168,7 +178,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--effort-tiers",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Run each stage as routine or deliberative rather than treating them alike. A "
              "routine stage gets a lean prompt, a single reviewer, and no escalation offer; a "
              "deliberative one gets everything configured. Each stage declares what the next "
@@ -183,7 +194,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--deliberation",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Let a stage stop and pull in a panel when it hits a genuine crux. The agent "
              "names the question, finishes with its working answer, and a focused panel "
              "resolves it for the next pass. Most steps are execution; this is for the few "
@@ -210,7 +222,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--ideation-panel",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Widen Stage 02's hypotheses with a panel of proposers working from distinct "
              "lenses (mechanism, contrarian, adjacent field, null/artifact, regime). They "
              "propose blind to each other; candidates are deduplicated, scored on novelty, "
@@ -845,6 +858,7 @@ def resolve_search_context(ui: TerminalUI, *, mode: str, operator: str, codex_sa
 def configure_effort(manager, args, *, backend_name: str, model: str, ui: TerminalUI, fake_mode: bool,
                      stage_timeout: int) -> None:
     """Turn on effort tiering, and give routine stages a cheap gate to use."""
+    manager.rigor_level = getattr(args, "rigor", "")
     if not getattr(args, "effort_tiers", False):
         return
     manager.effort_plan = EffortPlan(enabled=True)
@@ -904,6 +918,12 @@ def main() -> int:
     args = parse_args()
     repo_root = Path(__file__).resolve().parent
     runs_dir = repo_root / args.runs_dir
+    resolved_rigor = resolve_rigor(
+        args.rigor, {flag: getattr(args, flag, None) for flag in feature_flags()}
+    )
+    for flag, on in resolved_rigor.items():
+        setattr(args, flag, on)
+
     unattended = resolve_unattended(args)
     persona_text = load_persona(args.persona)
     ui = TerminalUI(interactive=not unattended)
@@ -925,6 +945,7 @@ def main() -> int:
         return 0
 
     ui.show_banner()
+    ui.show_status(describe_rigor(args.rigor, resolved_rigor), level="info")
 
     if args.resume_run:
         start_stage = resolve_stage(args.redo_stage)

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -59,6 +59,9 @@ from src.rcb import (  # noqa: E402
 )
 from src.terminal_ui import TerminalUI  # noqa: E402
 from src.deliberation import DEFAULT_MAX_DELIBERATIONS  # noqa: E402
+from src.rigor import DEFAULT_LEVEL, LEVELS, feature_flags  # noqa: E402
+from src.rigor import help_text as rigor_help_text  # noqa: E402
+from src.rigor import resolve as resolve_rigor  # noqa: E402
 from src.utils import (  # noqa: E402
     DEFAULT_OUTPUT_FORMAT,
     DEFAULT_VENUE,
@@ -160,8 +163,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
              "that can cut a stage short.",
     )
     parser.add_argument(
+        "--rigor",
+        choices=list(LEVELS),
+        default=DEFAULT_LEVEL,
+        help=rigor_help_text(),
+    )
+    parser.add_argument(
         "--review-panel",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Replace the single reviewer agent with a deliberating panel of role-differentiated "
              "reviewers ("
              + ", ".join(role.key for role in DEFAULT_PANEL)
@@ -185,7 +195,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--effort-tiers",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Run each stage as routine or deliberative rather than treating them alike. A "
              "routine stage gets a lean prompt, a single reviewer, and no escalation offer; a "
              "deliberative one gets everything configured. Each stage declares what the next "
@@ -200,7 +211,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--deliberation",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Let a stage stop and pull in a panel when it hits a genuine crux. The agent "
              "names the question, finishes with its working answer, and a focused panel "
              "resolves it for the next pass. Most steps are execution; this is for the few "
@@ -227,7 +239,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--ideation-panel",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=None,
         help="Widen Stage 02's hypotheses with a panel of proposers working from distinct "
              "lenses (mechanism, contrarian, adjacent field, null/artifact, regime). They "
              "propose blind to each other; candidates are deduplicated, scored on novelty, "
@@ -401,6 +414,10 @@ def _run_tree_duration(workspace: Path) -> int | None:
 
 
 def run(args: argparse.Namespace) -> BenchmarkResult:
+    for flag, on in resolve_rigor(
+        args.rigor, {flag: getattr(args, flag, None) for flag in feature_flags()}
+    ).items():
+        setattr(args, flag, on)
     started_at = time.monotonic()
     workspace = Path(args.workspace).expanduser().resolve()
     if not workspace.exists():

--- a/src/manager.py
+++ b/src/manager.py
@@ -246,6 +246,8 @@ class ResearchManager:
         self.ideation_panel: IdeationPanel | None = None
         self.crux_panel: CruxPanel | None = None
         self.effort_plan = EffortPlan(enabled=False)
+        #: The `--rigor` level this run was started with, recorded on the scorecard.
+        self.rigor_level: str = ""
         self.concentration = Concentration()
         #: A cheaper operator for routine stages. The strong model stays for the few steps
         #: whose output the rest of the run inherits.
@@ -905,7 +907,7 @@ class ResearchManager:
         the reason one looks unfinished.
         """
         try:
-            scorecard = write_scorecard(paths)
+            scorecard = write_scorecard(paths, self.rigor_level)
         except Exception as exc:  # noqa: BLE001
             append_log_entry(paths.logs, "scorecard_failed", str(exc))
             return

--- a/src/rigor.py
+++ b/src/rigor.py
@@ -1,0 +1,122 @@
+"""One dial instead of four switches.
+
+The optional machinery arrived one feature at a time, and each arrival made the same locally
+correct argument: this is unproven, so do not impose it — default it off behind its own flag.
+Four features later the aggregate is indefensible. A user had to know four switches to get any
+of it, and AutoR then wrote them a scorecard whose entire purpose is to say *which of those
+four you should have picked*. An instrument that says "you cannot know this up front" sitting
+behind an interface that demands you know it up front is a contradiction, not a design.
+
+So the switches collapse into `--rigor`, and the levels are ordered by the two things that
+actually decide whether a feature belongs in a default: what it costs per run, and what
+evidence there is that it helps.
+
+============  =============================================================
+Level         What it turns on
+============  =============================================================
+``fast``      Nothing optional. What AutoR did before any of this existed.
+``standard``  Effort tiers. **This is the default.**
+``thorough``  ...plus crux deliberation and the ideation panel.
+``max``       ...plus the review panel.
+============  =============================================================
+
+The ordering is not a taste. Effort tiers is the only one of the four that makes a run
+*cheaper* — it withholds polish rounds from stages whose decisions are already made — so
+defaulting it on costs nothing and saves something. Crux deliberation is budgeted and only
+fires when the agent says it is stuck. The ideation panel is one-off. The review panel is last
+because it is both the most expensive (calls per *gate*, not per run) and the one the
+multi-agent feedback literature has direct evidence against.
+
+That last point is worth stating plainly: the feature built first here, and most elaborately,
+is the one that belongs furthest from the default.
+
+Individual flags still work and still win. They are escape hatches now rather than the
+interface: `--rigor thorough --no-ideation-panel` is a sentence someone might actually write,
+where four independent booleans were not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+FAST = "fast"
+STANDARD = "standard"
+THOROUGH = "thorough"
+MAX = "max"
+
+LEVELS = (FAST, STANDARD, THOROUGH, MAX)
+DEFAULT_LEVEL = STANDARD
+
+#: The switches a level owns. Anything absent from a level's set is off at that level.
+#:
+#: Keys are the argparse destinations, so a feature added here without a matching flag would
+#: silently do nothing — :func:`feature_flags` is what keeps the two in step.
+_LEVEL_FEATURES: dict[str, frozenset[str]] = {
+    FAST: frozenset(),
+    STANDARD: frozenset({"effort_tiers"}),
+    THOROUGH: frozenset({"effort_tiers", "deliberation", "ideation_panel"}),
+    MAX: frozenset({"effort_tiers", "deliberation", "ideation_panel", "review_panel"}),
+}
+
+#: Why each feature sits where it does, so `--rigor --help` can say more than a list.
+FEATURE_NOTES: dict[str, str] = {
+    "effort_tiers": "runs settled stages cheaply; the only switch that lowers a run's cost",
+    "deliberation": "budgeted, and only fires when a stage says it is stuck",
+    "ideation_panel": "one extra round of proposers at Stage 02",
+    "review_panel": "calls per gate rather than per run, and the costliest of the four",
+}
+
+
+def feature_flags() -> tuple[str, ...]:
+    """Every switch a level can control, in the order they were introduced."""
+    return ("effort_tiers", "deliberation", "ideation_panel", "review_panel")
+
+
+def normalize_level(value: Any) -> str:
+    if not isinstance(value, str):
+        return DEFAULT_LEVEL
+    lowered = value.strip().lower()
+    return lowered if lowered in LEVELS else DEFAULT_LEVEL
+
+
+def features_for(level: str) -> frozenset[str]:
+    return _LEVEL_FEATURES[normalize_level(level)]
+
+
+def resolve(level: str, overrides: dict[str, bool | None]) -> dict[str, bool]:
+    """Decide each switch: an explicit flag wins, otherwise the level decides.
+
+    ``None`` means the user did not say, which is why the switches are declared with
+    ``BooleanOptionalAction`` and no default — a plain ``store_true`` cannot tell "off because
+    they asked" from "off because nobody mentioned it", and that difference is the whole
+    reason an override can beat a level.
+    """
+    enabled = features_for(level)
+    return {
+        flag: (enabled and flag in enabled) if overrides.get(flag) is None else bool(overrides[flag])
+        for flag in feature_flags()
+    }
+
+
+def describe(level: str, resolved: dict[str, bool]) -> str:
+    """One line for the run log and the banner."""
+    on = [flag for flag in feature_flags() if resolved.get(flag)]
+    if not on:
+        return f"rigor {normalize_level(level)}: no optional machinery."
+    return f"rigor {normalize_level(level)}: " + ", ".join(flag.replace("_", " ") for flag in on) + "."
+
+
+def help_text() -> str:
+    """The `--rigor` help, built from the table so the two cannot drift."""
+    parts = []
+    for level in LEVELS:
+        enabled = features_for(level)
+        names = ", ".join(flag.replace("_", " ") for flag in feature_flags() if flag in enabled)
+        parts.append(f"{level}: {names or 'nothing optional'}")
+    return (
+        "How much optional machinery to run. "
+        + " | ".join(parts)
+        + f". Defaults to {DEFAULT_LEVEL}. Individual switches override the level, so "
+        "`--rigor thorough --no-ideation-panel` does what it says."
+    )

--- a/src/scorecard.py
+++ b/src/scorecard.py
@@ -65,6 +65,8 @@ class FeatureReport:
 @dataclass
 class Scorecard:
     features: list[FeatureReport] = field(default_factory=list)
+    #: The dial the run was started with, so the card can be read against what was asked for.
+    level: str = ""
 
     @property
     def optional_calls(self) -> int:
@@ -94,6 +96,7 @@ class Scorecard:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "rigor": self.level,
             "headline": self.headline(),
             "optional_model_calls": self.optional_calls,
             "keep": [r.key for r in self.by_verdict(KEEP)],
@@ -243,8 +246,10 @@ FEATURES: tuple[dict[str, Any], ...] = (
 )
 
 
-def build_scorecard(paths: RunPaths) -> Scorecard:
-    return Scorecard(features=[_report(paths=paths, **feature) for feature in FEATURES])
+def build_scorecard(paths: RunPaths, level: str = "") -> Scorecard:
+    return Scorecard(
+        features=[_report(paths=paths, **feature) for feature in FEATURES], level=level
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +270,11 @@ def render_markdown(scorecard: Scorecard) -> str:
     lines = [
         "# What the optional machinery bought",
         "",
+        (
+            f"Run at `--rigor {scorecard.level}`."
+            if scorecard.level
+            else ""
+        ),
         scorecard.headline(),
         "",
         "| Feature | Flag | Verdict | Extra calls |",
@@ -300,9 +310,9 @@ def render_markdown(scorecard: Scorecard) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def write_scorecard(paths: RunPaths) -> Scorecard:
+def write_scorecard(paths: RunPaths, level: str = "") -> Scorecard:
     """Build the scorecard and leave it where the run's other review artifacts live."""
-    scorecard = build_scorecard(paths)
+    scorecard = build_scorecard(paths, level)
     paths.reviews_dir.mkdir(parents=True, exist_ok=True)
     write_text(paths.reviews_dir / SCORECARD_JSON, json.dumps(scorecard.to_dict(), indent=2, ensure_ascii=False))
     write_text(paths.reviews_dir / SCORECARD_MD, render_markdown(scorecard))

--- a/tests/test_rigor.py
+++ b/tests/test_rigor.py
@@ -1,0 +1,171 @@
+"""One dial in place of four switches.
+
+The tests that matter are the ones about the seam between the level and the individual flags,
+because that seam is what makes the dial an interface rather than a fifth switch: an explicit
+flag has to win in *both* directions, or `--rigor thorough --no-ideation-panel` is a lie.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.rigor import (
+    DEFAULT_LEVEL,
+    FAST,
+    FEATURE_NOTES,
+    LEVELS,
+    MAX,
+    STANDARD,
+    THOROUGH,
+    describe,
+    feature_flags,
+    features_for,
+    help_text,
+    normalize_level,
+    resolve,
+)
+
+
+def _resolve(level: str, **overrides) -> dict[str, bool]:
+    return resolve(level, {flag: overrides.get(flag) for flag in feature_flags()})
+
+
+class LevelTests(unittest.TestCase):
+    def test_the_default_is_standard(self) -> None:
+        self.assertEqual(DEFAULT_LEVEL, STANDARD)
+
+    def test_fast_is_exactly_the_old_behaviour(self) -> None:
+        self.assertEqual(features_for(FAST), frozenset())
+        self.assertFalse(any(_resolve(FAST).values()))
+
+    def test_the_default_turns_on_only_the_switch_that_lowers_cost(self) -> None:
+        # Effort tiers withholds polish rounds from settled stages, so defaulting it on costs
+        # nothing and saves something. Nothing else is cheap enough to impose.
+        self.assertEqual(features_for(STANDARD), frozenset({"effort_tiers"}))
+
+    def test_the_levels_are_nested(self) -> None:
+        # A higher level must never turn something off that a lower one turned on, or the dial
+        # stops being a dial.
+        for lower, higher in zip(LEVELS, LEVELS[1:]):
+            self.assertTrue(
+                features_for(lower) <= features_for(higher),
+                f"{higher} does not contain {lower}",
+            )
+
+    def test_the_costliest_feature_is_last(self) -> None:
+        # The review panel bills per gate rather than per run, and is the one the multi-agent
+        # feedback literature has direct evidence against.
+        self.assertNotIn("review_panel", features_for(THOROUGH))
+        self.assertIn("review_panel", features_for(MAX))
+
+    def test_max_turns_everything_on(self) -> None:
+        self.assertEqual(features_for(MAX), frozenset(feature_flags()))
+        self.assertTrue(all(_resolve(MAX).values()))
+
+    def test_an_unknown_level_falls_back_rather_than_raising(self) -> None:
+        self.assertEqual(normalize_level("paranoid"), DEFAULT_LEVEL)
+        self.assertEqual(normalize_level(None), DEFAULT_LEVEL)
+        self.assertEqual(normalize_level(" Thorough "), THOROUGH)
+
+
+class OverrideTests(unittest.TestCase):
+    """An explicit flag has to beat the level in both directions."""
+
+    def test_a_flag_can_add_something_the_level_omits(self) -> None:
+        self.assertTrue(_resolve(STANDARD, review_panel=True)["review_panel"])
+
+    def test_a_flag_can_remove_something_the_level_includes(self) -> None:
+        # This is the case a plain store_true could never express.
+        self.assertFalse(_resolve(THOROUGH, ideation_panel=False)["ideation_panel"])
+
+    def test_unspecified_means_the_level_decides(self) -> None:
+        resolved = _resolve(THOROUGH)
+        self.assertTrue(resolved["deliberation"])
+        self.assertFalse(resolved["review_panel"])
+
+    def test_an_override_does_not_disturb_the_other_switches(self) -> None:
+        resolved = _resolve(THOROUGH, ideation_panel=False)
+        self.assertTrue(resolved["effort_tiers"])
+        self.assertTrue(resolved["deliberation"])
+
+
+class ConsistencyTests(unittest.TestCase):
+    def test_every_level_only_names_real_switches(self) -> None:
+        # A feature listed in a level but missing from feature_flags() would be silently
+        # dropped by resolve(), which is the quietest possible way for a dial to do nothing.
+        known = set(feature_flags())
+        for level in LEVELS:
+            self.assertTrue(features_for(level) <= known, level)
+
+    def test_every_switch_is_reachable_from_some_level(self) -> None:
+        reachable = set().union(*(features_for(level) for level in LEVELS))
+        self.assertEqual(reachable, set(feature_flags()))
+
+    def test_every_switch_has_a_note_explaining_its_placement(self) -> None:
+        self.assertEqual(set(FEATURE_NOTES), set(feature_flags()))
+
+    def test_resolve_always_answers_for_every_switch(self) -> None:
+        for level in LEVELS:
+            self.assertEqual(set(_resolve(level)), set(feature_flags()))
+
+
+class DescriptionTests(unittest.TestCase):
+    def test_a_bare_level_is_described_by_what_it_turned_on(self) -> None:
+        self.assertIn("effort tiers", describe(STANDARD, _resolve(STANDARD)))
+
+    def test_a_level_with_nothing_on_says_so(self) -> None:
+        self.assertIn("no optional machinery", describe(FAST, _resolve(FAST)))
+
+    def test_the_description_follows_the_overrides_not_the_level(self) -> None:
+        resolved = _resolve(STANDARD, review_panel=True)
+        self.assertIn("review panel", describe(STANDARD, resolved))
+
+    def test_the_help_lists_every_level_and_the_default(self) -> None:
+        text = help_text()
+        for level in LEVELS:
+            self.assertIn(level, text)
+        self.assertIn(f"Defaults to {DEFAULT_LEVEL}", text)
+        self.assertIn("--no-ideation-panel", text)
+
+
+class CommandLineTests(unittest.TestCase):
+    def _args(self, *argv):
+        import sys
+        import main
+
+        original = sys.argv
+        sys.argv = ["main.py", "--goal", "x", *argv]
+        try:
+            args = main.parse_args()
+        finally:
+            sys.argv = original
+        return args
+
+    def test_the_switches_default_to_unset_not_to_false(self) -> None:
+        args = self._args()
+        # None is what lets an override be distinguished from silence.
+        for flag in feature_flags():
+            self.assertIsNone(getattr(args, flag), flag)
+
+    def test_the_negative_form_exists_for_every_switch(self) -> None:
+        for flag in feature_flags():
+            args = self._args(f"--no-{flag.replace('_', '-')}")
+            self.assertIs(getattr(args, flag), False, flag)
+
+    def test_the_positive_form_still_works(self) -> None:
+        self.assertIs(self._args("--review-panel").review_panel, True)
+
+    def test_the_dial_defaults_to_standard_on_the_command_line(self) -> None:
+        self.assertEqual(self._args().rigor, DEFAULT_LEVEL)
+
+    def test_the_benchmark_entry_point_carries_the_same_dial(self) -> None:
+        import rcb_agent
+
+        args = rcb_agent.parse_args(["--workspace", "."])
+        self.assertEqual(args.rigor, DEFAULT_LEVEL)
+        for flag in feature_flags():
+            self.assertIsNone(getattr(args, flag), flag)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fair criticism, and it lands. Over this stretch I added **18 flags, four of them on/off feature switches** — and then built a scorecard whose entire purpose is to tell you *which of those four you should have picked*.

**An instrument that says "you cannot know this up front", sitting behind an interface that demands you know it up front, is a contradiction rather than a design.**

Each addition made the same locally correct argument — *this is unproven, so default it off behind its own flag* — and the aggregate was indefensible.

## One dial

```
--rigor {fast,standard,thorough,max}     default: standard
```

| Level | Turns on | Why here |
|:---|:---|:---|
| `fast` | nothing | What AutoR did before any of this existed |
| **`standard`** | effort tiers | The only switch that *lowers* a run's cost |
| `thorough` | + crux deliberation, ideation panel | Budgeted and one-off respectively |
| `max` | + review panel | Bills per *gate*, and has direct evidence against it |

The levels nest. The ordering follows cost per run and evidence, not taste:

- **Effort tiers** withholds polish rounds from settled stages — it makes runs *cheaper*, so defaulting it on costs nothing.
- **Crux deliberation** is budgeted at three, and fires only when a stage says it is stuck.
- **The review panel** costs 5–11 calls *per gate*, and [arXiv:2607.14713](https://arxiv.org/abs/2607.14713) found uniform multi-agent deliberation losing to a single pass.

Worth stating plainly: **the feature I built first here, and most elaborately, is the one that belongs furthest from the default.**

## Overrides win in both directions

```bash
python main.py --rigor thorough --no-ideation-panel
python main.py --rigor fast --review-panel
```

The switches use `BooleanOptionalAction` with **no default**, because a plain `store_true` cannot tell *"off because they asked"* from *"off because nobody mentioned it"* — and that difference is the only thing that lets an override beat a level.

The per-feature knobs (`--panel-roles`, `--ideation-lenses`, `--deliberation-voices`, …) are untouched. They were never the problem; needing four booleans to get any behaviour at all was.

## The loop this is meant to close

Run at a level → read the scorecard → move the dial. The level is printed at startup and recorded on the card, so the card reads against what was asked for. Not: read four documents and guess.

## Verification

1,412 tests, 24 new. Mutation-verified:

| Mutant | Tests killed |
|:---|:---|
| level always wins, overrides ignored | 3 |
| default level turns nothing on | 2 |
| levels stop nesting | 2 |
| unknown level raises instead of falling back | 1 |

**Caught by a control run rather than by review:** the startup banner used `ui` before it was constructed, taking out 40 tests. Clean `origin/main` was green at 1,387, so the failures were unambiguously mine rather than inherited — worth running that control before assuming otherwise.

Also verified end to end: a default `--fake-operator` run now prints `rigor standard: effort tiers`, writes `effort.json` with `enabled: true`, and the scorecard honestly reports `Effort tiers: drop` for a two-stage run where nothing was routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)