### PR TITLE
Route a research round's decision instead of jumping around the router

### DIFF
--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -137,6 +137,25 @@ The division of labour is the point:
   refused, recorded, and replaced by the default edge — which at every node is the
   forward one, so a refusal degrades to the old pipeline rather than to a stall.
 
+### A research round's decision goes through the router too
+
+`src/research_rounds.py` closes a round at Stage 06 with `converged`,
+`refine_design` (back to 03), `new_hypothesis` (back to 02) or `abandon`. The two
+backward decisions are edges the graph already has, and they used to reach them by
+setting `_jump_target_stage` — around the router entirely.
+
+That had two costs. The run's most consequential routing decisions arrived at the
+archive marked `bypassed` with no choice set, so the estimator excluded exactly the
+moves it most wanted to learn about. And the jump happened whatever the guards said.
+
+A closed round now *declares* an intent, and the router treats it as a proposal that
+outranks the backend — the round has already reasoned about the results and written
+its conclusion to disk, so asking again would be buying an opinion on a settled
+question. What it does not outrank is the guards. A refused intent falls to the
+forward edge and the round ledger records that it was not acted on, which it could
+not do before: `record_round` runs at approval, before the router has ruled, so the
+ledger could claim a round was acted on when its move was refused.
+
 Blocked moves are shown to the agent *with the reason they are blocked*. Hiding
 them is the more obvious design and it is the wrong one: an agent that can see
 "`07_writing` is closed because H2 has no verdict" routes to the analysis stage

--- a/src/manager.py
+++ b/src/manager.py
@@ -57,6 +57,9 @@ from .prompt_fragments import compose_stage_template
 from .validity_review import ValidityReviewer, format_findings_for_prompt
 from .research_rounds import (
     ROUND_CLOSING_STAGE_NUMBER,
+    RoundIntent,
+    amend_last_round,
+    discard_pending_decision,
     Round,
     latest_round,
     unreopened_abandonment,
@@ -241,6 +244,9 @@ class ResearchManager:
         #: reads the visit rather than the run-global ledger, so this is what scopes
         #: it to the traversal that actually made the decision.
         self._closed_round: int = 0
+        #: What the round that just closed asked for, if it asked for anything. Read
+        #: by `_advance_from` and cleared on every stage entry.
+        self._round_intent: "RoundIntent | None" = None
         self._redo_start_stage: StageSpec | None = None
         self._research_diagram: bool = False
         self._final_stage: StageSpec | None = None
@@ -510,6 +516,7 @@ class ResearchManager:
             self._jump_target_stage = None
             self._jump_reason = ""
             self._closed_round = 0
+            self._round_intent = None
             approved = self._run_stage(paths, stage)
 
             # Three things reach this seam: `/back <stage>`, a rollback after retry
@@ -707,6 +714,7 @@ class ResearchManager:
         if state.path:
             state.path[-1].closed_round = self._closed_round
 
+        intent = self._round_intent
         decision = self.router.choose(
             paths=paths,
             stage=stage,
@@ -714,7 +722,21 @@ class ResearchManager:
             state=state,
             score=score,
             final_stage=self._final_stage,
+            declared=(intent.target, intent.reason) if intent is not None else None,
         )
+        if intent is not None:
+            honoured = decision.target == intent.target
+            amend_last_round(
+                paths,
+                acted_on=honoured,
+                budget_note="" if honoured else (decision.refusal or "the move was not available"),
+            )
+            if not honoured:
+                self.ui.show_status(
+                    f"Round {intent.number} asked to go back to `{intent.target}` and could "
+                    f"not: {decision.refusal or 'the move was not available'}.",
+                    level="warn",
+                )
         graph_leave(
             paths,
             state,
@@ -743,10 +765,24 @@ class ResearchManager:
             # later stage's approved summary in memory describing work that the
             # revisit is about to replace.
             self._print(self._format_rollback_preview(paths, target))
-            rollback_to_stage(
+            reason = f"Graph revisit from {stage.slug}: {decision.reason}"
+            rollback_to_stage(paths, target, reason=reason)
+            # `_rollback_and_jump` did this and the router path did not, so moving
+            # the round decision onto the router would have silently dropped it. A
+            # rollback is the strongest evidence a review can produce — an approval
+            # already given turned out to be wrong — and standing rules from one are
+            # the highest-weight group in the approval prompt. Losing them would make
+            # the review gate get *easier* with each round, which is the inversion
+            # the round machinery exists to prevent.
+            record_correction(
                 paths,
-                target,
-                reason=f"Graph revisit from {stage.slug}: {decision.reason}",
+                stage=stage,
+                attempt_no=0,
+                text=(
+                    f"{stage.stage_title} was rolled back to {target.stage_title}. "
+                    f"Reason: {reason}"
+                ),
+                source="rollback",
             )
             return target
 
@@ -3127,6 +3163,18 @@ class ResearchManager:
         reason: str,
         kind: str,
     ) -> bool:
+        # A skipped Stage 06 never reaches `record_round`, so its declaration is
+        # never consumed and never unlinked. Left on disk, the *next* Stage 06 closes
+        # its round from the previous visit's file — inheriting a conclusion drawn
+        # from results it did not produce.
+        if stage.number == ROUND_CLOSING_STAGE_NUMBER and discard_pending_decision(paths):
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} round_decision_discarded",
+                "The stage was skipped, so the round it declared never closed. The "
+                "declaration was dropped rather than left for the next visit to inherit.",
+            )
+
         final_stage_path = paths.stage_file(stage)
         rescued = self._validated_draft_for_skip(paths, stage) if kind == "auto" else None
         if rescued is not None:
