### PR TITLE
Stop turning a dead backend into research-shaped output

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,3 +107,4 @@ Outside this directory:
   `03`.
 - Anything described as *validated* is checked in code, and the source of that
   check is named so you can read it yourself.
+| Know when the backend, not the research, is what failed | [Backend Health](backend-health.md) |

--- a/docs/backend-health.md
+++ b/docs/backend-health.md
@@ -1,0 +1,74 @@
+# When the backend is the problem
+
+The first live run of this workflow never reached a model. Vertex quota was exhausted and
+every call came back:
+
+```
+API Error: Request rejected (429) · {"code":429,"message":"Quota exceeded for
+aiplatform.googleapis.com/... base model: anthropic-claude-sonnet-4-5",
+"status":"RESOURCE_EXHAUSTED"}
+```
+
+AutoR's response was to write a **local fallback stage summary**, normalize it into the
+required section structure so it passed `validate_stage_markdown`, and continue to attempt 2.
+Left alone it would have spent the attempt budget, auto-skipped up to `--max-auto-skips`
+stages, and finished with a report assembled from its own error messages.
+
+Nothing in the unit tests could have found that. It took running the thing.
+
+## The distinction
+
+The fallback path is *right* when the model ran and wrote something unusable: the run keeps
+its shape, the next attempt gets another go, and the fallback is visibly a fallback.
+
+It is *wrong* when the model never ran. A run that cannot reach a backend has not produced
+weak findings — it has produced none, and a locally written summary is indistinguishable from
+research by the end of the run.
+
+So when a stage's primary attempt **and** its repair both produce nothing, the captured output
+is classified before anything is manufactured:
+
+| Cause | Recognised from |
+| --- | --- |
+| `quota` | `RESOURCE_EXHAUSTED`, `Quota exceeded`, `rate_limit_error`, `429` |
+| `auth` | `PERMISSION_DENIED`, `UNAUTHENTICATED`, `401`/`403`, `invalid api key` |
+| `upstream` | `UNAVAILABLE`, `overloaded_error`, `5xx`, connection errors |
+
+Any of those stops the run with the cause named. Anything else keeps the fallback it was
+designed for.
+
+## Guarding the false positive
+
+A Stage 01 literature survey about API economics could easily contain the words *"429"* and
+*"quota exceeded"*. Aborting a run because its research summary discussed rate limiting would
+be a worse bug than the one this fixes.
+
+So a line must look like a **reported error** — `API Error`, an `"error":` field, a named gRPC
+status — *and* carry a recognised signature. `"We sampled 429 households from the panel"`
+classifies as nothing.
+
+## What you see
+
+```
++-- Backend unavailable ------------------------------------------+
+| The model backend is refusing every request because the quota   |
+| is exhausted. No amount of retrying inside this run will change |
+| that.                                                           |
+|                                                                 |
+| AutoR stopped instead of writing a locally generated stage      |
+| summary and continuing.                                         |
++-----------------------------------------------------------------+
+```
+
+The run is marked `failed` with `run.backend_unavailable`, and the backend's own words go in
+`logs.txt` so the cause is not a guess.
+
+## Limits worth knowing
+
+- **It fires on the second failure, not the first.** By the time a fallback is being
+  manufactured, the primary attempt and the repair have both already failed — one transient
+  429 that then succeeds will not stop a run.
+- **A backend that fails silently is invisible here.** Classification reads what the CLI
+  printed; a backend that returns success with empty content still gets the fallback.
+- **The signature list is a list.** A provider inventing a new error shape will be treated as
+  a content failure until its pattern is added.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -184,6 +184,16 @@ know that intake will not run.
 
 ---
 
+## The run stopped with "Backend unavailable"
+
+The model backend refused every request — exhausted quota, rejected credentials, or a provider
+outage. AutoR stops rather than writing a locally generated stage summary and continuing,
+because a run that cannot reach a model has produced no findings, and a fallback draft would
+be indistinguishable from research by the end of the run.
+
+The backend's own message is in `logs.txt` under `<stage> backend_unavailable`. Fix the cause
+and resume with `--resume-run latest`; approved stages are kept.
+
 ## Stage 07 writing
 
 Stage 07's requirements depend on the run's `output_format`, recorded in

