### PR TITLE
Write where the grader reads, and say what 50 means

### DIFF
--- a/src/prompts/07_writing_markdown.md
+++ b/src/prompts/07_writing_markdown.md
@@ -37,6 +37,22 @@ up its figures, checking evidence-to-claim alignment, and producing the structur
 - Keep the story centered on one clear contribution rather than a bag of unrelated observations.
 - Where the run reproduces published work, state the comparison explicitly: the published number, your number, and whether they agree.
 
+## What Gets Read First
+
+A reader — human or automated — forms a verdict on the result before reaching the
+methodology. Where the deliverable is graded, that is not a metaphor: a grader scoring a
+figure may be shown the picture and only the opening of the report, while a grader scoring a
+written result sees all of it. Write for that.
+
+- The headline numbers go in the Abstract and again in Results, with units, not only in a
+  table further down.
+- The figure ranked first in `report_plan.json` is discussed early. If it is only referenced
+  in a late section, the argument for it lands where nobody is reading.
+- Long methodology belongs after the result it produced, not before it.
+
+This is the ordinary shape of a well-written paper; the grading only makes the cost of
+getting it wrong concrete.
+
 ## Report Structure
 
 Use this section layout unless the research genuinely calls for a different one. Depth matters far

--- a/src/rcb.py
+++ b/src/rcb.py
@@ -298,6 +298,31 @@ def build_benchmark_goal(
                 "(no PDF, EPS, SVG, TIFF, or BMP — the judge cannot render them).\n"
                 f"- `{resolved}/report/report.md` — the final research report.\n"
             ),
