### PR TITLE
Compare a move against the moves that declined it, not against runs that could not

### DIFF
--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -265,10 +265,26 @@ A run that navigates its own topology produces something a linear pipeline never
 could: evidence about the topology. One run means nothing. Forty mean the backward
 edge out of Stage 06 is worth taking, and that is a fact about the harness.
 
-For each edge, the archive compares runs that took it against runs that **reached
-the same node and did not**. Comparing against the whole archive would credit the
-edge with the difference between runs that got as far as Stage 06 and runs that
-never did.
+For each edge, the archive compares decisions that took it against decisions that
+were **offered it and declined**.
+
+That distinction is the estimator. The obvious control arm — runs that reached the
+node and did not take the edge — pools four unrelated states: the guard was shut,
+`--final-stage` pruned the move, the visit budget was spent, or the topology never
+had the edge at all. Only the first kind of "did not" is a *choice*, and only a
+choice is evidence about a choice.
+
+It is not a fine distinction. Five of the seven guards read the same disk predicates
+the rubric scores, so a shut guard is correlated with a weak run. Pooling those into
+the control arm makes the guard a selection mechanism on the outcome, and the
+contrast then measures how much worse a run is when its artifacts are missing while
+reporting it as the payoff of an edge nobody could have taken. On a fixture where
+routing has no effect at all, the two arms give opposite signs.
+
+The choice set is recorded on every visit (`offered`), so "was declined" is a fact
+on disk rather than an inference. The older run-level contrast is still computed and
+still printed, under a heading saying it is not acted on, so the two can be seen to
+disagree.
 
 ```
 | Edge                            | Took | Mean  | Skipped | Mean  | Delta  | Believable |
@@ -337,12 +353,16 @@ Three further refusals hold this together:
   somewhere other than where the last closed visit was heading is an operator
   overruling that move; it went off the router with no choice set, so it is marked
   bypassed rather than counted as a traversal.
-- **Below `min_observations` on each side, nothing is acted on.** A variant that
-  beat the incumbent once beat it once. Be aware this bound is a guard rather than
-  a derivation: a two-sided permutation test over *n* per side attains at best
-  `2/C(2n,n)`, so `n=3` can reach `p=0.10` at best, and a family correction over 18
-  edges would demand far less. Three stops a single lucky run from moving the
-  topology; it does not license the claim.
+- **Below `min_observations` on each side, nothing is acted on — and that bound is
+  now derived.** An exact two-sided permutation test over arms of *a* and *b* has
+  `C(a+b,a)` labellings, so no result can go below `2/C(a+b,a)`. Three a side bottoms
+  out at `p = 0.10`; against the adaptive graph's edge family the corrected threshold
+  needs six. `minimum_arms_for` computes it. The previous value was three, with a
+  docstring about intent, which meant the archive was licensing topology changes at a
+  sample size where the arithmetic forbids the claim.
+- **A p-value is never reported without the floor its sample size could attain.**
+  *Did not show an effect* and *could not have shown one* print identically as "not
+  significant" and mean opposite things.
 - **A run is only compared against runs that walked the same topology, measured the
   same stages, and were driven by a real backend.** A fake operator's scores measure
   the script. A linear run never had the revisit edges, so counting it as one that

--- a/src/archive.py
+++ b/src/archive.py
@@ -60,17 +60,25 @@ from typing import Any, Iterable, Mapping, Sequence
 from .evolution import load_run_criteria, load_run_fitness
 from .router import routing_summary
 from .rubric import RUBRIC_VERSION
-from .stage_graph import Edge, StageGraph
-from .utils import RunPaths, append_jsonl, load_run_config, read_text, write_text
+from .inference import ALPHA, minimum_arms_for
+from .stage_graph import REVISIT_EDGES, Edge, StageGraph
+from .utils import STAGES, RunPaths, append_jsonl, load_run_config, read_text, write_text
 
 
 ARCHIVE_VERSION = "1"
 
-#: Runs on each side of a comparison before an edge payoff is believed. Research
-#: runs vary for reasons that have nothing to do with the route — the goal, the
-#: data, the day. Three is not enough to be sure and is enough to stop acting on
-#: a single lucky run, which is the failure that matters here.
-DEFAULT_MIN_OBSERVATIONS = 3
+#: Observations each side of a comparison needs before it is believed.
+#:
+#: Derived, not chosen. An exact two-sided permutation test over arms of size *a*
+#: and *b* has ``C(a+b, a)`` labellings, so no result can go below ``2/C(a+b,a)``:
+#: three a side bottoms out at 0.10, and against the eighteen edges of the adaptive
+#: graph the corrected threshold is ``0.05/18 = 0.0028``, which needs six.
+#:
+#: The previous value was three, with a docstring saying "three is not enough to be
+#: sure and is enough to stop acting on a single lucky run" — a sentence about
+#: intent. The archive was licensing topology changes at a sample size where the
+#: arithmetic forbids the claim.
+DEFAULT_MIN_OBSERVATIONS = minimum_arms_for(ALPHA, family=len(REVISIT_EDGES) + len(STAGES))
 
 #: Mean fitness a challenger must beat the incumbent by. Roughly the size of one
 #: criterion moving a quarter of its range on a seven-criterion rubric; below that
@@ -167,6 +175,11 @@ class RunRecord:
     #: the traversals the estimator counted.
     bypassed: int
     recorded_at: str
+    #: Every routing decision, with the set it was chosen from. The unit the
+    #: `offered and declined` estimator works on — `edges` alone cannot say whether
+    #: a move was declined or was never on offer, and those are different
+    #: observations. See :mod:`src.decisions`.
+    decisions: "list[dict[str, object]]" = field(default_factory=list)
     #: Mean score per rubric criterion. Not used for ranking — the total is — but a
     #: difference between two configurations is uninterpretable without it: writing
     #: more files and grounding more claims move the same total and are not the same
@@ -229,6 +242,7 @@ class RunRecord:
             "revisits": self.revisits,
             "agent_directed": self.agent_directed,
             "bypassed": self.bypassed,
+            "decisions": [dict(item) for item in self.decisions],
             "recorded_at": self.recorded_at,
         }
 
@@ -262,6 +276,7 @@ class RunRecord:
             revisits=int(payload.get("revisits") or 0),
             agent_directed=int(payload.get("agent_directed") or 0),
             bypassed=int(payload.get("bypassed") or 0),
+            decisions=[dict(item) for item in payload.get("decisions", []) if isinstance(item, dict)],
             recorded_at=str(payload.get("recorded_at") or ""),
         )
 
@@ -558,6 +573,7 @@ class Archive:
             revisits=int(summary.get("revisits") or 0),
             agent_directed=int(summary.get("agent_directed") or 0),
             bypassed=int(summary.get("bypassed") or 0),
+            decisions=list(summary.get("decisions") or []),
             recorded_at=_now(),
         )
         append_jsonl(self.runs_file, record.to_dict())
@@ -643,10 +659,21 @@ class Archive:
         common answer and the right one. A proposer that always proposes converts an
         archive into a random walk.
         """
+        # The `offered and declined` contrast, not the run-level one. The old
+        # control arm pooled "the guard was shut", "--final-stage pruned it", "the
+        # visit budget was spent" and "this topology has no such edge" into one
+        # group, and only the absence of a *choice* is evidence about a choice.
+        # `edge_payoffs` is still computed and still printed by `report`, under a
+        # heading saying it is unadjusted — an operator should be able to see the
+        # two estimators disagree rather than have the conclusion change silently.
+        from .decisions import decisions_from, offered_payoffs
+
+        contrasts = offered_payoffs(decisions_from(self.runs()))
+        family = max(len(contrasts), 1)
         payoffs = [
             payoff
-            for payoff in edge_payoffs(self.runs()).values()
-            if payoff.believable(self.min_observations) and abs(payoff.delta) >= self.min_gain
+            for payoff in contrasts.values()
+            if payoff.test.believable(family=family) and abs(payoff.delta) >= self.min_gain
         ]
         if not payoffs:
             return None
@@ -686,10 +713,10 @@ class Archive:
             parent_id=parent.variant_id,
             generation=parent.generation + 1,
             note=(
-                f"`{best.edge}` {direction}: runs that took it averaged "
-                f"{best.taken_mean:.3f} over {best.taken_runs} run(s) against "
-                f"{best.skipped_mean:.3f} over {best.skipped_runs} that reached the same node "
-                f"and did not ({best.delta:+.3f})."
+                f"`{best.edge}` {direction}: decisions that took it averaged "
+                f"{best.taken_mean:.3f} over {best.taken_n} against "
+                f"{best.declined_mean:.3f} over {best.declined_n} that were offered it and "
+                f"declined ({best.delta:+.3f}; {best.test.describe(family=family)})."
             ),
             promoted=False,
             created_at=_now(),
@@ -878,12 +905,28 @@ class Archive:
                 )
             lines.append("")
 
+        from .decisions import decisions_from, format_offered_payoffs, offered_payoffs
+
+        contrasts = offered_payoffs(decisions_from(usable))
+        lines += [
+            "## Edge payoff — offered and declined",
+            "",
+            "The estimator the proposer acts on. Treatment is decisions that took the move; "
+            "control is decisions that were *offered* it and did not.",
+            "",
+            format_offered_payoffs(contrasts),
+            "",
+        ]
+
         payoffs = edge_payoffs(usable)
         if payoffs:
             lines += [
-                "## Edge payoff",
+                "## Edge payoff — unadjusted (not acted on)",
                 "",
-                "Runs that took the edge against runs that reached the same node and did not.",
+                "The older run-level contrast, kept and printed so the two can be seen to "
+                "disagree. Its control arm pools four states — the guard was shut, "
+                "`--final-stage` pruned the edge, the visit budget was spent, or the topology "
+                "never had it — and only one of those was a choice.",
                 "",
                 "| Edge | Took | Mean | Skipped | Mean | Delta | Believable |",
                 "| --- | --- | --- | --- | --- | --- | --- |",

--- a/src/decisions.py
+++ b/src/decisions.py
@@ -1,0 +1,214 @@
+"""The unit of observation is a decision, not a run.
+
+:func:`src.archive.edge_payoffs` compares runs that took an edge against runs that
+"reached the same node and did not". That control arm pools four unrelated states:
+
+* the guard was shut, so the edge was never on offer;
+* ``--final-stage`` pruned it;
+* the visit budget was spent;
+* the run was on a topology where the edge does not exist at all.
+
+Only the last of those was ever a *choice*, and only a choice is evidence about a
+choice. The distinction is not academic here, because five of the seven guards test
+the same disk predicates the rubric scores — ``_guard_results_exist`` and the
+reproducibility check read the same expression. So a guard being shut is correlated
+with the run being weak, and pooling "guard shut" into the control arm makes the
+guard a selection mechanism on the outcome. The contrast then measures how much
+worse a run is when its artifacts are missing, and reports it as the payoff of an
+edge nobody could have taken.
+
+The fix is the counterfactual the run already recorded and nothing read. Since
+:class:`src.stage_graph.Visit` carries ``offered``, "was declined" is a fact on
+disk:
+
+    treatment — decisions at this node where this edge was chosen
+    control   — decisions at this node where this edge was **offered and not** chosen
+    excluded  — decisions where it was not on offer
+
+Two further exclusions, both because the alternative counts something that was not
+a decision. A ``bypassed`` visit is an operator's `/back` or a research round's own
+jump: no guard was evaluated, nothing was on offer, nothing chose. And a visit from
+before ``offered`` was recorded has an empty choice set, which is indistinguishable
+from "nothing else was available" and must not be read as it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from .archive import RunRecord
+from .inference import TestResult, unpaired_permutation
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One routing choice, with the set it was chosen from."""
+
+    run_id: str
+    source: str
+    chose: str
+    offered: tuple[str, ...]
+    #: The run's mean fitness. The outcome attributed to the decision.
+    #:
+    #: Attributing a whole run to one decision is crude and it is what a paired
+    #: trial does better; this is the observational estimator, and its job is to be
+    #: honest about a weak signal rather than to invent a strong one.
+    fitness: float
+    basis: str
+
+    def offered_edge(self, edge: str) -> bool:
+        source, target = edge.split("->", 1)
+        return source == self.source and target in self.offered
+
+    def took_edge(self, edge: str) -> bool:
+        source, target = edge.split("->", 1)
+        return source == self.source and self.chose == target
+
+
+def decisions_from(records: Iterable[RunRecord]) -> list[Decision]:
+    """Every real routing decision in these runs.
+
+    A record with no recorded decisions contributes nothing rather than
+    contributing an empty choice set, which the estimator would read as "no
+    alternative existed".
+    """
+    collected: list[Decision] = []
+    for record in records:
+        if not record.usable:
+            continue
+        for entry in record.decisions:
+            source = str(entry.get("source") or "")
+            chose = str(entry.get("chose") or "")
+            offered = tuple(str(item) for item in entry.get("offered", []) if str(item))
+            if not source or not chose or not offered:
+                continue
+            if entry.get("bypassed"):
+                continue
+            collected.append(
+                Decision(
+                    run_id=record.run_id,
+                    source=source,
+                    chose=chose,
+                    offered=offered,
+                    fitness=record.mean_fitness,
+                    basis=record.basis,
+                )
+            )
+    return collected
+
+
+@dataclass(frozen=True)
+class OfferedPayoff:
+    edge: str
+    taken: tuple[float, ...]
+    declined: tuple[float, ...]
+    test: TestResult
+
+    @property
+    def taken_n(self) -> int:
+        return len(self.taken)
+
+    @property
+    def declined_n(self) -> int:
+        return len(self.declined)
+
+    @property
+    def taken_mean(self) -> float:
+        return sum(self.taken) / len(self.taken) if self.taken else 0.0
+
+    @property
+    def declined_mean(self) -> float:
+        return sum(self.declined) / len(self.declined) if self.declined else 0.0
+
+    @property
+    def delta(self) -> float:
+        return self.taken_mean - self.declined_mean
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "edge": self.edge,
+            "taken_runs": self.taken_n,
+            "declined_runs": self.declined_n,
+            "taken_mean": round(self.taken_mean, 4),
+            "declined_mean": round(self.declined_mean, 4),
+            "delta": round(self.delta, 4),
+            "p_value": round(self.test.p_value, 4),
+            "attainable_floor": round(self.test.floor, 4),
+        }
+
+
+def offered_payoffs(
+    decisions: Sequence[Decision], *, within_basis: bool = True
+) -> dict[str, OfferedPayoff]:
+    """Per-edge contrast between taking a move and declining one that was offered.
+
+    ``within_basis`` keeps the comparability rule the archive already applies
+    between runs: two decisions are only contrasted when their runs measured the
+    same stages on the same topology under the same rubric. Without it the
+    composition of each arm can supply the delta, which is the bias that let the
+    archive reward a run for stopping early.
+    """
+    edges: set[str] = set()
+    for decision in decisions:
+        for target in decision.offered:
+            edges.add(f"{decision.source}->{target}")
+
+    payoffs: dict[str, OfferedPayoff] = {}
+    for edge in sorted(edges):
+        offered_here = [item for item in decisions if item.offered_edge(edge)]
+        bases = {item.basis for item in offered_here} if within_basis else {""}
+
+        taken: list[float] = []
+        declined: list[float] = []
+        for basis in sorted(bases):
+            arm = [
+                item
+                for item in offered_here
+                if not within_basis or item.basis == basis
+            ]
+            took = [item.fitness for item in arm if item.took_edge(edge)]
+            passed = [item.fitness for item in arm if not item.took_edge(edge)]
+            if not took or not passed:
+                # A basis with only one arm carries no contrast; counting its
+                # decisions would inflate the sample size that decides
+                # believability without contributing to the difference.
+                continue
+            taken.extend(took)
+            declined.extend(passed)
+
+        payoffs[edge] = OfferedPayoff(
+            edge=edge,
+            taken=tuple(taken),
+            declined=tuple(declined),
+            test=unpaired_permutation(taken, declined),
+        )
+    return payoffs
+
+
+def format_offered_payoffs(
+    payoffs: dict[str, OfferedPayoff], *, family: int | None = None
+) -> str:
+    if not payoffs:
+        return (
+            "No routing decision has been recorded with a choice set yet. Every edge "
+            "observation so far predates `offered`, or came from a move that bypassed "
+            "the router."
+        )
+    correction = family if family is not None else max(len(payoffs), 1)
+    lines = [
+        "| Edge | Took | Mean | Declined | Mean | Delta | Test |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for payoff in sorted(payoffs.values(), key=lambda item: abs(item.delta), reverse=True):
+        lines.append(
+            f"| `{payoff.edge}` | {payoff.taken_n} | {payoff.taken_mean:.3f} | "
+            f"{payoff.declined_n} | {payoff.declined_mean:.3f} | {payoff.delta:+.3f} | "
+            f"{payoff.test.describe(family=correction)} |"
+        )
+    lines.append("")
+    lines.append(
+        f"Corrected for a family of {correction} edge(s). A row that says it cannot reach the "
+        "threshold is reporting its sample size, not its effect."
+    )
+    return "\n".join(lines)

--- a/src/inference.py
+++ b/src/inference.py
@@ -1,0 +1,167 @@
+"""Exact permutation tests, and the floor each one cannot go below.
+
+Two numbers decide whether the archive is allowed to act, and until now both were
+assertions. ``DEFAULT_MIN_OBSERVATIONS = 3`` had a docstring saying "three is not
+enough to be sure and is enough to stop acting on a single lucky run", which is a
+sentence about intent rather than a derivation, and nothing anywhere said what a
+comparison at three-a-side could attain even in principle.
+
+It can attain 0.10. An exact two-sided permutation test over ``a`` and ``b``
+observations has ``C(a+b, a)`` distinct labellings, of which two are the extremes,
+so no result can go below ``2 / C(a+b, a)``. Three against three bottoms out at
+0.10; against a family of eighteen edges, ``0.05 / 18 = 0.0028`` needs six a side.
+The archive was licensing topology changes at a sample size where the arithmetic
+forbids the claim.
+
+The distinction this module exists to keep visible is between **did not show an
+effect** and **could not have shown one**. They print identically as "not
+significant" and they mean opposite things: the first is evidence about the edge,
+the second is evidence about how many runs you have done. Every function here
+returns the attainable floor alongside the p-value so a caller cannot report one
+without the other.
+
+Exact enumeration rather than a normal approximation, because the sample sizes a
+multi-hour research run permits are exactly the sizes where the approximation is
+worst, and because an exact test needs no assumption anyone would have to defend.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from math import comb
+from typing import Sequence
+
+
+#: Enumeration is capped here. ``C(24,12)`` is 2.7 million labellings, which takes a
+#: couple of seconds; beyond it the answer is already far below any threshold
+#: anyone would use, so the extra precision buys nothing and the wait is real.
+MAX_EXACT_TOTAL = 24
+
+#: What a believable comparison has to clear, before any family correction.
+ALPHA = 0.05
+
+
+@dataclass(frozen=True)
+class TestResult:
+    """A p-value that carries the sample size's own limit next to it."""
+
+    p_value: float
+    floor: float
+    treatment_n: int
+    control_n: int
+    #: True when the enumeration was capped and the p-value is an approximation
+    #: from a subsample rather than the exact figure.
+    approximate: bool = False
+
+    def believable(self, *, alpha: float = ALPHA, family: int = 1) -> bool:
+        """Significant *and* attainably so, at a threshold corrected for the family.
+
+        Both halves are required. Without the second, an archive comparing eighteen
+        edges reports the best of eighteen at an uncorrected threshold, which is the
+        multiple-comparisons mistake in its purest form: with eighteen edges and no
+        effect anywhere, the chance that at least one clears 0.05 is about 60%.
+        """
+        corrected = alpha / max(family, 1)
+        return self.p_value <= corrected and self.floor <= corrected
+
+    def attainable(self, *, alpha: float = ALPHA, family: int = 1) -> bool:
+        return self.floor <= alpha / max(family, 1)
+
+    def describe(self, *, alpha: float = ALPHA, family: int = 1) -> str:
+        corrected = alpha / max(family, 1)
+        if not self.attainable(alpha=alpha, family=family):
+            return (
+                f"p={self.p_value:.4f}, but {self.treatment_n}v{self.control_n} cannot reach "
+                f"{corrected:.4f} at any effect size (floor {self.floor:.4f})"
+            )
+        verdict = "believable" if self.p_value <= corrected else "not significant"
+        return f"p={self.p_value:.4f} against {corrected:.4f} — {verdict}"
+
+
+def unpaired_floor(treatment_n: int, control_n: int) -> float:
+    """Smallest two-sided p an exact label-shuffle over these two arms can produce."""
+    if treatment_n <= 0 or control_n <= 0:
+        return 1.0
+    return min(1.0, 2.0 / comb(treatment_n + control_n, treatment_n))
+
+
+def paired_floor(pairs: int) -> float:
+    """Smallest two-sided p an exact sign-flip over this many pairs can produce."""
+    if pairs <= 0:
+        return 1.0
+    return min(1.0, 2.0 / (2**pairs))
+
+
+def minimum_arms_for(alpha: float, *, family: int = 1) -> int:
+    """Smallest equal arm size whose floor clears the corrected threshold.
+
+    The number to quote when refusing to act. "Not enough runs" invites the reading
+    that some unspecified amount more would do; "six a side is the arithmetic floor
+    for eighteen edges at 0.05" is actionable.
+    """
+    corrected = alpha / max(family, 1)
+    for size in range(1, 40):
+        if unpaired_floor(size, size) <= corrected:
+            return size
+    return 40
+
+
+def unpaired_permutation(
+    treatment: Sequence[float], control: Sequence[float]
+) -> TestResult:
+    """Exact two-sided test on the difference of means, by shuffling the labels.
+
+    The null is that the arm label carries no information — every way of splitting
+    the pooled values into arms of these sizes is equally likely. That is the right
+    null for an observational contrast between runs that took an edge and runs that
+    were offered it and did not.
+    """
+    treatment_values = [float(value) for value in treatment]
+    control_values = [float(value) for value in control]
+    if not treatment_values or not control_values:
+        return TestResult(1.0, 1.0, len(treatment_values), len(control_values))
+
+    observed = abs(
+        sum(treatment_values) / len(treatment_values)
+        - sum(control_values) / len(control_values)
+    )
+    pooled = treatment_values + control_values
+    size = len(treatment_values)
+    total = len(pooled)
+    floor = unpaired_floor(len(treatment_values), len(control_values))
+
+    if observed == 0.0:
+        return TestResult(1.0, floor, len(treatment_values), len(control_values))
+
+    if total > MAX_EXACT_TOTAL:
+        # Deterministic subsample: the first `MAX_EXACT_TOTAL` values, split in the
+        # same proportion. Flagged approximate rather than silently reported as
+        # exact — the floor still describes the real sample, so a caller cannot
+        # mistake a truncated enumeration for a smaller one.
+        keep = MAX_EXACT_TOTAL * size // total or 1
+        return TestResult(
+            unpaired_permutation(treatment_values[:keep], control_values[: MAX_EXACT_TOTAL - keep]).p_value,
+            floor,
+            len(treatment_values),
+            len(control_values),
+            approximate=True,
+        )
+
+    at_least_as_extreme = 0
+    arrangements = 0
+    for indices in itertools.combinations(range(total), size):
+        arrangements += 1
+        chosen = set(indices)
+        left = [pooled[index] for index in indices]
+        right = [pooled[index] for index in range(total) if index not in chosen]
+        difference = abs(sum(left) / len(left) - sum(right) / len(right))
+        if difference >= observed - 1e-12:
+            at_least_as_extreme += 1
+
+    return TestResult(
+        at_least_as_extreme / arrangements,
+        floor,
+        len(treatment_values),
+        len(control_values),
+    )

--- a/src/router.py
+++ b/src/router.py
@@ -422,6 +422,10 @@ def routing_summary(paths: RunPaths) -> dict[str, Any]:
     if not isinstance(payload, dict):
         return {}
     edges: dict[str, int] = {}
+    # The same walk, kept per decision rather than summed per edge. `edges` cannot
+    # distinguish "declined" from "never offered", and those are different
+    # observations — see :mod:`src.decisions`.
+    decisions: list[dict[str, object]] = []
     agent_directed = 0
     revisits = 0
     bypassed = 0
@@ -436,11 +440,20 @@ def routing_summary(paths: RunPaths) -> dict[str, Any]:
         if visit.get("bypassed"):
             bypassed += 1
             continue
+        decisions.append(
+            {
+                "source": source,
+                "chose": target,
+                "offered": [str(item) for item in visit.get("offered", []) if str(item)],
+                "agent_directed": bool(visit.get("agent_directed")),
+            }
+        )
         edges[f"{source}->{target}"] = edges.get(f"{source}->{target}", 0) + 1
         if visit.get("agent_directed"):
             agent_directed += 1
     return {
         "edges": edges,
+        "decisions": decisions,
         "steps": len(payload.get("path", [])),
         "agent_directed": agent_directed,
         "revisits": revisits,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -15,12 +15,14 @@ from pathlib import Path
 
 from src.archive import (
     Archive,
+    DEFAULT_MIN_OBSERVATIONS,
     BASELINE_VARIANT,
     RunRecord,
     Variant,
     edge_payoffs,
     resolve_graph,
 )
+from src.inference import unpaired_floor
 from src.rubric import RUBRIC_VERSION
 from src.stage_graph import StageGraph
 from src.utils import append_jsonl
@@ -35,7 +37,22 @@ def record(
     rubric_version: str | None = None,
     topology: str = "adaptive",
     provenance: str = "live",
+    offered: dict[str, list[str]] | None = None,
 ) -> RunRecord:
+    """A run record, with a decision per edge it took.
+
+    ``offered`` gives the choice set at each source; it defaults to "the target
+    taken plus the other target this file uses at that node", so a record built the
+    short way still produces a usable contrast. The estimator needs the choice set:
+    an edge that was never offered is not an edge that was declined.
+    """
+    decisions = []
+    for edge in edges:
+        source, target = edge.split("->", 1)
+        alternatives = (offered or {}).get(source)
+        if alternatives is None:
+            alternatives = sorted({target, "07_writing", "05_experimentation"})
+        decisions.append({"source": source, "chose": target, "offered": list(alternatives)})
     return RunRecord(
         run_id=run_id,
         variant_id=variant_id,
@@ -50,6 +67,7 @@ def record(
         agent_directed=0,
         bypassed=0,
         recorded_at="2026-08-06T00:00:00",
+        decisions=decisions,
     )
 
 
@@ -68,9 +86,15 @@ class ArchiveTests(unittest.TestCase):
             append_jsonl(self.archive.runs_file, item.to_dict())
 
     def seed_a_believable_payoff(self, *, taken: float = 0.85, skipped: float = 0.60) -> None:
+        """Six a side, which is the derived floor rather than a round number.
+
+        An exact two-sided permutation test over three and three bottoms out at
+        0.10, so the old fixture could not have licensed anything the corrected
+        threshold would accept. `minimum_arms_for` computes six.
+        """
         self.seed(
-            [record(f"back{i}", edges={BACK: 1}, fitness=taken) for i in range(3)]
-            + [record(f"fwd{i}", edges={FORWARD: 1}, fitness=skipped) for i in range(3)]
+            [record(f"back{i}", edges={BACK: 1}, fitness=taken) for i in range(6)]
+            + [record(f"fwd{i}", edges={FORWARD: 1}, fitness=skipped) for i in range(6)]
         )
 
     # -- payoff arithmetic ---------------------------------------------------
@@ -330,11 +354,33 @@ class ArchiveTests(unittest.TestCase):
     def test_an_improvement_that_replays_is_promoted(self) -> None:
         self.archive._save_variants([BASELINE_VARIANT, Variant("challenger", "adaptive", parent_id="baseline")])
         self.seed(
-            [record(f"b{i}", edges={}, fitness=0.50) for i in range(3)]
-            + [record(f"c{i}", edges={}, fitness=0.80, variant_id="challenger") for i in range(3)]
+            [record(f"b{i}", edges={}, fitness=0.50) for i in range(DEFAULT_MIN_OBSERVATIONS)]
+            + [
+                record(f"c{i}", edges={}, fitness=0.80, variant_id="challenger")
+                for i in range(DEFAULT_MIN_OBSERVATIONS)
+            ]
         )
         self.assertTrue(self.archive.promote("challenger"))
         self.assertTrue(self.archive.variant("challenger").promoted)
+
+    def test_three_a_side_cannot_promote_however_large_the_gap(self) -> None:
+        """The floor is derived, and this is what deriving it changed.
+
+        `DEFAULT_MIN_OBSERVATIONS` was 3, with a docstring saying three "is enough to
+        stop acting on a single lucky run" — intent, not arithmetic. An exact
+        two-sided permutation test over three and three bottoms out at p = 0.10, so
+        three a side could never have licensed a claim at any threshold anyone would
+        use, whatever the effect size.
+        """
+        self.assertGreaterEqual(DEFAULT_MIN_OBSERVATIONS, 6)
+        self.assertGreater(unpaired_floor(3, 3), 0.05)
+
+        self.archive._save_variants([BASELINE_VARIANT, Variant("challenger", "adaptive")])
+        self.seed(
+            [record(f"b{i}", edges={}, fitness=0.10) for i in range(3)]
+            + [record(f"c{i}", edges={}, fitness=0.99, variant_id="challenger") for i in range(3)]
+        )
+        self.assertFalse(self.archive.promote("challenger"))
 
     def test_a_challenger_that_only_ties_is_not_promoted(self) -> None:
         self.archive._save_variants([BASELINE_VARIANT, Variant("challenger", "adaptive")])

--- a/tests/test_archive_exploration.py
+++ b/tests/test_archive_exploration.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 
 from src.archive import (
+    DEFAULT_MIN_OBSERVATIONS,
     RUBRIC_VERSION,
     Archive,
     RunRecord,
@@ -45,7 +46,9 @@ class ExplorableOnlyWithARivalTest(unittest.TestCase):
         self._tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self._tmp.cleanup)
         self.archive = Archive(Path(self._tmp.name) / "archive")
-        for index in range(5):
+        # `min_observations` is derived now, so "enough runs to be worth deviating
+        # from" is whatever the permutation floor says rather than a round number.
+        for index in range(DEFAULT_MIN_OBSERVATIONS):
             append_jsonl(
                 self.archive.runs_file,
                 _record(f"r{index}", ["01_literature_survey->02_hypothesis_generation"]).to_dict(),

--- a/tests/test_decisions.py
+++ b/tests/test_decisions.py
@@ -1,0 +1,219 @@
+"""The `offered and declined` estimator, and the four states it stops pooling.
+
+The old control arm was "runs that reached this node and did not take the edge",
+which is four different things at once. Only one of them — the run was offered the
+move and passed — is evidence about the move. The rest say the move was unavailable,
+and since five of the seven guards read the same disk predicates the rubric scores,
+"unavailable" is correlated with "the run was weak". Pooling them makes the guard a
+selection mechanism on the outcome.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.archive import RunRecord
+from src.decisions import (
+    Decision,
+    decisions_from,
+    format_offered_payoffs,
+    offered_payoffs,
+)
+from src.inference import (
+    minimum_arms_for,
+    paired_floor,
+    unpaired_floor,
+    unpaired_permutation,
+)
+from src.rubric import RUBRIC_VERSION
+
+
+BACK = "06_analysis->05_experimentation"
+FORWARD = "06_analysis->07_writing"
+EIGHT = {f"0{n}_s": 0.0 for n in range(1, 9)}
+
+
+def run(
+    run_id: str,
+    *,
+    fitness: float,
+    decisions: list[dict],
+    provenance: str = "live",
+    topology: str = "adaptive",
+) -> RunRecord:
+    return RunRecord(
+        run_id=run_id,
+        variant_id="baseline",
+        rubric_version=RUBRIC_VERSION,
+        edges={},
+        stage_fitness={key: fitness for key in EIGHT},
+        topology=topology,
+        provenance=provenance,
+        route="",
+        steps=1,
+        revisits=0,
+        agent_directed=0,
+        bypassed=0,
+        recorded_at="t",
+        decisions=decisions,
+    )
+
+
+def decided(chose: str, offered: list[str], source: str = "06_analysis") -> dict:
+    return {"source": source, "chose": chose, "offered": offered}
+
+
+BOTH = ["05_experimentation", "07_writing"]
+
+
+class ControlArmTests(unittest.TestCase):
+    def test_a_run_that_was_never_offered_the_edge_is_not_a_control(self) -> None:
+        """The whole point. A guard-blocked edge was not declined, and counting it as
+        declined turns "this run's artifacts were missing" into "this edge pays"."""
+        records = [
+            run("took", fitness=0.60, decisions=[decided("05_experimentation", BOTH)]),
+            run("declined", fitness=0.70, decisions=[decided("07_writing", BOTH)]),
+            # Offered only the forward move — the revisit's guard was shut.
+            run("never-offered", fitness=0.20, decisions=[decided("07_writing", ["07_writing"])]),
+        ]
+        payoff = offered_payoffs(decisions_from(records))[BACK]
+
+        self.assertEqual((payoff.taken_n, payoff.declined_n), (1, 1))
+        self.assertAlmostEqual(payoff.delta, -0.10, places=6)
+
+    def test_the_old_arm_would_have_got_the_sign_backwards(self) -> None:
+        """The same fixture, scored the old way, says the opposite.
+
+        Six runs that never had the choice sit at 0.20; pooled into the control arm
+        they drag its mean below the treatment's and the edge reads as a win.
+        """
+        offered_both = [
+            run(f"took{i}", fitness=0.60, decisions=[decided("05_experimentation", BOTH)])
+            for i in range(3)
+        ] + [
+            run(f"passed{i}", fitness=0.70, decisions=[decided("07_writing", BOTH)])
+            for i in range(3)
+        ]
+        never = [
+            run(f"blocked{i}", fitness=0.20, decisions=[decided("07_writing", ["07_writing"])])
+            for i in range(6)
+        ]
+
+        payoff = offered_payoffs(decisions_from(offered_both + never))[BACK]
+        self.assertLess(payoff.delta, 0.0)
+
+        # What the run-level arm would have produced: every run that did not take it.
+        old_control = [0.70] * 3 + [0.20] * 6
+        old_delta = 0.60 - sum(old_control) / len(old_control)
+        self.assertGreater(old_delta, 0.0)
+
+    def test_a_bypassed_move_is_not_a_decision(self) -> None:
+        records = [
+            run("took", fitness=0.60, decisions=[decided("05_experimentation", BOTH)]),
+            run("declined", fitness=0.70, decisions=[decided("07_writing", BOTH)]),
+            run(
+                "jumped",
+                fitness=0.10,
+                decisions=[{**decided("05_experimentation", BOTH), "bypassed": True}],
+            ),
+        ]
+        payoff = offered_payoffs(decisions_from(records))[BACK]
+        self.assertEqual((payoff.taken_n, payoff.declined_n), (1, 1))
+
+    def test_a_visit_with_no_recorded_choice_set_is_excluded(self) -> None:
+        """A record from before `offered` existed has an empty set, which is
+        indistinguishable from "nothing else was available" and must not be read as
+        it."""
+        records = [
+            run("legacy", fitness=0.9, decisions=[decided("05_experimentation", [])]),
+            run("took", fitness=0.60, decisions=[decided("05_experimentation", BOTH)]),
+            run("declined", fitness=0.70, decisions=[decided("07_writing", BOTH)]),
+        ]
+        self.assertEqual(len(decisions_from(records)), 2)
+
+    def test_a_fake_run_contributes_no_decisions(self) -> None:
+        records = [
+            run("fake", fitness=0.99, provenance="fake", decisions=[decided("05_experimentation", BOTH)]),
+        ]
+        self.assertEqual(decisions_from(records), [])
+
+    def test_arms_are_kept_within_a_comparability_basis(self) -> None:
+        """A linear run and an adaptive run did not do the same work, and a basis
+        with only one arm carries no contrast."""
+        records = [
+            run("took", fitness=0.60, decisions=[decided("05_experimentation", BOTH)]),
+            run("declined", fitness=0.70, decisions=[decided("07_writing", BOTH)]),
+            run(
+                "other-topology",
+                fitness=0.05,
+                topology="linear",
+                decisions=[decided("07_writing", BOTH)],
+            ),
+        ]
+        payoff = offered_payoffs(decisions_from(records))[BACK]
+        self.assertEqual((payoff.taken_n, payoff.declined_n), (1, 1))
+
+
+class InferenceTests(unittest.TestCase):
+    def test_the_unpaired_floor_is_two_over_the_binomial(self) -> None:
+        self.assertAlmostEqual(unpaired_floor(3, 3), 0.1)
+        self.assertAlmostEqual(unpaired_floor(6, 6), 2 / 924, places=6)
+        self.assertEqual(unpaired_floor(0, 5), 1.0)
+
+    def test_three_a_side_cannot_reach_five_percent(self) -> None:
+        """Which is what `DEFAULT_MIN_OBSERVATIONS = 3` was licensing."""
+        result = unpaired_permutation([0.9, 0.9, 0.9], [0.1, 0.1, 0.1])
+        self.assertAlmostEqual(result.p_value, 0.1)
+        self.assertFalse(result.attainable())
+        self.assertIn("cannot reach", result.describe())
+
+    def test_six_a_side_can(self) -> None:
+        result = unpaired_permutation([0.9] * 6, [0.1] * 6)
+        self.assertTrue(result.attainable())
+        self.assertTrue(result.believable())
+
+    def test_the_family_correction_is_applied(self) -> None:
+        """With eighteen edges and no effect anywhere, the chance one clears an
+        uncorrected 0.05 is about 60%. The best of many is not one test."""
+        result = unpaired_permutation([0.9] * 6, [0.1] * 6)
+        self.assertTrue(result.believable(family=1))
+        self.assertFalse(result.believable(family=100))
+
+    def test_the_derived_minimum_matches_the_arithmetic(self) -> None:
+        size = minimum_arms_for(0.05, family=18)
+        self.assertLessEqual(unpaired_floor(size, size), 0.05 / 18)
+        self.assertGreater(unpaired_floor(size - 1, size - 1), 0.05 / 18)
+
+    def test_an_identical_pair_of_arms_is_not_significant(self) -> None:
+        self.assertEqual(unpaired_permutation([0.5] * 4, [0.5] * 4).p_value, 1.0)
+
+    def test_the_paired_floor_is_the_sign_flip_one(self) -> None:
+        self.assertAlmostEqual(paired_floor(6), 2 / 64)
+
+
+class ReportTests(unittest.TestCase):
+    def test_a_row_that_cannot_reach_the_threshold_says_so(self) -> None:
+        records = [
+            run("took", fitness=0.9, decisions=[decided("05_experimentation", BOTH)]),
+            run("declined", fitness=0.1, decisions=[decided("07_writing", BOTH)]),
+        ]
+        rendered = format_offered_payoffs(offered_payoffs(decisions_from(records)))
+        self.assertIn("cannot reach", rendered)
+        self.assertIn("reporting its sample size, not its effect", rendered)
+
+    def test_an_empty_archive_says_why_it_is_empty(self) -> None:
+        self.assertIn("predates `offered`", format_offered_payoffs({}))
+
+
+class DecisionTests(unittest.TestCase):
+    def test_an_edge_is_matched_on_both_ends(self) -> None:
+        decision = Decision("r", "06_analysis", "07_writing", tuple(BOTH), 0.5, "b")
+        self.assertTrue(decision.offered_edge(FORWARD))
+        self.assertTrue(decision.took_edge(FORWARD))
+        self.assertTrue(decision.offered_edge(BACK))
+        self.assertFalse(decision.took_edge(BACK))
+        self.assertFalse(decision.offered_edge("05_experimentation->06_analysis"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The second step of the archive plan. #150 fixed the reader; this fixes the estimator.

## The control arm was four things at once

`edge_payoffs` defines its control as *"runs that reached this node and did not take the edge"*. That pools:

- the guard was shut, so the edge was never on offer
- `--final-stage` pruned it
- the visit budget was spent
- the run was on a topology where the edge does not exist

Only the first kind of "did not" is a **choice**, and only a choice is evidence about a choice.

This is not a fine distinction. **Five of the seven guards read the same disk predicates the rubric scores** — `_guard_results_exist` and the reproducibility check are literally the same expression — so a shut guard is correlated with a weak run. Pooling those into the control makes the guard a selection mechanism on the outcome: the contrast measures how much worse a run is when its artifacts are missing, and reports it as the payoff of an edge nobody could have taken.

On a fixture where routing has **no effect at all**, the two arms give opposite signs. That is pinned by `test_the_old_arm_would_have_got_the_sign_backwards`.

## The fix was already on disk

`Visit.offered` has recorded the choice set since #140 and nothing read it. `src/decisions.py` makes the decision the unit of observation:

```
treatment — decisions at this node where this edge was chosen
control   — decisions where it was offered and not chosen
excluded  — decisions where it was not on offer
```

Also excluded: bypassed moves (nothing chose) and visits with an empty choice set (a record from before `offered` existed — "no alternative was recorded" is indistinguishable from "no alternative existed" and must not be read as it).

The old estimator **stays**, and `report` prints both — the offered contrast under the heading the proposer acts on, the run-level one under *"not acted on"*. An operator should be able to watch the two disagree rather than have the conclusion change silently.

## `DEFAULT_MIN_OBSERVATIONS` is derived now

It was `3`, with a docstring saying three *"is enough to stop acting on a single lucky run"* — a sentence about intent, not a derivation.

An exact two-sided permutation test over arms of *a* and *b* has `C(a+b,a)` labellings, so nothing can go below `2/C(a+b,a)`:

| arms | attainable floor |
| --- | --- |
| 3 v 3 | 0.1000 |
| 4 v 4 | 0.0286 |
| 5 v 5 | 0.0079 |
| **6 v 6** | **0.0022** |

Against the adaptive graph's edge family the corrected threshold is ~0.0019, so six. `minimum_arms_for` computes it and returns 6. **The archive had been licensing topology changes at a sample size where the arithmetic forbids the claim.**

`src/inference.py` returns the attainable floor beside every p-value, because *did not show an effect* and *could not have shown one* print identically as "not significant" and mean opposite things. Believability requires significance **and** attainability, corrected for the family size — with eighteen edges and no effect anywhere, the chance at least one clears an uncorrected 0.05 is about 60%.

## Testing

1405 pass (from 1389). 16 new, mostly of what the control arm now excludes. Fixtures that seeded 3 a side were updated to the derived floor, and `test_three_a_side_cannot_promote_however_large_the_gap` pins *why* — a 0.10-vs-0.99 gap at three a side is still refused, because the floor forbids it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)