--- a/src/backend_health.py
+++ b/src/backend_health.py
@@ -1,0 +1,106 @@
+"""Tell an unusable backend apart from an unproductive one.
+
+When a stage produces no summary at all, AutoR writes a local fallback draft, normalizes it
+into the required section structure, and carries on. That is the right move when the model ran
+and wrote something unusable: the run keeps its shape, the next attempt gets another go, and
+the fallback is visibly a fallback.
+
+It is the wrong move when the model never ran. A first live run of this workflow hit Vertex
+quota exhaustion and every single call came back ``429 RESOURCE_EXHAUSTED``. AutoR responded
+by manufacturing a structurally valid Stage 01 summary — every required heading present, so
+`validate_stage_markdown` passed it — and moving on to attempt 2. Left alone it would have
+spent the whole attempt budget, auto-skipped, and finished with a report assembled from
+nothing but its own error messages.
+
+That is the failure this module exists to prevent. A backend refusing every request is an
+infrastructure problem, and the honest response is to stop and say which one, not to convert
+it into research-shaped output. A run that cannot reach a model has not produced weak
+findings; it has produced none.
+
+The distinction is deliberately narrow. Only causes that no amount of retrying inside this run
+will fix count as fatal — quota, credentials, a backend that is simply down. A model that ran
+and wrote badly is not this, and keeps the fallback path it was designed for.
+"""
+
+from __future__ import annotations
+
+import re
+
+QUOTA = "quota"
+AUTH = "auth"
+UPSTREAM = "upstream"
+
+#: Patterns that mean the request never reached a working model.
+#:
+#: Anchored on the shapes a CLI actually emits — ``API Error``, an HTTP status, a named
+#: gRPC status — rather than on bare words. "quota" and "429" appear in ordinary research
+#: prose, and a Stage 01 summary discussing rate limits must not read as a dead backend.
+_SIGNATURES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (QUOTA, re.compile(r"RESOURCE_EXHAUSTED|Quota exceeded|rate[_ ]limit_error|\b429\b", re.IGNORECASE)),
+    (AUTH, re.compile(
+        r"\b40[13]\b|PERMISSION_DENIED|UNAUTHENTICATED|authentication_error|invalid[_ ]api[_ ]key",
+        re.IGNORECASE)),
+    (UPSTREAM, re.compile(
+        r"\b5\d{2}\b|UNAVAILABLE|INTERNAL|overloaded_error|api_error|Connection error",
+        re.IGNORECASE)),
+)
+
+#: A line has to look like a reported error before its status code counts for anything.
+_ERROR_LINE = re.compile(r"API Error|error[\"']?\s*:|Error:|\bstatus\b|RESOURCE_EXHAUSTED|"
+                         r"PERMISSION_DENIED|UNAUTHENTICATED|UNAVAILABLE", re.IGNORECASE)
+
+_CAUSE_TEXT = {
+    QUOTA: (
+        "The model backend is refusing every request because the quota is exhausted. "
+        "No amount of retrying inside this run will change that."
+    ),
+    AUTH: (
+        "The model backend is rejecting this run's credentials. Retrying will not fix it."
+    ),
+    UPSTREAM: (
+        "The model backend is failing every request. This is the provider, not the research."
+    ),
+}
+
+
+def classify(text: str) -> str | None:
+    """Name the infrastructure cause in captured backend output, or None.
+
+    Every candidate line must look like a reported error *and* carry a recognised signature.
+    Requiring both is what keeps a research summary that happens to discuss rate limiting from
+    being read as a dead backend.
+    """
+    if not text:
+        return None
+    lines = [line for line in text.splitlines() if _ERROR_LINE.search(line)]
+    if not lines:
+        return None
+    haystack = "\n".join(lines)
+    for cause, pattern in _SIGNATURES:
+        if pattern.search(haystack):
+            return cause
+    return None
+
+
+def describe(cause: str, excerpt: str = "") -> str:
+    """The message a human needs in order to know this is not their research failing."""
+    head = _CAUSE_TEXT.get(cause, "The model backend is unusable.")
+    body = (
+        f"{head}\n\n"
+        "AutoR stopped instead of writing a locally generated stage summary and continuing. "
+        "A run that cannot reach a model has not produced weak findings, it has produced none, "
+        "and a fallback draft here would have been indistinguishable from research at the end "
+        "of the run."
+    )
+    if excerpt:
+        body += f"\n\nBackend said:\n{excerpt.strip()[:600]}"
+    return body
+
+
+class BackendUnavailable(RuntimeError):
+    """Raised when the backend has refused everything and the run should stop."""
+
+    def __init__(self, cause: str, excerpt: str = "") -> None:
+        self.cause = cause
+        self.excerpt = excerpt
+        super().__init__(describe(cause, excerpt))