@@ -3331,17 +3379,22 @@ class ResearchManager:
 
         target = next(item for item in STAGES if item.slug == resume_slug)
         self.ui.show_status(
-            f"Round {entry.number} chose {entry.decision}. Starting round {entry.number + 1} "
+            f"Round {entry.number} chose {entry.decision}. Asking for round {entry.number + 1} "
             f"from {target.stage_title}.",
             level="warn",
         )
-        self._rollback_and_jump(
-            paths=paths,
-            current_stage=stage,
-            target_stage=target,
-            reason=(
-                f"Round {entry.number} concluded {entry.decision}: {entry.rationale}"
-            ),
+        # Declared, not taken. `06->03` and `06->02` are edges the graph already has,
+        # and going around the router meant the run's most consequential routing
+        # decisions arrived at the archive as `bypassed` with no choice set — the
+        # exact observations `Visit.offered` exists to keep out of the estimator.
+        #
+        # It also means the move is now checked. `_rollback_and_jump` jumped whatever
+        # the guards said; a declared intent has to be admissible, and a refusal is
+        # recorded with its reason.
+        self._round_intent = RoundIntent(
+            target=target.slug,
+            reason=f"Round {entry.number} concluded {entry.decision}: {entry.rationale}",
+            number=entry.number,
         )
 
     def _run_validity_review(self, paths: RunPaths, stage: StageSpec, stage_markdown: str) -> None:

--- a/src/research_rounds.py
+++ b/src/research_rounds.py
@@ -102,6 +102,19 @@ class Round:
         }
 
 
+@dataclass(frozen=True)
+class RoundIntent:
+    """What a closed round asked the run to do next.
+
+    A request, not an instruction. It goes to the router like any other proposed
+    move: admissible or refused, and recorded either way with its choice set.
+    """
+
+    target: str
+    reason: str
+    number: int
+
+
 def load_rounds(paths: RunPaths) -> list[Round]:
     payload = _load_json(paths.research_rounds)
     if not isinstance(payload, dict):
@@ -351,3 +364,48 @@ def format_round_status(paths: RunPaths, max_rounds: int) -> str:
     else:
         shape = final.decision
     return f"{len(rounds)} round(s); {shape}"
