### PR TITLE
Hold a run to the deliverables its own task statement asked for

### DIFF
--- a/src/deliverables.py
+++ b/src/deliverables.py
@@ -1,0 +1,221 @@
+"""Hold a run to the deliverables its own task statement asked for.
+
+AutoR's rubric measures how *well* a stage worked: whether references resolve, whether
+the decision ledger is populated, whether claims trace to artifacts. None of that asks
+the prior question -- did the run answer what it was asked?
+
+Observed on ResearchClawBench Astronomy_000. The task statement said:
+
+    "derive statistically rigorous upper limits on ULB masses **and self-interaction
+     coupling strengths**"
+
+The run produced a rigorous mass exclusion band and never reported a coupling limit. Its
+own rubric scored 1.000. The scored criterion asking for the coupling constant in GeV^-1
+scored 25/100, and it carried half the task's weight. Nothing in the pipeline noticed,
+because nothing was comparing the report against the ask.
+
+This module adds that comparison, structurally rather than semantically. Stage 07 writes
+`artifacts/deliverables_coverage.json` enumerating what the task demanded and where each
+demand is answered. The gate then checks things a machine can actually settle:
+
+* every `task_quote` is a **verbatim** span of the task statement, so the stage cannot
+  soften an inconvenient requirement into one it happens to have met;
+* every demanding sentence in the task statement is covered by some quote, so it cannot
+  enumerate a convenient subset;
+* an answered deliverable names where it is answered, and that location appears in the
+  report; an unanswered one states why.
+
+What the gate deliberately does not do is judge whether the answer is *correct*. That is
+the same line every other AutoR validator holds.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from .utils import RunPaths, read_text
+
+COVERAGE_FILENAME = "deliverables_coverage.json"
+
+#: Verbs that turn a sentence of a task statement into something owed. Drawn from the 40
+#: ResearchClawBench task descriptions plus the ordinary vocabulary of a research brief.
+DEMAND_VERBS = (
+    "derive", "compute", "calculate", "estimate", "quantify", "measure",
+    "compare", "benchmark", "evaluate", "assess", "validate", "verify",
+    "identify", "determine", "characterize", "characterise", "analyze", "analyse",
+    "predict", "classify", "reconstruct", "reproduce", "replicate",
+    "produce", "generate", "construct", "build", "develop", "implement",
+    "demonstrate", "show", "establish", "constrain", "test",
+)
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
+_WORD = re.compile(r"[a-z0-9]+")
+
+
+def _normalize(text: str) -> str:
+    """Collapse whitespace so a quote survives re-wrapping."""
+    return " ".join(text.split())
+
+
+def _content_words(text: str) -> set[str]:
+    return {w for w in _WORD.findall(text.lower()) if len(w) > 3}
+
+
+def demanding_sentences(task_statement: str) -> list[str]:
+    """Sentences of the task statement that ask for something.
+
+    A research brief is mostly context; the demands are the handful of sentences with a
+    verb like "derive" or "compare" in them. Those are what a report owes an answer to.
+    """
+    found: list[str] = []
+    for raw in _SENTENCE_SPLIT.split(task_statement or ""):
+        sentence = _normalize(raw).strip("-*# \t")
+        if len(sentence) < 25:
+            continue
+        lowered = sentence.lower()
+        if any(re.search(rf"\b{verb}\w*\b", lowered) for verb in DEMAND_VERBS):
+            found.append(sentence)
+    return found
+
+
+def load_coverage(paths: RunPaths) -> Any:
+    path = paths.artifacts_dir / COVERAGE_FILENAME
+    if not path.exists():
+        return None
+    try:
+        return json.loads(read_text(path))
+    except json.JSONDecodeError:
+        return "invalid"
+
+
+def validate_deliverables_coverage(paths: RunPaths, task_statement: str) -> list[str]:
+    """Check that the report answers what the task statement asked for."""
+    problems: list[str] = []
+    payload = load_coverage(paths)
+    if payload is None:
+        return [f"requires {COVERAGE_FILENAME} under workspace/artifacts."]
+    if payload == "invalid":
+        return [f"{COVERAGE_FILENAME} is not valid JSON."]
+
+    entries = payload.get("deliverables") if isinstance(payload, dict) else payload
+    if not isinstance(entries, list) or not entries:
+        return [f"{COVERAGE_FILENAME} must contain a non-empty 'deliverables' list."]
+
+    normalized_task = _normalize(task_statement).lower()
+    report_text = _normalize(read_text(paths.report_file)).lower() if paths.report_file.exists() else ""
+
+    quotes: list[str] = []
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            problems.append(f"{COVERAGE_FILENAME} entry {index} must be an object.")
+            continue
+
+        quote = _normalize(str(entry.get("task_quote") or ""))
+        if not quote:
+            problems.append(f"{COVERAGE_FILENAME} entry {index} is missing a non-empty task_quote.")
+        elif quote.lower() not in normalized_task:
+            # The teeth: without this a stage can restate the requirement as something it
+            # already did and mark it answered.
+            problems.append(
+                f"{COVERAGE_FILENAME} entry {index} quotes text that is not in the task "
+                f"statement: {quote[:80]!r}. Quote the task verbatim."
+            )
+        else:
+            quotes.append(quote)
+
+        addressed = entry.get("addressed")
+        if not isinstance(addressed, bool):
+            problems.append(f"{COVERAGE_FILENAME} entry {index} needs a boolean 'addressed'.")
+            continue
+
+        if addressed:
+            where = _normalize(str(entry.get("where") or ""))
+            if not where:
+                problems.append(
+                    f"{COVERAGE_FILENAME} entry {index} is marked addressed but does not say where."
+                )
+            elif report_text and not _locator_appears(where, report_text):
+                problems.append(
+                    f"{COVERAGE_FILENAME} entry {index} points at {where[:60]!r}, which does not "
+                    "appear in report.md."
+                )
+        elif not _normalize(str(entry.get("reason") or "")):
+            problems.append(
+                f"{COVERAGE_FILENAME} entry {index} is not addressed and gives no reason. "
+                "An unmet requirement must be stated, not omitted."
+            )
+
+    problems.extend(_uncovered_demands(task_statement, quotes))
+    return problems
+
+
+def _locator_appears(where: str, report_text: str) -> bool:
+    """Whether a stated location is findable in the report.
+
+    Deliberately loose -- a section title, a figure filename, or a heading all count. The
+    point is that the pointer is not fabricated, not that it follows a format.
+    """
+    candidate = where.lower()
+    if candidate in report_text:
+        return True
+    for fragment in re.split(r"[/,;|]| and ", candidate):
+        fragment = fragment.strip()
+        if len(fragment) >= 6 and fragment in report_text:
+            return True
+    return False
+
+
+def _uncovered_demands(task_statement: str, quotes: list[str]) -> list[str]:
+    """Demanding sentences no quote speaks to.
+
+    Overlap is measured on content words rather than exact containment: a stage may
+    legitimately quote the clause rather than the whole sentence, and requiring the whole
+    sentence would push it toward quoting everything and answering nothing.
+    """
+    if not quotes:
+        return []
+    quoted_words: set[str] = set()
+    for quote in quotes:
+        quoted_words |= _content_words(quote)
+
+    missed: list[str] = []
+    for sentence in demanding_sentences(task_statement):
+        words = _content_words(sentence)
+        if not words:
+            continue
+        if len(words & quoted_words) / len(words) < 0.34:
+            missed.append(sentence)
+    return [
+        f"{COVERAGE_FILENAME} does not account for what the task asked: {sentence[:110]!r}"
+        for sentence in missed[:5]
+    ]
+
+
+def format_deliverables_for_prompt(task_statement: str) -> str:
+    """The prompt block that tells a stage what it owes, and how it will be checked."""
+    demands = demanding_sentences(task_statement)
+    if not demands:
+        return ""
+    listed = "\n".join(f"{index}. {sentence}" for index, sentence in enumerate(demands, start=1))
+    return (
+        "The task statement asks for the following. A report that is rigorous about "
+        "something else still fails the task.\n\n"
+        f"{listed}\n\n"
+        f"Before this stage can be approved, write `workspace/artifacts/{COVERAGE_FILENAME}`:\n\n"
+        "```json\n"
+        '{"deliverables": [\n'
+        '  {"task_quote": "<verbatim span of the task statement>",\n'
+        '   "addressed": true,\n'
+        '   "where": "<section heading or images/figure.png in report.md>"},\n'
+        '  {"task_quote": "<verbatim span>", "addressed": false,\n'
+        '   "reason": "<why it could not be answered>"}\n'
+        "]}\n"
+        "```\n\n"
+        "- `task_quote` must appear **verbatim** in the task statement. Restating a "
+        "requirement as something you happened to do is the failure this check exists for.\n"
+        "- Every numbered demand above must be spoken to by some quote.\n"
+        "- `where` must actually appear in `report.md`.\n"
+        "- Reporting a requirement as unmet is a valid outcome. Omitting it is not."
+    )

--- a/src/operator.py
+++ b/src/operator.py
@@ -936,6 +936,26 @@ Original stderr:
                     "priority_fixes": ["Replace this placeholder with a real report review."],
                 },
             )
+            # A coverage record the real gate accepts, saying plainly that it is fake.
+            # It quotes the task statement verbatim rather than inventing a requirement,
+            # because that is exactly the rule a real run is held to.
+            from .deliverables import COVERAGE_FILENAME, demanding_sentences
+
+            _statement = read_text(paths.user_input)
+            _fake_reason = (
+                "fake-operator mode does not do research; nothing was actually derived."
+            )
+            _entries = [
+                {"task_quote": sentence, "addressed": False, "reason": _fake_reason}
+                for sentence in demanding_sentences(_statement)
+            ] or [
+                {
+                    "task_quote": " ".join(_statement.split())[:120],
+                    "addressed": False,
+                    "reason": _fake_reason,
+                }
+            ]
+            _write_json(paths.artifacts_dir / COVERAGE_FILENAME, {"deliverables": _entries})
 
         if stage.number >= 7:
             venue = selected_venue_key(paths)

--- a/src/utils.py
+++ b/src/utils.py
@@ -786,6 +786,14 @@ def build_prompt(
         "# Original User Request",
         user_request.strip(),
     ]
+    # Placed straight after the request it is derived from: what the task demands, and
+    # the artifact that will be checked against those demands. A run can be rigorous
+    # about the wrong question, and nothing else in the prompt notices.
+    from .deliverables import format_deliverables_for_prompt
+
+    deliverables_block = format_deliverables_for_prompt(user_request)
+    if deliverables_block:
+        sections.extend(["# What the Task Asks For", deliverables_block])
     if obligations_context:
         sections.extend(["# Obligations Carried Forward", obligations_context.strip()])
     if web_search_context:
@@ -870,6 +878,12 @@ def build_continuation_prompt(
     ]
     if web_search_context:
         sections.extend(["# Web Search Capability", web_search_context.strip()])
+    # A contract that only appears on the first attempt is one every retry can forget.
+    from .deliverables import format_deliverables_for_prompt
+
+    _deliverables = format_deliverables_for_prompt(read_text(paths.user_input))
+    if _deliverables:
+        sections.extend(["# What the Task Asks For", _deliverables])
     if intake_context_text:
         sections.extend([
             "# Intake Context (User-Provided Resources and Clarifications)",
@@ -1347,6 +1361,16 @@ def validate_stage_artifacts(
         problems.extend(
             f"{stage.stage_title}: {problem}"
             for problem in validate_markdown_report(paths)
+        )
+
+        # Rigour about the wrong question still fails the task. Everything above this
+        # measures how well the report was made; this measures whether it answered what
+        # was asked.
+        from .deliverables import validate_deliverables_coverage
+
+        problems.extend(
+            f"{stage.stage_title}: {problem}"
+            for problem in validate_deliverables_coverage(paths, read_text(paths.user_input))
         )
 
         if not (paths.artifacts_dir / "citation_verification.json").exists():

--- a/tests/test_manager_smoke.py
+++ b/tests/test_manager_smoke.py
@@ -416,6 +416,24 @@ class ScriptedSmokeOperator:
                 paths.artifacts_dir / "self_review.json",
                 json.dumps({"overall_score": 8.5, "final_verdict": "ready", "rounds": 1}),
             )
+            # The Stage 07 gate now also asks what the task demanded and where the report
+            # answers it. Quote the statement verbatim, as a real run must.
+            from src.deliverables import COVERAGE_FILENAME, demanding_sentences
+
+            statement = read_text(paths.user_input)
+            write_text(
+                paths.artifacts_dir / COVERAGE_FILENAME,
+                json.dumps({
+                    "deliverables": [
+                        {"task_quote": sentence, "addressed": False,
+                         "reason": "scripted smoke operator does no research."}
+                        for sentence in demanding_sentences(statement)
+                    ] or [
+                        {"task_quote": " ".join(statement.split())[:120], "addressed": False,
+                         "reason": "scripted smoke operator does no research."}
+                    ]
+                }),
+            )
 
         if stage.number >= 8:
             review_path = paths.reviews_dir / "readiness.md"

--- a/tests/test_markdown_report.py
+++ b/tests/test_markdown_report.py
@@ -17,6 +17,7 @@ from src.experiment_manifest import write_experiment_manifest
 from src.rcb import export_run
 from src.diagram_gen import inject_diagram_into_markdown
 from src.utils import (
+    read_text,
     DEFAULT_OUTPUT_FORMAT,
     DEFAULT_VENUE,
     OUTPUT_FORMAT_CHOICES,
@@ -211,6 +212,18 @@ class MarkdownStage07GateTests(unittest.TestCase):
         write_text(
             paths.artifacts_dir / "self_review.json",
             json.dumps({"overall_score": 8.5, "final_verdict": "ready", "rounds": 1}),
+        )
+
+        from src.deliverables import COVERAGE_FILENAME, demanding_sentences
+
+        _statement = read_text(paths.user_input)
+        write_text(
+            paths.artifacts_dir / COVERAGE_FILENAME,
+            json.dumps({"deliverables": [
+                {"task_quote": s, "addressed": False, "reason": "fixture does no research."}
+                for s in demanding_sentences(_statement)
+            ] or [{"task_quote": " ".join(_statement.split())[:120] or "goal",
+                   "addressed": False, "reason": "fixture does no research."}]}),
         )
         generate_report_review(paths)
 

--- a/tests/test_rcb_scoring.py
+++ b/tests/test_rcb_scoring.py
@@ -25,6 +25,7 @@ from src.rcb import (
     reference_papers,
 )
 from src.utils import (
+    read_text,
     FIXED_STAGE_OPTIONS,
     MAX_REPORT_FIGURES,
     STAGES,
@@ -220,6 +221,17 @@ class FigureBudgetGateTests(unittest.TestCase):
             ),
         )
         write_text(paths.artifacts_dir / "self_review.json", json.dumps({"overall_score": 8}))
+        from src.deliverables import COVERAGE_FILENAME, demanding_sentences
+
+        _statement = read_text(paths.user_input)
+        write_text(
+            paths.artifacts_dir / COVERAGE_FILENAME,
+            json.dumps({"deliverables": [
+                {"task_quote": s, "addressed": False, "reason": "fixture does no research."}
+                for s in demanding_sentences(_statement)
+            ] or [{"task_quote": " ".join(_statement.split())[:120] or "goal",
+                   "addressed": False, "reason": "fixture does no research."}]}),
+        )
         write_validity_chain(paths, evidence="results/metrics.json")
         generate_report_review(paths)
 

--- a/tests/test_task_deliverables_contract.py
+++ b/tests/test_task_deliverables_contract.py
@@ -1,0 +1,259 @@
+"""Does the report answer what the task asked?
+
+Every other AutoR gate measures how *well* a stage worked. None asked the prior question.
+
+Observed on ResearchClawBench Astronomy_000. The task statement said "derive statistically
+rigorous upper limits on ULB masses **and self-interaction coupling strengths**". The run
+delivered a rigorous mass exclusion band and no coupling limit. Its own rubric scored
+1.000. The scored criterion asking for the coupling constant in GeV^-1 scored 25/100 and
+carried half the task's weight, and nothing in the pipeline noticed.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.deliverables import (
+    COVERAGE_FILENAME,
+    demanding_sentences,
+    format_deliverables_for_prompt,
+    validate_deliverables_coverage,
+)
+from src.utils import STAGES, build_prompt, build_run_paths, ensure_run_layout, write_text
+
+# The real statement, trimmed to the sentence the run failed.
+# One demanding sentence, so a single quote can legitimately cover the whole task and
+# the pass-cases below test the gate rather than the fixture.
+TASK = (
+    "The dataset holds posterior samples for two black holes. "
+    "The goal is to derive statistically rigorous upper limits on ULB masses and "
+    "self-interaction coupling strengths, using astrophysical data to probe particle physics."
+)
+
+#: Two demands, for the case where a stage answers one and quietly drops the other.
+TWO_DEMAND_TASK = (
+    "The goal is to derive upper limits on ULB masses and self-interaction coupling strengths. "
+    "Separately, compare the box method against the full posterior approach on both objects."
+)
+MASS_QUOTE = "derive statistically rigorous upper limits on ULB masses and self-interaction coupling strengths"
+
+
+class DemandExtractionTest(unittest.TestCase):
+    def test_it_finds_the_sentence_that_was_missed(self) -> None:
+        found = demanding_sentences(TASK)
+        self.assertTrue(any("coupling strengths" in s for s in found))
+
+    def test_context_without_a_demand_verb_is_not_a_demand(self) -> None:
+        self.assertEqual(demanding_sentences(
+            "The dataset contains posterior samples. It was collected in 2019."), [])
+
+    def test_a_fragment_is_too_short_to_be_a_demand(self) -> None:
+        self.assertEqual(demanding_sentences("Derive it."), [])
+
+    def test_bullet_markers_do_not_hide_a_demand(self) -> None:
+        found = demanding_sentences("- Compare the box method against the full posterior approach.")
+        self.assertEqual(len(found), 1)
+        self.assertFalse(found[0].startswith("-"))
+
+
+class CoverageGateTest(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, TASK)
+        write_text(self.paths.report_file,
+                   "# Report\n\n## Coupling Limits\n\nSee images/fig1_coupling.png\n")
+
+    def _write(self, payload) -> None:
+        write_text(self.paths.artifacts_dir / COVERAGE_FILENAME, json.dumps(payload))
+
+    def _check(self):
+        return validate_deliverables_coverage(self.paths, TASK)
+
+    def test_a_missing_file_is_a_problem(self) -> None:
+        self.assertIn(COVERAGE_FILENAME, " ".join(self._check()))
+
+    def test_invalid_json_is_a_problem(self) -> None:
+        write_text(self.paths.artifacts_dir / COVERAGE_FILENAME, "{not json")
+        self.assertIn("not valid JSON", " ".join(self._check()))
+
+    def test_an_empty_list_is_a_problem(self) -> None:
+        self._write({"deliverables": []})
+        self.assertIn("non-empty", " ".join(self._check()))
+
+    def test_a_covered_addressed_deliverable_passes(self) -> None:
+        self._write({"deliverables": [
+            {"task_quote": MASS_QUOTE, "addressed": True, "where": "Coupling Limits"}]})
+        self.assertEqual(self._check(), [])
+
+    def test_an_honestly_unmet_deliverable_passes(self) -> None:
+        """Reporting a requirement as unmet is a valid outcome; omitting it is not."""
+        self._write({"deliverables": [
+            {"task_quote": MASS_QUOTE, "addressed": False,
+             "reason": "the coupling derivation did not converge in the time available"}]})
+        self.assertEqual(self._check(), [])
+
+    def test_an_unmet_deliverable_with_no_reason_fails(self) -> None:
+        self._write({"deliverables": [{"task_quote": MASS_QUOTE, "addressed": False}]})
+        self.assertIn("gives no reason", " ".join(self._check()))
+
+    def test_a_paraphrased_quote_is_rejected(self) -> None:
+        """The teeth. Without this a stage restates the requirement as one it already met."""
+        self._write({"deliverables": [
+            {"task_quote": "derive limits on boson masses", "addressed": True,
+             "where": "Coupling Limits"}]})
+        self.assertIn("not in the task statement", " ".join(self._check()))
+
+    def test_a_verbatim_quote_survives_rewrapping(self) -> None:
+        self._write({"deliverables": [
+            {"task_quote": "derive statistically rigorous\n  upper limits on ULB masses and "
+                           "self-interaction coupling strengths",
+             "addressed": True, "where": "Coupling Limits"}]})
+        self.assertEqual(self._check(), [])
+
+    def test_answering_only_part_of_the_task_is_caught(self) -> None:
+        """The observed failure shape: satisfy one demand, quietly drop the other."""
+        write_text(self.paths.user_input, TWO_DEMAND_TASK)
+        self._write({"deliverables": [
+            {"task_quote": "derive upper limits on ULB masses and self-interaction coupling "
+                           "strengths", "addressed": True, "where": "Coupling Limits"}]})
+        problems = validate_deliverables_coverage(self.paths, TWO_DEMAND_TASK)
+        self.assertIn("does not account for what the task asked", " ".join(problems))
+        self.assertIn("box method", " ".join(problems))
+
+    def test_covering_both_demands_passes(self) -> None:
+        write_text(self.paths.user_input, TWO_DEMAND_TASK)
+        write_text(self.paths.report_file,
+                   "# Report\n\n## Coupling Limits\n\n## Box Method Comparison\n")
+        self._write({"deliverables": [
+            {"task_quote": "derive upper limits on ULB masses and self-interaction coupling "
+                           "strengths", "addressed": True, "where": "Coupling Limits"},
+            {"task_quote": "compare the box method against the full posterior approach on both "
+                           "objects", "addressed": True, "where": "Box Method Comparison"}]})
+        self.assertEqual(validate_deliverables_coverage(self.paths, TWO_DEMAND_TASK), [])
+
+    def test_a_fabricated_location_is_caught(self) -> None:
+        self._write({"deliverables": [
+            {"task_quote": MASS_QUOTE, "addressed": True, "where": "Section 9: Coupling Tables"}]})
+        self.assertIn("does not appear in report.md", " ".join(self._check()))
+
+    def test_a_figure_reference_counts_as_a_location(self) -> None:
+        self._write({"deliverables": [
+            {"task_quote": MASS_QUOTE, "addressed": True, "where": "images/fig1_coupling.png"}]})
+        self.assertEqual(self._check(), [])
+
+    def test_addressed_must_be_a_boolean(self) -> None:
+        self._write({"deliverables": [{"task_quote": MASS_QUOTE, "addressed": "yes"}]})
+        self.assertIn("boolean", " ".join(self._check()))
+
+    def test_a_bare_list_is_accepted_as_well_as_the_wrapper(self) -> None:
+        self._write([{"task_quote": MASS_QUOTE, "addressed": True, "where": "Coupling Limits"}])
+        self.assertEqual(self._check(), [])
+
+
+class PromptBlockTest(unittest.TestCase):
+    def test_the_block_lists_what_the_task_demands(self) -> None:
+        block = format_deliverables_for_prompt(TASK)
+        self.assertIn("coupling strengths", block)
+        self.assertIn(COVERAGE_FILENAME, block)
+
+    def test_it_says_the_quote_must_be_verbatim(self) -> None:
+        self.assertIn("verbatim", format_deliverables_for_prompt(TASK))
+
+    def test_it_says_an_unmet_requirement_must_be_reported(self) -> None:
+        self.assertIn("Omitting it is not", format_deliverables_for_prompt(TASK))
+
+    def test_a_statement_with_no_demands_yields_no_block(self) -> None:
+        self.assertEqual(format_deliverables_for_prompt("Some background prose."), "")
+
+    def test_the_block_reaches_the_stage_prompt(self) -> None:
+        prompt = build_prompt(STAGES[6], "template", TASK, "memory")
+        self.assertIn("# What the Task Asks For", prompt)
+        self.assertIn("coupling strengths", prompt)
+
+    def test_a_goal_with_no_demands_adds_no_heading(self) -> None:
+        prompt = build_prompt(STAGES[6], "template", "Background only.", "memory")
+        self.assertNotIn("# What the Task Asks For", prompt)
+
+
+class AddressedWithoutALocationTest(CoverageGateTest):
+    def test_addressed_but_no_where_is_a_problem(self) -> None:
+        """"Yes we did it" with no pointer is the easiest way to pass a coverage check
+        without having covered anything."""
+        self._write({"deliverables": [{"task_quote": MASS_QUOTE, "addressed": True}]})
+        self.assertIn("does not say where", " ".join(self._check()))
+
+    def test_a_blank_where_is_the_same_as_none(self) -> None:
+        self._write({"deliverables": [
+            {"task_quote": MASS_QUOTE, "addressed": True, "where": "   "}]})
+        self.assertIn("does not say where", " ".join(self._check()))
+
+
+class TheStageGateCallsItTest(unittest.TestCase):
+    """Through `validate_stage_artifacts`, not just the validator in isolation.
+
+    A checker nothing calls is the same as no checker.
+    """
+
+    def _paths_with_complete_report(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, TASK)
+        write_text(paths.report_file, "# Report\n\n## Coupling Limits\n\ntext\n")
+        return paths
+
+    def test_stage_07_markdown_reports_the_missing_artifact(self) -> None:
+        from src.utils import validate_stage_artifacts
+
+        paths = self._paths_with_complete_report()
+        problems = " ".join(validate_stage_artifacts(STAGES[6], paths))
+        self.assertIn(COVERAGE_FILENAME, problems)
+
+    def test_an_earlier_stage_is_not_asked_for_it(self) -> None:
+        """The contract is a Stage 07 gate; Stage 03 has no report to check it against."""
+        from src.utils import validate_stage_artifacts
+
+        paths = self._paths_with_complete_report()
+        problems = " ".join(validate_stage_artifacts(STAGES[2], paths))
+        self.assertNotIn(COVERAGE_FILENAME, problems)
+
+
+class RefinementTurnsKeepTheContractTest(unittest.TestCase):
+    """A contract that only appears on the first attempt is one every retry can forget.
+
+    Stage 07 took nine attempts on the observed run. If the requirement is stated once and
+    then drops out, the attempt that finally passes is the one that never saw it.
+    """
+
+    def _continuation(self, statement: str) -> str:
+        from src.utils import build_continuation_prompt
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, statement)
+        return build_continuation_prompt(STAGES[6], "template", paths, "handoff", "feedback")
+
+    def test_a_retry_still_sees_what_the_task_asked(self) -> None:
+        prompt = self._continuation(TASK)
+        self.assertIn("# What the Task Asks For", prompt)
+        self.assertIn("coupling strengths", prompt)
+
+    def test_both_builders_agree(self) -> None:
+        from src.utils import build_prompt
+
+        first = build_prompt(STAGES[6], "template", TASK, "memory")
+        retry = self._continuation(TASK)
+        for prompt in (first, retry):
+            self.assertIn("# What the Task Asks For", prompt)
+
+    def test_a_goal_with_no_demands_adds_nothing_on_retry(self) -> None:
+        self.assertNotIn("# What the Task Asks For", self._continuation("Background only."))


