### PR TITLE
Plan the scored deliverable at the stage that can still change it

### DIFF
--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -77,7 +77,7 @@ After the pipeline finishes — **whether or not it succeeded** — the adapter 
 | `report/report.md` | see below |
 | `report/images/*.png` | `workspace/report/images` first, then `figures`, `writing`, `results`, `artifacts` (PNG only, capped — see below) |
 | `code/` | `workspace/code` |
-| `outputs/` | `workspace/results` and `workspace/notes`, **images excluded** |
+| `outputs/` | `workspace/results` and `workspace/notes`, **images excluded** — and any image a stage wrote straight to `<workspace>/outputs/`, or anywhere under `<workspace>/report/` other than a published slot, is deleted; see below |
 
 Run-tree figures under `report/images/` keep their filenames, because those are the names
 `report.md` references. A same-named figure swept up from elsewhere is the one that gets
@@ -86,30 +86,84 @@ qualified.
 #### The five image slots
 
 This is where most of the score is. Across the 40 shipped tasks, 91 of 154 checklist items
-are `type: image` and they carry **60.6% of total weight** (median 62%; images are the
-majority of weight in 25 of 40 tasks). The scorer shows the judge at most five agent images
-per item:
+are `type: image` and they carry **60.6% of total weight** (median 62.5%; images are the
+strict majority of weight in **24 of 40** tasks and at or above half in 25 — `Material_000`
+is exactly 50/50). Every number in this section is re-derivable from
+`tasks/*/target_study/checklist.json`: sum `weight` grouped on `type` for the weights, count
+the `type: image` entries per task for the criterion counts. They move when the task set
+does, and they were last measured on 2026-08-10 against the 40 shipped tasks.
+
+The judge is **not** shown five images chosen for the item. `evaluation/score.py` collects
+one set per *workspace* and hands the first five of that same set to every image criterion:
 
 ```python
+generated_images = _find_generated_images(workspace)               # once, per workspace
+...
 for search_dir in [workspace / "outputs", workspace / "report"]:   # outputs first
     for ext in IMAGE_EXTENSIONS:
         images.extend(search_dir.rglob(f"*{ext}"))                 # filesystem order
 ...
-for img in generated_images[:5]:
+for img in generated_images[:5]:                                   # per item, the same five
 ```
 
-Two consequences drive the export:
+Four consequences drive the export, and the plan the run writes at Stage 03:
 
-1. **`outputs/` is drained before `report/`.** A diagnostic plot left in `workspace/results`
-   would take a slot from a figure the report argues with, so images are excluded from the
-   `outputs/` mirror entirely. The machine-readable results still go across.
+1. **`outputs/` is drained before `report/`.** A diagnostic plot there takes a slot from a
+   figure the report argues with, so images are excluded from the `outputs/` mirror
+   entirely — the machine-readable results still go across — **and** `collect_figures`
+   deletes any image a stage wrote directly to `<workspace>/outputs/`, which the goal
+   contract's own instruction to keep `outputs/` up to date makes easy to do by accident.
+   Withholding them from the mirror is only half the defence: six stray PNGs there take all
+   five slots and the report's figures reach the judge as nothing.
 2. **`rglob` order is filesystem order, not alphabetical.** Naming cannot influence which
    five survive. The only lever is publishing no more than five — so `collect_figures`
    enforces `MAX_REPORT_FIGURES`, picks by the report's own reference order, and prunes
    anything else already at the benchmark path. A figure the report references is never
    pruned; Stage 07's gate is what keeps a run from arriving over budget.
+   The prune is the *same walk* as the sweep, over both trees: `rglob` over `outputs/` and
+   over `report/`, not `iterdir()` over `report/images/`. `report/images/` is not the only
+   place under `report/` the scorer looks, so a loose `report/panel.png` or a nested
+   `report/images/panels/*.png` takes a slot exactly the way a stray `outputs/` plot does —
+   and both sort *ahead* of `report/images/` in the walk. The only images that survive the
+   prune are the published slots and any image the winning report links directly.
+3. **No shipped task has more than five image criteria**, and 34 of 40 have three or fewer
+   (distribution over image criteria per task: 0×3, 1×10, 2×9, 3×12, 4×3, 5×3). Five is a
+   ceiling, not a target. The weight is earned by figures that settle *different* questions;
+   several views of one result spend most of the budget on one criterion.
+4. **Image criteria are shown only the first 10,000 characters of `report.md`**
+   (`report_text[:10000]` in `_build_image_prompt`; `_build_text_prompt` interpolates
+   `report_text` whole, so text criteria are *not* truncated). This is an ordering
+   constraint, not a length limit, and the goal text has to say so in those words: the
+   ~39% of weight the text criteria carry reads the entire report, so a run told its report
+   is "forfeited" past 10,000 characters would cut methodology and discussion that were
+   still being scored. The headline numbers, the results and the figure captions come
+   first; everything else comes after them, not instead of them.
+   That number is the benchmark's, not AutoR's: it lives in this file and in
+   `build_benchmark_goal`'s prose, and deliberately not as a constant in `src/` — nothing in
+   AutoR should start truncating on it.
 
 A sixth figure does not add a sixth chance to match. It randomises which five are seen.
+
+#### Where the five are chosen
+
+Not at export, and not at Stage 07. The run commits to its figures at **Stage 03**, in
+`workspace/notes/report_plan.json`: one entry per slot, each naming the claim it settles,
+what the reader should see, what the figure looks like if that claim holds and if it does
+not, and the result file it will be computed from. Stage 06 produces them, Stage 07
+publishes them in slot order, and — in markdown mode, which is what the benchmark runs — a
+planned figure that was neither published nor explicitly dropped is a refusal rather than a
+silence. `docs/stage-contract.md` carries the gate rows and `src/report_plan.py` the
+validator.
+
+That machinery is **not** benchmark-specific. It is the discipline
+`hypothesis_manifest.json` and `experimental_protocol.json` already apply — commit to the
+choice before the results can influence it — applied a third time, to figures, and every
+AutoR run gets it. What *is* benchmark-specific is everything above: the ~61% image weight,
+the one fixed set of five, the 10,000-character excerpt and the `outputs/`-before-`report/`
+sweep. Those reach the run through one place only, `build_benchmark_goal`, which a
+non-benchmark run never receives. Outside the benchmark a markdown run is told only that at
+most `MAX_REPORT_FIGURES` figures reach its reader — which `validate_markdown_report` has
+always enforced — and a LaTeX run is told there is no ceiling at all.
 
 #### Reference papers
 
@@ -151,13 +205,19 @@ not whether every stage was approved.
 | Triage artifact | `artifacts/report_review.json` | `artifacts/layout_review.json` |
 | Also required | `citation_verification.json`, `self_review.json` | same, plus `build_log.txt` and a `.bib` |
 | Figure budget | at most 5, all referenced | none |
+| Report plan | required at Stage 03; every slot must be published or carry `dropped_because` | required at Stage 03; coverage not checked |
 | Post-approval | — | `writing/paper_package/` bundle |
 
 The markdown gates are not "a file exists". Stage 07 fails and retries if `report.md` is
 shorter than 1,200 characters, references no figures, still holds placeholder text, or
 carries a figure reference that is absolute, remote, unrenderable, or points at a file that
-is not there, or publishes more than five figures. A broken figure link is the expensive
+is not there, or publishes more than five figures, or leaves a figure the Stage 03 plan
+committed to neither published nor explicitly dropped. A broken figure link is the expensive
 defect here: the judge reads the prose promising a figure and is shown nothing.
+
+The coverage check is narrowed to markdown on purpose: a LaTeX run has no single
+well-defined published-figure location for it to match against, and `layout_review.json`
+covers that branch instead.
 
 ### 3. Spends the time it is given
 