+
+def amend_last_round(paths: RunPaths, *, acted_on: bool, budget_note: str = "") -> Round | None:
+    """Correct the last round's record once the router has ruled on its intent.
+
+    `record_round` runs at Stage 06 approval; whether the intent was honoured is not
+    known until the router has evaluated it, which happens afterwards. Writing
+    `acted_on` at approval time and leaving it meant the ledger could claim a round
+    was acted on when the move it asked for was refused — a claim nothing later would
+    contradict, in the one artifact a reader consults to find out what the run
+    decided.
+    """
+    rounds = load_rounds(paths)
+    if not rounds:
+        return None
+    last = rounds[-1]
+    amended = Round(
+        number=last.number,
+        decision=last.decision,
+        rationale=last.rationale,
+        what_we_learned=last.what_we_learned,
+        what_changes_next=last.what_changes_next,
+        negative_result=last.negative_result,
+        hypothesis_verdicts=last.hypothesis_verdicts,
+        recorded_at=last.recorded_at,
+        acted_on=acted_on,
+        budget_note=budget_note,
+        reopens_round=last.reopens_round,
+    )
+    _write_rounds(paths, [*rounds[:-1], amended])
+    return amended
+
+
+def discard_pending_decision(paths: RunPaths) -> bool:
+    """Drop a round declaration that no round will close.
+
+    `_skip_stage` returns before the approval branch, so a Stage 06 that exhausted
+    its retries never reaches `record_round` and never unlinks the file. Left there,
+    the *next* Stage 06 closes its round from the previous visit's declaration —
+    inheriting a conclusion drawn from results it did not produce.
+    """
+    if not paths.round_decision.exists():
+        return False
+    paths.round_decision.unlink(missing_ok=True)
+    return True
+

--- a/src/router.py
+++ b/src/router.py
@@ -112,6 +112,7 @@ class StageRouter:
         state: GraphState,
         score: StageScore | None = None,
         final_stage: StageSpec | None = None,
+        declared: tuple[str, str] | None = None,
     ) -> RoutingDecision:
         moves = graph.moves(paths, stage.slug, state, final_stage=final_stage)
         live = [move for move in moves if move.admissible]
@@ -119,7 +120,7 @@ class StageRouter:
         default_target = default.target if default is not None else FINISH
         # Computed here anyway; recorded rather than dropped. See `Visit.offered`.
         offered = tuple(sorted(move.target for move in live))
-        blocked = {
+        blocked_kinds = {
             move.target: move.blocked_kind for move in moves if move.blocked_kind
         }
 
@@ -153,7 +154,36 @@ class StageRouter:
                 )
             return RoutingDecision(
                 FINISH, "finish", "No further move is available.", FINISH, False,
-                offered=offered, blocked=blocked,
+                offered=offered, blocked=blocked_kinds,
+            )
+
+        # A closed research round's decision is a proposal like any other, and it
+        # outranks the backend: the round has already reasoned about the results and
+        # written its conclusion to disk, so asking a second time would be paying for
+        # an opinion on a settled question. What it does not outrank is the guards —
+        # `_rollback_and_jump` jumped regardless of them, and this does not.
+        if declared is not None:
+            target, reason = declared
+            chosen = next((move for move in live if move.edge.target == target), None)
+            if chosen is None:
+                unavailable = next((move for move in moves if move.edge.target == target), None)
+                detail = (
+                    f"the round asked for `{target}`: {unavailable.blocked_because}"
+                    if unavailable is not None
+                    else f"the round asked for `{target}`, which is not a move out of {stage.slug}"
+                )
+                return self._refuse(
+                    paths, stage, default, default_target, detail,
+                    offered=offered, blocked=blocked_kinds,
+                )
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} route_from_round",
+                f"target: {target}\nreason: {reason}",
+            )
+            return RoutingDecision(
+                target, chosen.edge.kind, reason, default_target, agent_directed=True,
+                offered=offered, blocked=blocked_kinds,
             )
 
         should_ask = self.mode == "agent" or (self.mode == "auto" and len(live) > 1)
@@ -165,7 +195,7 @@ class StageRouter:
                 default_target,
                 agent_directed=False,
                 offered=offered,
-                blocked=blocked,
+                blocked=blocked_kinds,
             )
 
         proposal = self._ask(paths=paths, stage=stage, moves=moves, state=state, score=score)
