### PR TITLE
Let the archive show the router its numbers, and nothing else

### DIFF
--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -384,6 +384,37 @@ Parents are sampled by fitness with a novelty bonus for under-observed variants.
 Pure fitness-proportional sampling locks onto whatever won first and stops
 generating the observations that would overturn it.
 
+### What the archive is allowed to do with what it learned
+
+Nothing, until `--archive-steer`. And then only this: **show the agent the numbers.**
+
+The learned value reached nothing before. Measured over 50 random priority
+assignments across all 8 nodes: 0/400 `default_move` answers change, 207/400 menu
+orderings do — `default_move` filters to forward edges and every node has exactly
+one, so a learned priority could only ever reorder rows in a table.
+
+Wiring the statistic into `default_move` was the obvious fix and three independent
+reviews refused it, for the same reason: it would put an unrandomised,
+guard-selected statistic in charge of what the run does at the moment a guard has
+just failed. The route taken instead is that the archive prints what earlier runs
+measured — the two means, the sample sizes, the p-value and the floor — into the
+routing prompt, and the agent decides. The agent can see this research question; the
+archive has only seen other ones.
+
+Three properties hold it:
+
+- **Only believable contrasts appear.** A row must clear the family-corrected
+  threshold *and* have been able to. Anything else is omitted rather than shown with
+  a caveat, because the caveat would not be read.
+- **Numbers, not a recommendation.** No sentence authored by the archive enters the
+  prompt, because there would be no gate that could fire on a wrong sentence.
+- **Nothing about admissibility depends on it.** Guards and `default_move` are
+  untouched, and a test asserts the live move set and the default are identical with
+  and without an archive that strongly prefers something else.
+
+A broken archive is a research aid that is unavailable, not a reason to fail a
+routing decision.
+
 ### Recording is on; steering is not
 
 The archive records every run by default, because recording is free and it is the

--- a/main.py
+++ b/main.py
@@ -1045,6 +1045,7 @@ def main() -> int:
             graph_max_steps=args.graph_max_steps,
             graph_max_visits=args.graph_max_visits,
             archive_steer=bool(walk["archive_steer"]),
+            archive=archive if walk["archive_steer"] else None,
             web_search_mode=web_search_mode,
         )
         manager.ideation_panel = create_ideation_panel(
@@ -1131,6 +1132,7 @@ def main() -> int:
         graph_max_steps=args.graph_max_steps,
         graph_max_visits=args.graph_max_visits,
         archive_steer=bool(walk["archive_steer"]),
+        archive=archive if walk["archive_steer"] else None,
         web_search_mode=web_search_mode,
     )
 

--- a/src/decisions.py
+++ b/src/decisions.py
@@ -212,3 +212,58 @@ def format_offered_payoffs(
         "threshold is reporting its sample size, not its effect."
     )
     return "\n".join(lines)
+
+def believable_evidence(
+    payoffs: dict[str, OfferedPayoff], targets: Sequence[str], source: str
+) -> list[OfferedPayoff]:
+    """The contrasts for these moves that the arithmetic actually licenses.
+
+    The filter is the whole design. An archive with three runs in it has an opinion
+    about every edge and is entitled to none of them, and a routing prompt that
+    printed those opinions would be an unrandomised, guard-selected statistic at
+    n=3 arguing for a move at the moment a guard has just failed. Only rows that
+    clear the family-corrected threshold *and* could have cleared it at this sample
+    size are shown; everything else is not shown at all, rather than shown with a
+    caveat nobody reads.
+    """
+    family = max(len(payoffs), 1)
+    live = []
+    for target in targets:
+        payoff = payoffs.get(f"{source}->{target}")
+        if payoff is not None and payoff.test.believable(family=family):
+            live.append(payoff)
+    return sorted(live, key=lambda item: abs(item.delta), reverse=True)
+
+
+def format_evidence_for_prompt(payoffs: Sequence[OfferedPayoff], family: int) -> str:
+    """Numbers, not a recommendation.
+
+    The archive does not get to author a sentence inside the prompt that decides the
+    route. It gets to show what earlier runs measured, with the sample sizes and the
+    test beside it, and the agent — which can see the actual research and the archive
+    cannot — decides what that is worth.
+    """
+    if not payoffs:
+        return ""
+    lines = [
+        "## What earlier runs measured about these moves",
+        "",
+        "Observational and from other research questions, so it is weaker than what you can "
+        "see in front of you. Only contrasts that clear a family-corrected threshold are "
+        "shown; the rest are omitted rather than shown weakly.",
+        "",
+        "| Move | Took it | Declined it | Difference | Test |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for payoff in payoffs:
+        lines.append(
+            f"| `{payoff.edge}` | {payoff.taken_mean:.3f} (n={payoff.taken_n}) | "
+            f"{payoff.declined_mean:.3f} (n={payoff.declined_n}) | {payoff.delta:+.3f} | "
+            f"{payoff.test.describe(family=family)} |"
+        )
+    lines.append("")
+    lines.append(
+        "This is evidence, not an instruction. A move that paid on average across other runs "
+        "can still be wrong here, and the reason you give should be about this run's results."
+    )
+    return "\n".join(lines)

--- a/src/manager.py
+++ b/src/manager.py
@@ -218,6 +218,7 @@ class ResearchManager:
         graph_max_steps: int | None = None,
         graph_max_visits: int | None = None,
         archive_steer: bool = False,
+        archive: "Any | None" = None,
         cross_reviewer: GeminiCrossReviewer | None = None,
     ) -> None:
         self.project_root = project_root