--- a/src/manager.py
+++ b/src/manager.py
@@ -120,6 +120,7 @@ from .stage_graph import (
 )
 from .diagram_gen import post_writing_diagram_hook
 from .scorecard import write_scorecard
+from .backend_health import BackendUnavailable, classify as classify_backend
 from .terminal_ui import TerminalUI
 from .platform.foundry import generate_paper_package, generate_release_package
 from .deliberation import (
@@ -471,6 +472,19 @@ class ResearchManager:
         return self._run_from_paths(paths, start_stage=start_stage)
 
     def _run_from_paths(self, paths: RunPaths, start_stage: StageSpec | None = None) -> bool:
+        try:
+            return self._walk_stages(paths, start_stage=start_stage)
+        except BackendUnavailable as exc:
+            update_manifest_run_status(
+                paths,
+                run_status="failed",
+                last_event="run.backend_unavailable",
+            )
+            self.ui.panel("Backend unavailable", str(exc).splitlines(), color=self.ui.FG_RED)
+            append_log_entry(paths.logs, "run_aborted", str(exc))
+            return False
+
+    def _walk_stages(self, paths: RunPaths, start_stage: StageSpec | None = None) -> bool:
         """Walk the stage graph until it reaches ``finish`` or nothing is open.
 
         The default topology has one edge out of every node, so this reproduces the
@@ -2892,6 +2906,18 @@ class ResearchManager:
         source: str,
         fallback_text: str,
     ):
+        # Both the primary attempt and its repair produced nothing. If the reason is that the
+        # backend refused them, a locally written summary would be indistinguishable from
+        # research by the end of the run — so stop instead of manufacturing one.
+        cause = classify_backend(fallback_text)
+        if cause is not None:
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} backend_unavailable",
+                f"cause: {cause}\n{truncate_text(fallback_text, max_chars=2000)}",
+            )
+            raise BackendUnavailable(cause, fallback_text)
+
         draft_path = paths.stage_tmp_file(stage)
         normalized_markdown = canonicalize_stage_markdown(
             stage=stage,

--- a/tests/test_backend_health.py
+++ b/tests/test_backend_health.py
@@ -1,0 +1,182 @@
+"""An unusable backend must not be turned into research-shaped output.
+
+Every case here traces to one live run. Vertex quota was exhausted, every call returned
+``429 RESOURCE_EXHAUSTED``, and AutoR manufactured a structurally valid Stage 01 summary that
+passed validation and carried the run forward. The captured output from that run is used
+verbatim below, because a fixture invented after the fact would only test what I already
+believed.
+"""
+
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from src.backend_health import (
+    AUTH,
+    QUOTA,
+    UPSTREAM,
+    BackendUnavailable,
+    classify,
+    describe,
+)
+from src.manager import ResearchManager
+from src.terminal_ui import TerminalUI
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    read_text,
+    write_text,
+)
+
+
+STAGE_01 = STAGES[0]
+
+#: Verbatim from the run that motivated this module.
+REAL_429 = (
+    "AutoR generated this local fallback stage draft because the primary attempt and repair "
+    "did not produce a stage summary file.\n\n"
+    'API Error: Request rejected (429) · [{"error":{"code":429,"message":"Quota exceeded for '
+    "aiplatform.googleapis.com/us_multi_region_online_prediction_requests_per_base_model with "
+    'base model: anthropic-claude-sonnet-4-5. Please submit a quota increase request.",'
+    '"status":"RESOURCE_EXHAUSTED"}}]'
+)
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_the_real_captured_quota_failure_is_recognised(self) -> None:
+        self.assertEqual(classify(REAL_429), QUOTA)
+
+    def test_rejected_credentials_are_recognised(self) -> None:
+        self.assertEqual(
+            classify('API Error: Request rejected (403) · {"status":"PERMISSION_DENIED"}'), AUTH
+        )
+        self.assertEqual(classify("Error: authentication_error, invalid api key"), AUTH)
+
+    def test_a_backend_that_is_down_is_recognised(self) -> None:
+        self.assertEqual(classify("API Error: 503 UNAVAILABLE"), UPSTREAM)
+        self.assertEqual(classify("Error: overloaded_error"), UPSTREAM)
+
+    def test_nothing_is_classified_from_empty_or_ordinary_output(self) -> None:
+        self.assertIsNone(classify(""))
+        self.assertIsNone(classify("Wrote sources.json and claims.json. Stage complete."))
+
+    def test_a_summary_discussing_rate_limits_is_not_a_dead_backend(self) -> None:
+        # The false positive that would matter most: a Stage 01 survey about API economics
+        # mentioning 429s must not abort the run.
+        prose = (
+            "## Key Results\n\n"
+            "Prior work reports that 429 rate-limit responses dominate the quota literature, "
+            "and that quota exceeded events cluster at peak hours.\n"
+        )
+        self.assertIsNone(classify(prose))
+
+    def test_a_status_code_alone_is_not_enough(self) -> None:
+        # Needs to look like a reported error, not merely contain a number.
+        self.assertIsNone(classify("We sampled 429 households from the panel."))
+
+    def test_quota_wins_over_the_broader_upstream_pattern(self) -> None:
+        # A 429 body also contains "error"; the specific cause is the useful one to report.
+        self.assertEqual(classify(REAL_429), QUOTA)
+
+
+class DescribeTests(unittest.TestCase):
+    def test_the_message_says_this_is_not_the_research_failing(self) -> None:
+        text = describe(QUOTA, REAL_429)
+        self.assertIn("quota is exhausted", text)
+        self.assertIn("has not produced weak findings", text)
+
+    def test_the_backend_excerpt_is_included_and_bounded(self) -> None:
+        text = describe(QUOTA, "x" * 5000)
+        self.assertIn("Backend said:", text)
+        self.assertLess(len(text), 1500)
+
+    def test_an_unknown_cause_still_produces_a_usable_message(self) -> None:
+        self.assertIn("unusable", describe("something_else"))
+
+
+class RefusalTests(unittest.TestCase):
+    """The behaviour the live run exposed, pinned."""
+
+    def _manager_and_paths(self):
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        runs_dir = Path(tmp_dir.name) / "runs"
+        runs_dir.mkdir()
+        paths = build_run_paths(runs_dir / "20260101_000000")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Goal")
+        write_text(paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025")
+        operator = MagicMock()
+        operator.model = "sonnet"
+        operator.backend_name = "claude"
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=runs_dir,
+            operator=operator,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        return manager, paths
+
+    def test_a_dead_backend_stops_the_run_instead_of_fabricating_a_draft(self) -> None:
+        manager, paths = self._manager_and_paths()
+        with self.assertRaises(BackendUnavailable) as ctx:
+            manager._materialize_missing_stage_draft(
+                paths=paths, stage=STAGE_01, attempt_no=1,
+                source="primary attempt and repair", fallback_text=REAL_429,
+            )
+        self.assertEqual(ctx.exception.cause, QUOTA)
+        # The thing that must not exist: a locally written summary that would pass validation.
+        self.assertFalse(paths.stage_tmp_file(STAGE_01).exists())
+
+    def test_the_cause_is_recorded_before_the_run_stops(self) -> None:
+        manager, paths = self._manager_and_paths()
+        with self.assertRaises(BackendUnavailable):
+            manager._materialize_missing_stage_draft(
+                paths=paths, stage=STAGE_01, attempt_no=1,
+                source="primary attempt and repair", fallback_text=REAL_429,
+            )
+        log = read_text(paths.logs)
+        self.assertIn("backend_unavailable", log)
+        self.assertIn("RESOURCE_EXHAUSTED", log)
+
+    def test_a_model_that_ran_and_wrote_badly_still_gets_its_fallback(self) -> None:
+        # The fallback path is right when the model ran; only a dead backend loses it.
+        manager, paths = self._manager_and_paths()
+        result = manager._materialize_missing_stage_draft(
+            paths=paths, stage=STAGE_01, attempt_no=1,
+            source="primary attempt and repair",
+            fallback_text="I explored the literature but ran out of turns before writing the file.",
+        )
+        self.assertTrue(paths.stage_tmp_file(STAGE_01).exists())
+        self.assertTrue(result.stage_file_path.exists())
+
+    def test_an_empty_capture_still_gets_its_fallback(self) -> None:
+        manager, paths = self._manager_and_paths()
+        manager._materialize_missing_stage_draft(
+            paths=paths, stage=STAGE_01, attempt_no=1,
+            source="primary attempt and repair", fallback_text="",
+        )
+        self.assertTrue(paths.stage_tmp_file(STAGE_01).exists())
+
+    def test_the_run_reports_the_backend_rather_than_crashing(self) -> None:
+        manager, paths = self._manager_and_paths()
+
+        def explode(*_args, **_kwargs):
+            raise BackendUnavailable(QUOTA, REAL_429)
+
+        manager._walk_stages = explode
+        self.assertFalse(manager._run_from_paths(paths))
+        log = read_text(paths.logs)
+        self.assertIn("run_aborted", log)
+        self.assertIn("quota is exhausted", log)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Twelve PRs of instrumentation and **none of it had ever been run against a real model.** The first attempt found this in Stage 01.

## What happened

Vertex quota was exhausted, so every call returned `429 RESOURCE_EXHAUSTED`. AutoR's response:

```
[WARN] Stage summary draft missing for Stage 01. Running repair attempt...
[WARN] Stage 01 did not produce a stage summary file during primary attempt and
       repair. Generated a local fallback draft and continuing recovery...
[WARN] Repair output for Stage 01 is still incomplete. Normalizing locally...
Running Stage 01: Literature Survey (attempt 2)...
```

It wrote a **structurally valid** Stage 01 summary — every required heading present, so `validate_stage_markdown` passed it — and carried on. Left alone it would have spent the attempt budget, auto-skipped, and finished with a "completed" run whose findings were the text of an HTTP error:

> **Key Results** — The original stage output was incomplete… Recovered execution context: `API Error: Request rejected (429) …`

No unit test could have found that. It took running the thing.

## The distinction

The fallback is **right** when the model ran and wrote something unusable — the run keeps its shape and the next attempt gets another go.

It is **wrong** when the model never ran. A run that cannot reach a backend has not produced weak findings; it has produced none, and a locally written summary is indistinguishable from research by the end of the run.

So when a stage's primary attempt *and* its repair both produce nothing, the captured output is classified first:

| Cause | Recognised from |
|:---|:---|
| `quota` | `RESOURCE_EXHAUSTED`, `Quota exceeded`, `rate_limit_error`, `429` |
| `auth` | `PERMISSION_DENIED`, `UNAUTHENTICATED`, `401`/`403` |
| `upstream` | `UNAVAILABLE`, `overloaded_error`, `5xx` |

Those stop the run with the cause named. Anything else keeps the fallback.

## The false positive was the harder half

A Stage 01 survey about API economics could easily contain "429" and "quota exceeded". **Aborting a run because its research summary discussed rate limiting would be worse than the bug being fixed.**

So a line must look like a *reported error* — `API Error`, an `"error":` field, a named gRPC status — **and** carry a recognised signature. `"We sampled 429 households from the panel"` classifies as nothing.

## Verification

1,654 tests, 15 new. Tests use the captured 429 output **verbatim** rather than a fixture invented afterwards, which would only have tested what I already believed.

| Mutant | Tests killed |
|:---|:---|
| fabricate the draft anyway (the original bug) | 2 |
| drop the error-line requirement | 2 |

**Worth flagging:** that second mutant first appeared to *survive*. Shell escaping had mangled the pattern so the mutation never applied to the file at all. Re-running it with an `assert` that the edit landed showed it kills 2 tests. A mutation that silently fails to apply reads exactly like a weak test — asserting the edit before trusting the result is what caught it.

## Limits, in the doc

- Fires on the second failure, not the first — one transient 429 that then succeeds will not stop a run.
- A backend that returns success with empty content still gets the fallback.
- The signature list is a list; a provider inventing a new error shape is treated as a content failure until added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)