@@ -173,7 +203,7 @@ class StageRouter:
             return self._refuse(
                 paths, stage, default, default_target,
                 "the router produced no readable decision",
-                offered=offered, blocked=blocked,
+                offered=offered, blocked=blocked_kinds,
             )
 
         target = str(proposal.get("target") or "").strip()
@@ -188,14 +218,15 @@ class StageRouter:
                 else f"`{target}` is not a move out of {stage.slug}"
             )
             return self._refuse(
-                paths, stage, default, default_target, detail, offered=offered, blocked=blocked
+                paths, stage, default, default_target, detail, offered=offered,
+                blocked=blocked_kinds,
             )
 
         if not reason:
             return self._refuse(
                 paths, stage, default, default_target,
                 f"`{target}` was chosen with no stated reason",
-                offered=offered, blocked=blocked,
+                offered=offered, blocked=blocked_kinds,
             )
 
         if chosen.edge.kind == "revisit" and graph.repeats_a_previous_reason(state, target, reason):
@@ -203,7 +234,7 @@ class StageRouter:
                 paths, stage, default, default_target,
                 f"the run has already gone back to `{target}` for this same reason and it was not "
                 "resolved; going again on the same grounds is a loop, not an iteration",
-                offered=offered, blocked=blocked,
+                offered=offered, blocked=blocked_kinds,
             )
 
         append_log_entry(
@@ -213,7 +244,7 @@ class StageRouter:
         )
         return RoutingDecision(
             target, chosen.edge.kind, reason, default_target, agent_directed=True,
-            offered=offered, blocked=blocked,
+            offered=offered, blocked=blocked_kinds,
         )
 
     # -- refusal -------------------------------------------------------------

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -167,7 +167,7 @@ class GraphWalkTests(unittest.TestCase):
         _operator, manager = self.build(stage_graph=StageGraph.adaptive(), routing_mode="agent")
         sent_back = {"done": False}
 
-        def choose(*, paths, stage, graph, state, score=None, final_stage=None):
+        def choose(*, paths, stage, graph, state, score=None, final_stage=None, **_kwargs):
             if stage.slug == STAGE_06.slug and not sent_back["done"]:
                 sent_back["done"] = True
                 return RoutingDecision(
@@ -206,7 +206,7 @@ class GraphWalkTests(unittest.TestCase):
         _operator, manager = self.build(stage_graph=StageGraph.adaptive(), routing_mode="agent")
         seen: list[str] = []
 
-        def choose(*, paths, stage, graph, state, score=None, final_stage=None):
+        def choose(*, paths, stage, graph, state, score=None, final_stage=None, **_kwargs):
             if stage.slug == STAGE_06.slug and STAGE_06.slug not in seen:
                 seen.append(STAGE_06.slug)
                 manifest_before = load_run_manifest(paths.run_manifest)
@@ -237,7 +237,7 @@ class GraphWalkTests(unittest.TestCase):
             graph_max_visits=99,
         )
 
-        def choose(*, paths, stage, graph, state, score=None, final_stage=None):
+        def choose(*, paths, stage, graph, state, score=None, final_stage=None, **_kwargs):
             if stage.slug == STAGE_05.slug:
                 return RoutingDecision(STAGE_06.slug, "advance", "on", STAGE_06.slug, True)
             if stage.slug == STAGE_06.slug:

--- a/tests/test_research_rounds.py
+++ b/tests/test_research_rounds.py
@@ -22,6 +22,9 @@ from unittest.mock import patch
 
 from src.evolution import EvolutionConfig
 from src.manager import ResearchManager
+from src.review_policy import policy_path
+from src.router import routing_summary
+from src.stage_graph import StageGraph, load_graph_state
 from src.research_rounds import (
     DECISIONS,
     current_round_number,
@@ -35,7 +38,14 @@ from src.research_rounds import (
     unreopened_abandonment,
     validate_round_decision,
 )
-from src.utils import STAGES, build_run_paths, ensure_run_layout, validate_stage_artifacts, write_text
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_layout,
+    read_text,
+    validate_stage_artifacts,
+    write_text,
+)
 from tests.prereg_support import write_round_decision, write_validity_chain
 
 