+            "## How This Report Is Graded",
+            (
+                "Each criterion is scored 0-100 against the *original published paper*, where "
+                "**50 means as good as that paper**. The bands that matter most are the cheap "
+                "ones at the bottom:\n\n"
+                "- **0** — the criterion is absent from the report.\n"
+                "- **1-10** — mentioned, but with no quantitative result, or only a vague "
+                "generic statement.\n"
+                "- **41-50** — comparable to the published paper.\n\n"
+                "So the first thing worth having is coverage: a result the report never "
+                "mentions scores zero, and there is no partial credit for a result the run "
+                "produced but did not write down. The second is that every covered result "
+                "carries its number — mentioning it without one caps that criterion in single "
+                "digits.\n\n"
+                "Two grader rules to write against, verbatim from the rubric: *no credit for "
+                "vague or generic statements*, and *no inflation for well-written but shallow "
+                "content; substance over style; longer does not mean better*. The grader is "
+                "also told to be sceptical of plausible-sounding AI text with fabricated "
+                "numbers, so a number without a file behind it is worse than no number.\n\n"
+                "**A figure criterion is graded on the picture plus only the first 10,000 "
+                "characters of this report.** Text criteria see all of it. Figures carry the "
+                "majority of the weight, so the argument for your most important figure has to "
+                "be inside that window — put the headline numbers and the main result early, "
+                "and leave the long methodology for later in the document."
+            ),
             "## Report Requirements",
             (
                 f"`{resolved}/report/report.md` is the scored deliverable. It must be a standalone "

--- a/src/report_plan.py
+++ b/src/report_plan.py
@@ -103,6 +103,20 @@ MIN_SHOWS_CHARS = 40
 MIN_BRANCH_CHARS = 20
 MIN_DROP_REASON_CHARS = 20
 
+#: How much of the report a figure criterion's grader actually reads.
+#:
+#: ResearchClawBench's scorer passes ``report_text[:10000]`` when it grades an
+#: image criterion (evaluation/score.py:138) while passing the whole report for a
+#: text criterion. Image criteria carry 60.6% of the benchmark's weight, so the
+#: prose that argues for a figure is worth nothing past this point — the grader
+#: is shown the picture and, beyond the window, none of the argument for it.
+#:
+#: Only the *first* slot is held to it. Requiring every figure's argument inside
+#: 10k characters would refuse a long paper whose fifth figure is legitimately
+#: discussed late; requiring the highest-ranked one is a claim about the report's
+#: own priorities, which is what the slot ranking already declares.
+JUDGE_VISIBLE_PREFIX_CHARS = 10_000
+
 #: A ceiling, so the field cannot become a list that satisfies a count.
 MAX_HEADLINE_NUMBERS = 8
 
@@ -873,6 +887,7 @@ def validate_report_plan_coverage(
         return []
 
     referenced = set()
+    report_text = ""
     if paths.report_file.is_file():
         try:
             report_text = paths.report_file.read_text(encoding="utf-8")
@@ -882,6 +897,10 @@ def validate_report_plan_coverage(
             PurePosixPath(target.split("#", 1)[0].split("?", 1)[0].strip()).name.casefold()
             for target in extract_markdown_image_targets(report_text)
         }
+    visible = {
+        PurePosixPath(target.split("#", 1)[0].split("?", 1)[0].strip()).name.casefold()
+        for target in extract_markdown_image_targets(report_text[:JUDGE_VISIBLE_PREFIX_CHARS])
+    }
 
     search_dirs = [paths.report_images_dir, *figures_dirs]
     problems: list[str] = []
@@ -900,6 +919,24 @@ def validate_report_plan_coverage(
             "and reference it from report.md, or record `dropped_because` on that slot in "
             f"report_plan.json ({MIN_DROP_REASON_CHARS} characters or more) saying what "
             "happened to the claim it carried."
+        )
+
+    lead = next((item for item in sorted(plan.figures, key=lambda x: x.slot) if not item.is_dropped), None)
+    if (
+        lead is not None
+        and lead.filename
+        and lead.filename.casefold() in referenced
+        and lead.filename.casefold() not in visible
+        and len(report_text) > JUDGE_VISIBLE_PREFIX_CHARS
+    ):
+        # The report does reference it — just too late to count where it counts.
+        problems.append(
+            f"the report first references slot {lead.slot} ({lead.filename}) after "
+            f"{JUDGE_VISIBLE_PREFIX_CHARS:,} characters. A grader scoring a figure sees the "
+            f"picture and only the first {JUDGE_VISIBLE_PREFIX_CHARS:,} characters of the "
+            "prose, so the argument for the report's own highest-ranked figure lands outside "
+            "what is read. Move the result it settles forward, or move the figure's discussion "
+            "into the section that states the headline numbers."
         )
 
     if all(item.is_dropped for item in plan.figures):

--- a/tests/test_report_plan.py
+++ b/tests/test_report_plan.py
@@ -809,3 +809,110 @@ class NoFigureFloorTest(unittest.TestCase):
         self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
         ensure_run_layout(self.paths)
         write_text(self.paths.user_input, "goal")
+
+
+class JudgeVisibleWindowTest(unittest.TestCase):
+    """A figure's argument has to be where a figure grader reads.
+
+    ResearchClawBench's scorer passes ``report_text[:10000]`` when grading an
+    image criterion and the whole report when grading a text one
+    (evaluation/score.py:138). Image criteria carry 60.6% of the weight, so
+    prose arguing for a figure is worth nothing past that point — the grader
+    sees the picture and none of the case for it.
+
+    Only the highest-ranked undropped slot is held to this. Requiring every
+    figure's argument inside 10k characters would refuse a long paper whose
+    fifth figure is legitimately discussed late.
+    """
+
+    def setUp(self) -> None:
+        import json
+        import tempfile
+        from pathlib import Path
+
+        from src.utils import build_run_paths, ensure_run_layout, write_text
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(
+            self.paths.report_plan,
+            json.dumps(
+                {
+                    "figures": [
+                        {
+                            "slot": 1,
+                            "filename": "main.png",
+                            "supports": ["H1"],
+                            "shows": "Accuracy against context length for the method and the baseline.",
+                            "if_supported": "the method's curve stays above the baseline",
+                            "if_refuted": "the two curves overlap within their bands",
+                            "source_artifact": "results/acc.json",
+                            "dropped_because": "",
+                        }
+                    ],
+                    "headline_numbers": [
+                        {"quantity": "accuracy", "unit": "percent", "source_artifact": "results/acc.json"}
+                    ],
+                }
+            ),
+        )
+        self.paths.report_images_dir.mkdir(parents=True, exist_ok=True)
+        (self.paths.report_images_dir / "main.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    def _report(self, *, reference_late: bool, long: bool = True) -> None:
+        from src.report_plan import JUDGE_VISIBLE_PREFIX_CHARS
+        from src.utils import write_text
+
+        filler = "Methodology prose that occupies space without saying much. " * (
+            260 if long else 2
+        )
+        ref = "![Main](images/main.png)"
+        body = (
+            f"# R\n\n## Abstract\n\nshort\n\n{filler}\n\n{ref}\n"
+            if reference_late
+            else f"# R\n\n## Abstract\n\n{ref}\n\n{filler}"
+        )
+        write_text(self.paths.report_file, body)
+        if long:
+            self.assertGreater(len(body), JUDGE_VISIBLE_PREFIX_CHARS)
+
+    def _window_problems(self) -> list[str]:
+        from src.report_plan import validate_report_plan_coverage
+
+        # "characters" also appears in the not-published message ("20 characters
+        # or more"), so match the window message specifically.
+        return [
+            p for p in validate_report_plan_coverage(self.paths) if "first references slot" in p
+        ]
+
+    def test_the_lead_figure_discussed_early_passes(self) -> None:
+        self._report(reference_late=False)
+        self.assertEqual(self._window_problems(), [])
+
+    def test_the_lead_figure_discussed_only_late_is_refused(self) -> None:
+        self._report(reference_late=True)
+        self.assertTrue(self._window_problems())
+
+    def test_a_short_report_is_never_held_to_the_window(self) -> None:
+        """Nothing falls outside a window the report never reaches."""
+        self._report(reference_late=True, long=False)
+        self.assertEqual(self._window_problems(), [])
+
+    def test_an_unpublished_figure_is_reported_as_missing_not_as_late(self) -> None:
+        """The two failures are different and must not be conflated."""
+        from src.report_plan import validate_report_plan_coverage
+        from src.utils import write_text
+
+        (self.paths.report_images_dir / "main.png").unlink()
+        write_text(self.paths.report_file, "# R\n\nno figure here\n")
+        problems = validate_report_plan_coverage(self.paths)
+        self.assertTrue(any("neither published nor dropped" in p for p in problems))
+        self.assertEqual(self._window_problems(), [])
+
+    def test_the_window_matches_the_scorer(self) -> None:
+        from src.report_plan import JUDGE_VISIBLE_PREFIX_CHARS
+
+        self.assertEqual(JUDGE_VISIBLE_PREFIX_CHARS, 10_000)


### PR DESCRIPTION
Follow-on to #160, from reading ResearchClawBench's scorer rather than its docs.

## The grading scale was never shown to the run

`evaluation/score.py` scores each criterion **0–100 against the original published paper, where 50 means as good as that paper**. The cheap bands are at the bottom:

| band | meaning |
|---|---|
| **0** | the criterion is absent from the report |
| **1–10** | mentioned, but no quantitative result — or only a vague generic statement |
| **41–50** | comparable to the published paper |
| **>50** | better than the published paper |

So coverage is the first thing worth having: a result the run produced but never wrote down scores **zero**, and there is no partial credit for it. The second is that every covered result carries its number — mentioning it without one caps that criterion in single digits.

The benchmark goal now states the scale and quotes the two grader rules that bear on drafting, verbatim: *no credit for vague or generic statements*, and *no inflation for well-written but shallow content; substance over style; longer does not mean better*. It also passes on that the grader is told to be sceptical of plausible-sounding AI text with fabricated numbers — so a number with no file behind it is worse than no number at all.

## A figure criterion sees only the first 10,000 characters

```python
# evaluation/score.py:138 — image criteria only
{report_text[:10000] if report_text else 'No report text available.'}
```

Text criteria get the whole document. Image criteria — **60.6% of the weight** — get the picture plus that prefix. Prose arguing for a figure past that point is worth nothing: the grader sees the picture and none of the case for it.

`validate_report_plan_coverage` now refuses a report whose highest-ranked undropped figure is first referenced after the window, and only when the report is long enough for the window to bind.

**Only the lead slot is held to it.** Requiring every figure's argument inside 10k characters would refuse a long paper whose fifth figure is legitimately discussed late. The first slot is different — it is a claim about the report's own priorities, which the slot ranking already declares.

## Stage 07 guidance

Headline numbers in the Abstract and again in Results, with units. The lead figure discussed early. Long methodology after the result it produced. That is the ordinary shape of a well-written paper; the grading only makes the cost of getting it wrong concrete.

## Tests

Both directions, plus a control that a short report is never held to a window it does not reach, and one that keeps the two failure modes distinct — a figure that was never published is reported as **missing**, not as **late**. (That test caught my own filter matching `"characters"`, which also appears in the not-published message's "20 characters or more".)

1,622 tests green. A fake run completes every stage on the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)