### PR DESCRIPTION
AutoR's rubric measures **how well** a stage worked — references resolve, the decision ledger is populated, claims trace to artifacts. Nothing asked the prior question: **did the run answer what it was asked?**

## The observed failure

ResearchClawBench `Astronomy_000`. The task statement said:

> "derive statistically rigorous upper limits on ULB masses **and self-interaction coupling strengths**"

The run produced a rigorous mass exclusion band and **never reported a coupling limit**. Its own rubric scored `1.000` across all five criteria. The scored criterion asking for the coupling constant in GeV⁻¹ scored **25/100** and carried **half the task's weight**.

Nothing in the pipeline noticed, because nothing was comparing the report against the ask. Rigour about the wrong question still fails the task.

## What this adds

`src/deliverables.py`:

- **`demanding_sentences`** pulls the sentences of the task statement that ask for something — the ones carrying a verb like *derive, compare, quantify, constrain*. A brief is mostly context; the demands are the handful of sentences a report owes an answer to. On the observed task it pulls exactly the sentence that was missed.
- **Every stage prompt**, first attempt and every retry, now carries those demands under `# What the Task Asks For`. Stage 07 took nine attempts on that run — a contract stated once is one the attempt that finally passes never saw.
- **Stage 07 in markdown mode** must write `workspace/artifacts/deliverables_coverage.json` saying, per demand, whether it is answered and where.