@@ -289,6 +299,127 @@ class AbandonmentStandsUntilOverruledTest(RoundTestCase):
         standing = unreopened_abandonment(self.paths)
         self.assertIsNotNone(standing)
         self.assertEqual(standing.number, 1)
+
+
+class RoundIntentGoesThroughTheRouterTest(unittest.TestCase):
+    """A round's decision is a proposal, not a jump.
+
+    `06->03` and `06->02` are edges the graph already has. Going around the router
+    meant the run's most consequential routing decisions reached the archive as
+    `bypassed` with no choice set — the exact observations `Visit.offered` exists to
+    keep out of the estimator — and were taken whatever the guards said.
+    """
+
+    def _manager(self, tmp_dir: str, max_rounds: int = 3):
+        from tests.test_manager_smoke import ScriptedSmokeOperator
+
+        operator = ScriptedSmokeOperator()
+        manager = ResearchManager(
+            project_root=REPO_ROOT,
+            runs_dir=Path(tmp_dir) / "runs",
+            operator=operator,
+            output_stream=io.StringIO(),
+            max_rounds=max_rounds,
+            stage_graph=StageGraph.adaptive(),
+            evolution=EvolutionConfig(rounds=0),
+        )
+        return operator, manager
+
+    def _declare(self, manager, decision: str, **extra):
+        original = manager.operator.run_stage
+
+        def run_stage(stage, prompt, run_paths, attempt_no, continue_session=False):
+            result = original(stage, prompt, run_paths, attempt_no, continue_session)
+            if stage.number == 6 and not load_rounds(run_paths):
+                payload = {
+                    "decision": decision,
+                    "rationale": "The first design could not separate the effect from noise.",
+                    "what_we_learned": "The comparison was confounded by tuning on the split.",
+                    "what_changes_next": "Tune both arms on a held-out development split.",
+                    "negative_result": False,
+                }
+                payload.update(extra)
+                write_text(run_paths.round_decision, json.dumps(payload))
+            return result
+
+        manager.operator.run_stage = run_stage
+
+    def test_a_round_revisit_is_recorded_as_a_decision_with_its_choice_set(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operator, manager = self._manager(tmp_dir)
+            paths = manager._create_run("Round routing.", venue="neurips_2025")
+            self._declare(manager, "refine_design")
+            with patch.object(manager, "_ask_choice", return_value="5"):
+                self.assertTrue(manager._run_from_paths(paths))
+
+            state = load_graph_state(paths)
+            revisits = [visit for visit in state.path if visit.kind == "revisit"]
+            self.assertTrue(revisits)
+            move = revisits[0]
+            self.assertEqual(move.chose, "03_study_design")
+            self.assertFalse(move.bypassed, msg="a routed decision must not read as a jump")
+            self.assertIn("03_study_design", move.offered)
+            self.assertTrue(move.agent_directed)
+
+            summary = routing_summary(paths)
+            self.assertIn("06_analysis->03_study_design", summary["edges"])
+            self.assertEqual(summary["bypassed"], 0)
+
+    def test_a_round_revisit_still_plants_the_rollback_correction(self) -> None:
+        """`_rollback_and_jump` recorded one and the router path did not, so moving
+        the decision across would have silently dropped a rigour signal: standing
+        rules from a rollback are the highest-weight group in the approval prompt,
+        and losing them makes the gate get easier with each round."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _operator, manager = self._manager(tmp_dir)
+            paths = manager._create_run("Round routing.", venue="neurips_2025")
+            self._declare(manager, "refine_design")
+            with patch.object(manager, "_ask_choice", return_value="5"):
+                manager._run_from_paths(paths)
+
+            policy = read_text(policy_path(paths))
+            self.assertIn('"source": "rollback"', policy)
+            self.assertIn("rolled back to Stage 03: Study Design", policy)
+            self.assertIn("refine_design", policy)
+
+    def test_the_ledger_says_a_refused_intent_was_not_acted_on(self) -> None:
+        """`record_round` runs at approval, before the router has ruled. Written
+        then and left, the ledger could claim a round was acted on when the move it
+        asked for was refused — in the one artifact a reader consults to find out
+        what the run decided."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _operator, manager = self._manager(tmp_dir)
+            paths = manager._create_run("Round routing.", venue="neurips_2025")
+            self._declare(manager, "refine_design")
+
+            real_choose = manager.router.choose
+
+            def refuse(**kwargs):
+                kwargs.pop("declared", None)
+                return real_choose(**kwargs)
+
+            with patch.object(manager, "_ask_choice", return_value="5"), patch.object(
+                manager.router, "choose", side_effect=refuse
+            ):
+                manager._run_from_paths(paths)
+
+            rounds = load_rounds(paths)
+            self.assertTrue(rounds)
+            self.assertFalse(rounds[0].acted_on)
+
+    def test_a_skipped_stage_does_not_leave_its_declaration_behind(self) -> None:
+        """A skipped Stage 06 never reaches `record_round`, so nothing unlinks the
+        file, and the next Stage 06 would close its round from the previous visit's
+        conclusion — drawn from results it did not produce."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _operator, manager = self._manager(tmp_dir)
+            paths = manager._create_run("Skip probe.", venue="neurips_2025")
+            write_text(paths.round_decision, json.dumps({"decision": "refine_design"}))
+
+            manager._skip_stage(paths, STAGE_06, attempt_no=1, reason="out of attempts", kind="auto")
+
+            self.assertFalse(paths.round_decision.exists())
+            self.assertIn("round_decision_discarded", read_text(paths.logs))
 
 
 class PromptCarryForwardTest(RoundTestCase):


### PR DESCRIPTION
The fourth of the four. `06→03` and `06→02` are edges the graph already has, and a closed round reached them by setting `_jump_target_stage` — which the walk treats as an operator override.

Two costs. The run's **most consequential routing decisions** arrived at the archive marked `bypassed` with no choice set, so the estimator excluded exactly the moves it most wanted to learn about. And the jump happened whatever the guards said.

A round now *declares* an intent and the router consumes it:

- It **outranks the backend** — the round has already reasoned about the results and written its conclusion to disk, so asking again would buy an opinion on a settled question.
- It **does not outrank the guards**. A refused intent falls to the forward edge with the refusal recorded.
- The move lands in the archive as a decision with its `offered` set.

## Three things that had to move with it

Each would otherwise have broken quietly.

**The rollback correction.** `_rollback_and_jump` recorded a standing rule with `source="rollback"`; the router's revisit branch called only `rollback_to_stage`. Rollback rules are the highest-weight group in the approval prompt, so dropping them would make the review gate get **easier with each round** — the exact inversion the round machinery exists to prevent. The revisit branch now records it, for every revisit rather than only a round's.

**The ledger's `acted_on`.** `record_round` runs at Stage 06 approval, strictly before the router rules. Written then and left, the ledger could claim a round was acted on when the move it asked for was refused — an unchallenged claim in the one artifact a reader consults to find out what the run decided.

**A skipped stage's leftover declaration.** `_skip_stage` returns before the approval branch, so a Stage 06 that exhausted its retries never reaches `record_round` and never unlinks `round_decision.json`. Left there, the *next* Stage 06 closes its round from the previous visit's file — inheriting a conclusion drawn from results it did not produce.

## What stayed cut

The round budget stays in `_close_round`. Expressing it as a guard was considered and cut for the reasons in #143: a guard sees only `(RunPaths, GraphState)` and could not read `--max-rounds`, and blocking `06→03` on a spent budget would also stop an analysis that exposed a confound from routing back to design.

## Testing

1487 pass. Each of the three rules mutation-checked — reverting any one fails exactly one test:

| Reverted | Test that dies |
| --- | --- |
| `record_correction` on the revisit path | `test_a_round_revisit_still_plants_the_rollback_correction` |
| `acted_on=honoured` → `acted_on=True` | `test_the_ledger_says_a_refused_intent_was_not_acted_on` |
| stale-declaration discard | `test_a_skipped_stage_does_not_leave_its_declaration_behind` |

Plus `test_a_round_revisit_is_recorded_as_a_decision_with_its_choice_set`, which asserts the move is **not** `bypassed`, carries its `offered` set, and reaches `routing_summary().edges`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)