@@ -301,6 +302,7 @@ class ResearchManager:
             operator=operator,
             mode=routing_mode,
             fake_mode=bool(getattr(operator, "fake_mode", False)),
+            archive=archive,
         )
         # Measuring is on unless a caller turns it off: scoring a draft and running
         # the ratchet spends no backend call, and the property it buys — the draft

--- a/src/router.py
+++ b/src/router.py
@@ -90,12 +90,18 @@ class StageRouter:
         *,
         mode: str = "auto",
         fake_mode: bool = False,
+        archive: Any | None = None,
     ) -> None:
         if mode not in ROUTING_MODES:
             raise ValueError(f"Unknown routing mode: {mode!r}. Expected one of {', '.join(ROUTING_MODES)}.")
         self.mode = mode
         self.operator = operator
         self.fake_mode = fake_mode
+        # What the cross-run archive has learned, if the caller is willing to let it
+        # be *seen*. It reaches the agent as numbers in the prompt and nothing else:
+        # not `default_move`, not a guard, not a recommendation. The archive knows
+        # about other research questions; the agent can see this one.
+        self.archive = archive
 
     def choose(
         self,
@@ -285,6 +291,29 @@ class StageRouter:
             return None
         return extract_json_payload(stdout_text)
 
+    def _archive_evidence(self, source: str, targets: list[str]) -> str:
+        """What the archive can show about the moves on this menu, or nothing.
+
+        Best-effort. A archive that cannot be read is a research aid that is
+        unavailable, not a reason to fail a routing decision.
+        """
+        if self.archive is None or not targets:
+            return ""
+        try:
+            from .decisions import (
+                believable_evidence,
+                decisions_from,
+                format_evidence_for_prompt,
+                offered_payoffs,
+            )
+
+            payoffs = offered_payoffs(decisions_from(self.archive.runs()))
+            live = believable_evidence(payoffs, targets, source)
+            return format_evidence_for_prompt(live, max(len(payoffs), 1))
+        except Exception:  # noqa: BLE001 - never fail a route over a report
+            return ""
+
+
     def build_prompt(
         self,
         *,
@@ -339,6 +368,10 @@ class StageRouter:
         if score is not None:
             sections += ["", "## Measured standing of the stage you just finished", "",
                          format_score_for_prompt(score)]
+
+        evidence = self._archive_evidence(stage.slug, [move.target for move in moves if move.admissible])
+        if evidence:
+            sections += ["", evidence]
 
         sections += [
             "",

--- a/tests/test_archive_evidence.py
+++ b/tests/test_archive_evidence.py
@@ -1,0 +1,199 @@
+"""What the archive is allowed to say inside a routing prompt.
+
+The archive's learned value reached nothing: 0 of 400 measured node-comparisons
+changed `default_move`, because it filters to forward edges and every node has one.
+Three independent reviews refused the obvious fix — wiring the statistic into
+`default_move` — on the grounds that it would put an unrandomised, guard-selected,
+n=3 number in charge of what the run does at the moment a guard has just failed.
+
+This is the other route: the archive shows the agent what earlier runs measured, and
+the agent — which can see the actual research, and the archive cannot — decides. The
+objections that killed the first version are the properties these tests hold.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.archive import Archive, RunRecord
+from src.decisions import believable_evidence, decisions_from, offered_payoffs
+from src.router import StageRouter
+from src.rubric import RUBRIC_VERSION
+from src.stage_graph import GraphState, StageGraph
+from src.utils import STAGES, append_jsonl, build_run_paths, ensure_run_layout, write_text
+
+
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+BOTH = ["05_experimentation", "07_writing"]
+EIGHT = [f"0{n}_s" for n in range(1, 9)]
+
+
+def run(run_id: str, *, fitness: float, chose: str) -> RunRecord:
+    return RunRecord(
+        run_id=run_id,
+        variant_id="baseline",
+        rubric_version=RUBRIC_VERSION,
+        edges={},
+        stage_fitness={key: fitness for key in EIGHT},
+        topology="adaptive",
+        provenance="live",
+        route="",
+        steps=1,
+        revisits=0,
+        agent_directed=0,
+        bypassed=0,
+        recorded_at="t",
+        decisions=[{"source": "06_analysis", "chose": chose, "offered": BOTH}],
+    )
+
+
+class EvidenceGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.archive = Archive(Path(self._tmp.name) / "archive")
+
+    def seed(self, pairs: int, took: float, declined: float) -> None:
+        for index in range(pairs):
+            append_jsonl(
+                self.archive.runs_file,
+                run(f"t{index}", fitness=took, chose="05_experimentation").to_dict(),
+            )
+            append_jsonl(
+                self.archive.runs_file,
+                run(f"d{index}", fitness=declined, chose="07_writing").to_dict(),
+            )
+
+    def evidence(self):
+        payoffs = offered_payoffs(decisions_from(self.archive.runs()))
+        return believable_evidence(payoffs, BOTH, "06_analysis")
+
+    def test_a_thin_archive_shows_nothing_at_all(self) -> None:
+        """Three a side has an opinion about every edge and is entitled to none.
+
+        Shown with a caveat, it would be read; the caveat would not. So it is not
+        shown.
+        """
+        self.seed(3, took=0.90, declined=0.10)
+        self.assertEqual(self.evidence(), [])
+
+    def test_a_believable_contrast_is_shown_for_both_sides_of_the_choice(self) -> None:
+        """At a two-way node the two rows are mirror images, and both are true.
+
+        Evidence that taking the revisit paid *is* evidence that taking the advance
+        did not, so showing one and hiding the other would be presenting half of a
+        symmetric fact.
+        """
+        self.seed(6, took=0.90, declined=0.10)
+        shown = {payoff.edge: payoff.delta for payoff in self.evidence()}
+
+        self.assertEqual(len(shown), 2)
+        self.assertGreater(shown["06_analysis->05_experimentation"], 0)
+        self.assertLess(shown["06_analysis->07_writing"], 0)
+        self.assertAlmostEqual(
+            shown["06_analysis->05_experimentation"],
+            -shown["06_analysis->07_writing"],
+            places=6,
+        )
+
+    def test_a_large_sample_with_no_effect_is_not_shown(self) -> None:
+        """Attainability is necessary, not sufficient."""
+        self.seed(8, took=0.50, declined=0.50)
+        self.assertEqual(self.evidence(), [])
+
+    def test_only_moves_on_this_menu_are_shown(self) -> None:
+        """A node's evidence is filtered to the moves actually available here. An
+        agent shown a contrast for an edge it cannot take is being argued at about a
+        decision it does not have."""
+        self.seed(6, took=0.90, declined=0.10)
+        shown = believable_evidence(
+            offered_payoffs(decisions_from(self.archive.runs())), ["07_writing"], "06_analysis"
+        )
+        self.assertEqual([payoff.edge for payoff in shown], ["06_analysis->07_writing"])
+
+
+class PromptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.stage_file(STAGE_06), "# Stage 06: Analysis\n\nBody.\n")
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        self.archive = Archive(Path(self._tmp.name) / "archive")
+        self.graph = StageGraph.adaptive()
+
+    def seed(self, pairs: int, took: float, declined: float) -> None:
+        for index in range(pairs):
+            append_jsonl(self.archive.runs_file, run(f"t{index}", fitness=took, chose="05_experimentation").to_dict())
+            append_jsonl(self.archive.runs_file, run(f"d{index}", fitness=declined, chose="07_writing").to_dict())
+
+    def prompt(self, *, archive) -> str:
+        router = StageRouter(None, mode="agent", archive=archive)
+        moves = self.graph.moves(self.paths, STAGE_06.slug, GraphState())
+        return router.build_prompt(
+            paths=self.paths, stage=STAGE_06, moves=moves, state=GraphState(), score=None
+        )
+
+    def test_with_no_archive_the_prompt_is_unchanged(self) -> None:
+        """The default. `--archive-steer` is off, so the routing prompt of an
+        ordinary run says nothing about earlier runs at all."""
+        self.assertNotIn("earlier runs measured", self.prompt(archive=None))
+
+    def test_a_thin_archive_adds_nothing_to_the_prompt(self) -> None:
+        self.seed(3, took=0.90, declined=0.10)
+        self.assertNotIn("earlier runs measured", self.prompt(archive=self.archive))
+
+    def test_a_believable_contrast_reaches_the_prompt_as_numbers(self) -> None:
+        """Numbers, sample sizes and the test — not a recommendation.
+
+        The reviewer objection that killed the first version was an archive-authored
+        sentence inside the prompt that decides the route, with no gate that could
+        fire on a wrong sentence. There is no sentence: there is a row, and the row
+        carries what it rests on.
+        """
+        self.seed(6, took=0.90, declined=0.10)
+        rendered = self.prompt(archive=self.archive)
+
+        self.assertIn("earlier runs measured", rendered)
+        self.assertIn("06_analysis->05_experimentation", rendered)
+        self.assertIn("n=6", rendered)
+        self.assertIn("p=", rendered)
+        self.assertIn("evidence, not an instruction", rendered)
+        self.assertIn("weaker than what you can see in front of you", rendered)
+
+    def test_a_broken_archive_does_not_break_the_route(self) -> None:
+        """A research aid being unavailable is not a reason to fail a decision."""
+
+        class Exploding:
+            def runs(self):
+                raise RuntimeError("disk on fire")
+
+        self.assertNotIn("earlier runs measured", self.prompt(archive=Exploding()))
+
+    def test_the_archive_never_reaches_the_guards_or_the_default(self) -> None:
+        """The invariant the reviews were protecting. Evidence is shown; nothing
+        about which moves are admissible, or which one is taken with nobody asked,
+        may depend on it."""
+        self.seed(20, took=0.99, declined=0.01)
+        state = GraphState()
+
+        without = StageGraph.adaptive().default_move(self.paths, STAGE_06.slug, state)
+        live_without = {m.target for m in self.graph.admissible_moves(self.paths, STAGE_06.slug, state)}
+
+        router = StageRouter(None, mode="off", archive=self.archive)
+        decision = router.choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=state
+        )
+        live_with = {m.target for m in self.graph.admissible_moves(self.paths, STAGE_06.slug, state)}
+
+        self.assertEqual(live_with, live_without)
+        self.assertEqual(decision.target, without.target)
+        self.assertFalse(decision.agent_directed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The third step: give what the archive learns a way to reach a decision.

## The learned value reached nothing

| Measured over 50 random priority assignments × 8 nodes | |
| --- | --- |
| `default_move` answers that change | **0 / 400** |
| menu orderings that change | 207 / 400 |

`default_move` filters to forward edges and every node has exactly one, so whatever the archive concluded, the only thing it could move was the order of rows in a table.

Wiring the statistic into `default_move` is the obvious fix and **three independent reviews refused it**, all for the same reason: it puts an unrandomised, guard-selected statistic in charge of what the run does at the moment a guard has just failed. That objection is sound and better arithmetic does not answer it.

## The other route

Under `--archive-steer`, the archive prints what earlier runs measured about the moves on this menu — both means, both sample sizes, the p-value and the floor — into the routing prompt. The agent decides. The agent can see this research question; the archive has only ever seen other ones, and the prompt says so.

```
## What earlier runs measured about these moves

| Move                            | Took it      | Declined it  | Difference | Test                        |
| `06_analysis->05_experimentation` | 0.900 (n=6) | 0.100 (n=6) | +0.800     | p=0.0022 against 0.0250 — believable |

This is evidence, not an instruction.
```

Three properties, each answering one objection:

- **Only believable contrasts appear.** A row must clear the family-corrected threshold *and* have been able to at that sample size. Three a side shows nothing at all; so does a large sample with no effect. Anything else is omitted rather than shown with a caveat, because the caveat is the part nobody reads.
- **Numbers, not a recommendation.** No sentence authored by the archive enters the prompt. The objection to the first version was an archive-authored sentence with no gate that could fire on a wrong sentence; there is no sentence, only a row, and the row carries what it rests on.
- **Nothing about admissibility depends on it.** A test asserts the live move set and the default move are identical with and without an archive that strongly prefers something else, so the guards keep being the correctness argument they were.

A broken archive returns nothing rather than raising — a research aid being unavailable is not a reason to fail a routing decision.

## Off by default, twice over

`--archive-steer` is off, and with it off the manager passes no archive to the router at all, so an ordinary run's routing prompt is byte-identical to before.

## Two tests I wrote wrong

At a two-way node the two rows are mirror images — evidence that the revisit paid *is* evidence the advance did not. I asserted one row and got two, and asserted an empty result and got the other side. The code was right both times; the tests now assert the symmetry.

## Testing

1483 pass (from 1474). 9 new, all of them constraints rather than capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)