## The gate checks only what a machine can settle

| Check | Why |
| --- | --- |
| Every `task_quote` is a **verbatim** span of the statement | Without it a stage restates an inconvenient requirement as one it happened to meet — the exact failure being fixed |
| Every demanding sentence is spoken to by some quote | Otherwise a stage enumerates a convenient subset |
| An answered deliverable names where, and that location appears in `report.md` | A pointer that resolves is checkable; correctness is not |
| An unanswered one states why | **Reporting a requirement as unmet is a valid outcome. Omitting it is not.** |

Coverage overlap is measured on content words, not exact containment: quoting the clause rather than the whole sentence is legitimate, and demanding the whole sentence would push a stage toward quoting everything and answering nothing.

The gate never judges whether the answer is *correct* — the same line every other AutoR validator holds.

## The fakes are held to the same rule

Both the fake operator and the scripted smoke operator now write a coverage record the **real** gate accepts: quoting the statement verbatim and marking every demand unmet, because neither does research. Holding the fakes to the same rule is what keeps the rule honest — an exemption for test doubles is how a gate quietly stops applying.

## Verification

- **1433 tests green** (+45), `py_compile` clean.
- **Mutation swept with a control run: 16 mutants, all killed** — the verbatim check removed, the coverage floor removed or stuck on/off, the locator check removed, a missing `where` or `reason` accepted, `addressed` no longer boolean, an empty list accepted, the demand verbs emptied, short sentences kept, and the prompt block or the gate itself unwired in either builder.

**Two survivors in the first pass were both real:** nothing covered an addressed entry with no location, and nothing drove the gate through `validate_stage_artifacts` — a checker nothing calls is the same as no checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)