--- a/docs/stage-contract.md
+++ b/docs/stage-contract.md
@@ -135,6 +135,8 @@ everything Stage 03, 05, and 06 required.
 | --- | --- |
 | **01** | `workspace/literature/sources.json` and `workspace/literature/claims.json` exist and cross-reference correctly (see [the evidence ledger](#the-evidence-ledger)). |
 | **03+** | At least one machine-readable file under `workspace/data/` with a suffix in `.json .jsonl .csv .tsv .parquet .yaml .yml`. |
+| **03+** | `workspace/notes/report_plan.json` exists and is a commitment (see [the report plan](#the-report-plan)). |
+| **06+** | Every live slot's and headline number's `source_artifact` resolves to a file that is not empty. |
 | **05+** | At least one result file under `workspace/results/` with a suffix in `.json .jsonl .csv .tsv .parquet .npz .npy`. |
 | **05+** | `workspace/results/experiment_manifest.json` exists and is structurally valid. |
 | **06+** | At least one figure under `workspace/figures/` with a suffix in `.png .pdf .svg .jpg .jpeg`. |
@@ -156,6 +158,7 @@ Stage 07's requirements depend on the run's `output_format`.
 | **07+** | `workspace/artifacts/citation_verification.json`, structurally valid. |
 | **07+** | `workspace/artifacts/self_review.json`. |
 | **07+** | `workspace/artifacts/report_review.json`, structurally valid. |
+| **07+** | Every slot in `report_plan.json` was published under `report/images/` and referenced from `report.md`, or carries a `dropped_because` of at least 20 characters — and not every slot may be dropped. |
 
 The upper bound is not a style preference. A benchmark judge is shown only the first five
 images it finds, in filesystem order, so a sixth figure does not add a sixth chance to be
@@ -195,6 +198,40 @@ owns to be at least that new.
 This is what stops a re-run from being credited with the previous attempt's
 files. Stages that only *consume* an artifact class (for example Stage 05
 reading `workspace/data/`) check existence but not freshness.
+
+### The report plan
+
+`workspace/notes/report_plan.json` is where the run commits to its figures —
+at Stage 03, before a result exists that could choose them for it. The
+validator is `src/report_plan.py`.
+
+Each entry in `figures` needs a `slot` (unique, contiguous from 1), a bare
+`filename` with a publishable image suffix, a `supports` list naming the claim
+the figure settles (a `hypothesis_manifest.json` id, or `exploratory:<slug>`),
+a `shows` sentence, an `if_supported` and an `if_refuted` that are not the same
+sentence, and a `source_artifact` under `results/`, `data/` or `outputs/`.
+`headline_numbers` names the quantities the report must state, each with a unit
+and a `source_artifact`. In markdown mode there may be at most
+`MAX_REPORT_FIGURES` slots.
+
+Two rules exist to stop the file being satisfied without committing to
+anything:
+
+- **Every slot must carry at least one claim no other slot carries.** This is
+  the only rule here that pushes the figure count *down*; nothing in the module
+  ever asks for more figures, because `MAX_REPORT_FIGURES` is a ceiling and a
+  gate that restated it as a goal would have made it a quota.
+- **A slot cannot be born dropped.** `dropped_because` is skipped by the Stage
+  06 source check and the Stage 07 coverage check, so a slot abandoned in the
+  same plan that declares it would owe nothing at all. Dropping is only allowed
+  once AutoR has stamped the plan — that is, from the Stage 03 approval onward,
+  which is what makes it a record of the results changing the plan rather than
+  padding.
+
+`declared_at`, `digest` and `amendments` are AutoR's, written by
+`stamp_report_plan` on Stage 03 approval and kept in `report_plan_stamp.json`
+outside `workspace/`. The agent does not write them, and the validators ignore
+them in the file.
 
 ### The evidence ledger
 

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -534,7 +534,13 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         web_search_context=web_search_context,
         web_search_mode=args.web_search,
         # Stages are told to keep code/, outputs/ and report/images/ up to date in the
-        # benchmark workspace, so 'Files Produced' must resolve against it too.
+        # benchmark workspace, so 'Files Produced' must resolve against it too. Three gates
+        # now read what this becomes (`ResearchManager.artifact_dirs`), not just the
+        # summary check: the Stage 03 machine-data gate, the Stage 06 check that every
+        # planned figure's `source_artifact` exists, and the Stage 07 check that every
+        # planned figure was published. Dropping this argument would not merely lose a
+        # convenience — it would turn a compliant benchmark run, whose results and figures
+        # live outside the run tree by contract, into three false refusals.
         artifact_roots=[workspace],
         cross_reviewer=resolve_cross_reviewer(args.cross_review, args.cross_review_model),
     )

--- a/src/experiment_manifest.py
+++ b/src/experiment_manifest.py
@@ -73,6 +73,7 @@ RECORD_ARTIFACTS = frozenset(
         "notes/hypothesis_manifest.json",
         "notes/preregistration.json",
         "notes/experimental_protocol.json",
+        "notes/report_plan.json",
         "notes/research_rounds.json",
         "notes/round_decision.json",
     }

--- a/src/information_flow.py
+++ b/src/information_flow.py
@@ -24,7 +24,17 @@ consumer pairs, so the information topology can be printed, tested, and diffed
 rather than reconstructed by reading thirteen ``if`` statements.
 
 A channel is deliberately allowed to have no producer (``produced_by=None``):
-run configuration and the researcher profile come from outside the stage graph.
+run configuration, the researcher profile and the deliverable contract come
+from outside the stage graph.
+
+**A constraint has to arrive while it can still be obeyed.** The figure ceiling
+was the worst case of the opposite: ``MAX_REPORT_FIGURES`` reached Stage 07 and
+nowhere earlier, so the run learned how many figures a reader would see four
+stages after it decided which figures to make, when the only remaining move was
+to delete the weakest. ``report_contract`` delivers the shape of the deliverable
+to the stage that plans the work (03) as well as the stages that draw (06) and
+publish (07) it, and ``report_plan`` carries the resulting choice forward. An
+edge here is cheaper than a repair there.
 """
 
 from __future__ import annotations
@@ -149,6 +159,65 @@ def _venue(context: ChannelContext) -> str:
     return format_venue_for_prompt(context.paths)
 
 
+def _report_contract(context: ChannelContext) -> str:
+    """The shape of the scored deliverable, sent to the stages that can still act on it.
+
+    Everything here is true of *any* AutoR run in the given output format, and
+    the figure ceiling is read from ``MAX_REPORT_FIGURES`` rather than written
+    out, so the prompt cannot drift away from the gate that enforces it
+    (``validate_markdown_report``). Nothing benchmark-specific belongs in this
+    block: no grader, no weighting, no scoring model. A benchmark that scores a
+    report its own way says so in its own goal text, which reaches every stage
+    verbatim through ``user_input``.
+
+    Conditioned on the output format because the ceiling is not universal: a
+    latex run targets a venue that routinely carries eight or ten figures, and
+    shipping "at most five" there would damage the paper rather than focus it.
+
+    The deliverable's *path* is not repeated here — ``## Run Configuration``
+    already names it in the same prompt, and this block is about the shape of
+    the thing, not its location.
+    """
+    from .utils import MAX_REPORT_FIGURES, selected_output_format
+
+    if selected_output_format(context.paths) != "markdown":
+        return "\n".join(
+            [
+                "- The scored deliverable is one compiled paper, and the venue named in "
+                "`## Run Configuration` sets how many figures it may carry. Plan one "
+                "figure per claim.",
+                "- Choose the figures now, against the claims they carry. A figure chosen "
+                "at the end is chosen by whatever happened to exist by then.",
+            ]
+        )
+    return "\n".join(
+        [
+            "- The scored deliverable is one markdown report, named in "
+            "`## Run Configuration`. Everything else the run produces is evidence for it, "
+            "not a substitute for it.",
+            f"- At most {MAX_REPORT_FIGURES} figures reach the reader, and Stage 07's gate "
+            "refuses a report that publishes more. A sixth figure is not extra coverage; "
+            "it is work nobody sees.",
+            "- Choose the figures now, against the claims they carry. A figure chosen at "
+            "the end is chosen by whatever happened to exist by then.",
+            "- A slot that answers no question the other slots leave open is a slot spent "
+            "twice. Fewer figures, each settling a different claim, beats a full set of "
+            "views of one result.",
+            "- The ceiling is not a target and there is no floor. Count the questions a "
+            "figure has to settle and plan that many: some reports rest on one, and a "
+            "report whose result is a single number may honestly carry none. Padding "
+            "toward the ceiling costs the figures that were carrying a claim.",
+        ]
+    )
+
+
+def _report_plan(context: ChannelContext) -> str | None:
+    from .report_plan import format_report_plan_for_prompt, load_report_plan
+
+    plan = load_report_plan(context.paths)
+    return format_report_plan_for_prompt(plan) if plan is not None else None
+
+
 def _artifact_index(context: ChannelContext) -> str:
     from .artifact_index import format_artifact_index_for_prompt, write_artifact_index
 
@@ -251,6 +320,21 @@ CHANNELS: tuple[Channel, ...] = (
         consumed_by=_from("00_intake"),
         build=_venue,
         rationale="Venue and output format bind every stage's deliverable shape.",
+    ),
+    Channel(
+        key="report_contract",
+        heading="## Deliverable Contract",
+        produced_by=None,
+        consumed_by=frozenset({"03_study_design", "06_analysis", "07_writing"}),
+        build=_report_contract,
+        rationale=(
+            "The shape of the scored deliverable binds the stage that plans the figures "
+            "(03), the stage that draws them (06) and the stage that publishes them (07). "
+            "Stages 04 and 05 write and run code: a ceiling on how many figures reach the "
+            "reader changes nothing about what to implement or execute, and sending it "
+            "there would invite plotting instead of running. Stages 00-02 have no "
+            "deliverable to shape yet, and Stage 08 packages a report it cannot change."
+        ),
     ),
     Channel(
         key="artifact_index",
@@ -361,6 +445,43 @@ CHANNELS: tuple[Channel, ...] = (
         consumed_by=_from("05_experimentation"),
         build=_preregistration,
         rationale="From the freeze onward this is the authoritative statement of what the run predicted.",
+    ),
+    Channel(
+        key="report_plan",
+        heading="# Report Plan (declared at Stage 03)",
+        produced_by="03_study_design",
+        consumed_by=frozenset(
+            {
+                "03_study_design",
+                "04_implementation",
+                "05_experimentation",
+                "06_analysis",
+                "07_writing",
+            }
+        ),
+        build=_report_plan,
+        preface=(
+            "The figures below were chosen before any result existed, and they are a "
+            "commitment rather than a suggestion. Each slot names the file its numbers "
+            "come from: the stages that write and run code owe those files at those "
+            "paths. Stage 06 draws the figures, under exactly the filenames declared "
+            "here, and Stage 07 publishes them. **Do not draw a figure before Stage 06** "
+            "— a figure drawn before the results exist is a figure fitted to nothing. A "
+            "slot that has to be abandoned carries `dropped_because` saying what happened "
+            "to the claim it was going to settle."
+        ),
+        rationale=(
+            "03 re-reads its own plan so a second round amends it rather than rewriting "
+            "it from scratch, the way 05 re-reads the experiment manifest. 04 and 05 need "
+            "it because each slot names a `source_artifact`: 04 writes the code that emits "
+            "those files and 05 is the stage that actually emits them, and the Stage 06 "
+            "gate that refuses a slot whose source does not exist is unfixable by then if "
+            "neither stage was told the paths. 06 draws the figures and 07 publishes them. "
+            "Stages 00-02 precede the plan; Stage 08 cannot change a published report. The "
+            "preface withholds the drawing instruction from everyone before 06 on purpose "
+            "— the plan reaches 04 and 05 as a list of files to produce, not as an "
+            "invitation to plot instead of run."
+        ),
     ),
     Channel(
         key="research_rounds",

--- a/src/manager.py
+++ b/src/manager.py
@@ -74,6 +74,11 @@ from .preregistration import (
     freeze_preregistration,
     load_preregistration,
 )
+from .report_plan import (
+    load_report_plan,
+    recorded_report_plan_stamp,
+    stamp_report_plan,
+)
 from .run_skills import install_run_skills
 from .manifest import (
     ensure_run_manifest,
@@ -2349,6 +2354,8 @@ class ResearchManager:
                     )
                 if stage.slug == "02_hypothesis_generation":
                     self._measure_pool_adoption(paths, stage, stage_markdown)
+                if stage.slug == "03_study_design":
+                    self._stamp_report_plan(paths)
                 if stage.slug == "04_implementation":
                     self._freeze_preregistration(paths)
                 self._run_validity_review(paths, stage, stage_markdown)
@@ -2465,6 +2472,19 @@ class ResearchManager:
         # before results exist on every route in.
         if stage.number >= 5:
             self._freeze_preregistration(paths)
+
+        # Same route in, same problem: a run resumed above Stage 03 has a figure
+        # plan that was never dated, and one edited between approvals has a
+        # digest that no longer describes it. Stamping is idempotent, so the
+        # normal path pays nothing here.
+        if stage.number >= 6:
+            self._stamp_report_plan(
+                paths,
+                reason=(
+                    "the plan changed outside a Stage 03 approval; recorded while preparing "
+                    f"{stage.slug}"
+                ),
+            )
 
         # No hypotheses at all is a different problem from unfrozen ones, and
         # the stage that first needs them is the one that has to fix it.
@@ -3436,6 +3456,102 @@ class ResearchManager:
                 f"digest: {amended.digest}"
             ),
         )
+
+    def _report_plan_amendment_reason(self, paths: RunPaths, *, declared: bool = False) -> str:
+        """Why the plan moved, taken from the round that asked it to move.
+
+        ``validate_round_decision`` already requires ``what_changes_next`` to be
+        at least 40 characters before a round may re-enter Stage 03, so the
+        reason a second-round plan differs is already written down and already
+        argued for. Asking the run to state it again would be the same sentence
+        twice, and the second copy would be the one nobody checked.
+
+        Read from ``research_rounds.json`` rather than ``round_decision.json``,
+        because ``record_round`` unlinks the latter once the round is closed.
+
+        ``declared`` is whether the plan already carries a date. The fallback
+        differs on it because the two situations are different facts: a first
+        write is a declaration, while a rewrite with no round behind it — a
+        ``--redo-stage``, a manual edit — is a revision nothing on record asked
+        for, and calling that "initial declaration" would put a false sentence
+        in the amendment ledger.
+        """
+        round_entry = latest_round(paths)
+        if round_entry is not None and round_entry.what_changes_next.strip():
+            return f"round {round_entry.number}: {round_entry.what_changes_next.strip()}"
+        if declared:
+            return "revised at Stage 03 with no round on record explaining the change"
+        return "initial declaration"
+
+    def _stamp_report_plan(self, paths: RunPaths, reason: str | None = None) -> None:
+        """Date the figure plan, and record it whenever it moves.
+
+        The agent writes *which* figures it will produce and what each one
+        settles. ``declared_at``, ``digest`` and ``amendments`` are AutoR's,
+        because asking a language model for a sha256 is a wish rather than a
+        gate — the same split the preregistration already uses.
+
+        Stamping is idempotent by content: a round that legitimately left the
+        plan alone produces no amendment, so the ledger stays a record of real
+        movement instead of a count of how many times a stage was approved.
+
+        A missing plan is not logged here. It is not this hook's finding: the
+        Stage 03 artifact gate refuses a run with no plan, and that refusal is
+        already written to the log by the validation path. Logging it again from
+        a hook that fires on every stage from 06 onward would turn one refusal
+        into a repeated line.
+        """
+        before = load_report_plan(paths)
+        if before is None:
+            return
+        # What AutoR last stamped, not what the file says it was stamped with.
+        # The two disagree exactly when a stage rewrote the plan wholesale, and
+        # that is the case the log most needs to name: reading the file would
+        # report the second write of a moved plan as a first declaration.
+        recorded = recorded_report_plan_stamp(paths)
+        already_declared = recorded is not None
+        amendments_before = len(recorded[2]) if recorded is not None else len(before.amendments)
+        stamped = stamp_report_plan(
+            paths,
+            reason
+            or self._report_plan_amendment_reason(
+                paths, declared=already_declared or bool(before.declared_at)
+            ),
+        )
+        if stamped is None:
+            return
+        if len(stamped.amendments) > amendments_before:
+            append_log_entry(
+                paths.logs,
+                "report_plan amended",
+                (
+                    "The figure plan changed after it was declared.\n"
+                    f"reason: {stamped.amendments[-1].get('reason', '')}\n"
+                    f"amendments on record: {len(stamped.amendments)}\n"
+                    f"previous digest: {stamped.amendments[-1].get('previous_digest', '')}\n"
+                    f"digest: {stamped.digest}"
+                ),
+            )
+            return
+        if not already_declared:
+            append_log_entry(
+                paths.logs,
+                "report_plan declared",
+                (
+                    f"Declared {len(stamped.figures)} figures and "
+                    f"{len(stamped.headline_numbers)} headline numbers before any result "
+                    "existed.\n"
+                    f"declared_at: {stamped.declared_at}\n"
+                    f"digest: {stamped.digest}\n"
+                    "slots: "
+                    + (
+                        ", ".join(
+                            f"{figure.slot}:{figure.filename}" for figure in stamped.figures
+                        )
+                        or "none"
+                    )
+                ),
+            )
 
     def _record_inbound_channels(
         self, paths: RunPaths, stage: StageSpec, delivered: list[str]

--- a/src/operator.py
+++ b/src/operator.py
@@ -739,6 +739,57 @@ Original stderr:
             },
         )
 
+        # Stage 03+: which figures the report will carry, chosen before any
+        # result exists. Written once and then left alone: the plan has no
+        # freshness requirement, and rewriting it every stage would erase the
+        # `declared_at` and `digest` the manager stamps on Stage 03 approval —
+        # the very evidence that the choice predates the results.
+        #
+        # Exactly one entry, naming the figure this stub actually publishes and
+        # references at Stage 07, so the fixture exercises the published path
+        # rather than the dropped one. One entry rather than five on purpose:
+        # MAX_REPORT_FIGURES is a ceiling, and a fixture that filled it would
+        # teach the ceiling as a target to everyone who reads this file.
+        if not paths.report_plan.exists():
+            _write_json(
+                paths.report_plan,
+                {
+                    "figures": [
+                        {
+                            "slot": 1,
+                            "filename": "fake_comparison.png",
+                            "supports": ["H1"],
+                            "shows": (
+                                "Placeholder produced by fake-operator mode. In a real run "
+                                "this slot would show the placeholder score (dimensionless) "
+                                "for the baseline and treatment conditions. Nothing here was "
+                                "measured."
+                            ),
+                            "if_supported": (
+                                "the treatment bar would stand above the baseline bar; fake "
+                                "mode measures nothing, so it does not"
+                            ),
+                            "if_refuted": (
+                                "the two bars would be indistinguishable, which is what a "
+                                "fabricated placeholder actually shows"
+                            ),
+                            "source_artifact": "results/fake_results.json",
+                            "dropped_because": "",
+                        }
+                    ],
+                    "headline_numbers": [
+                        {
+                            "quantity": (
+                                "placeholder score, treatment minus baseline (not a "
+                                "measurement)"
+                            ),
+                            "unit": "dimensionless",
+                            "source_artifact": "results/fake_results.json",
+                        }
+                    ],
+                },
+            )
+
         # Stage 03+: machine-readable data under workspace/data.
         _write_json(
             paths.data_dir / "fake_dataset.json",

--- a/src/prompts/03_study_design.md
+++ b/src/prompts/03_study_design.md
@@ -21,7 +21,6 @@ Convert the approved hypotheses into a concrete study or experimental design tha
 - Put design docs, evaluation plans, ablation plans, and protocol notes under `{{WORKSPACE_NOTES_DIR}}`.
 - Put benchmark or dataset planning notes under `{{WORKSPACE_DATA_DIR}}`.
 - Create machine-readable dataset manifests under `{{WORKSPACE_DATA_DIR}}` rather than only markdown descriptions.
-- Put planned result templates or reporting skeletons under `{{WORKSPACE_RESULTS_DIR}}`.
 
 ## Quality Bar
 
@@ -60,6 +59,88 @@ Rules:
   beating — and a `tuning_budget` equal in effort to what the method will get. Beating a
   baseline nobody tried to make strong measures the effort split, not the method.
 
+## Report Plan (required)
+
+The deliverable is a report, and its figures are chosen here — before any result exists —
+against the claims they carry. A figure chosen at the end is chosen by whatever happened to
+exist. How many of them reach the reader is stated in the injected `## Deliverable Contract`.
+
+Write `{{WORKSPACE_NOTES_DIR}}/report_plan.json` before the design stage ends:
+
+```json
+{
+  "figures": [
+    {
+      "slot": 1,
+      "filename": "main_result.png",
+      "supports": ["H1"],
+      "shows": "Accuracy (%) against context length (tokens) for the method and the long-context baseline, five seeds, band = stderr.",
+      "if_supported": "the method's curve stays above the baseline's beyond 8k tokens",
+      "if_refuted": "the two curves overlap within their bands at every length",
+      "source_artifact": "results/accuracy_by_length.json",
+      "dropped_because": ""
+    },
+    {
+      "slot": 2,
+      "filename": "data_overview.png",
+      "supports": ["exploratory:input-distribution"],
+      "shows": "Distribution of document length (tokens) and label balance across the two evaluation splits.",
+      "if_supported": "the splits are comparable, so a between-split difference is about the method",
+      "if_refuted": "the splits differ in length, so every later comparison is read conditioned on it",
+      "source_artifact": "data/splits_summary.json",
+      "dropped_because": ""
+    }
+  ],
+  "headline_numbers": [
+    {
+      "quantity": "held-out accuracy, method vs baseline",
+      "unit": "percentage points",
+      "source_artifact": "results/accuracy_by_length.json"
+    }
+  ]
+}
+```
+
+Rules:
+
+- `slot` ranks the figures from 1 with no gaps. The ranking is the point: the weakest figure
+  is identified now, while it can still be replaced, rather than by whatever order the export
+  happens to walk at the end.
+- `filename` is the bare filename, with its image extension, that the figure will be published
+  under — no directory, no path. It is the join key between this plan and the published report,
+  so two slots may not share one.
+- `supports` names the claim the figure settles: an id from the Stage 02 hypotheses, or
+  `exploratory:<slug>`. **Every figure must carry at least one claim no other figure carries.**
+  Two slots answering the same question is one slot spent twice.
+- `shows` is what a reader should see in it, naming both axes and their units.
+- `if_supported` and `if_refuted` are what the figure looks like each way. They may not be the
+  same sentence: a figure that cannot say what refutation would look like is decoration, not
+  evidence. This is the figure-level version of a hypothesis's decision rule.
+- `source_artifact` is the result, data or output file the figure will be computed from, never
+  a note. Naming it here is what makes producing it Stage 04's job.
+- `headline_numbers` are the quantities the report must state, with their units and where each
+  is computed from. `dimensionless` and `count` are units; an empty string is not. Their
+  `source_artifact` is held to the same rule as a figure's and checked at Stage 06: name a file
+  the run will actually write, not one it might. A headline number is not a substitute for a
+  slot: a relationship, a distribution or a comparison that a reader can only be handed as a
+  number is one a figure would have settled faster.
+- To choose all of the above: list the quantities, relationships and comparisons the task
+  statement itself names, then give each one a slot or a headline number. That is coverage.
+- **How many slots.** Exactly as many as there are distinct questions a figure can settle,
+  and not one more. The ceiling in `## Deliverable Contract` is a ceiling, not a target, and
+  there is no floor: a study whose argument rests on one figure plans one. An extra figure is
+  not free — a reader's attention is finite and, where the deliverable is scored, a surplus
+  figure displaces one that carried a claim.
+  Work it out from the chain, not from the number: list the results the study establishes —
+  the data it rests on, each intermediate quantity, the finding — then ask of each link
+  whether a reader can accept it from a number in the prose or needs to see it. Only the
+  second kind gets a slot. A question no slot settles is one the prose has to carry alone, and
+  that is often correct.
+- Do not write `declared_at`, `digest` or `amendments` — the workflow manager stamps those on
+  approval, and a later round amends this file rather than rewriting it.
+- **Produce no figure files at this stage.** This is a plan. The figures are drawn at Stage 06,
+  from real results.
+
 ## Feasibility (required)
 
 Cost the primary design before it leaves this stage. State all three in `Key Results` and in
@@ -80,6 +161,7 @@ Additional expectations for this stage:
 - `Key Results` should include:
   - the proposed study design
   - datasets, baselines, and evaluation criteria
+  - which figures the report will carry and the claim each one settles
   - validity and reproducibility considerations
   - the feasibility estimate and the first thing cut
   - what the implementation stage must deliver

--- a/src/prompts/05_experimentation.md
+++ b/src/prompts/05_experimentation.md
@@ -42,6 +42,11 @@ existed.
   replacing the primary one with a metric that came out better is not.
 - Record per-condition spread, not just means. Stage 06 has to state how the spread was
   measured and over how many runs, and it can only do that if this stage saved it.
+- The figures the report will carry were declared in `{{WORKSPACE_NOTES_DIR}}/report_plan.json`,
+  each against the result file it will be computed from, and so was every `headline_numbers`
+  entry. Those files are outputs of this stage: write them at the paths the plan names, for the
+  headline numbers as much as for the figures. If one cannot be produced, say so in `Key Results`
+  rather than leaving Stage 06 to discover the gap.
 - Log the search: how many configurations you tried for the method, how many for each
   baseline, and the point in the process at which the evaluation split was first read. Put
   the counts in `Key Results` and the detail under `{{WORKSPACE_NOTES_DIR}}`. Report them

--- a/src/prompts/06_analysis.md
+++ b/src/prompts/06_analysis.md
@@ -18,6 +18,8 @@ Interpret the available evidence rigorously and determine what claims the curren
 - Put analysis notes, evaluation breakdowns, and interpretive documents under `{{WORKSPACE_RESULTS_DIR}}` or `{{WORKSPACE_NOTES_DIR}}`.
 - Put figures, plots, or tables created for interpretation under `{{WORKSPACE_FIGURES_DIR}}` or `{{WORKSPACE_RESULTS_DIR}}`.
 - Create real figure files (`.png`, `.pdf`, `.svg`, `.jpg`) under `{{WORKSPACE_FIGURES_DIR}}`; a described figure is not a figure.
+- Produce the figures `{{WORKSPACE_NOTES_DIR}}/report_plan.json` claims, under `{{WORKSPACE_FIGURES_DIR}}`, using exactly the filename each slot declares.
+- If a planned figure cannot be produced from the artifact its slot names, set `dropped_because` on that slot and say what happened to the claim it carried. Do not substitute an unrelated plot into its filename.
 - Every figure supporting a verdict must show the dispersion that verdict rests on — error bars, per-seed points, or a band — with n stated in the caption.
 - Read `{{WORKSPACE_RESULTS_DIR}}/experiment_manifest.json` before drawing conclusions, so the analysis tracks the actual standardized experiment bundle.
 

--- a/src/prompts/07_writing_markdown.md
+++ b/src/prompts/07_writing_markdown.md
@@ -105,27 +105,32 @@ Complete the stage in this order within a single stage conversation.
 
 1. Read the injected `## Writing Manifest` and the prior approved stage context. It lists the figures, result files, data files, and approved stage summaries available to you — use them directly rather than inventing equivalents.
 2. Identify the single central technical story of the report.
-3. Decide which figures carry that story, and confirm each one exists or can be produced from real run artifacts.
+3. Read the injected `# Report Plan`; the figure set was chosen at Stage 03 against the claims it carries. Your job is to publish it, not to re-choose it.
 4. Check the framing against the actual strongest validated result, not a wishful story.
 
 ### Phase 2: Figures
 
 Figures are the highest-value part of this deliverable. The reviewer grades them by putting your
 image side by side with the corresponding figure from the published study and asking whether yours
-shows the same thing. Plan them deliberately.
+shows the same thing. They were chosen at Stage 03; this phase produces them.
 
-5. Decide on **three to {{MAX_REPORT_FIGURES}} figures**, no more. Budget them against the claims
-   that matter: the data, the main result, and the evidence that the main result holds.
+5. **Publish the planned figures in slot order, at most {{MAX_REPORT_FIGURES}}.** Every slot you
+   do not publish needs `dropped_because` in `report_plan.json` and a sentence in `Key Results`;
+   a slot you publish that the plan does not name will be flagged in `report_review.json`.
+   Dropping is for a figure the results made impossible, not for one you ran out of time for:
+   the plan's claims still have to be carried, and a report that ends up below three figures is
+   one where the data, the main result and the evidence it holds are not all shown.
 6. **Make the first figure a composite summary panel.** This is the single highest-return figure
-   in the report. Build one multi-panel figure that carries the whole result at a glance:
+   in the report, and it is slot 1's default role. Build one multi-panel figure that carries the
+   whole result at a glance:
    - a 2x2 or 1x3 grid built with `plt.subplots`, each panel labelled `a)`, `b)`, `c)`, `d)` in
      the panel title
    - the primary measurement or map, plotted from the real data
    - the key relationship, with the **experimental points overlaid on the fitted or predicted
      curve**, and a legend naming both
-   - a final panel that is plain text: the headline numbers with their units and uncertainties
-     (`Dirac point: -0.043 eV`, `n = 2,000`, `R^2 = 0.94`), rendered with `ax.text` on
-     `ax.axis("off")`
+   - a final panel that is plain text: the plan's `headline_numbers` with their units and
+     uncertainties (`Dirac point: -0.043 eV`, `n = 2,000`, `R^2 = 0.94`), rendered with
+     `ax.text` on `ax.axis("off")`
    Published summary figures look exactly like this, and a reviewer comparing against one will
    find your equivalent panel inside it.
 7. Generate every figure from the real data and results in the workspace, using a script under
@@ -141,30 +146,32 @@ shows the same thing. Plan them deliberately.
 ### Phase 3: Drafting
 
 10. Write `{{WORKSPACE_REPORT_FILE}}` end to end in academic prose.
-11. Report concrete numbers, not adjectives. "Accuracy improved to 0.87 from a 0.81 baseline
+11. **State the headline numbers, with their units, in the report's first section.** What
+    argues for the figures has to come before anything long.
+12. Report concrete numbers, not adjectives. "Accuracy improved to 0.87 from a 0.81 baseline
     (n=2,000, 5-fold CV, ±0.02)" is scoreable; "performance improved substantially" is not.
-12. Every quantitative claim must trace to a file under `{{WORKSPACE_RESULTS_DIR}}` or a figure in
+13. Every quantitative claim must trace to a file under `{{WORKSPACE_RESULTS_DIR}}` or a figure in
     `report/images/`. Say where a number came from when it is not obvious.
-13. Embed each figure at the point in the narrative where it is discussed, with a caption that
+14. Embed each figure at the point in the narrative where it is discussed, with a caption that
     states what the reader should conclude from it:
     `![Held-out AUROC by model class; the proposed method leads across all five folds.](images/main_result.png)`
-14. Keep tables in markdown table syntax so they survive as text.
-15. Keep every reference in the `## References` section in a consistent, readable style.
-16. Cut anything that does not carry evidence. Padding, generic background, and well-written but
+15. Keep tables in markdown table syntax so they survive as text.
+16. Keep every reference in the `## References` section in a consistent, readable style.
+17. Cut anything that does not carry evidence. Padding, generic background, and well-written but
     shallow content are explicitly penalized.
 
 ### Phase 4: Quality Polish
 
-17. Remove AI-writing patterns where they actually weaken the prose.
-18. Run a reverse-outline check: the first sentences of paragraphs should form a coherent narrative.
-19. Check logic consistency — no contradiction between introduction and results, no terminology
+18. Remove AI-writing patterns where they actually weaken the prose.
+19. Run a reverse-outline check: the first sentences of paragraphs should form a coherent narrative.
+20. Check logic consistency — no contradiction between introduction and results, no terminology
     drift, no claim in the abstract or introduction that lacks support later.
-20. Verify every figure reference resolves. Walk the list of `![...](images/...)` links and confirm
+21. Verify every figure reference resolves. Walk the list of `![...](images/...)` links and confirm
     each target file exists in `{{WORKSPACE_REPORT_IMAGES_DIR}}`.
 
 ### Phase 5: Evidence Audit
 
-21. Write `{{WORKSPACE_ARTIFACTS_DIR}}/citation_verification.json`. The gate reads this file, so it
+22. Write `{{WORKSPACE_ARTIFACTS_DIR}}/citation_verification.json`. The gate reads this file, so it
     needs a non-empty `overall_status`, an integer `total_citations`, and a non-empty
     `claim_coverage` list in which **every** entry has a non-empty `claim` and at least one
     `citation_keys` or `source_ids` value. Record verified and unresolved citations, missing
@@ -194,11 +201,11 @@ shows the same thing. Plan them deliberately.
 
 ### Phase 6: Self-Review
 
-22. Score the draft on narrative clarity, claims-evidence alignment, technical rigor, experiment
+23. Score the draft on narrative clarity, claims-evidence alignment, technical rigor, experiment
     design, writing quality, structure and flow, references and figures, and completeness.
-23. Classify each issue as CRITICAL, MAJOR, or MINOR. Fix the CRITICAL ones first, then the most
+24. Classify each issue as CRITICAL, MAJOR, or MINOR. Fix the CRITICAL ones first, then the most
     important MAJOR ones.
-24. Write `{{WORKSPACE_ARTIFACTS_DIR}}/self_review.json` with per-dimension scores, an overall
+25. Write `{{WORKSPACE_ARTIFACTS_DIR}}/self_review.json` with per-dimension scores, an overall
     score, issues found, issues fixed, and a final verdict.
 
 Minimum bar:
@@ -211,7 +218,7 @@ Minimum bar:
 
 ### Phase 7: Stage Summary
 
-25. Write the stage summary draft to `{{STAGE_OUTPUT_PATH}}`.
+26. Write the stage summary draft to `{{STAGE_OUTPUT_PATH}}`.
 
 ## Claim Provenance (required)
 

--- a/src/rcb.py
+++ b/src/rcb.py
@@ -61,6 +61,7 @@ from .utils import (
     extract_markdown_image_targets,
     read_text,
     resolve_output_format,
+    resolve_report_image,
     truncate_text,
     write_text,
 )
@@ -240,6 +241,42 @@ def build_benchmark_goal(
         else "Write this file during Stage 07 (Writing) at the latest, in addition to the "
         "normal LaTeX paper package. Do not defer it to the end of the run."
     )
+    # Every benchmark-specific number AutoR ships lives in this block and nowhere else. The
+    # figure count is derived from MAX_REPORT_FIGURES rather than typed, and the other three
+    # are properties of ResearchClawBench's scorer that no AutoR constant should encode: they
+    # would be wrong for any run that is not this benchmark. Re-measured 2026-08-10 over the
+    # 40 shipped `tasks/*/target_study/checklist.json` and `evaluation/score.py`; the rule for
+    # reproducing them is in docs/researchclawbench.md.
+    #
+    # None of this is a checklist item. The run is being told the shape of the exam — a
+    # report, figures carrying most of it, a fixed handful of image slots, a truncated
+    # excerpt — which is not the answers, and the checklist is not in the workspace at all.
+    scoring_block = (
+        "The judge scores this report against a checklist built from the original paper, and "
+        "most of that checklist is images: across the benchmark's 40 shipped tasks, image "
+        "criteria carry about 61% of the total weight. The figures are the larger half of the "
+        "score, which makes them something to plan rather than something to produce.\n\n"
+        f"- **One fixed set of at most {MAX_REPORT_FIGURES} images is shown against every image "
+        "criterion.** It is collected once from the whole workspace, not chosen per criterion, "
+        f"so figure number {MAX_REPORT_FIGURES + 1} buys no extra coverage: it is never seen, "
+        f"and it randomises which {MAX_REPORT_FIGURES} are.\n"
+        f"- No shipped task has more than {MAX_REPORT_FIGURES} image criteria, and most have "
+        "three or fewer. That is a ceiling, not a target. What earns the weight is each "
+        "figure settling a different question the task statement asks; several views of one "
+        "result spend the whole budget on one criterion.\n"
+        "- Image criteria are shown only the **first ~10,000 characters** of the report. The "
+        "headline numbers, the results and the figure captions have to come before anything "
+        "long, or the criteria carrying most of the weight never reach them. This is an "
+        "*ordering* constraint, not a length limit: the text criteria that carry the rest of "
+        "the score read the whole report, so do not truncate the methodology or the "
+        "discussion to fit — put them after the results instead.\n"
+        f"- **No image belongs anywhere under `{resolved}` except `report/images/`.** The "
+        "scorer sweeps `outputs/` before `report/`, and `report/` in full — not just "
+        "`report/images/` — so one diagnostic plot in either place takes a slot from a "
+        "figure the report argues with. AutoR deletes images under `outputs/` and every "
+        "unreferenced image under `report/` when it exports, so a plot saved outside "
+        "`report/images/` is lost rather than merely unhelpful."
+    )
     return "\n\n".join(
         [
             "# Benchmark Run: ResearchClawBench",
@@ -269,9 +306,13 @@ def build_benchmark_goal(
                 "to the report itself, for example `![Result](images/main_result.png)` — never "
                 "with absolute paths. Report concrete numbers, not adjectives; the judge compares "
                 "your results against the original paper's and is explicitly sceptical of "
-                "plausible-sounding claims with no evidence behind them. Length is not rewarded.\n\n"
+                "plausible-sounding claims with no evidence behind them. Length is not rewarded, "
+                "and the criteria that carry most of the score stop reading at roughly 10,000 "
+                "characters — order the report accordingly, see below.\n\n"
                 f"{report_instruction}"
             ),
+            "## How This Report Is Scored",
+            scoring_block,
             reference_block,
             "## Research Task",
             instructions.strip(),
@@ -346,7 +387,9 @@ def mirror_tree(source: Path, destination: Path, *, skip_suffixes: frozenset[str
     return copied
 
 
-def _figure_candidates(paths: RunPaths, images_dir: Path) -> list[tuple[str, Path]]:
+def _figure_candidates(
+    paths: RunPaths, images_dir: Path, outputs_dir: Path | None = None
+) -> list[tuple[str, Path]]:
     """Every figure that could be published, as (name, source), best source first."""
     candidates: list[tuple[str, Path]] = []
     claimed: dict[str, Path] = {}
@@ -359,12 +402,21 @@ def _figure_candidates(paths: RunPaths, images_dir: Path) -> list[tuple[str, Pat
     # The run tree's own report/images/ comes first: in markdown mode those are the figures the
     # report actually references by name, so they must keep their filenames. A same-named figure
     # swept up later from figures/ or results/ is the one that gets qualified.
+    #
+    # The benchmark's own ``outputs/`` comes *last*, and only because
+    # :func:`collect_figures` deletes every image left there. A plot a stage wrote straight to
+    # ``outputs/`` is a slot stolen from a chosen figure, so it must never outrank one — but
+    # deleting it without first offering it a leftover slot would throw away the only images a
+    # run produced when it wrote them nowhere else, and an image the judge cannot see scores
+    # the same as no research at all. Ranked last, it fills a slot only when nothing better
+    # wants it.
     for source_root in (
         paths.report_images_dir,
         paths.figures_dir,
         paths.writing_dir,
         paths.results_dir,
         paths.artifacts_dir,
+        *([outputs_dir] if outputs_dir is not None else []),
     ):
         for path in _iter_files(source_root):
             if path.suffix.lower() not in FIGURE_SUFFIXES:
@@ -388,10 +440,28 @@ def _figure_candidates(paths: RunPaths, images_dir: Path) -> list[tuple[str, Pat
 def collect_figures(paths: RunPaths, workspace: Path, report_text: str = "") -> list[str]:
     """Publish at most :data:`MAX_REPORT_FIGURES` figures into ``report/images/``.
 
-    The scorer shows the judge five agent images per checklist item, picked by an unsorted
-    ``rglob``. Publishing a sixth does not add a sixth chance to match — it randomises which
-    five are seen, on the ~61% of the benchmark's weight that is image-graded. So the budget
-    is enforced here, and figures the report actually references win the slots.
+    The scorer collects one fixed set of images per *workspace*, by an unsorted ``rglob`` over
+    ``outputs/`` and then ``report/``, and shows the first five of that one set against every
+    image criterion. Publishing a sixth does not add a sixth chance to match — it randomises
+    which five are seen, on the ~61% of the benchmark's weight that is image-graded. So the
+    budget is enforced here, and figures the report actually references win the slots.
+
+    That sweep is an ``rglob`` over two whole trees, not over ``report/images/``. It starts at
+    ``outputs/``, which is where the goal contract sends derived data, so an image a stage
+    wrote straight to the benchmark's ``outputs/`` outranks every figure the report argues
+    with — six diagnostic PNGs there take all five slots and the report's own figures reach
+    the judge as nothing. A loose ``report/panel.png`` or a nested
+    ``report/images/panels/*.png`` is the same theft one directory over. :func:`mirror_tree`
+    keeps AutoR's exports out of ``outputs/``; the prune below removes the ones a stage put
+    in either tree by hand, walking exactly as far as the scorer does. Together they are the
+    only reason a planned figure survives to be seen.
+
+    The prune is a delete, so what it deletes has to have been *offered a slot first*.
+    ``outputs/`` is therefore the last-ranked candidate source: an image there can never
+    outrank a figure the report argues with, but a run that wrote its only plots there — no
+    report references, nothing in the run tree — is published from them rather than left with
+    an empty ``report/images/``. Deleting the last image in a workspace scores the same as
+    having done no research.
 
     A figure the report references is never dropped, even when that pushes past the budget:
     breaking a live link is worse than overshooting, and Stage 07's own gate is what keeps a
@@ -400,7 +470,7 @@ def collect_figures(paths: RunPaths, workspace: Path, report_text: str = "") -> 
     images_dir = workspace / "report" / "images"
     images_dir.mkdir(parents=True, exist_ok=True)
 
-    candidates = _figure_candidates(paths, images_dir)
+    candidates = _figure_candidates(paths, images_dir, workspace / "outputs")
     by_name = dict(candidates)
 
     referenced: list[str] = []
@@ -429,8 +499,35 @@ def collect_figures(paths: RunPaths, workspace: Path, report_text: str = "") -> 
     # Anything already sitting at the benchmark path that did not make the cut would still be
     # swept up by the scorer, so the budget has to be enforced on disk, not just on the list.
     keep = set(selected)
-    for path in sorted(images_dir.iterdir()):
-        if path.is_file() and path.suffix.lower() in JUDGE_IMAGE_SUFFIXES and path.name not in keep:
+
+    # What survives is exactly what the report argues with: the published slots, plus any
+    # image the winning report links that already lives somewhere else under `report/`. The
+    # second set is why this is not a blanket delete — an agent that wrote
+    # `report/figure1.png` and linked it as `![](figure1.png)` has a live link, and breaking
+    # one is worse than overshooting the budget.
+    protected = {(images_dir / name).resolve() for name in keep}
+    for target in extract_markdown_image_targets(report_text):
+        linked = resolve_report_image(workspace / "report", target)
+        if linked is not None and linked.is_file():
+            protected.add(linked.resolve())
+
+    # The scorer's sweep is `rglob` over `outputs/` and then `report/`, so the prune has to
+    # be the same walk over the same two trees — hidden files and nested directories
+    # included, because a prune that searches less than the sweep does leaves exactly the
+    # files that win the slots. `outputs/` is drained entirely: it is swept *first*, so an
+    # image there is not an extra figure but a slot taken from a chosen one, and the goal
+    # contract's own instruction to keep `outputs/` up to date makes leaving one there easy.
+    # Under `report/`, a nested or loose image is the same theft one directory over —
+    # `report/images/` is not the only place the scorer looks. Suffixes are matched
+    # case-insensitively, which is a superset of the scorer's `*{ext}` glob here and the same
+    # set on a case-insensitive filesystem: erring the other way would mean a `PLOT.PNG` that
+    # scores on a mac and not on this box.
+    for root in (workspace / "outputs", workspace / "report"):
+        for path in sorted(root.rglob("*")):
+            if not path.is_file() or path.suffix.lower() not in JUDGE_IMAGE_SUFFIXES:
+                continue
+            if path.resolve() in protected:
+                continue
             path.unlink()
 
     return sorted(keep)

--- a/src/report_plan.py
+++ b/src/report_plan.py
@@ -1,0 +1,951 @@
+"""Choose the figures before the results exist, and hold the report to that choice.
+
+Preregistration fixes what the run predicted. The experimental protocol fixes
+what would count as having shown it. This fixes *what the reader is shown* —
+the last place the same defect had left to hide.
+
+A report's figures were being chosen at the end, out of whatever the run
+happened to produce, and then pruned to fit the ceiling by the order a
+directory walk returned. That is choosing the evidence after seeing it, one
+level up: the figure that survives is the one that exists, not the one that
+settles a question. The plan moves the choice to Stage 03, where the design is
+still being decided and a missing figure is a thing to go and compute rather
+than a thing to delete.
+
+The artifact is ``workspace/notes/report_plan.json``. Each slot commits to a
+filename, the claim it settles, what a reader should see, what the figure looks
+like if that claim holds and if it does not, and the result file it will be
+computed from. Alongside them, ``headline_numbers`` names the quantities the
+report has to state — the numbers that make the figures legible in prose.
+
+Three gates hang off it, deliberately at three different stages:
+
+1. **Shape, from Stage 03.** Held at the stage that writes it. The
+   ``experimental_protocol.json`` precedent is the counter-example: the Stage 03
+   prompt asks for it and the gate first fires at Stage 05, so a Stage 03 that
+   skipped it is approved and the failure surfaces two stages later, where the
+   only repair is a rollback.
+2. **The sources resolve, from Stage 06.** "Never draw a figure from numbers
+   you did not compute", checked while there is still a stage that could
+   compute them.
+3. **Coverage, at Stage 07, markdown only.** Every planned slot was either
+   published and referenced, or dropped with a recorded reason. Narrowed to
+   markdown on purpose: the latex branch has no single well-defined published
+   figure location (figures are placed by the document), and that branch runs
+   its own layout review instead.
+
+**On the anti-gaming shape of the rules.**
+
+- The length floors (40 characters on ``shows``, 20 on each branch sentence and
+  on ``dropped_because``) are floors under *a sentence was written*, nothing
+  more. They are not quality thresholds and must not grow into them: whether a
+  figure is a good figure is the review panel's judgement, and a gate that
+  tried to measure it would only be measuring length. The cap of eight headline
+  numbers exists for the mirror-image reason — so the field cannot become a
+  dumping ground that satisfies a count.
+- ``if_supported`` must differ from ``if_refuted``. This is trivially defeated
+  by inserting "not", and that is acceptable. Like ``why_competent`` on a
+  baseline, the guard's job is to make the empty move cost a written sentence
+  and put that sentence in the record where a reviewer reads it — not to be
+  unforgeable.
+- Every figure must carry at least one ``supports`` id no other figure carries.
+  This is the one rule here that pushes the figure count *down*: a run that
+  cannot name a distinct claim for slot 5 has no slot 5. Nothing in this module
+  ever asks for more figures. The only count refusals are "none at all" and
+  "more than the ceiling", because ``MAX_REPORT_FIGURES`` is a ceiling and a
+  gate that restated it as a goal would have converted it into a quota.
+
+**The digest is AutoR's, not the agent's.** ``declared_at``, ``digest`` and
+``amendments`` are written by :func:`stamp_report_plan` on Stage 03 approval.
+Asking a language model for a sha256 is a wish, not a gate, so the validators
+ignore all three: the agent writes ``figures`` and ``headline_numbers`` and
+nothing else. A later round *amends* the plan rather than rewriting it — an
+unchanged plan is stamped once and never again, so a round that legitimately
+left the choice alone does not manufacture a spurious amendment, and a round
+that moved it leaves a ledger entry saying so.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Sequence
+
+from .utils import (
+    DEFAULT_OUTPUT_FORMAT,
+    FIGURE_SUFFIXES,
+    MAX_REPORT_FIGURES,
+    PREFERRED_REPORT_IMAGE_SUFFIX,
+    RunPaths,
+    extract_markdown_image_targets,
+)
+
+
+#: Where a figure's numbers may come from. ``notes/`` is deliberately absent: a
+#: figure computed from a note is a figure computed from prose. ``outputs/`` is
+#: here because a benchmark workspace points its result writes there.
+SOURCE_ARTIFACT_ROOTS = ("results", "data", "outputs")
+
+#: A figure may serve a question nobody preregistered — that is often the most
+#: interesting figure in a run. It has to say so, and the slug still has to be
+#: distinct from every other slot's, so "exploratory" cannot be a wildcard used
+#: five times.
+EXPLORATORY_PREFIX = "exploratory:"
+MIN_EXPLORATORY_SLUG_CHARS = 3
+
+#: Floors under "a sentence was written". See the module docstring: these are
+#: not quality thresholds.
+MIN_SHOWS_CHARS = 40
+MIN_BRANCH_CHARS = 20
+MIN_DROP_REASON_CHARS = 20
+
+#: A ceiling, so the field cannot become a list that satisfies a count.
+MAX_HEADLINE_NUMBERS = 8
+
+#: Above this, a file has content and is not read back to prove it. Only the
+#: empty-file case matters here, and a result artifact can be a large binary.
+_WHITESPACE_PROBE_BYTES = 4096
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _digest(payload: object) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _load_json(path: Path) -> object | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _normalised(value: str) -> str:
+    """Whitespace- and case-insensitive form, for comparing two sentences."""
+    return " ".join(value.split()).casefold()
+
+
+# ----------------------------------------------------------------------------
+# The artifact
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PlannedFigure:
+    slot: int
+    filename: str
+    supports: list[str]
+    shows: str
+    if_supported: str
+    if_refuted: str
+    source_artifact: str
+    dropped_because: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "slot": self.slot,
+            "filename": self.filename,
+            "supports": list(self.supports),
+            "shows": self.shows,
+            "if_supported": self.if_supported,
+            "if_refuted": self.if_refuted,
+            "source_artifact": self.source_artifact,
+            "dropped_because": self.dropped_because,
+        }
+
+    @property
+    def is_dropped(self) -> bool:
+        return len(self.dropped_because.strip()) >= MIN_DROP_REASON_CHARS
+
+
+@dataclass(frozen=True)
+class HeadlineNumber:
+    quantity: str
+    unit: str
+    source_artifact: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "quantity": self.quantity,
+            "unit": self.unit,
+            "source_artifact": self.source_artifact,
+        }
+
+
+@dataclass(frozen=True)
+class ReportPlan:
+    figures: list[PlannedFigure]
+    headline_numbers: list[HeadlineNumber]
+    declared_at: str = ""
+    digest: str = ""
+    #: Why this study's report carries no figure. Required only when ``figures``
+    #: is empty, which three of the forty benchmark tasks genuinely are.
+    no_figures_because: str = ""
+    amendments: list[dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "declared_at": self.declared_at,
+            "digest": self.digest,
+            "no_figures_because": self.no_figures_because,
+            "amendments": [dict(item) for item in self.amendments],
+            "figures": [item.to_dict() for item in self.figures],
+            "headline_numbers": [item.to_dict() for item in self.headline_numbers],
+        }
+
+
+def _entries(payload: dict, key: str) -> list:
+    """The list at ``key``, or an empty one.
+
+    ``.get(key, [])`` is not enough: ``"figures": null`` and ``"figures": 5``
+    are both things a model writes, and both are iterated straight into a
+    ``TypeError`` that escapes ``validate_stage_artifacts`` and ends the run.
+    A malformed plan has to come back as a refusal the stage can act on, the
+    same as a missing one — the gate is not a place to crash.
+    """
+    value = payload.get(key)
+    return value if isinstance(value, list) else []
+
+
+def load_report_plan(paths: RunPaths) -> ReportPlan | None:
+    payload = _load_json(paths.report_plan)
+    if not isinstance(payload, dict):
+        return None
+
+    figures: list[PlannedFigure] = []
+    for entry in _entries(payload, "figures"):
+        if not isinstance(entry, dict):
+            continue
+        raw_slot = entry.get("slot")
+        try:
+            slot = int(raw_slot)
+        except (TypeError, ValueError):
+            slot = 0
+        if isinstance(raw_slot, bool):
+            slot = 0
+        supports_value = entry.get("supports")
+        if isinstance(supports_value, str):
+            supports = [supports_value.strip()] if supports_value.strip() else []
+        elif isinstance(supports_value, list):
+            # Deduplicated, order preserved. One slot listing `["H1", "H1"]` claims one
+            # question, not two, and the distinctness rule below counts *slots per claim*:
+            # left as written, a slot's own repeat would make `claimed["H1"]` 2 and refuse
+            # the only slot carrying it, with a message blaming a second slot that does not
+            # exist.
+            supports = list(dict.fromkeys(_text(item) for item in supports_value if _text(item)))
+        else:
+            supports = []
+        figures.append(
+            PlannedFigure(
+                slot=slot,
+                filename=_text(entry.get("filename")),
+                supports=supports,
+                shows=_text(entry.get("shows")),
+                if_supported=_text(entry.get("if_supported")),
+                if_refuted=_text(entry.get("if_refuted")),
+                source_artifact=_text(entry.get("source_artifact")),
+                dropped_because=_text(entry.get("dropped_because")),
+            )
+        )
+
+    headline_numbers = [
+        HeadlineNumber(
+            quantity=_text(entry.get("quantity")),
+            unit=_text(entry.get("unit")),
+            source_artifact=_text(entry.get("source_artifact")),
+        )
+        for entry in _entries(payload, "headline_numbers")
+        if isinstance(entry, dict)
+    ]
+
+    return ReportPlan(
+        figures=figures,
+        headline_numbers=headline_numbers,
+        declared_at=_text(payload.get("declared_at")),
+        digest=_text(payload.get("digest")),
+        no_figures_because=_text(payload.get("no_figures_because")),
+        amendments=[dict(item) for item in _entries(payload, "amendments") if isinstance(item, dict)],
+    )
+
+
+def report_plan_digest(plan: ReportPlan) -> str:
+    """Hash the fields the plan commits to, and only those.
+
+    ``declared_at`` and ``amendments`` are excluded: a re-stamp with no change
+    to a single slot is not a change of plan, and a timestamp is not a choice.
+    ``dropped_because`` *is* included, because abandoning a slot is exactly the
+    kind of move the amendment ledger exists to record.
+    """
+    return _digest(
+        {
+            "figures": [item.to_dict() for item in plan.figures],
+            "headline_numbers": [item.to_dict() for item in plan.headline_numbers],
+        }
+    )
+
+
+def _write_report_plan(paths: RunPaths, plan: ReportPlan) -> None:
+    paths.report_plan.parent.mkdir(parents=True, exist_ok=True)
+    paths.report_plan.write_text(
+        json.dumps(plan.to_dict(), indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def report_plan_stamp_path(paths: RunPaths) -> Path:
+    """AutoR's own copy of the three fields the agent must not write.
+
+    Outside ``workspace/``, for the reason ``evolution_dir`` is: it is a record
+    of how the run reached its answer rather than part of the answer. The plan
+    itself has to stay in ``workspace/notes/`` — the agent writes it, amends it
+    and is shown it. But that means the agent also has write access to the
+    fields that are supposed to prove *when* it was written, and a stamp kept
+    only there is a receipt the payer prints.
+    """
+    return paths.run_root / "report_plan_stamp.json"
+
+
+def recorded_report_plan_stamp(paths: RunPaths) -> tuple[str, str, list[dict[str, str]]] | None:
+    """``(declared_at, digest, amendments)`` as AutoR last wrote them, or None.
+
+    None means "AutoR has never stamped this plan", which is the only state in
+    which the file's own ``declared_at`` is worth anything.
+    """
+    payload = _load_json(report_plan_stamp_path(paths))
+    if not isinstance(payload, dict):
+        return None
+    declared_at = _text(payload.get("declared_at"))
+    digest = _text(payload.get("digest"))
+    if not declared_at or not digest:
+        return None
+    amendments = [dict(item) for item in _entries(payload, "amendments") if isinstance(item, dict)]
+    return (declared_at, digest, amendments)
+
+
+def _write_report_plan_stamp(paths: RunPaths, plan: ReportPlan) -> None:
+    path = report_plan_stamp_path(paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "declared_at": plan.declared_at,
+                "digest": plan.digest,
+                "amendments": [dict(item) for item in plan.amendments],
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def stamp_report_plan(paths: RunPaths, reason: str = "initial declaration") -> ReportPlan | None:
+    """Record when the plan was declared, and every time it moved afterwards.
+
+    Called by the manager when Stage 03 is approved, and again as a safety net
+    from Stage 06 on for runs that reach there without passing through a Stage
+    03 approval (``--resume-run``, ``--redo-stage``, a ``--project-root``
+    bootstrap). A plan whose content digest is unchanged is not rewritten, so
+    carrying a correct plan through a second round does not manufacture an
+    amendment — copied from ``amend_preregistration``, for the same reason.
+
+    **The previous digest is read from AutoR's sidecar, never from the plan
+    file.** The agent owns ``report_plan.json``: Stage 03 writes it and Stage 06
+    is told to edit ``dropped_because`` into it. Trusting the ``digest`` and
+    ``declared_at`` inside it to say whether it moved makes the record
+    self-certifying, and it fails on the ordinary accident rather than only on
+    a hostile one — a stage that regenerates the whole file from its own
+    template, obeying "do not write declared_at, digest or amendments", leaves
+    a plan with no stamp at all. Read from the file, that is indistinguishable
+    from a first declaration: ``declared_at`` silently becomes a post-results
+    timestamp and the amendment ledger stays empty, which is precisely the
+    claim the artifact exists to make and the one it would then be making
+    falsely. Read from the sidecar, it is an amendment, and the file is
+    repaired on the spot.
+    """
+    plan = load_report_plan(paths)
+    if plan is None:
+        return None
+
+    recorded = recorded_report_plan_stamp(paths)
+    if recorded is not None:
+        declared_at, previous_digest, amendments = recorded
+    else:
+        declared_at, previous_digest, amendments = (
+            plan.declared_at,
+            plan.digest,
+            plan.amendments,
+        )
+
+    current = report_plan_digest(plan)
+    if previous_digest == current and declared_at:
+        stamped = ReportPlan(
+            figures=plan.figures,
+            headline_numbers=plan.headline_numbers,
+            declared_at=declared_at,
+            digest=current,
+            amendments=amendments,
+        )
+    elif not previous_digest:
+        stamped = ReportPlan(
+            figures=plan.figures,
+            headline_numbers=plan.headline_numbers,
+            declared_at=declared_at or _now(),
+            digest=current,
+            amendments=amendments,
+        )
+    else:
+        stamped = ReportPlan(
+            figures=plan.figures,
+            headline_numbers=plan.headline_numbers,
+            declared_at=declared_at or _now(),
+            digest=current,
+            amendments=[
+                *amendments,
+                {
+                    "recorded_at": _now(),
+                    "reason": reason,
+                    "previous_digest": previous_digest,
+                    "new_digest": current,
+                },
+            ],
+        )
+    _write_report_plan_stamp(paths, stamped)
+    # Only when the header on disk disagrees, so an unchanged plan keeps its
+    # bytes and a stamped-but-wiped one is put back.
+    if plan.to_dict() != stamped.to_dict():
+        _write_report_plan(paths, stamped)
+    return stamped
+
+
+# ----------------------------------------------------------------------------
+# Shape: the gate that runs from Stage 03, where the plan is written
+# ----------------------------------------------------------------------------
+
+
+def _hypothesis_ids(paths: RunPaths) -> set[str] | None:
+    """The ids a figure may cite, or ``None`` when there is no manifest to check against.
+
+    A ``--project-root`` run can reach Stage 03 with no Stage 02 manifest. The
+    membership check degrades to "name something" rather than refusing every
+    id, because the alternative is a gate that fails for a reason the run
+    cannot fix. An empty manifest is treated the same way as a missing one.
+    """
+    from .hypothesis_manifest import load_hypothesis_manifest
+
+    manifest = load_hypothesis_manifest(paths.hypothesis_manifest)
+    if manifest is None:
+        return None
+    identifiers = {
+        entry.identifier
+        for section in (
+            manifest.theoretical_propositions,
+            manifest.empirical_hypotheses,
+            manifest.paper_claims,
+        )
+        for entry in section
+        if entry.identifier
+    }
+    return identifiers or None
+
+
+def _relative_source(reference: str) -> PurePosixPath | None:
+    """The reference as a workspace-relative file path, or None when it is not one."""
+    cleaned = reference.strip().replace("\\", "/")
+    if not cleaned:
+        return None
+    candidate = PurePosixPath(cleaned)
+    if candidate.is_absolute():
+        return None
+    parts = [part for part in candidate.parts if part != "."]
+    if ".." in parts or len(parts) < 2:
+        return None
+    if parts[0] not in SOURCE_ARTIFACT_ROOTS:
+        return None
+    return PurePosixPath(*parts)
+
+
+def _source_artifact_problem(reference: str, label: str) -> str | None:
+    if not reference:
+        return (
+            f"{label} names no source_artifact. A figure has to say which file its numbers "
+            "come from, so producing that file is a stage's job rather than an afterthought."
+        )
+    if _relative_source(reference) is None:
+        roots = ", ".join(f"{root}/" for root in SOURCE_ARTIFACT_ROOTS)
+        return (
+            f"{label} draws from `{reference}`, which is not a workspace-relative file under "
+            f"{roots}. A figure is computed from a result the run produced, never from a note."
+        )
+    return None
+
+
+def _allowed_figure_suffixes(output_format: str) -> set[str]:
+    """The suffixes a published figure may carry, derived from the format's constants."""
+    if output_format == "markdown":
+        return {PREFERRED_REPORT_IMAGE_SUFFIX}
+    return set(FIGURE_SUFFIXES)
+
+
+def validate_report_plan(
+    paths: RunPaths,
+    output_format: str = DEFAULT_OUTPUT_FORMAT,
+) -> list[str]:
+    """Shape checks, from Stage 03 on: the plan is a commitment or it is nothing.
+
+    Held at the stage that writes the plan rather than at the stage that reads
+    it, so a plan-less Stage 03 is refused while the design can still be
+    changed.
+    """
+    plan = load_report_plan(paths)
+    if plan is None:
+        return [
+            "requires a report plan at workspace/notes/report_plan.json, written before any "
+            "result exists. Each figure the report will carry gets a slot: the filename it "
+            "will be published under, the claim it settles, what a reader should see in it, "
+            "what it looks like if that claim holds and if it does not, and the result file "
+            "it is computed from. `headline_numbers` names the quantities the report must "
+            "state, with their units."
+        ]
+
+    problems: list[str] = []
+    figures = plan.figures
+    #: Whether AutoR has ever stamped this plan. Read from AutoR's own copy
+    #: rather than the file's ``declared_at``, for the reason
+    #: :func:`recorded_report_plan_stamp` exists: the agent can write that
+    #: field. False means the plan is still being declared — the first Stage 03
+    #: that writes it, or a re-attempt of that stage.
+    declared = recorded_report_plan_stamp(paths) is not None
+
+    if not figures:
+        # A plan with no figures is unusual, not wrong. Measured over the 40
+        # ResearchClawBench tasks, three of them have no image criterion at all,
+        # and the median task has two — so a floor of one would make those three
+        # runs draw a figure that carries nothing, which is exactly the
+        # dilution the slot ranking exists to prevent. Following this codebase's
+        # habit, the move is not forbidden; it has to be on the record.
+        if len(str(plan.no_figures_because or "").strip()) < MIN_SHOWS_CHARS:
+            problems.append(
+                "report_plan.json declares no figures and does not say why. A report with no "
+                "figure is a real answer for some studies — set `no_figures_because` to the "
+                f"reason, in at least {MIN_SHOWS_CHARS} characters, naming what the prose "
+                "carries instead. Otherwise name the figure the report is built around, the "
+                "claim it settles and the file it comes from."
+            )
+    elif output_format == "markdown" and len(figures) > MAX_REPORT_FIGURES:
+        problems.append(
+            f"report_plan.json declares {len(figures)} figures, but at most "
+            f"{MAX_REPORT_FIGURES} reach the reader of a markdown report — the rest are work "
+            f"nobody sees. Drop the weakest slots. {MAX_REPORT_FIGURES} is a ceiling, not a "
+            "target: a plan with fewer slots, each settling a different claim, is a better "
+            "plan."
+        )
+
+    if figures and sorted(item.slot for item in figures) != list(range(1, len(figures) + 1)):
+        declared = ", ".join(str(item.slot) for item in figures)
+        problems.append(
+            f"report_plan.json declares slots [{declared}]; they must be unique and "
+            f"contiguous from 1 to {len(figures)}. The slot order is the ranking, and the "
+            "ranking is what makes the weakest figure identifiable now rather than at export."
+        )
+
+    seen_filenames: dict[str, int] = {}
+    for item in figures:
+        key = item.filename.casefold()
+        if key:
+            seen_filenames[key] = seen_filenames.get(key, 0) + 1
+
+    allowed_suffixes = _allowed_figure_suffixes(output_format)
+    claimed = Counter(identifier for item in figures for identifier in item.supports)
+    known_ids = _hypothesis_ids(paths)
+
+    for item in figures:
+        label = f"report_plan.json slot {item.slot}" if item.slot else "report_plan.json figure"
+
+        if not item.filename:
+            problems.append(
+                f"{label} declares no filename. The filename is the join key between this "
+                "plan and the published report: without it, `planned` and `published` cannot "
+                "be compared."
+            )
+        elif Path(item.filename).name != item.filename or "/" in item.filename or "\\" in item.filename:
+            problems.append(
+                f"{label} declares filename `{item.filename}`, which is not a bare filename. "
+                "Figures are published directly under the report's images directory, so a "
+                "path here names a figure the export cannot find."
+            )
+        elif Path(item.filename).suffix.lower() not in allowed_suffixes:
+            expected = ", ".join(sorted(allowed_suffixes))
+            problems.append(
+                f"{label} declares filename `{item.filename}`, whose format is not published "
+                f"by this run's deliverable. Use one of: {expected}."
+            )
+        elif seen_filenames.get(item.filename.casefold(), 0) > 1:
+            problems.append(
+                f"{label} declares filename `{item.filename}`, which another slot also "
+                "declares. Two slots writing one file is one figure with two plans."
+            )
+
+        if not item.supports:
+            problems.append(
+                f"{label} names no claim it supports. Cite a hypothesis id from "
+                f"hypothesis_manifest.json, or `{EXPLORATORY_PREFIX}<slug>` for a question "
+                "the run did not preregister."
+            )
+        else:
+            for identifier in item.supports:
+                if identifier.startswith(EXPLORATORY_PREFIX):
+                    slug = identifier[len(EXPLORATORY_PREFIX) :].strip()
+                    if len(slug) < MIN_EXPLORATORY_SLUG_CHARS:
+                        problems.append(
+                            f"{label} supports `{identifier}`, whose slug is shorter than "
+                            f"{MIN_EXPLORATORY_SLUG_CHARS} characters. Name the exploratory "
+                            "question, so a second slot cannot quietly claim the same one."
+                        )
+                elif known_ids is not None and identifier not in known_ids:
+                    problems.append(
+                        f"{label} supports `{identifier}`, which is not an id in "
+                        f"hypothesis_manifest.json. Cite a declared hypothesis, or label the "
+                        f"question `{EXPLORATORY_PREFIX}<slug>`."
+                    )
+            if all(claimed[identifier] > 1 for identifier in item.supports):
+                overlap = ", ".join(item.supports)
+                problems.append(
+                    f"{label} supports {overlap}, every one of which another slot already "
+                    "carries. A slot that answers no question the other slots leave open is "
+                    "a slot spent twice: give it a claim of its own, or drop it."
+                )
+
+        if len(item.shows) < MIN_SHOWS_CHARS:
+            problems.append(
+                f"{label} says nothing usable in `shows` ({len(item.shows)} characters). "
+                f"Describe what a reader should see, naming both axes and their units, in at "
+                f"least {MIN_SHOWS_CHARS} characters."
+            )
+
+        for branch_name, branch in (("if_supported", item.if_supported), ("if_refuted", item.if_refuted)):
+            if len(branch) < MIN_BRANCH_CHARS:
+                problems.append(
+                    f"{label} does not say what the figure looks like in `{branch_name}` "
+                    f"({len(branch)} characters, at least {MIN_BRANCH_CHARS} needed)."
+                )
+        if (
+            item.if_supported
+            and item.if_refuted
+            and _normalised(item.if_supported) == _normalised(item.if_refuted)
+        ):
+            problems.append(
+                f"{label} says the same thing whether the claim holds or not. A figure whose "
+                "two branches are one sentence is decoration: it cannot come out either way, "
+                "so it carries no claim."
+            )
+
+        problem = _source_artifact_problem(item.source_artifact, label)
+        if problem:
+            problems.append(problem)
+
+        if item.dropped_because and len(item.dropped_because) < MIN_DROP_REASON_CHARS:
+            problems.append(
+                f"{label} is dropped with a {len(item.dropped_because)}-character reason. "
+                f"Say what happened to the claim it carried, in at least "
+                f"{MIN_DROP_REASON_CHARS} characters."
+            )
+        elif item.dropped_because and not declared:
+            # Abandoning a slot is a move that only exists *after* the plan was
+            # declared. Before then, a dropped slot is the cheapest thing in
+            # this file: it satisfies every field check, is skipped by the
+            # Stage 06 source gate and by the Stage 07 coverage gate, and owes
+            # no figure. Five slots with four born dropped reads as a five-slot
+            # plan and commits to one.
+            problems.append(
+                f"{label} is dropped in the same plan that declares it. `dropped_because` "
+                "records a slot abandoned once the results were in; a slot the run never "
+                "intended to produce is not a plan, it is padding. Remove the slot, or "
+                "remove its `dropped_because` and commit to the figure."
+            )
+
+    if not plan.headline_numbers:
+        problems.append(
+            "report_plan.json declares no headline_numbers. Name the quantities the report "
+            "has to state, with units — a result the prose never puts a number on is a "
+            "result the reader has to take on trust."
+        )
+    elif len(plan.headline_numbers) > MAX_HEADLINE_NUMBERS:
+        problems.append(
+            f"report_plan.json declares {len(plan.headline_numbers)} headline numbers; at "
+            f"most {MAX_HEADLINE_NUMBERS}. These are the numbers the report leads with, not "
+            "an inventory of everything measured."
+        )
+
+    for index, number in enumerate(plan.headline_numbers, start=1):
+        label = f"report_plan.json headline number {index}"
+        if not number.quantity:
+            problems.append(f"{label} names no quantity.")
+        if not number.unit:
+            problems.append(
+                f"{label} has no unit. `dimensionless` and `count` are units; an empty "
+                "string is not."
+            )
+        problem = _source_artifact_problem(number.source_artifact, label)
+        if problem:
+            problems.append(problem)
+
+    return problems
+
+
+# ----------------------------------------------------------------------------
+# The sources resolve: the gate that runs from Stage 06, while it can be acted on
+# ----------------------------------------------------------------------------
+
+
+def _resolve_source_artifact(
+    paths: RunPaths,
+    relative: PurePosixPath,
+    extra_dirs: Sequence[Path],
+) -> Path | None:
+    """Find the file a slot names, in the run tree or in a configured artifact root.
+
+    ``extra_dirs`` are the directories the manager maps the ``results`` and
+    ``data`` categories onto for runs whose output contract points outside the
+    run tree (a benchmark workspace's ``outputs/``). Both the directory itself
+    and its parent are tried, because a workspace-relative reference such as
+    ``outputs/metrics.json`` is relative to the parent.
+
+    A non-empty match wins over an empty one wherever both exist, so a stray
+    zero-byte file in one root cannot mask the real artifact in another.
+    """
+    bases: list[Path] = [paths.workspace_root]
+    for directory in extra_dirs:
+        bases.append(directory)
+        bases.append(directory.parent)
+    found: list[Path] = []
+    for base in bases:
+        candidate = base / Path(str(relative))
+        if candidate.is_file():
+            found.append(candidate)
+    for directory in extra_dirs:
+        candidate = directory / relative.name
+        if candidate.is_file():
+            found.append(candidate)
+    for candidate in found:
+        if not _is_empty(candidate):
+            return candidate
+    return found[0] if found else None
+
+
+def _is_empty(path: Path) -> bool:
+    """No bytes, or nothing but whitespace.
+
+    The existence check is otherwise satisfied by ``touch``: the cheapest way
+    to clear "the file your figure comes from does not exist" is to create it
+    with nothing in it, and a figure drawn from an empty file is the thing this
+    gate exists to refuse. Anything with a byte of content in it passes — this
+    is a floor under *a file was written*, not a judgement about the data, and
+    a one-line CSV is a legitimate result. Only small files are read back:
+    anything above :data:`_WHITESPACE_PROBE_BYTES` has content by definition,
+    and a ``.parquet`` is not worth decoding to find that out.
+    """
+    try:
+        size = path.stat().st_size
+        if size == 0:
+            return True
+        if size > _WHITESPACE_PROBE_BYTES:
+            return False
+        return not path.read_bytes().strip()
+    except OSError:
+        return False
+
+
+def validate_report_plan_sources(
+    paths: RunPaths,
+    extra_dirs: Sequence[Path] = (),
+) -> list[str]:
+    """From Stage 06 on: the file each live commitment draws from has to exist.
+
+    "Never draw a figure from numbers you did not compute", enforced at the
+    stage that draws the figures rather than at the stage that publishes them,
+    where the only remaining move would be to delete the figure. A dropped slot
+    is skipped: abandoning a figure is allowed, and its reason is checked
+    elsewhere.
+
+    ``headline_numbers`` are held to the same rule, and this is the only gate
+    that ever reads their ``source_artifact``. Without it the field is the
+    cheapest thing in the plan: shape-checked once at Stage 03 and then never
+    resolved, so a quantity the report leads with could be sourced from a file
+    nothing ever wrote. A headline number has no ``dropped_because`` escape
+    because it has no slot to abandon — amend the plan instead, which is a move
+    the ledger records.
+
+    An empty file is refused alongside a missing one, and says so differently.
+    Existence alone is satisfied by ``touch``: the cheapest way past "produce
+    it" would otherwise be to create the path with nothing in it, and a figure
+    drawn from an empty file is exactly the figure this gate is here to stop.
+    """
+    plan = load_report_plan(paths)
+    if plan is None:
+        return []
+
+    problems: list[str] = []
+    for item in plan.figures:
+        if item.is_dropped:
+            continue
+        relative = _relative_source(item.source_artifact)
+        if relative is None:
+            # Shape is the Stage 03 gate's business; reporting it twice would
+            # make one defect look like two.
+            continue
+        resolved = _resolve_source_artifact(paths, relative, extra_dirs)
+        if resolved is None:
+            problems.append(
+                f"report_plan.json slot {item.slot} plans `{item.filename}` from "
+                f"`{item.source_artifact}`, which does not exist. Produce it, or record "
+                "`dropped_because` on that slot and say what happened to the claim it "
+                "carried."
+            )
+        elif _is_empty(resolved):
+            problems.append(
+                f"report_plan.json slot {item.slot} plans `{item.filename}` from "
+                f"`{item.source_artifact}`, which is empty. A figure computed from an "
+                "empty file is a figure computed from nothing: write the result, or "
+                "record `dropped_because` on that slot and say what happened to the "
+                "claim it carried."
+            )
+
+    for index, number in enumerate(plan.headline_numbers, start=1):
+        relative = _relative_source(number.source_artifact)
+        if relative is None:
+            continue
+        resolved = _resolve_source_artifact(paths, relative, extra_dirs)
+        if resolved is None:
+            problems.append(
+                f"report_plan.json headline number {index} ({number.quantity or 'unnamed'}) "
+                f"is computed from `{number.source_artifact}`, which does not exist. A "
+                "number the report leads with has to come from a file the run wrote: "
+                "produce it, or amend the plan to the quantity you can actually state."
+            )
+        elif _is_empty(resolved):
+            problems.append(
+                f"report_plan.json headline number {index} ({number.quantity or 'unnamed'}) "
+                f"is computed from `{number.source_artifact}`, which is empty. The number "
+                "the report leads with cannot come from a file with nothing in it: write "
+                "the result, or amend the plan to the quantity you can actually state."
+            )
+    return problems
+
+
+# ----------------------------------------------------------------------------
+# Coverage: the gate that runs at Stage 07, markdown only
+# ----------------------------------------------------------------------------
+
+
+def validate_report_plan_coverage(
+    paths: RunPaths,
+    figures_dirs: Sequence[Path] = (),
+) -> list[str]:
+    """At Stage 07: every planned slot was published, or dropped on the record.
+
+    Markdown only. The latex branch has no single well-defined location for a
+    published figure — the document places them — and it runs a layout review
+    that covers the same ground, so a coverage check there would refuse work it
+    cannot see.
+
+    Dropping stays cheap: one sentence on the slot. What it stops being is
+    silent, and because ``dropped_because`` is a committed field, writing it
+    moves the digest and the amendment ledger records that the plan changed
+    after the results were in.
+    """
+    plan = load_report_plan(paths)
+    if plan is None or not plan.figures:
+        # Absence and emptiness are the Stage 03 gate's refusals, and it runs
+        # here too.
+        return []
+
+    referenced = set()
+    if paths.report_file.is_file():
+        try:
+            report_text = paths.report_file.read_text(encoding="utf-8")
+        except OSError:
+            report_text = ""
+        referenced = {
+            PurePosixPath(target.split("#", 1)[0].split("?", 1)[0].strip()).name.casefold()
+            for target in extract_markdown_image_targets(report_text)
+        }
+
+    search_dirs = [paths.report_images_dir, *figures_dirs]
+    problems: list[str] = []
+    for item in plan.figures:
+        if item.is_dropped:
+            continue
+        published = bool(item.filename) and any(
+            (directory / item.filename).is_file() for directory in search_dirs
+        )
+        if published and item.filename.casefold() in referenced:
+            continue
+        supports = ", ".join(item.supports) or "no claim"
+        problems.append(
+            f"planned figure slot {item.slot} ({item.filename or 'unnamed'}, supports "
+            f"{supports}) was neither published nor dropped. Publish it under report/images/ "
+            "and reference it from report.md, or record `dropped_because` on that slot in "
+            f"report_plan.json ({MIN_DROP_REASON_CHARS} characters or more) saying what "
+            "happened to the claim it carried."
+        )
+
+    if all(item.is_dropped for item in plan.figures):
+        problems.append(
+            "report_plan.json drops every planned figure, so the report argues for nothing "
+            "the reader can see. Publish at least one of the planned slots, or re-plan the "
+            "figures against the results that exist."
+        )
+    return problems
+
+
+# ----------------------------------------------------------------------------
+# Prompt rendering
+# ----------------------------------------------------------------------------
+
+
+def format_report_plan_for_prompt(plan: ReportPlan) -> str:
+    lines: list[str] = []
+    if plan.declared_at:
+        lines.append(f"Declared at: {plan.declared_at} (Stage 03, before any result existed)")
+    if plan.amendments:
+        lines.append(f"Amendments on record: {len(plan.amendments)}")
+        for amendment in plan.amendments:
+            lines.append(
+                f"  - {amendment.get('recorded_at', '')}: {amendment.get('reason', '')}"
+            )
+    if lines:
+        lines.append("")
+
+    lines.append("Planned figures:")
+    for item in plan.figures:
+        status = " — DROPPED" if item.is_dropped else ""
+        lines.append(f"- **Slot {item.slot}: `{item.filename}`**{status}")
+        lines.append(f"  - Supports: {', '.join(item.supports) or 'nothing declared'}")
+        lines.append(f"  - Shows: {item.shows}")
+        lines.append(f"  - If the claim holds: {item.if_supported}")
+        lines.append(f"  - If it does not: {item.if_refuted}")
+        lines.append(f"  - Computed from: `{item.source_artifact}`")
+        if item.is_dropped:
+            lines.append(f"  - Dropped because: {item.dropped_because}")
+
+    if plan.headline_numbers:
+        lines.append("")
+        lines.append("Headline numbers the report must state:")
+        for number in plan.headline_numbers:
+            lines.append(
+                f"- {number.quantity} ({number.unit}), from `{number.source_artifact}`"
+            )
+    return "\n".join(lines)

--- a/src/utils.py
+++ b/src/utils.py
@@ -74,6 +74,11 @@ class RunPaths:
     hypothesis_manifest: Path
     preregistration: Path
     experimental_protocol: Path
+    #: Which figures the report will carry and which claim each one settles,
+    #: declared at Stage 03. Under ``notes/`` rather than ``data/`` on purpose:
+    #: ``.json`` is a machine-data suffix, so a plan under ``data/`` would
+    #: satisfy the Stage 03 data gate, which exists to prove work happened.
+    report_plan: Path
     research_rounds: Path
     round_decision: Path
     hypothesis_outcomes: Path
@@ -194,10 +199,11 @@ MIN_REPORT_CHARS = 1200
 
 #: How many figures may reach the judge.
 #:
-#: ResearchClawBench's scorer attaches at most five agent images per checklist item
-#: (``generated_images[:5]``), selected by an unsorted ``rglob`` over ``outputs/`` and then
-#: ``report/``. Filesystem order is not alphabetical, so naming cannot influence which five
-#: survive — the only way to choose them is to publish no more than five. Image items carry
+#: ResearchClawBench's scorer collects one set of agent images per *workspace*, by an
+#: unsorted ``rglob`` over ``outputs/`` and then ``report/``, and attaches the first five of
+#: that same set to every image checklist item (``generated_images[:5]``) — not five chosen
+#: per item. Filesystem order is not alphabetical, so naming cannot influence which five
+#: survive; the only way to choose them is to publish no more than five. Image items carry
 #: ~61% of the benchmark's total weight, so a sixth figure does not dilute the score, it
 #: randomises it.
 MAX_REPORT_FIGURES = 5
@@ -254,6 +260,7 @@ def build_run_paths(run_root: Path) -> RunPaths:
         hypothesis_manifest=workspace_root / "notes" / "hypothesis_manifest.json",
         preregistration=workspace_root / "notes" / "preregistration.json",
         experimental_protocol=workspace_root / "notes" / "experimental_protocol.json",
+        report_plan=workspace_root / "notes" / "report_plan.json",
         research_rounds=workspace_root / "notes" / "research_rounds.json",
         round_decision=workspace_root / "notes" / "round_decision.json",
         hypothesis_outcomes=workspace_root / "results" / "hypothesis_outcomes.json",
@@ -1288,6 +1295,16 @@ def validate_stage_artifacts(
                 f"{stage.stage_title} requires machine-readable data artifacts produced or updated during the current stage execution."
             )
 
+        # Which figures the report will carry, held at the stage that writes it.
+        # The experimental protocol is the counter-example: the Stage 03 prompt
+        # asks for it and the gate first fires at Stage 05, so a Stage 03 that
+        # skipped it is approved and the failure surfaces two stages later,
+        # where the only repair is a rollback.
+        from .report_plan import validate_report_plan
+
+        for problem in validate_report_plan(paths, selected_output_format(paths)):
+            problems.append(f"{stage.stage_title} {problem}")
+
     if stage.number >= 5:
         # The scientific-validity chain, distinct from the artifact gates around
         # it: the hypotheses were frozen before results existed (05), every one
@@ -1320,10 +1337,22 @@ def validate_stage_artifacts(
     if stage.number >= 6:
         from .experimental_protocol import validate_outcome_statistics
         from .preregistration import validate_hypothesis_outcomes
+        from .report_plan import validate_report_plan_sources
 
         for problem in validate_hypothesis_outcomes(paths):
             problems.append(f"{stage.stage_title} {problem}")
         for problem in validate_outcome_statistics(paths):
+            problems.append(f"{stage.stage_title} {problem}")
+        # Never draw a figure from numbers you did not compute — checked at the
+        # stage that draws them, where producing the missing file is still a
+        # move the run can make.
+        for problem in validate_report_plan_sources(
+            paths,
+            [
+                *(artifact_dirs or {}).get("results", ()),
+                *(artifact_dirs or {}).get("data", ()),
+            ],
+        ):
             problems.append(f"{stage.stage_title} {problem}")
 
         if count_in("figures", paths.figures_dir, FIGURE_SUFFIXES) == 0:
@@ -1344,9 +1373,17 @@ def validate_stage_artifacts(
             problems.append(f"{stage.stage_title} {problem}")
 
     if stage.number >= 7 and selected_output_format(paths) == "markdown":
+        from .report_plan import validate_report_plan_coverage
+
         problems.extend(
             f"{stage.stage_title}: {problem}"
             for problem in validate_markdown_report(paths)
+        )
+        problems.extend(
+            f"{stage.stage_title}: {problem}"
+            for problem in validate_report_plan_coverage(
+                paths, [*(artifact_dirs or {}).get("figures", ())]
+            )
         )
 
         if not (paths.artifacts_dir / "citation_verification.json").exists():

--- a/src/writing_manifest.py
+++ b/src/writing_manifest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import re
 
 from .artifact_index import indexed_artifacts_for_category, write_artifact_index
+from .report_plan import load_report_plan
 from .utils import (
     MAX_REPORT_FIGURES,
     MIN_REPORT_CHARS,
@@ -331,12 +332,27 @@ def generate_report_review(paths: RunPaths) -> dict[str, object]:
 
     over_budget = max(0, len(available) - MAX_REPORT_FIGURES)
 
+    # A figure nobody planned is the defect ``report_plan.json`` exists to stop: a slot filled
+    # by whatever the run happened to produce. Advisory rather than a refusal, because the
+    # plan is amendable and a late figure that earns its slot is a legitimate move — but the
+    # Stage 07 prompt tells the run this will be flagged, and a promise no reader keeps is
+    # worth less than no promise. Only checked once a plan exists: a run with none is the
+    # Stage 03 gate's finding, and repeating it here would make one defect look like two.
+    unplanned: list[str] = []
+    plan = load_report_plan(paths)
+    if plan is not None and plan.figures:
+        planned_names = {item.filename.casefold() for item in plan.figures if item.filename}
+        unplanned = [
+            path.name for path in available if path.name.casefold() not in planned_names
+        ]
+
     issue_counts = {
         "broken_image_links": len(broken),
         "non_relative_image_links": len(non_relative),
         "unrenderable_images": len(unrenderable),
         "non_png_images": len(non_preferred),
         "unreferenced_images": len(unreferenced),
+        "unplanned_images": len(unplanned),
         "figures_over_budget": over_budget,
     }
     issue_counts["total"] = sum(issue_counts.values())
@@ -422,6 +438,21 @@ def generate_report_review(paths: RunPaths) -> dict[str, object]:
                     f"importance. {over_budget} figure(s) must go."
                 ),
                 "evidence": [path.name for path in available][:_REPORT_ISSUE_SAMPLE_LIMIT],
+            }
+        )
+    if unplanned:
+        issues.append(
+            {
+                "category": "unplanned_image",
+                "severity": "minor",
+                "summary": (
+                    f"{len(unplanned)} image(s) under report/images/ are not slots in "
+                    "report_plan.json. The figure set was chosen at Stage 03 against the "
+                    "claims it carries; an unplanned figure spends a judge slot on a claim "
+                    "nobody argued for. Publish the planned slot instead, or amend the plan "
+                    "to say which claim this figure settles."
+                ),
+                "evidence": unplanned[:_REPORT_ISSUE_SAMPLE_LIMIT],
             }
         )
     if unreferenced:

--- a/tests/prereg_support.py
+++ b/tests/prereg_support.py
@@ -75,6 +75,58 @@ def write_experimental_protocol(paths: RunPaths, *, planned_seeds: int = 5) -> N
     )
 
 
+def write_report_plan(
+    paths: RunPaths,
+    *,
+    filename: str = "accuracy.png",
+    source_artifact: str = "results/metrics.json",
+    figures=None,
+    headline_numbers=None,
+) -> None:
+    """One planned figure, one headline number: the smallest plan the gate accepts.
+
+    Deliberately one entry rather than five. The fixture is read by everyone who
+    adds a test, and a five-entry fixture would teach the ceiling as a target
+    exactly the way a five-entry prompt example would.
+
+    ``filename`` defaults to the figure the run fixtures in this suite publish,
+    so the Stage 07 coverage check sees a plan the package actually delivered.
+    """
+    write_text(
+        paths.report_plan,
+        json.dumps(
+            {
+                "figures": figures
+                if figures is not None
+                else [
+                    {
+                        "slot": 1,
+                        "filename": filename,
+                        "supports": [HYPOTHESIS_ID],
+                        "shows": (
+                            "Held-out accuracy (%) for the treatment and the baseline, "
+                            "five seeds, band = stderr."
+                        ),
+                        "if_supported": "the treatment's bar clears the baseline's error band",
+                        "if_refuted": "the two bars overlap within their error bands",
+                        "source_artifact": source_artifact,
+                        "dropped_because": "",
+                    }
+                ],
+                "headline_numbers": headline_numbers
+                if headline_numbers is not None
+                else [
+                    {
+                        "quantity": "held-out accuracy, treatment vs baseline",
+                        "unit": "percentage points",
+                        "source_artifact": source_artifact,
+                    }
+                ],
+            }
+        ),
+    )
+
+
 def write_round_decision(paths: RunPaths, *, decision: str = "converged", **overrides) -> None:
     payload = {
         "decision": decision,
@@ -107,6 +159,10 @@ def write_validity_chain(
     not already written it, because the gates reject a verdict or a claim that
     cites a file that does not exist — a rejection covered by its own test
     rather than by every fixture tripping over it.
+
+    The figure plan is part of the same chain: it is declared at Stage 03, one
+    stage before the freeze, and its single slot is drawn from the same evidence
+    artifact the verdict cites.
     """
     evidence_path = paths.workspace_root / evidence
     if not evidence_path.exists():
@@ -115,6 +171,7 @@ def write_validity_chain(
 
     write_hypothesis_manifest(paths)
     write_experimental_protocol(paths)
+    write_report_plan(paths, source_artifact=evidence)
     prereg = freeze_preregistration(paths)
     if prereg is None:  # pragma: no cover - only if the manifest write failed
         raise AssertionError("preregistration did not freeze from the test manifest")

--- a/tests/test_fake_pipeline_end_to_end.py
+++ b/tests/test_fake_pipeline_end_to_end.py
@@ -99,6 +99,39 @@ class FakePipelineEndToEndTest(unittest.TestCase):
             with self.subTest(stage=stage.slug):
                 self.assertEqual(validate_stage_artifacts(stage, self.paths), [])
 
+    def test_the_figure_plan_is_dated_before_the_experiments_run(self) -> None:
+        """The claim ``report_plan.json`` makes is *when* it was written.
+
+        AutoR stamps the plan on Stage 03's approval; a safety net at Stage 06
+        catches runs that reach there another way. Both together mean a run
+        always ends up with a dated plan, so "it has a date" holds even if the
+        Stage 03 hook is gone — and a plan first dated at Stage 06 was chosen
+        after the results existed, which is the failure the plan exists to
+        prevent. The order in the log is therefore the assertion, not the
+        presence of the date.
+        """
+        log = self.paths.logs.read_text(encoding="utf-8")
+        declared = log.find("report_plan declared")
+        experiments = log.find("05_experimentation inbound_channels")
+        self.assertNotEqual(declared, -1, "the figure plan was never dated")
+        self.assertNotEqual(experiments, -1, "this run never reached Stage 05")
+        self.assertLess(
+            declared,
+            experiments,
+            "the figure plan was dated after the experiments started, so it is a "
+            "description of what happened rather than a plan",
+        )
+
+    def test_a_single_round_run_does_not_manufacture_a_plan_amendment(self) -> None:
+        """The plan is stamped once per approval and again from Stage 06 on. If
+        stamping were not idempotent by content, a run that never changed its
+        plan would still arrive with an amendment ledger describing changes that
+        did not happen."""
+        plan = json.loads(self.paths.report_plan.read_text(encoding="utf-8"))
+        self.assertTrue(plan.get("declared_at"))
+        self.assertTrue(plan.get("digest"))
+        self.assertEqual(plan.get("amendments"), [])
+
     def test_node_output_does_not_grow_with_the_run(self) -> None:
         """The relay is what made stage summaries grow 235 -> 1,211 words.
 

--- a/tests/test_information_flow.py
+++ b/tests/test_information_flow.py
@@ -25,7 +25,14 @@ from src.information_flow import (
     inbound_channels,
     render_inbound,
 )
-from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+from src.utils import (
+    MAX_REPORT_FIGURES,
+    STAGES,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    write_text,
+)
 
 
 BY_KEY = {channel.key: channel for channel in CHANNELS}
@@ -97,6 +104,146 @@ class HypothesisDuplicationTest(unittest.TestCase):
         mutable = BY_KEY["hypotheses"].consumed_by
         self.assertIn("03_study_design", mutable)
         self.assertIn("04_implementation", mutable)
+
+
+class DeliverableContractTest(unittest.TestCase):
+    """The constraint that decides most of the work has to arrive before the work.
+
+    ``MAX_REPORT_FIGURES`` used to reach Stage 07 and nowhere else: the run was
+    told how many figures a reader would see four stages after it chose which
+    figures to make, when the only move left was deleting the weakest. These
+    tests hold the arrival time and the derivation, not the sentences.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    def _context(self, slug: str) -> ChannelContext:
+        return ChannelContext(paths=self.paths, stage=STAGE[slug], attempt_no=1)
+
+    def _render(self, slug: str) -> str:
+        return BY_KEY["report_contract"].build(self._context(slug))
+
+    def test_the_planning_stage_is_told_the_deliverable_shape(self) -> None:
+        served = {c.key for c in inbound_channels(STAGE["03_study_design"], CHANNELS)}
+        self.assertIn("report_contract", served)
+
+    def test_the_stages_that_write_and_run_code_are_not(self) -> None:
+        """A figure ceiling at 04/05 invites plotting instead of implementing."""
+        for slug in ("04_implementation", "05_experimentation"):
+            served = {c.key for c in inbound_channels(STAGE[slug], CHANNELS)}
+            with self.subTest(stage=slug):
+                self.assertNotIn("report_contract", served)
+
+    def test_the_ceiling_is_derived_from_the_constant_and_not_typed_out(self) -> None:
+        """One encoding of the rule. Move the constant, the prompt moves with it."""
+        from unittest.mock import patch
+
+        import src.utils as utils
+
+        with patch.object(utils, "MAX_REPORT_FIGURES", 7):
+            moved = self._render("03_study_design")
+        self.assertIn("7", moved)
+        self.assertNotIn("5 figures", moved)
+
+    def test_a_latex_run_is_never_shipped_a_five_figure_ceiling(self) -> None:
+        """The ceiling is markdown's, not every run's: a venue paper carries more."""
+        ensure_run_config(self.paths, output_format="latex")
+        latex = self._render("03_study_design")
+        self.assertNotIn(str(MAX_REPORT_FIGURES), latex)
+        self.assertIn("venue", latex.lower())
+
+    def test_the_shared_channels_carry_nothing_benchmark_specific(self) -> None:
+        """The scoring numbers are one benchmark's and travel in its own goal text.
+
+        Every AutoR run receives these two blocks, so a weighting, a grader or a
+        benchmark name in either one would ship one benchmark's scoring model to
+        runs that have no grader at all. Scanned on the delivered surface — what
+        the agent reads — not on the module source, because a docstring
+        explaining the rule is not a prompt.
+
+        The scan covers only the text *AutoR* wrote. ``report_plan``'s body is
+        the run's own plan read back, so the tokens do not apply to it: a
+        perfectly good ``shows`` says "Accuracy (%) against context length", and
+        a scan that included it would either fail on the suite's own plan
+        fixture or, worse, pass because this test happens to run without one.
+        The empty-population trap is the reason the split is explicit rather
+        than incidental: ``report_plan``'s heading and preface are AutoR's and
+        are scanned; its body is the agent's and is not.
+        """
+        for key in ("report_contract", "report_plan"):
+            channel = BY_KEY[key]
+            autor_authored = key != "report_plan"
+            for slug in sorted(channel.consumed_by):
+                body = (channel.build(self._context(slug)) or "") if autor_authored else ""
+                delivered = " ".join([channel.heading, channel.preface, body]).lower()
+                for token in ("researchclawbench", "judge", "rubric", "checklist", "%"):
+                    with self.subTest(channel=key, stage=slug, token=token):
+                        self.assertNotIn(token, delivered)
+
+    def test_the_contract_scan_runs_over_a_non_empty_body(self) -> None:
+        """The control for the scan above: an empty body passes every token check."""
+        for slug in sorted(BY_KEY["report_contract"].consumed_by):
+            with self.subTest(stage=slug):
+                self.assertTrue((BY_KEY["report_contract"].build(self._context(slug)) or "").strip())
+
+
+class ReportPlanChannelTest(unittest.TestCase):
+    """Stage 03's first outbound edge: a plan nobody reads is documentation."""
+
+    def test_the_plan_is_produced_by_the_stage_that_plans(self) -> None:
+        self.assertEqual(BY_KEY["report_plan"].produced_by, "03_study_design")
+
+    def test_the_plan_reaches_the_stages_that_act_on_it(self) -> None:
+        consumers = BY_KEY["report_plan"].consumed_by
+        for slug in ("04_implementation", "06_analysis", "07_writing"):
+            with self.subTest(stage=slug):
+                self.assertIn(slug, consumers)
+
+    def test_the_planning_stage_reads_its_own_plan_back(self) -> None:
+        """A second round amends the plan; it cannot amend what it is not shown."""
+        self.assertIn("03_study_design", BY_KEY["report_plan"].consumed_by)
+
+    def test_the_stage_that_has_to_emit_the_source_files_is_sent_it(self) -> None:
+        """Every slot names a ``source_artifact``, and Stage 05 is the stage that
+        writes those files. The Stage 06 gate refuses a slot whose source does
+        not exist, and by Stage 06 the stage that could have produced it has
+        run: withholding the paths from 05 makes that refusal unfixable. The
+        Stage 05 prompt already instructs the run to "write them at the paths
+        the plan names", which it cannot do from a plan it is not shown."""
+        self.assertIn("05_experimentation", BY_KEY["report_plan"].consumed_by)
+
+    def test_no_stage_before_the_drawing_stage_is_told_to_draw(self) -> None:
+        """The plan reaches 04 and 05 as files to emit, not as figures to plot.
+
+        The preface is the only instruction that travels with the plan, and it
+        is the same text for every consumer. A blanket "produce them" would
+        reach the two stages whose job is to write and run code, contradicting
+        Stage 03's own "produce no figure files at this stage" and inviting
+        exactly the plotting-instead-of-running that keeps the figure ceiling
+        out of 04 and 05.
+        """
+        preface = BY_KEY["report_plan"].preface.lower()
+        self.assertIn("do not draw a figure before stage 06", preface)
+        self.assertIn("stage 06 draws the figures", preface)
+
+    def test_every_channel_produced_by_a_stage_reaches_a_later_one(self) -> None:
+        """Producing for nobody downstream is a record, not a channel."""
+        order = {slug: index for index, slug in enumerate(ALL_STAGES)}
+        for channel in CHANNELS:
+            if channel.produced_by is None:
+                continue
+            later = [
+                consumer
+                for consumer in channel.consumed_by
+                if order[consumer] > order[channel.produced_by]
+            ]
+            with self.subTest(channel=channel.key):
+                self.assertTrue(later, f"{channel.key} is consumed only by its own producer")
 
 
 class DeliveryTest(unittest.TestCase):

--- a/tests/test_manager_smoke.py
+++ b/tests/test_manager_smoke.py
@@ -268,6 +268,42 @@ class ScriptedSmokeOperator:
             )
             produced.append(relative_to_run(paths.experimental_protocol, paths.run_root))
 
+        if stage.number >= 3 and not paths.report_plan.exists():
+            # One slot, naming the figure this operator actually publishes and
+            # references at Stage 07. Written once rather than every stage: the
+            # plan has no freshness requirement, and rewriting it would erase
+            # the `declared_at` and `digest` the manager stamps on approval.
+            write_text(
+                paths.report_plan,
+                json.dumps(
+                    {
+                        "figures": [
+                            {
+                                "slot": 1,
+                                "filename": "accuracy.png",
+                                "supports": ["H1"],
+                                "shows": (
+                                    "Held-out accuracy (%) for retrieval-on and retrieval-off "
+                                    "across five folds, band = stderr."
+                                ),
+                                "if_supported": "the retrieval-on bar clears the retrieval-off band",
+                                "if_refuted": "the two bars overlap within their bands",
+                                "source_artifact": "results/metrics.json",
+                                "dropped_because": "",
+                            }
+                        ],
+                        "headline_numbers": [
+                            {
+                                "quantity": "held-out accuracy, retrieval-on minus retrieval-off",
+                                "unit": "percentage points",
+                                "source_artifact": "results/metrics.json",
+                            }
+                        ],
+                    }
+                ),
+            )
+            produced.append(relative_to_run(paths.report_plan, paths.run_root))
+
         if stage.number >= 3:
             data_path = paths.data_dir / "study_design.json"
             write_text(

--- a/tests/test_prompt_gate_correspondence.py
+++ b/tests/test_prompt_gate_correspondence.py
@@ -82,6 +82,7 @@ VALIDATOR_SOURCES = (
     "utils.py",
     "preregistration.py",
     "experimental_protocol.py",
+    "report_plan.py",
     "validity_review.py",
     "research_rounds.py",
     "evidence_ledger.py",

--- a/tests/test_rcb_scoring.py
+++ b/tests/test_rcb_scoring.py
@@ -13,7 +13,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from tests.prereg_support import write_validity_chain
+from tests.prereg_support import HYPOTHESIS_ID, write_report_plan, write_validity_chain
 from src.rcb import (
     JUDGE_IMAGE_SUFFIXES,
     build_benchmark_goal,
@@ -96,12 +96,92 @@ class FigureBudgetTests(unittest.TestCase):
                 "hypothesis_outcomes.json",
                 "metrics.json",
                 "preregistration.json",
+                "report_plan.json",
                 "research_rounds.json",
             ],
         )
         # outputs/ is swept before report/, so an image there would take a judge slot.
         self.assertEqual(
             [p for p in _judge_visible_images(workspace) if p.parent.name == "outputs"], []
+        )
+
+    def test_a_png_a_stage_wrote_to_the_benchmark_outputs_takes_no_judge_slot(self) -> None:
+        paths, workspace = self._run_and_workspace()
+        # Withholding images from the outputs/ *mirror* is only half the defence: the goal
+        # contract points every stage at <workspace>/outputs/ for derived data, so a stage
+        # can write a plot there directly. The scorer drains outputs/ before report/, so
+        # six of them take all five slots and the one figure the report argues with is
+        # never seen — the planned figure set buys nothing without this prune.
+        outputs = workspace / "outputs"
+        (outputs / "diagnostics").mkdir(parents=True)
+        for index in range(MAX_REPORT_FIGURES + 1):
+            (outputs / f"diag_{index}.png").write_bytes(b"\x89PNG diag" + str(index).encode())
+        (outputs / "diagnostics" / "nested.svg").write_bytes(b"<svg/>")
+        (outputs / "table.json").write_text('{"rows": 3}')
+        (paths.report_images_dir / "main.png").write_bytes(b"\x89PNG main")
+        write_text(paths.report_file, self._report("main.png"))
+
+        export_run(paths=paths, workspace=workspace, pipeline_completed=True)
+
+        # The scorer's own sweep order, and the five it would actually attach.
+        visible = [p.name for p in _judge_visible_images(workspace)]
+        self.assertIn("main.png", visible[:MAX_REPORT_FIGURES])
+        self.assertEqual(visible, ["main.png"])
+        # Derived data is what outputs/ is for. Only the images are pruned, including the
+        # nested one: the prune has to reach everywhere the scorer's rglob does.
+        self.assertTrue((outputs / "table.json").exists())
+
+    def test_an_image_loose_or_nested_under_report_takes_no_judge_slot(self) -> None:
+        """``report/images/`` is not the only place the scorer looks under ``report/``.
+
+        The sweep is ``rglob`` over the whole ``report/`` tree, so a plot saved beside
+        ``report.md`` or one directory deeper inside ``images/`` competes for the same five
+        slots as a published figure — and both sort ahead of ``report/images/main.png`` in
+        the walk. A prune that only reads ``images_dir.iterdir()`` leaves exactly those
+        files, which is the same defect as leaving them in ``outputs/`` one directory over.
+        """
+        paths, workspace = self._run_and_workspace()
+        for index in range(MAX_REPORT_FIGURES + 1):
+            (workspace / "report" / f"loose_{index}.png").parent.mkdir(
+                parents=True, exist_ok=True
+            )
+            (workspace / "report" / f"loose_{index}.png").write_bytes(
+                b"\x89PNG loose" + str(index).encode()
+            )
+        nested = workspace / "report" / "images" / "panels"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "panel.png").write_bytes(b"\x89PNG panel")
+        (paths.report_images_dir / "main.png").write_bytes(b"\x89PNG main")
+        write_text(paths.report_file, self._report("main.png"))
+
+        export_run(paths=paths, workspace=workspace, pipeline_completed=True)
+
+        self.assertEqual([p.name for p in _judge_visible_images(workspace)], ["main.png"])
+        # report.md is not an image and is never touched by the prune.
+        self.assertTrue((workspace / "report" / "report.md").is_file())
+
+    def test_a_live_link_to_a_loose_report_image_is_not_pruned(self) -> None:
+        """Breaking a live link is worse than overshooting, here as everywhere else.
+
+        An agent that wrote its report at the benchmark path and linked
+        ``![](figure1.png)`` beside it has a figure the judge can both read about and see.
+        Deleting it would leave the prose promising a figure and the judge shown nothing —
+        the most expensive defect in this deliverable.
+        """
+        paths, workspace = self._run_and_workspace()
+        (workspace / "report").mkdir(parents=True, exist_ok=True)
+        (workspace / "report" / "figure1.png").write_bytes(b"\x89PNG f1")
+        (workspace / "report" / "orphan.png").write_bytes(b"\x89PNG orphan")
+        (workspace / "report" / "report.md").write_text(
+            "# Agent Report\n\n" + (_PARAGRAPH * 40) + "\n\n![Result](figure1.png)\n",
+            encoding="utf-8",
+        )
+
+        result = export_run(paths=paths, workspace=workspace, pipeline_completed=True)
+
+        self.assertEqual(result.report_source, "agent")
+        self.assertEqual(
+            sorted(p.name for p in _judge_visible_images(workspace)), ["figure1.png"]
         )
 
     def test_the_reports_own_figures_are_the_ones_the_judge_sees(self) -> None:
@@ -221,6 +301,28 @@ class FigureBudgetGateTests(unittest.TestCase):
         )
         write_text(paths.artifacts_dir / "self_review.json", json.dumps({"overall_score": 8}))
         write_validity_chain(paths, evidence="results/metrics.json")
+        # One planned slot, pointing at the first figure this fixture publishes, so the
+        # Stage 07 coverage check sees a plan that was kept. Deliberately not one entry per
+        # published figure: the budget tests here are about the ceiling, and an unplanned
+        # published figure is a report_review issue rather than a refusal.
+        write_report_plan(
+            paths,
+            figures=[
+                {
+                    "slot": 1,
+                    "filename": names[0],
+                    "supports": [HYPOTHESIS_ID],
+                    "shows": (
+                        "Held-out accuracy (%) against training steps for the treatment "
+                        "and the baseline, five seeds, band = stderr."
+                    ),
+                    "if_supported": "the treatment's curve stays above the baseline's band",
+                    "if_refuted": "the two curves overlap within their bands throughout",
+                    "source_artifact": "results/r.json",
+                    "dropped_because": "",
+                }
+            ],
+        )
         generate_report_review(paths)
 
     def test_a_run_within_budget_passes(self) -> None:
@@ -399,6 +501,66 @@ class CollectFiguresUnitTests(unittest.TestCase):
         )
 
         self.assertEqual(published, ["b.png", "g.png"])
+
+
+class OutputsPruneIsNotADataLossTest(unittest.TestCase):
+    """The prune deletes; so it has to offer a slot before it deletes.
+
+    Draining ``outputs/`` is right when there is a chosen figure to protect — a
+    stray plot there is a slot stolen, not a slot added. It is wrong when there
+    is nothing else: a run that wrote its only plots to the benchmark's
+    ``outputs/``, following the goal contract's own instruction to keep that
+    directory up to date, would reach the judge with an empty workspace, and an
+    image the judge cannot see scores exactly what no research scores. So
+    ``outputs/`` ranks last among the candidate sources rather than being
+    excluded from them.
+    """
+
+    def _workspace(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        root = Path(tmp_dir.name)
+        workspace = root / "workspace"
+        workspace.mkdir()
+        paths = build_run_paths(root / ".autor" / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Benchmark task")
+        write_text(paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025", output_format="markdown")
+        (workspace / "outputs").mkdir()
+        return paths, workspace
+
+    def test_a_run_whose_only_images_are_in_outputs_still_reaches_the_judge(self) -> None:
+        paths, workspace = self._workspace()
+        for name in ("main_result.png", "ablation.png"):
+            (workspace / "outputs" / name).write_bytes(b"\x89PNG " + name.encode())
+
+        export_run(paths=paths, workspace=workspace, pipeline_completed=False)
+
+        visible = sorted(p.name for p in _judge_visible_images(workspace))
+        self.assertEqual(visible, ["ablation.png", "main_result.png"])
+
+    def test_the_promotion_never_exceeds_the_budget(self) -> None:
+        paths, workspace = self._workspace()
+        for index in range(MAX_REPORT_FIGURES + 3):
+            (workspace / "outputs" / f"p{index}.png").write_bytes(b"\x89PNG " + str(index).encode())
+
+        export_run(paths=paths, workspace=workspace, pipeline_completed=False)
+
+        self.assertEqual(len(_judge_visible_images(workspace)), MAX_REPORT_FIGURES)
+
+    def test_an_outputs_plot_never_outranks_a_figure_the_report_argues_with(self) -> None:
+        """The property the prune exists for, unchanged by ranking outputs last."""
+        paths, workspace = self._workspace()
+        for index in range(MAX_REPORT_FIGURES + 1):
+            (workspace / "outputs" / f"diag_{index}.png").write_bytes(b"\x89PNG d" + str(index).encode())
+        (paths.report_images_dir / "main.png").write_bytes(b"\x89PNG main")
+        body = "# Report\n\n## Results\n\n" + (_PARAGRAPH * 40) + "\n\n![main](images/main.png)\n"
+        write_text(paths.report_file, body)
+
+        export_run(paths=paths, workspace=workspace, pipeline_completed=True)
+
+        self.assertEqual([p.name for p in _judge_visible_images(workspace)], ["main.png"])
 
 
 if __name__ == "__main__":

--- a/tests/test_report_plan.py
+++ b/tests/test_report_plan.py
@@ -1,0 +1,811 @@
+"""The figure plan: a commitment made before the results, or nothing at all.
+
+Two properties carry most of these tests, and both are about what the gate
+*cannot* be turned into. The refusal set has exactly two count rules — "no
+figures" and "more than the ceiling" — so a plan with one, two or three slots
+passes untouched; ``MAX_REPORT_FIGURES`` is a ceiling, and a gate that nudged
+toward it would have made it a quota. And every slot has to carry a claim no
+other slot carries, which is the only rule here that pushes the count down.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.report_plan import (
+    MAX_HEADLINE_NUMBERS,
+    MIN_BRANCH_CHARS,
+    MIN_DROP_REASON_CHARS,
+    MIN_SHOWS_CHARS,
+    format_report_plan_for_prompt,
+    load_report_plan,
+    report_plan_digest,
+    stamp_report_plan,
+    validate_report_plan,
+    validate_report_plan_coverage,
+    validate_report_plan_sources,
+)
+from src.utils import (
+    MAX_REPORT_FIGURES,
+    STAGES,
+    build_run_paths,
+    ensure_run_layout,
+    validate_stage_artifacts,
+    write_text,
+)
+from tests.prereg_support import write_hypothesis_manifest, write_report_plan
+
+
+STAGE_02 = next(stage for stage in STAGES if stage.number == 2)
+STAGE_03 = next(stage for stage in STAGES if stage.number == 3)
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+STAGE_07 = next(stage for stage in STAGES if stage.number == 7)
+
+
+def figure(slot: int, **overrides) -> dict:
+    entry = {
+        "slot": slot,
+        "filename": f"figure_{slot}.png",
+        "supports": [f"exploratory:question-{slot}"],
+        "shows": (
+            "Accuracy (%) against context length (tokens) for the method and the "
+            "long-context baseline, five seeds, band = stderr."
+        ),
+        "if_supported": "the method's curve stays above the baseline's beyond 8k tokens",
+        "if_refuted": "the two curves overlap within their bands at every length",
+        "source_artifact": "results/accuracy_by_length.json",
+        "dropped_because": "",
+    }
+    entry.update(overrides)
+    return entry
+
+
+class ReportPlanTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    def write_plan(self, figures=None, headline_numbers=None, **extra) -> None:
+        payload = {
+            "figures": figures if figures is not None else [figure(1)],
+            "headline_numbers": headline_numbers
+            if headline_numbers is not None
+            else [
+                {
+                    "quantity": "held-out accuracy, method vs baseline",
+                    "unit": "percentage points",
+                    "source_artifact": "results/accuracy_by_length.json",
+                }
+            ],
+        }
+        payload.update(extra)
+        write_text(self.paths.report_plan, json.dumps(payload))
+
+    def problems(self, **kwargs) -> list[str]:
+        return validate_report_plan(self.paths, kwargs.pop("output_format", "markdown"))
+
+
+class ValidPlanTest(ReportPlanTestCase):
+    def test_a_complete_plan_passes(self) -> None:
+        self.write_plan()
+        self.assertEqual(self.problems(), [])
+
+    def test_a_missing_plan_names_the_path_and_what_it_must_contain(self) -> None:
+        problems = self.problems()
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("workspace/notes/report_plan.json", problems[0])
+        for expected in ("filename", "claim", "headline_numbers"):
+            self.assertIn(expected, problems[0])
+
+    def test_the_plan_lives_beside_the_protocol_and_not_under_data(self) -> None:
+        """`.json` under data/ would satisfy the Stage 03 data gate all by itself."""
+        self.assertEqual(self.paths.report_plan.parent, self.paths.notes_dir)
+        self.assertEqual(self.paths.report_plan.name, "report_plan.json")
+
+    def test_a_plan_that_is_not_an_object_loads_as_absent(self) -> None:
+        write_text(self.paths.report_plan, "[]")
+        self.assertIsNone(load_report_plan(self.paths))
+
+    def test_malformed_json_does_not_crash_the_gate(self) -> None:
+        write_text(self.paths.report_plan, "{not json")
+        problems = self.problems()
+        self.assertTrue(any("report_plan.json" in problem for problem in problems), problems)
+
+
+class FigureCountTest(ReportPlanTestCase):
+    def test_zero_figures_is_refused(self) -> None:
+        self.write_plan(figures=[])
+        self.assertTrue(any("declares no figures" in p for p in self.problems()))
+
+    def test_one_two_and_three_figure_plans_are_accepted_with_no_complaint(self) -> None:
+        """The explicit no-floor test. The ceiling must never read as a target."""
+        for count in (1, 2, 3):
+            with self.subTest(figures=count):
+                self.write_plan(figures=[figure(index) for index in range(1, count + 1)])
+                self.assertEqual(self.problems(), [])
+
+    def test_the_ceiling_fires_one_figure_above_the_cap(self) -> None:
+        self.write_plan(figures=[figure(i) for i in range(1, MAX_REPORT_FIGURES + 2)])
+        problems = self.problems()
+        self.assertTrue(any("ceiling, not a" in p for p in problems), problems)
+
+    def test_the_ceiling_does_not_fire_at_the_cap(self) -> None:
+        self.write_plan(figures=[figure(i) for i in range(1, MAX_REPORT_FIGURES + 1)])
+        self.assertEqual(self.problems(), [])
+
+    def test_no_refusal_ever_asks_for_more_figures(self) -> None:
+        """A message that says 'add another figure' is a quota wearing a gate's clothes."""
+        cases = [
+            [],
+            [figure(1)],
+            [figure(1), figure(2)],
+            [figure(i) for i in range(1, MAX_REPORT_FIGURES + 2)],
+        ]
+        for figures in cases:
+            with self.subTest(count=len(figures)):
+                self.write_plan(figures=figures)
+                for problem in self.problems():
+                    lowered = problem.lower()
+                    self.assertNotIn("at least two", lowered)
+                    self.assertNotIn("at least three", lowered)
+                    self.assertNotIn("more figures", lowered)
+
+    def test_the_latex_branch_has_no_figure_ceiling(self) -> None:
+        """Five would damage a venue paper that legitimately carries ten."""
+        self.write_plan(
+            figures=[figure(index) for index in range(1, MAX_REPORT_FIGURES + 4)]
+        )
+        self.assertEqual(self.problems(output_format="latex"), [])
+
+
+class SlotTest(ReportPlanTestCase):
+    def test_a_duplicate_slot_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1), figure(1, filename="second.png",
+                                                 supports=["exploratory:second-question"])])
+        self.assertTrue(any("contiguous from 1" in p for p in self.problems()))
+
+    def test_a_gap_in_the_slots_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1), figure(3)])
+        self.assertTrue(any("contiguous from 1" in p for p in self.problems()))
+
+    def test_a_non_integer_slot_is_refused_rather_than_crashing(self) -> None:
+        self.write_plan(figures=[figure("first")])
+        self.assertTrue(any("contiguous from 1" in p for p in self.problems()))
+
+
+class FilenameTest(ReportPlanTestCase):
+    def test_a_duplicate_filename_is_refused(self) -> None:
+        self.write_plan(
+            figures=[
+                figure(1, filename="one.png"),
+                figure(2, filename="one.png", supports=["exploratory:second-question"]),
+            ]
+        )
+        self.assertTrue(any("another slot also" in p for p in self.problems()))
+
+    def test_a_missing_filename_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1, filename="")])
+        self.assertTrue(any("declares no filename" in p for p in self.problems()))
+
+    def test_a_subdirectory_figure_cannot_be_planned(self) -> None:
+        """`report/images/panels/a.png` passes every current export gate and is never seen."""
+        self.write_plan(figures=[figure(1, filename="panels/a.png")])
+        self.assertTrue(any("not a bare filename" in p for p in self.problems()))
+
+    def test_a_parent_traversal_filename_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1, filename="../a.png")])
+        self.assertTrue(any("not a bare filename" in p for p in self.problems()))
+
+    def test_a_jpg_cannot_be_planned_for_a_markdown_report(self) -> None:
+        """The other live export defect: a .jpg reaches the reader as nothing."""
+        self.write_plan(figures=[figure(1, filename="main.jpg")])
+        problems = self.problems()
+        self.assertTrue(any(".png" in p for p in problems), problems)
+
+    def test_a_pdf_figure_is_allowed_for_a_latex_run(self) -> None:
+        self.write_plan(figures=[figure(1, filename="main.pdf")])
+        self.assertEqual(self.problems(output_format="latex"), [])
+
+
+class SupportsTest(ReportPlanTestCase):
+    def test_a_figure_with_no_claim_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1, supports=[])])
+        self.assertTrue(any("names no claim" in p for p in self.problems()))
+
+    def test_two_figures_with_identical_supports_are_refused(self) -> None:
+        """Five views of one result is one figure and four wasted slots."""
+        self.write_plan(
+            figures=[
+                figure(1, supports=["exploratory:one-question"]),
+                figure(2, filename="two.png", supports=["exploratory:one-question"]),
+            ]
+        )
+        problems = self.problems()
+        self.assertTrue(any("slot spent twice" in p for p in problems), problems)
+
+    def test_a_slot_that_repeats_its_own_claim_is_not_a_second_slot(self) -> None:
+        """The distinctness rule counts slots per claim, not mentions of a claim.
+
+        ``["H1", "H1"]`` in one slot is one question written twice. Counting
+        mentions made the only slot carrying H1 look like the second of two and
+        refused it, with a message blaming a slot that does not exist — a
+        refusal the run cannot act on because the thing it names is not there.
+        """
+        self.write_plan(figures=[figure(1, supports=["exploratory:one-question"] * 2)])
+        self.assertEqual(self.problems(), [])
+
+    def test_the_repeat_does_not_hide_a_genuine_duplicate(self) -> None:
+        """The control: deduplicating within a slot must not disarm the rule."""
+        self.write_plan(
+            figures=[
+                figure(1, supports=["exploratory:one-question"] * 2),
+                figure(2, filename="two.png", supports=["exploratory:one-question"]),
+            ]
+        )
+        self.assertTrue(any("slot spent twice" in p for p in self.problems()))
+
+    def test_a_composite_that_adds_one_new_claim_is_not_the_slot_refused(self) -> None:
+        """The composite carries something of its own; the slot it subsumes does not."""
+        self.write_plan(
+            figures=[
+                figure(1, supports=["exploratory:one-question"]),
+                figure(
+                    2,
+                    filename="two.png",
+                    supports=["exploratory:one-question", "exploratory:second-question"],
+                ),
+            ]
+        )
+        problems = [p for p in self.problems() if "slot spent twice" in p]
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("slot 1", problems[0])
+
+    def test_overlap_is_allowed_while_every_slot_carries_something_of_its_own(self) -> None:
+        self.write_plan(
+            figures=[
+                figure(1, supports=["exploratory:one-question", "exploratory:shared-question"]),
+                figure(
+                    2,
+                    filename="two.png",
+                    supports=["exploratory:shared-question", "exploratory:second-question"],
+                ),
+            ]
+        )
+        self.assertEqual(self.problems(), [])
+
+    def test_an_exploratory_slug_must_name_something(self) -> None:
+        self.write_plan(figures=[figure(1, supports=["exploratory:x"])])
+        self.assertTrue(any("slug" in p for p in self.problems()))
+
+    def test_an_id_the_hypothesis_manifest_does_not_declare_is_refused(self) -> None:
+        write_hypothesis_manifest(self.paths)
+        self.write_plan(figures=[figure(1, supports=["H7"])])
+        problems = self.problems()
+        self.assertTrue(any("hypothesis_manifest.json" in p for p in problems), problems)
+
+    def test_a_declared_hypothesis_id_is_accepted(self) -> None:
+        write_hypothesis_manifest(self.paths)
+        self.write_plan(figures=[figure(1, supports=["H1"])])
+        self.assertEqual(self.problems(), [])
+
+    def test_without_a_manifest_the_membership_check_degrades_to_non_empty(self) -> None:
+        """A `--project-root` run has no Stage 02 manifest and cannot be asked for one here."""
+        self.write_plan(figures=[figure(1, supports=["H7"])])
+        self.assertEqual(self.problems(), [])
+
+
+class SentenceTest(ReportPlanTestCase):
+    def test_a_short_shows_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1, shows="a plot")])
+        self.assertTrue(any(str(MIN_SHOWS_CHARS) in p for p in self.problems()))
+
+    def test_the_shows_floor_is_not_a_units_regex(self) -> None:
+        """A guard that reduced the value to a shape would only measure shape."""
+        self.write_plan(
+            figures=[
+                figure(
+                    1,
+                    shows=(
+                        "The relationship between the two conditions across the whole "
+                        "evaluation, drawn as a paired comparison."
+                    ),
+                )
+            ]
+        )
+        self.assertEqual(self.problems(), [])
+
+    def test_a_missing_branch_sentence_is_refused(self) -> None:
+        for branch in ("if_supported", "if_refuted"):
+            with self.subTest(branch=branch):
+                self.write_plan(figures=[figure(1, **{branch: ""})])
+                problems = self.problems()
+                self.assertTrue(any(branch in p for p in problems), problems)
+
+    def test_a_short_branch_sentence_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1, if_refuted="no")])
+        self.assertTrue(any(str(MIN_BRANCH_CHARS) in p for p in self.problems()))
+
+    def test_identical_branches_are_refused(self) -> None:
+        sentence = "the two curves are drawn against each other"
+        self.write_plan(figures=[figure(1, if_supported=sentence, if_refuted=sentence)])
+        self.assertTrue(any("decoration" in p for p in self.problems()))
+
+    def test_branches_that_differ_only_in_whitespace_and_case_are_refused(self) -> None:
+        self.write_plan(
+            figures=[
+                figure(
+                    1,
+                    if_supported="The two curves separate beyond 8k tokens",
+                    if_refuted="the  two curves   SEPARATE beyond 8k tokens ",
+                )
+            ]
+        )
+        self.assertTrue(any("decoration" in p for p in self.problems()))
+
+    def test_inserting_not_defeats_the_branch_guard_and_that_is_the_documented_bargain(self) -> None:
+        """Recorded as a property so nobody later mistakes this guard for proof."""
+        self.write_plan(
+            figures=[
+                figure(
+                    1,
+                    if_supported="the two curves separate beyond 8k tokens",
+                    if_refuted="the two curves do not separate beyond 8k tokens",
+                )
+            ]
+        )
+        self.assertEqual(self.problems(), [])
+        module = (Path(__file__).resolve().parent.parent / "src" / "report_plan.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("trivially defeated", module)
+
+
+class SourceArtifactTest(ReportPlanTestCase):
+    def test_a_missing_source_artifact_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1, source_artifact="")])
+        self.assertTrue(any("names no source_artifact" in p for p in self.problems()))
+
+    def test_a_figure_drawn_from_a_note_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1, source_artifact="notes/design.json")])
+        self.assertTrue(any("never from a note" in p for p in self.problems()))
+
+    def test_an_absolute_source_artifact_is_refused(self) -> None:
+        self.write_plan(figures=[figure(1, source_artifact="/tmp/results/x.json")])
+        self.assertTrue(any("workspace-relative" in p for p in self.problems()))
+
+    def test_a_bare_directory_is_not_a_source_artifact(self) -> None:
+        self.write_plan(figures=[figure(1, source_artifact="results")])
+        self.assertTrue(any("workspace-relative" in p for p in self.problems()))
+
+    def test_the_benchmark_outputs_root_is_accepted(self) -> None:
+        self.write_plan(figures=[figure(1, source_artifact="outputs/metrics.json")])
+        self.assertEqual(self.problems(), [])
+
+
+class HeadlineNumberTest(ReportPlanTestCase):
+    def test_zero_headline_numbers_is_refused(self) -> None:
+        self.write_plan(headline_numbers=[])
+        self.assertTrue(any("no headline_numbers" in p for p in self.problems()))
+
+    def test_more_than_the_cap_is_refused(self) -> None:
+        self.write_plan(
+            headline_numbers=[
+                {
+                    "quantity": f"quantity {index}",
+                    "unit": "count",
+                    "source_artifact": "results/metrics.json",
+                }
+                for index in range(MAX_HEADLINE_NUMBERS + 1)
+            ]
+        )
+        self.assertTrue(any("at most" in p for p in self.problems()))
+
+    def test_each_field_is_required(self) -> None:
+        base = {
+            "quantity": "held-out accuracy",
+            "unit": "percentage points",
+            "source_artifact": "results/metrics.json",
+        }
+        for missing in base:
+            with self.subTest(field=missing):
+                self.write_plan(headline_numbers=[{**base, missing: ""}])
+                self.assertTrue(self.problems(), f"{missing} was not required")
+
+    def test_dimensionless_is_a_unit(self) -> None:
+        self.write_plan(
+            headline_numbers=[
+                {
+                    "quantity": "effect size",
+                    "unit": "dimensionless",
+                    "source_artifact": "results/metrics.json",
+                }
+            ]
+        )
+        self.assertEqual(self.problems(), [])
+
+
+class SourceExistenceTest(ReportPlanTestCase):
+    def test_a_source_that_does_not_exist_is_refused_from_stage_06(self) -> None:
+        self.write_plan()
+        problems = validate_report_plan_sources(self.paths)
+        self.assertTrue(any("does not exist" in p for p in problems), problems)
+        self.assertTrue(any("dropped_because" in p for p in problems), problems)
+
+    def test_a_source_that_exists_passes(self) -> None:
+        self.write_plan()
+        write_text(self.paths.results_dir / "accuracy_by_length.json", "{}")
+        self.assertEqual(validate_report_plan_sources(self.paths), [])
+
+    def test_a_dropped_slot_is_not_asked_for_its_source(self) -> None:
+        # The headline number's own source is written, so the only thing this
+        # assertion can be failing on is the dropped slot.
+        write_text(self.paths.results_dir / "accuracy_by_length.json", "{}")
+        self.write_plan(
+            figures=[
+                figure(
+                    1,
+                    dropped_because=(
+                        "the length sweep never finished, so the claim it carried is "
+                        "reported as untested"
+                    ),
+                )
+            ]
+        )
+        self.assertEqual(validate_report_plan_sources(self.paths), [])
+
+    def test_a_headline_number_is_held_to_the_same_rule_as_a_figure(self) -> None:
+        """The one gate that ever resolves ``headline_numbers[].source_artifact``.
+
+        Shape is checked at Stage 03 and nowhere else, so without this the field
+        is the cheapest thing in the plan: a number the report leads with could
+        name a file nothing ever wrote and no stage would notice. There is no
+        ``dropped_because`` escape here — a headline number has no slot to
+        abandon, so the move is to amend the plan.
+        """
+        write_text(self.paths.results_dir / "accuracy_by_length.json", "{}")
+        self.write_plan(
+            headline_numbers=[
+                {
+                    "quantity": "held-out accuracy, method vs baseline",
+                    "unit": "percentage points",
+                    "source_artifact": "results/never_written.json",
+                }
+            ]
+        )
+        problems = validate_report_plan_sources(self.paths)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("headline number 1", problems[0])
+        self.assertIn("results/never_written.json", problems[0])
+        self.assertNotIn("dropped_because", problems[0])
+
+    def test_a_configured_artifact_root_satisfies_the_check(self) -> None:
+        """A benchmark run writes results outside the run tree; the gate follows it."""
+        benchmark = Path(self._tmp.name) / "benchmark"
+        (benchmark / "outputs").mkdir(parents=True)
+        (benchmark / "outputs" / "accuracy_by_length.json").write_text("{}", encoding="utf-8")
+        self.write_plan(figures=[figure(1, source_artifact="outputs/accuracy_by_length.json")])
+        self.assertEqual(
+            validate_report_plan_sources(self.paths, [benchmark / "outputs"]), []
+        )
+
+    def test_a_shape_violation_is_not_reported_twice(self) -> None:
+        """The Stage 03 gate owns shape; a second copy would make one defect look like two."""
+        write_text(self.paths.results_dir / "accuracy_by_length.json", "{}")
+        self.write_plan(figures=[figure(1, source_artifact="notes/design.json")])
+        self.assertEqual(validate_report_plan_sources(self.paths), [])
+
+
+class CoverageTest(ReportPlanTestCase):
+    def publish(self, filename: str, *, reference: bool = True) -> None:
+        self.paths.report_images_dir.mkdir(parents=True, exist_ok=True)
+        (self.paths.report_images_dir / filename).write_bytes(b"png")
+        body = "# Report\n\n"
+        if reference:
+            body += f"![A figure.](images/{filename})\n"
+        write_text(self.paths.report_file, body)
+
+    def test_a_published_and_referenced_figure_is_covered(self) -> None:
+        self.write_plan()
+        self.publish("figure_1.png")
+        self.assertEqual(validate_report_plan_coverage(self.paths), [])
+
+    def test_a_silently_missing_figure_is_refused(self) -> None:
+        self.write_plan()
+        write_text(self.paths.report_file, "# Report\n")
+        problems = validate_report_plan_coverage(self.paths)
+        self.assertTrue(any("neither published nor dropped" in p for p in problems), problems)
+        self.assertTrue(any("figure_1.png" in p for p in problems), problems)
+        self.assertTrue(any("exploratory:question-1" in p for p in problems), problems)
+
+    def test_a_figure_on_disk_that_the_report_never_references_is_refused(self) -> None:
+        """The judge is shown the file; the reader is shown the report. Both, or neither."""
+        self.write_plan()
+        self.publish("figure_1.png", reference=False)
+        problems = validate_report_plan_coverage(self.paths)
+        self.assertTrue(any("neither published nor dropped" in p for p in problems), problems)
+
+    def test_a_dropped_slot_passes_coverage(self) -> None:
+        self.write_plan(
+            figures=[
+                figure(1),
+                figure(
+                    2,
+                    filename="figure_2.png",
+                    supports=["exploratory:second-question"],
+                    dropped_because=(
+                        "the second sweep did not converge in the time left; the claim it "
+                        "carried is reported as untested"
+                    ),
+                ),
+            ]
+        )
+        self.publish("figure_1.png")
+        self.assertEqual(validate_report_plan_coverage(self.paths), [])
+
+    def test_a_one_word_drop_reason_does_not_account_for_a_slot(self) -> None:
+        self.write_plan(figures=[figure(1, dropped_because="skipped")])
+        write_text(self.paths.report_file, "# Report\n")
+        problems = validate_report_plan_coverage(self.paths)
+        self.assertTrue(any("neither published nor dropped" in p for p in problems), problems)
+        self.assertTrue(
+            any(str(MIN_DROP_REASON_CHARS) in p for p in problems),
+            "the refusal has to say how long a drop reason has to be",
+        )
+
+    def test_dropping_every_slot_is_refused(self) -> None:
+        self.write_plan(
+            figures=[
+                figure(
+                    1,
+                    dropped_because=(
+                        "nothing finished in time and the report carries no figure at all"
+                    ),
+                )
+            ]
+        )
+        problems = validate_report_plan_coverage(self.paths)
+        self.assertTrue(any("drops every planned figure" in p for p in problems), problems)
+
+    def test_a_configured_figures_root_counts_as_published(self) -> None:
+        benchmark_images = Path(self._tmp.name) / "benchmark" / "report" / "images"
+        benchmark_images.mkdir(parents=True)
+        (benchmark_images / "figure_1.png").write_bytes(b"png")
+        self.write_plan()
+        write_text(self.paths.report_file, "# Report\n\n![A figure.](images/figure_1.png)\n")
+        self.assertEqual(validate_report_plan_coverage(self.paths, [benchmark_images]), [])
+
+    def test_no_plan_means_no_coverage_refusal(self) -> None:
+        self.assertEqual(validate_report_plan_coverage(self.paths), [])
+
+
+class DigestAndAmendmentTest(ReportPlanTestCase):
+    def test_the_digest_ignores_the_stamp_fields(self) -> None:
+        self.write_plan()
+        first = load_report_plan(self.paths)
+        assert first is not None
+        self.write_plan(declared_at="2026-01-01T00:00:00", amendments=[{"reason": "x"}])
+        second = load_report_plan(self.paths)
+        assert second is not None
+        self.assertEqual(report_plan_digest(first), report_plan_digest(second))
+
+    def test_the_digest_moves_when_a_committed_field_moves(self) -> None:
+        self.write_plan()
+        first = load_report_plan(self.paths)
+        assert first is not None
+        self.write_plan(figures=[figure(1, filename="renamed.png")])
+        second = load_report_plan(self.paths)
+        assert second is not None
+        self.assertNotEqual(report_plan_digest(first), report_plan_digest(second))
+
+    def test_stamping_dates_the_plan_without_recording_an_amendment(self) -> None:
+        self.write_plan()
+        stamped = stamp_report_plan(self.paths)
+        assert stamped is not None
+        self.assertTrue(stamped.declared_at)
+        self.assertEqual(stamped.amendments, [])
+        self.assertEqual(stamped.digest, report_plan_digest(stamped))
+
+    def test_stamping_is_idempotent_on_unchanged_content(self) -> None:
+        """A round that legitimately left the plan alone must not fake an amendment."""
+        self.write_plan()
+        first = stamp_report_plan(self.paths)
+        assert first is not None
+        before = self.paths.report_plan.read_text(encoding="utf-8")
+        again = stamp_report_plan(self.paths, "second round")
+        assert again is not None
+        self.assertEqual(again.amendments, [])
+        self.assertEqual(self.paths.report_plan.read_text(encoding="utf-8"), before)
+
+    def test_a_changed_plan_appends_exactly_one_amendment(self) -> None:
+        self.write_plan()
+        stamp_report_plan(self.paths)
+        payload = json.loads(self.paths.report_plan.read_text(encoding="utf-8"))
+        first_digest = payload["digest"]
+        payload["figures"][0]["filename"] = "renamed.png"
+        write_text(self.paths.report_plan, json.dumps(payload))
+
+        amended = stamp_report_plan(self.paths, "round 2: the length sweep replaced the ablation")
+        assert amended is not None
+        self.assertEqual(len(amended.amendments), 1)
+        self.assertEqual(amended.amendments[0]["previous_digest"], first_digest)
+        self.assertEqual(amended.amendments[0]["new_digest"], amended.digest)
+        self.assertIn("round 2", amended.amendments[0]["reason"])
+
+    def test_dropping_a_slot_in_a_later_round_is_recorded_as_an_amendment(self) -> None:
+        self.write_plan()
+        stamp_report_plan(self.paths)
+        payload = json.loads(self.paths.report_plan.read_text(encoding="utf-8"))
+        payload["figures"][0]["dropped_because"] = (
+            "the sweep never ran, and the claim it carried is reported as untested"
+        )
+        write_text(self.paths.report_plan, json.dumps(payload))
+        amended = stamp_report_plan(self.paths, "round 2: dropped the length sweep")
+        assert amended is not None
+        self.assertEqual(len(amended.amendments), 1)
+
+    def test_the_first_declaration_survives_an_amendment(self) -> None:
+        self.write_plan()
+        first = stamp_report_plan(self.paths)
+        assert first is not None
+        payload = json.loads(self.paths.report_plan.read_text(encoding="utf-8"))
+        payload["figures"][0]["filename"] = "renamed.png"
+        write_text(self.paths.report_plan, json.dumps(payload))
+        amended = stamp_report_plan(self.paths, "moved")
+        assert amended is not None
+        self.assertEqual(amended.declared_at, first.declared_at)
+
+    def test_stamping_a_plan_that_does_not_exist_does_nothing(self) -> None:
+        self.assertIsNone(stamp_report_plan(self.paths))
+        self.assertFalse(self.paths.report_plan.exists())
+
+    def test_a_stamped_plan_still_passes_the_gate(self) -> None:
+        self.write_plan()
+        stamp_report_plan(self.paths)
+        self.assertEqual(self.problems(), [])
+
+
+class PromptRenderingTest(ReportPlanTestCase):
+    def test_the_rendered_plan_carries_every_committed_field(self) -> None:
+        self.write_plan()
+        plan = load_report_plan(self.paths)
+        assert plan is not None
+        rendered = format_report_plan_for_prompt(plan)
+        self.assertIn("figure_1.png", rendered)
+        self.assertIn("exploratory:question-1", rendered)
+        self.assertIn("results/accuracy_by_length.json", rendered)
+        self.assertIn("held-out accuracy", rendered)
+
+    def test_a_dropped_slot_says_so_in_the_prompt(self) -> None:
+        self.write_plan(
+            figures=[
+                figure(
+                    1,
+                    dropped_because="the sweep did not finish and the claim is reported untested",
+                )
+            ]
+        )
+        plan = load_report_plan(self.paths)
+        assert plan is not None
+        self.assertIn("DROPPED", format_report_plan_for_prompt(plan))
+
+    def test_an_amendment_is_visible_to_the_next_round(self) -> None:
+        self.write_plan()
+        stamp_report_plan(self.paths)
+        payload = json.loads(self.paths.report_plan.read_text(encoding="utf-8"))
+        payload["figures"][0]["filename"] = "renamed.png"
+        write_text(self.paths.report_plan, json.dumps(payload))
+        stamp_report_plan(self.paths, "round 2: swapped the ablation for the length sweep")
+        plan = load_report_plan(self.paths)
+        assert plan is not None
+        self.assertIn("round 2", format_report_plan_for_prompt(plan))
+
+
+class StageGateWiringTest(ReportPlanTestCase):
+    def test_stage_03_refuses_a_missing_plan(self) -> None:
+        """Held at the stage that writes it, not four stages later."""
+        problems = validate_stage_artifacts(STAGE_03, self.paths)
+        self.assertTrue(any("report_plan.json" in p for p in problems), problems)
+
+    def test_stage_02_is_not_held_to_the_plan(self) -> None:
+        problems = validate_stage_artifacts(STAGE_02, self.paths)
+        self.assertFalse(any("report_plan" in p for p in problems), problems)
+
+    def test_stage_03_accepts_a_complete_plan(self) -> None:
+        write_report_plan(self.paths)
+        problems = validate_stage_artifacts(STAGE_03, self.paths)
+        self.assertFalse(any("report_plan" in p for p in problems), problems)
+
+    def test_stage_06_reports_a_source_artifact_that_was_never_produced(self) -> None:
+        write_report_plan(self.paths, figures=[figure(1)])
+        problems = validate_stage_artifacts(STAGE_06, self.paths)
+        self.assertTrue(any("does not exist" in p for p in problems), problems)
+
+    def test_stage_07_reports_an_unpublished_planned_figure(self) -> None:
+        write_report_plan(self.paths, figures=[figure(1)])
+        write_text(self.paths.report_file, "# Report\n")
+        problems = validate_stage_artifacts(STAGE_07, self.paths)
+        self.assertTrue(any("neither published nor dropped" in p for p in problems), problems)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class NoFigureFloorTest(unittest.TestCase):
+    """The plan must not push a run toward more figures than its argument needs.
+
+    Measured over the forty ResearchClawBench tasks: image criteria per task run
+    {0: 3 tasks, 1: 10, 2: 9, 3: 12, 4: 3, 5: 3} — a median of two, and three
+    tasks with none at all. Not one task needs more than five. So the ceiling was
+    never the binding constraint; coverage is. A floor of three, or of one, makes
+    those runs draw a figure that carries nothing, and a surplus figure displaces
+    one that carried a claim rather than adding to it.
+    """
+
+    def test_no_prompt_asks_for_a_minimum_number_of_figures(self) -> None:
+        from pathlib import Path
+
+        prompts = Path(__file__).resolve().parent.parent / "src" / "prompts"
+        offenders = []
+        for path in sorted(prompts.glob("*.md")):
+            text = path.read_text(encoding="utf-8").lower()
+            for phrase in ("at least three figures", "at least two figures", "at least one figure"):
+                if phrase in text:
+                    offenders.append(f"{path.name}: {phrase}")
+        self.assertEqual(offenders, [], "\n".join(offenders))
+
+    def test_the_deliverable_contract_states_there_is_no_floor(self) -> None:
+        from pathlib import Path
+
+        text = (Path(__file__).resolve().parent.parent / "src" / "information_flow.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("no floor", text)
+
+    def test_a_plan_with_no_figures_is_allowed_when_it_says_why(self) -> None:
+        plan = {
+            "figures": [],
+            "headline_numbers": [
+                {"quantity": "upper limit on g", "unit": "GeV^-1", "source_artifact": "results/limit.json"}
+            ],
+            "no_figures_because": (
+                "The reproduction establishes one scalar upper limit; the prose states it "
+                "with its confidence interval and a figure would plot a single point."
+            ),
+        }
+        self._write(plan)
+        self.assertEqual(
+            [p for p in validate_report_plan(self.paths) if "no figures" in p], []
+        )
+
+    def test_a_plan_with_no_figures_and_no_reason_is_refused(self) -> None:
+        """Allowed is not the same as unremarked."""
+        self._write({"figures": [], "headline_numbers": [
+            {"quantity": "x", "unit": "count", "source_artifact": "results/m.json"}]})
+        problems = validate_report_plan(self.paths)
+        self.assertTrue(any("does not say why" in p for p in problems), problems)
+
+    def _write(self, payload: dict) -> None:
+        import json
+
+        from src.utils import write_text
+
+        write_text(self.paths.report_plan, json.dumps(payload))
+
+    def setUp(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from src.utils import build_run_paths, ensure_run_layout, write_text
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")

--- a/tests/test_report_plan_robustness.py
+++ b/tests/test_report_plan_robustness.py
@@ -1,0 +1,211 @@
+"""Three ways the figure plan was satisfiable without committing to anything.
+
+Each of these is a gate that was already there, held to the question "what is
+the *cheapest* thing that gets past it".
+
+1. A malformed plan crashed the gate instead of refusing the stage. ``"figures":
+   null`` is a thing a model writes, and it left a ``TypeError`` to escape
+   ``validate_stage_artifacts`` and end the run — a refusal the stage could
+   never see, let alone fix.
+2. A slot could be born dropped. ``dropped_because`` is skipped by the Stage 06
+   source gate and by the Stage 07 coverage gate, so a plan declaring five slots
+   with four already abandoned reads as a five-slot plan and owes one figure.
+3. ``touch`` satisfied the source gate. The cheapest way past "the file your
+   figure comes from does not exist" was to create it empty, which is the
+   figure-fitted-to-nothing the gate exists to refuse.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.report_plan import (
+    load_report_plan,
+    stamp_report_plan,
+    validate_report_plan,
+    validate_report_plan_sources,
+)
+from src.utils import build_run_paths, ensure_run_layout, write_text
+
+
+def figure(slot: int, **overrides) -> dict:
+    entry = {
+        "slot": slot,
+        "filename": f"figure_{slot}.png",
+        "supports": [f"exploratory:question-{slot}"],
+        "shows": (
+            "Accuracy (%) against context length (tokens) for the method and the "
+            "long-context baseline, five seeds, band = stderr."
+        ),
+        "if_supported": "the method's curve stays above the baseline's beyond 8k tokens",
+        "if_refuted": "the two curves overlap within their bands at every length",
+        "source_artifact": "results/accuracy_by_length.json",
+        "dropped_because": "",
+    }
+    entry.update(overrides)
+    return entry
+
+
+HEADLINE = [
+    {
+        "quantity": "held-out accuracy, method vs baseline",
+        "unit": "percentage points",
+        "source_artifact": "results/accuracy_by_length.json",
+    }
+]
+
+DROP_REASON = "the length sweep never finished, so the claim it carried is reported as untested"
+
+
+class ReportPlanRobustnessTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    def write_plan(self, figures, headline_numbers=None) -> None:
+        write_text(
+            self.paths.report_plan,
+            json.dumps(
+                {
+                    "figures": figures,
+                    "headline_numbers": HEADLINE if headline_numbers is None else headline_numbers,
+                }
+            ),
+        )
+
+
+class MalformedPlanTest(ReportPlanRobustnessTestCase):
+    """A gate is not a place to crash: every shape comes back as a refusal."""
+
+    def _refuses(self, raw: str) -> None:
+        write_text(self.paths.report_plan, raw)
+        problems = validate_report_plan(self.paths, "markdown")
+        self.assertTrue(problems, f"{raw} produced no refusal")
+
+    def test_a_null_figure_list_is_refused_rather_than_raising(self) -> None:
+        self._refuses('{"figures": null, "headline_numbers": null}')
+
+    def test_a_scalar_figure_list_is_refused_rather_than_raising(self) -> None:
+        self._refuses('{"figures": 5}')
+
+    def test_a_scalar_headline_list_is_refused_rather_than_raising(self) -> None:
+        self._refuses('{"figures": [], "headline_numbers": 3}')
+
+    def test_a_scalar_amendment_ledger_loads_as_no_amendments(self) -> None:
+        write_text(
+            self.paths.report_plan,
+            json.dumps({"figures": [figure(1)], "headline_numbers": HEADLINE, "amendments": 7}),
+        )
+        plan = load_report_plan(self.paths)
+        assert plan is not None
+        self.assertEqual(plan.amendments, [])
+
+    def test_the_refusal_reaches_the_stage_that_can_fix_it(self) -> None:
+        """Not a traceback: text the stage prompt can carry back on the retry."""
+        write_text(self.paths.report_plan, '{"figures": null}')
+        problems = validate_report_plan(self.paths, "markdown")
+        self.assertTrue(all(isinstance(problem, str) and problem for problem in problems))
+        self.assertTrue(any("report_plan.json" in problem for problem in problems))
+
+
+class DeclarationTimeDropTest(ReportPlanRobustnessTestCase):
+    """``dropped_because`` is a move that only exists after the plan was declared."""
+
+    def test_a_slot_dropped_in_the_plan_that_declares_it_is_refused(self) -> None:
+        self.write_plan([figure(1), figure(2, dropped_because=DROP_REASON)])
+        problems = validate_report_plan(self.paths, "markdown")
+        self.assertTrue(any("dropped in the same plan that declares it" in p for p in problems))
+
+    def test_padding_a_plan_with_born_dropped_slots_is_refused_slot_by_slot(self) -> None:
+        """Five slots, four of them owing nothing, was the cheap way to look thorough."""
+        self.write_plan(
+            [figure(1)] + [figure(n, dropped_because=DROP_REASON) for n in (2, 3, 4, 5)]
+        )
+        problems = validate_report_plan(self.paths, "markdown")
+        self.assertEqual(
+            sum("dropped in the same plan that declares it" in p for p in problems), 4
+        )
+
+    def test_a_plan_with_no_drops_is_untouched(self) -> None:
+        self.write_plan([figure(1), figure(2)])
+        self.assertEqual(validate_report_plan(self.paths, "markdown"), [])
+
+    def test_dropping_a_slot_after_autor_stamped_the_plan_is_allowed(self) -> None:
+        """The legitimate case: the results came in and the figure became impossible."""
+        self.write_plan([figure(1), figure(2)])
+        stamp_report_plan(self.paths)
+        self.write_plan([figure(1), figure(2, dropped_because=DROP_REASON)])
+        self.assertEqual(validate_report_plan(self.paths, "markdown"), [])
+
+    def test_the_agent_cannot_grant_itself_the_drop_by_writing_declared_at(self) -> None:
+        """The stamp AutoR keeps outside ``workspace/`` is what the rule reads."""
+        write_text(
+            self.paths.report_plan,
+            json.dumps(
+                {
+                    "figures": [figure(1), figure(2, dropped_because=DROP_REASON)],
+                    "headline_numbers": HEADLINE,
+                    "declared_at": "2020-01-01T00:00:00",
+                    "digest": "0" * 64,
+                }
+            ),
+        )
+        problems = validate_report_plan(self.paths, "markdown")
+        self.assertTrue(any("dropped in the same plan that declares it" in p for p in problems))
+
+
+class EmptySourceArtifactTest(ReportPlanRobustnessTestCase):
+    """``touch`` was the cheapest way past "produce the file your figure comes from"."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.source = self.paths.results_dir / "accuracy_by_length.json"
+        self.source.parent.mkdir(parents=True, exist_ok=True)
+        self.write_plan([figure(1)])
+
+    def test_a_zero_byte_source_is_refused(self) -> None:
+        self.source.write_text("")
+        problems = validate_report_plan_sources(self.paths)
+        self.assertTrue(any("which is empty" in problem for problem in problems))
+
+    def test_a_whitespace_only_source_is_refused(self) -> None:
+        self.source.write_text("\n  \n")
+        self.assertTrue(any("which is empty" in p for p in validate_report_plan_sources(self.paths)))
+
+    def test_the_empty_refusal_is_distinct_from_the_missing_one(self) -> None:
+        """Two different repairs; a run told the wrong one repairs the wrong thing."""
+        missing = validate_report_plan_sources(self.paths)
+        self.source.write_text("")
+        empty = validate_report_plan_sources(self.paths)
+        self.assertTrue(any("does not exist" in problem for problem in missing))
+        self.assertFalse(any("does not exist" in problem for problem in empty))
+
+    def test_a_headline_number_is_held_to_the_same_floor(self) -> None:
+        self.source.write_text("")
+        problems = validate_report_plan_sources(self.paths)
+        self.assertTrue(
+            any("headline number 1" in p and "which is empty" in p for p in problems)
+        )
+
+    def test_one_byte_of_content_passes(self) -> None:
+        """A floor under *a file was written*, not a judgement about the data."""
+        self.source.write_text("{}")
+        self.assertEqual(validate_report_plan_sources(self.paths), [])
+
+    def test_an_empty_copy_in_one_root_does_not_mask_the_real_one(self) -> None:
+        """The benchmark writes results outside the run tree; either copy may be the real one."""
+        self.source.write_text("")
+        outputs = Path(self._tmp.name) / "workspace" / "outputs"
+        outputs.mkdir(parents=True, exist_ok=True)
+        (outputs / "accuracy_by_length.json").write_text('{"accuracy": 0.91}')
+        self.assertEqual(validate_report_plan_sources(self.paths, [outputs]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_report_plan_stamping.py
+++ b/tests/test_report_plan_stamping.py
@@ -1,0 +1,291 @@
+"""Who dates the figure plan, and what a second round is allowed to do to it.
+
+The agent chooses the figures. AutoR dates them: ``declared_at``, ``digest``
+and ``amendments`` are written by the manager, never by the run, because asking
+a language model for a sha256 is a wish rather than a gate.
+
+What these tests hold is the drift discipline, not the wording of the log:
+
+- a plan that did not move produces **no** amendment, so the ledger counts real
+  changes rather than how many times a stage was approved;
+- a plan that did move produces **exactly one**, carrying the reason the round
+  already had to argue for in ``what_changes_next``;
+- a run that arrives at the stage which draws the figures without ever passing
+  through a Stage 03 approval — a resume, a ``--redo-stage``, a bootstrap — is
+  still stamped, the same way the preregistration freezes again at Stage 05.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.evolution import EvolutionConfig
+from src.manager import ResearchManager
+from src.operator import ClaudeOperator
+from src.report_plan import load_report_plan, report_plan_digest
+from src.terminal_ui import TerminalUI
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    initialize_memory,
+    read_text,
+    write_text,
+)
+from tests.prereg_support import close_round
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+#: ``STAGES`` is 1-indexed by stage number, so 06_analysis is element 5.
+#: Named rather than indexed inline: the stage that draws the figures is
+#: the one these tests are about, and an off-by-one here would silently
+#: move them onto Stage 07.
+STAGE_06 = next(stage for stage in STAGES if stage.slug == "06_analysis")
+
+
+def plan_payload() -> dict[str, object]:
+    """A plan as the Stage 03 agent writes it: figures and numbers, no stamp."""
+    return {
+        "figures": [
+            {
+                "slot": 1,
+                "filename": "main_result.png",
+                "supports": ["H1"],
+                "shows": (
+                    "Accuracy (%) against context length (tokens) for the method and the "
+                    "long-context baseline, five seeds, band = stderr."
+                ),
+                "if_supported": "the method's curve stays above the baseline beyond 8k tokens",
+                "if_refuted": "the two curves overlap within their bands at every length",
+                "source_artifact": "results/accuracy_by_length.json",
+                "dropped_because": "",
+            },
+            {
+                "slot": 2,
+                "filename": "data_overview.png",
+                "supports": ["exploratory:input-distribution"],
+                "shows": (
+                    "Distribution of document length (tokens) and label balance across the "
+                    "two evaluation splits."
+                ),
+                "if_supported": "the splits are comparable, so a difference is about the method",
+                "if_refuted": "the splits differ in length and every comparison is conditioned",
+                "source_artifact": "data/splits_summary.json",
+                "dropped_because": "",
+            },
+        ],
+        "headline_numbers": [
+            {
+                "quantity": "held-out accuracy, method vs baseline",
+                "unit": "percentage points",
+                "source_artifact": "results/accuracy_by_length.json",
+            }
+        ],
+    }
+
+
+class ReportPlanStampingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.runs_dir = Path(self._tmp.name) / "runs"
+        self.runs_dir.mkdir()
+        self.paths = build_run_paths(self.runs_dir / "run_0001")
+        ensure_run_layout(self.paths)
+        ensure_run_config(self.paths, model="sonnet", venue="neurips_2025")
+        initialize_memory(self.paths, "plan stamping")
+        write_text(self.paths.user_input, "plan stamping")
+        ui = TerminalUI()
+        self.manager = ResearchManager(
+            project_root=REPO_ROOT,
+            runs_dir=self.runs_dir,
+            operator=ClaudeOperator(model="sonnet", fake_mode=True, ui=ui),
+            ui=ui,
+            output_stream=io.StringIO(),
+            evolution=EvolutionConfig(rounds=0),
+        )
+
+    def _write_plan(self, payload: dict[str, object]) -> None:
+        self.paths.report_plan.parent.mkdir(parents=True, exist_ok=True)
+        write_text(self.paths.report_plan, json.dumps(payload, indent=2))
+
+    def _stored(self) -> dict[str, object]:
+        return json.loads(read_text(self.paths.report_plan))
+
+    def _edit_plan(self, dropped: str) -> None:
+        """Abandon slot 1, the way a later stage edits the file: in place.
+
+        The stamp fields stay where AutoR put them — the agent is told not to
+        write them, and rewriting the whole file from scratch is a different
+        failure with a different owner.
+        """
+        stored = self._stored()
+        stored["figures"][0]["dropped_because"] = dropped
+        write_text(self.paths.report_plan, json.dumps(stored, indent=2))
+
+    def test_the_first_stamp_dates_a_plan_the_agent_left_undated(self) -> None:
+        self._write_plan(plan_payload())
+        self.manager._stamp_report_plan(self.paths)
+
+        stored = self._stored()
+        self.assertTrue(stored.get("declared_at"), "the plan was never dated")
+        self.assertTrue(stored.get("digest"), "the plan has no content digest")
+        self.assertEqual(stored.get("amendments"), [], "a first declaration is not an amendment")
+
+    def test_a_plan_that_did_not_move_is_not_an_amendment(self) -> None:
+        """Otherwise the ledger counts approvals instead of changes."""
+        self._write_plan(plan_payload())
+        self.manager._stamp_report_plan(self.paths)
+        first = self._stored()
+
+        for _ in range(3):
+            self.manager._stamp_report_plan(self.paths, reason="a round that changed nothing")
+        again = self._stored()
+
+        self.assertEqual(again["amendments"], [])
+        self.assertEqual(again["digest"], first["digest"])
+        self.assertEqual(again["declared_at"], first["declared_at"])
+        self.assertEqual(read_text(self.paths.logs).count("report_plan declared"), 1)
+
+    def test_a_plan_that_moved_records_exactly_one_amendment(self) -> None:
+        self._write_plan(plan_payload())
+        self.manager._stamp_report_plan(self.paths)
+        before = self._stored()
+
+        self._edit_plan("the run never produced the length sweep")
+        self.manager._stamp_report_plan(self.paths, reason="round 2 abandoned the length sweep")
+
+        after = self._stored()
+        self.assertEqual(len(after["amendments"]), 1)
+        amendment = after["amendments"][0]
+        self.assertEqual(amendment["previous_digest"], before["digest"])
+        self.assertEqual(amendment["new_digest"], after["digest"])
+        self.assertNotEqual(after["digest"], before["digest"])
+        self.assertIn("report_plan amended", read_text(self.paths.logs))
+
+    def test_the_amendment_reason_is_the_one_the_round_already_argued_for(self) -> None:
+        """``what_changes_next`` is required to be 40+ chars before a round may
+        re-enter Stage 03, so the reason the plan moved is already written down
+        and already checked. Asking for it again would be the same sentence
+        twice, and the second copy is the one nobody reads."""
+        self._write_plan(plan_payload())
+        self.manager._stamp_report_plan(self.paths)
+        close_round(
+            self.paths,
+            decision="refine_design",
+            what_changes_next=(
+                "Replace the length sweep with a per-domain breakdown, because the sweep "
+                "cannot separate the effect from tokenizer differences."
+            ),
+        )
+
+        self._edit_plan("superseded by the per-domain breakdown figure")
+        self.manager._stamp_report_plan(self.paths)
+
+        reason = self._stored()["amendments"][0]["reason"]
+        self.assertIn("per-domain breakdown", reason)
+
+    def test_the_first_declaration_has_no_round_to_cite(self) -> None:
+        self.assertEqual(
+            self.manager._report_plan_amendment_reason(self.paths), "initial declaration"
+        )
+
+    def test_a_rewrite_no_round_asked_for_is_not_recorded_as_a_declaration(self) -> None:
+        """A --redo-stage or a hand edit is a revision nothing on record asked
+        for. Reusing the first-write wording would put a false sentence in the
+        ledger: the entry would say "initial declaration" about the second."""
+        self._write_plan(plan_payload())
+        self.manager._stamp_report_plan(self.paths)
+
+        self._edit_plan("nothing on record asked for this")
+        self.manager._stamp_report_plan(self.paths)
+
+        reason = self._stored()["amendments"][0]["reason"]
+        self.assertNotEqual(reason, "initial declaration")
+        self.assertIn("no round on record", reason)
+
+    def test_a_wholesale_rewrite_cannot_re_date_the_plan(self) -> None:
+        """The accident the ledger has to survive, not the attack.
+
+        Stage 06 is told to edit ``report_plan.json``, and Stage 03 is told not
+        to write ``declared_at``, ``digest`` or ``amendments``. A stage that
+        regenerates the file from its own template obeys both instructions and
+        produces a plan with no stamp on it. If the previous digest is read out
+        of that file, the second write is indistinguishable from the first:
+        ``declared_at`` becomes a post-results timestamp, the ledger stays
+        empty, and the artifact's one claim — that the figures were chosen
+        before the results existed — is now false with nothing recording it.
+        """
+        self._write_plan(plan_payload())
+        self.manager._stamp_report_plan(self.paths)
+        first = self._stored()
+
+        rewritten = plan_payload()
+        rewritten["figures"][0]["filename"] = "the_one_that_came_out_well.png"
+        self._write_plan(rewritten)  # no declared_at, no digest, no amendments
+        self.manager._stamp_report_plan(self.paths, reason="rewritten at Stage 06")
+
+        after = self._stored()
+        self.assertEqual(after["declared_at"], first["declared_at"], "the plan was re-dated")
+        self.assertEqual(len(after["amendments"]), 1, "the rewrite left no trace")
+        self.assertEqual(after["amendments"][0]["previous_digest"], first["digest"])
+        self.assertEqual(read_text(self.paths.logs).count("report_plan declared"), 1)
+        self.assertIn("report_plan amended", read_text(self.paths.logs))
+
+    def test_a_digest_the_run_wrote_itself_does_not_certify_the_plan(self) -> None:
+        """A sha256 is a wish when it is asked for and a no-op when it is
+        believed. Recomputing the digest over changed figures is a move any
+        stage with a Python interpreter can make, and believing it would let a
+        plan rewritten against the results claim it never moved."""
+        self._write_plan(plan_payload())
+        self.manager._stamp_report_plan(self.paths)
+        first = self._stored()
+
+        forged = self._stored()
+        forged["figures"][0]["filename"] = "swapped_for_the_result_that_worked.png"
+        write_text(self.paths.report_plan, json.dumps(forged, indent=2))
+        # The run recomputes the sha256 over its own new content — the same
+        # function AutoR uses — and writes it back as if nothing had moved.
+        forged["digest"] = report_plan_digest(load_report_plan(self.paths))
+        write_text(self.paths.report_plan, json.dumps(forged, indent=2))
+        self.manager._stamp_report_plan(self.paths, reason="forged")
+
+        after = self._stored()
+        self.assertEqual(len(after["amendments"]), 1, "the forged digest hid the change")
+        self.assertEqual(after["amendments"][0]["previous_digest"], first["digest"])
+        self.assertEqual(after["declared_at"], first["declared_at"])
+
+    def test_a_missing_plan_is_the_gate_s_finding_and_not_this_hook_s(self) -> None:
+        """The Stage 03 artifact gate refuses a run with no plan and says so in
+        the log. A hook that fires on every stage from 06 onward must not turn
+        that one refusal into a line per stage."""
+        self.manager._stamp_report_plan(self.paths)
+
+        self.assertFalse(self.paths.report_plan.exists())
+        self.assertNotIn("report_plan", read_text(self.paths.logs))
+
+    def test_a_run_that_never_passed_through_stage_03_is_stamped_anyway(self) -> None:
+        """Resume, --redo-stage and --project-root all skip the approval hook.
+        The stage that draws the figures is the last honest place to date them."""
+        self._write_plan(plan_payload())
+
+        self.manager._build_stage_prompt(self.paths, STAGE_06, None, False)
+
+        self.assertTrue(self._stored().get("declared_at"))
+
+    def test_the_stage_that_draws_the_figures_is_shown_the_plan(self) -> None:
+        self._write_plan(plan_payload())
+
+        prompt = self.manager._build_stage_prompt(self.paths, STAGE_06, None, False)
+
+        self.assertIn("Report Plan", prompt)
+        self.assertIn("main_result.png", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reports miss rubric points, and the plan stage is where that is decided. Stage 03's prompt is 1,701 words and mentions figures, the report, and `report/images` **zero times**. `MAX_REPORT_FIGURES` reaches Stage 07 only — four stages after the figures are planned, when the sole remaining lever is pruning the weakest.

## Measured against the real benchmark, not the docs

Parsed all 40 of `tasks/*/target_study/checklist.json` from the local ResearchClawBench checkout. The documented headline reproduces exactly: **91 of 154 criteria are `type: image`, carrying 60.6% of weight**, median per-task share 62.5%. (Docs say images are majority-weight in 25 of 40; a strict recount gives 24.)

What the docs do not say, and what set the design:

```
items per task        min 3   median 3   max 8
IMAGE items per task  min 0   median 2   max 5
image items per task  {0: 3 tasks, 1: 10, 2: 9, 3: 12, 4: 3, 5: 3}
tasks needing MORE than five figures:  0
```

A checklist item is `{type, content, keywords, weight, path}`, and the items are **the chain of results the original paper established** — data layer, intermediate quantity, finding — with image items pinned to the figures that argument rests on.

**So the five-slot ceiling was never the binding constraint.** Every task is coverable within five and the median needs two. Five arbitrary figures against two required ones wins nothing, and a sixth randomises which five the judge sees. The lever is producing the *right* two to four.

## What this adds

`workspace/notes/report_plan.json`, written at Stage 03 and carried forward. Per figure: the slot ranking, the filename it will be published under, the claim it settles, what it shows, what it looks like if the claim holds **and if it does not**, and the artifact it is computed from. Plus the headline numbers the report must state, with units and sources — 39% of the weight is text criteria scored on whether a number is present.

Two guards do most of the work:

- **`if_supported` and `if_refuted` may not be the same sentence.** A figure that cannot say what refutation would look like is decoration. This is the figure-level analogue of the decision rule preregistration already demands.
- **Every figure must carry at least one `supports` id no other figure carries.** That is "five different questions, not five views of one result", made mechanical.

Two typed channels carry it through the `information_flow` registry: `report_contract` tells Stages 03, 06 and 07 the deliverable's shape — the gap that started this — and `report_plan` carries the plan downstream. Each narrowing states its rationale, as the registry's tests require.

## Corrected before landing

The design as first built pushed toward **more** figures, which is the opposite of what the distribution supports. Stage 03's prompt said a study *"normally has at least three figures worth planning"* and asked a plan with fewer to justify itself — against a median of two, with 22 of 40 tasks needing two or fewer. A plan with no figures was refused outright, though three tasks have no image criterion at all.

The floor is gone. Slot count falls out of the chain of results, and a figureless plan is allowed when it records `no_figures_because` — this codebase's habit of requiring a record rather than forbidding the move. A test asserts no prompt asks for a minimum figure count.

## The line held

The run is never shown its own task's checklist, criterion text, or the target paper's figure paths. Those live in `target_study/`, the run has no access, and encoding any of it would be cheating rather than engineering. Only the aggregate shape is used.

## Verification

Stage 03's prompt goes 1,701 → 2,597 words. A fake run publishes 1 figure, plans 1 slot, and completes every stage on the first attempt — before and after merging main.

1,617 tests green against the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)