### PR TITLE
Score a run locally without the three traps that fake a zero

### DIFF
--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -384,6 +384,73 @@ can be inspected or resumed after the fact.
 
 ---
 
+## Scoring a run locally
+
+`tools/score_rcb_run.py` drives ResearchClawBench's own `score_workspace`, so every
+number it prints is that scorer's rather than a reimplementation. What it changes is
+three defaults that turn a failed judge call into a score of zero, and it will not
+print a total until it has checked that every item was actually judged.
+
+```bash
+python3 tools/score_rcb_run.py \
+  --workspace /path/to/workspaces/Astronomy_001_20260811_022244 \
+  --bench /path/to/ResearchClawBench \
+  --out score.json
+```
+
+Needs `anthropic`, the bench's `structai`, and `ANTHROPIC_VERTEX_PROJECT_ID`.
+
+### The three ways the stock scorer fakes a low score
+
+All three record as `{"score": 0, "reasoning": "Failed to parse scoring response."}`,
+which is indistinguishable in the output from a criterion the report genuinely missed.
+Scoring one run here, two of three items were judge failures: the honest total was
+**37.0** and the number on screen was **19.5**.
+
+| Stock default | Why it fails | Used here |
+|:---|:---|:---|
+| `max_tokens=500` | a reasoning judge spends the budget thinking and returns an empty body | 4096 |
+| `time_limit=120` | too short for a multimodal call carrying a target image plus five agent images | 600 |
+| `multi_thread(max_workers=16)` | concurrent multimodal calls were the actual cause of most failures | serial |
+
+The tool counts failed calls separately from scored ones and **refuses to quote a
+total while any call failed**. A benchmark number computed over silent judge failures
+is not a measurement of the run.
+
+### The judge is part of the result
+
+The reference judge is `gpt-5.1` (`evaluation/.env.example`). Without that key, Claude
+Opus through `AnthropicVertex` is a drop-in for `structai.LLMAgent` — `score.py` only
+ever calls the agent as `agent(prompt, image_paths=, return_example=, max_try=)` and
+expects a dict.
+
+On identical artifacts, **Gemini 2.5 Flash scored 37.0 where Claude Opus scored 20.8**.
+A sixteen-point spread is a property of the judge, not of the run, so a number quoted
+without naming its judge compares to nothing. The tool prints the judge on every run
+and writes it into the result file.
+
+### What the scale means
+
+`evaluation/score.py` scores each criterion 0–100 against the *original published
+paper*, where **50 means as good as that paper**:
+
+| Band | Meaning |
+|:---|:---|
+| 0 | absent from the report |
+| 1–10 | mentioned, but no quantitative result, or only a vague generic statement |
+| 41–50 | comparable to the published paper |
+| >50 | better than the published paper |
+
+Two consequences for reading a score. A run that produced a result but never wrote it
+down scores zero for it, with no partial credit — coverage is the cheapest points on
+the board. And a criterion mentioned without its number is capped in single digits, so
+the gap between 10 and 45 is real work, not phrasing.
+
+Image criteria are graded on the picture plus only the **first 10,000 characters** of
+the report (`report_text[:10000]`, `evaluation/score.py:138`); text criteria see the
+whole document. Since image criteria carry 60.6% of the weight, prose arguing for a
+figure past that point is worth nothing.
+
 ## How other agents score
 
 [researchclawbench-landscape.md](researchclawbench-landscape.md) works through the public

--- a/tests/test_score_rcb_run.py
+++ b/tests/test_score_rcb_run.py
@@ -1,0 +1,131 @@
+"""The local scorer must not let a judge failure pass as a score.
+
+ResearchClawBench's scorer records a failed judge call as
+``{"score": 0, "reasoning": "Failed to parse scoring response."}`` — identical
+in the output to a criterion the report genuinely missed. Scoring one run that
+way, two of three items were judge failures: the honest total was 37.0 and the
+number on screen was 19.5.
+
+These tests hold the properties that prevent repeating it: the three stock
+defaults that cause the failures are not in use, a failed call is counted rather
+than swallowed, and a total is refused while any call failed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOL = REPO_ROOT / "tools" / "score_rcb_run.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("score_rcb_run", TOOL)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class TrapDefaultsTest(unittest.TestCase):
+    """Each constant exists because a stock default fakes a zero."""
+
+    def setUp(self) -> None:
+        self.tool = _load()
+
+    def test_the_token_budget_leaves_room_for_a_reasoning_judge(self) -> None:
+        self.assertGreater(self.tool.JUDGE_MAX_TOKENS, 500)
+
+    def test_the_time_limit_fits_a_multimodal_call(self) -> None:
+        self.assertGreater(self.tool.JUDGE_TIME_LIMIT, 120)
+
+    def test_scoring_is_serial(self) -> None:
+        """Concurrent multimodal calls were the actual cause of most failures."""
+        self.assertEqual(self.tool.JUDGE_WORKERS, 1)
+
+    def test_each_constant_says_what_it_is_for(self) -> None:
+        text = TOOL.read_text(encoding="utf-8")
+        for marker in ("max_tokens=500", "time_limit=120", "max_workers=16"):
+            self.assertIn(marker, text, f"the stock default {marker} is not named")
+
+
+class JudgeFailureAccountingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = _load()
+
+    def _judge(self):
+        judge = self.tool.VertexJudge.__new__(self.tool.VertexJudge)
+        judge.model = "test-model"
+        judge.calls = 0
+        judge.failures = []
+        return judge
+
+    def test_an_unparseable_body_is_recorded_as_a_failure(self) -> None:
+        judge = self._judge()
+
+        class Boom:
+            def __getattr__(self, _name):
+                raise RuntimeError("vertex is down")
+
+        judge._client = Boom()
+        result = judge("prompt", max_try=1)
+
+        self.assertIsNone(result, "a failed call must not return a score")
+        self.assertEqual(len(judge.failures), 1)
+        self.assertIn("vertex is down", judge.failures[0])
+
+    def test_a_failure_is_not_reported_as_a_zero(self) -> None:
+        """The whole point. None is distinguishable; 0 is not."""
+        judge = self._judge()
+
+        class Boom:
+            def __getattr__(self, _name):
+                raise RuntimeError("nope")
+
+        judge._client = Boom()
+        self.assertIsNot(judge("p", max_try=1), 0)
+
+
+class JsonExtractionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = _load()
+
+    def test_a_bare_object_parses(self) -> None:
+        self.assertEqual(
+            self.tool._first_json_object('{"score": 42, "reasoning": "ok"}')["score"], 42
+        )
+
+    def test_an_object_wrapped_in_prose_parses(self) -> None:
+        parsed = self.tool._first_json_object('Here you go:\n{"score": 7}\nDone.')
+        self.assertEqual(parsed["score"], 7)
+
+    def test_no_object_yields_none_rather_than_a_guess(self) -> None:
+        self.assertIsNone(self.tool._first_json_object("I could not decide."))
+
+    def test_an_empty_body_yields_none(self) -> None:
+        """What a thinking model returns when max_tokens runs out."""
+        self.assertIsNone(self.tool._first_json_object(""))
+
+
+class JudgeIsPartOfTheResultTest(unittest.TestCase):
+    """A benchmark number quoted without its judge compares to nothing.
+
+    Measured on identical artifacts: Gemini 2.5 Flash 37.0, Claude Opus 20.8.
+    """
+
+    def test_the_tool_names_the_judge_in_its_output(self) -> None:
+        text = TOOL.read_text(encoding="utf-8")
+        self.assertIn("judge_model", text)
+        self.assertIn("TOTAL (judge", text)
+
+    def test_the_spread_between_judges_is_recorded(self) -> None:
+        text = TOOL.read_text(encoding="utf-8")
+        self.assertIn("37.0", text)
+        self.assertIn("20.8", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/score_rcb_run.py
+++ b/tools/score_rcb_run.py
@@ -1,0 +1,225 @@
+"""Score a finished ResearchClawBench workspace, without the scorer's three traps.
+
+An instrument, not a test. It drives ResearchClawBench's own ``score_workspace``
+so every number it prints is that scorer's, not a reimplementation — but it
+repairs three defaults that turn a judge failure into a score of zero, and it
+refuses to print a total until it has checked that every item was actually
+judged.
+
+**Why this exists.** The stock scorer records a failed judge call as
+``{"score": 0, "reasoning": "Failed to parse scoring response."}``, which is
+indistinguishable in the output from a criterion the report genuinely missed.
+Scoring one run here, two of three items were judge failures: the honest total
+was 37.0 and the number on screen was 19.5. Nothing in the output said which.
+
+**The three traps**, all at ``evaluation/score.py`` where ``LLMAgent`` is built:
+
+1. ``max_tokens=500`` — a reasoning model spends the budget thinking and returns
+   an empty body.
+2. ``time_limit=120`` — too short for a multimodal call carrying six images.
+3. ``multi_thread(max_workers=16)`` — concurrent multimodal calls were the actual
+   cause of most failures. Serialising is slower and finishes.
+
+**The judge is part of the result.** The reference judge is ``gpt-5.1``. On
+identical artifacts, Gemini 2.5 Flash scored 37.0 where Claude Opus scored 20.8
+— a 16-point spread that is a property of the judge, not the run. A benchmark
+number quoted without its judge is not comparable to anything, so this prints
+the judge on every line of output and refuses to write a result file without it.
+
+Usage::
+
+    python3 tools/score_rcb_run.py --workspace <ws> --bench /path/to/ResearchClawBench
+
+Requires ``anthropic`` and the bench's ``structai``; set
+``ANTHROPIC_VERTEX_PROJECT_ID``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+#: Room for a reasoning model to think and still answer. The stock 500 is what
+#: makes a thinking judge return nothing.
+JUDGE_MAX_TOKENS = 4096
+
+#: A multimodal call carrying a target image plus five agent images does not
+#: finish in the stock 120s.
+JUDGE_TIME_LIMIT = 600
+
+#: Serial. The stock 16 is the trap that actually fires.
+JUDGE_WORKERS = 1
+
+DEFAULT_JUDGE_MODEL = "claude-opus-4-5@20251101"
+
+
+class VertexJudge:
+    """A drop-in for ``structai.LLMAgent`` backed by Claude on Vertex.
+
+    ``score.py`` only ever calls the agent as
+    ``agent(prompt, image_paths=..., return_example=..., max_try=...)`` and
+    expects a dict back, so the whole surface is ``__call__``.
+    """
+
+    def __init__(self, *, model: str, project_id: str, region: str = "global") -> None:
+        from anthropic import AnthropicVertex
+
+        self.model = model
+        self._client = AnthropicVertex(project_id=project_id, region=region)
+        self.calls = 0
+        self.failures: list[str] = []
+
+    def __call__(
+        self,
+        prompt: str,
+        image_paths: list[str] | None = None,
+        return_example: dict | None = None,
+        max_try: int = 2,
+        **_: Any,
+    ) -> dict | None:
+        import base64
+        import mimetypes
+
+        content: list[dict[str, Any]] = []
+        for path in image_paths or []:
+            data = Path(path).read_bytes()
+            media_type = mimetypes.guess_type(path)[0] or "image/png"
+            content.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": media_type,
+                        "data": base64.b64encode(data).decode("ascii"),
+                    },
+                }
+            )
+        content.append({"type": "text", "text": prompt})
+
+        last = ""
+        for attempt in range(max_try):
+            self.calls += 1
+            try:
+                response = self._client.messages.create(
+                    model=self.model,
+                    max_tokens=JUDGE_MAX_TOKENS,
+                    temperature=0,
+                    messages=[{"role": "user", "content": content}],
+                )
+                text = "".join(
+                    block.text for block in response.content if getattr(block, "type", "") == "text"
+                ).strip()
+                parsed = _first_json_object(text)
+                if isinstance(parsed, dict) and "score" in parsed:
+                    return parsed
+                last = f"unparseable body ({len(text)} chars)"
+            except Exception as exc:  # noqa: BLE001 - the reason is what matters
+                last = f"{type(exc).__name__}: {exc}"
+        self.failures.append(last)
+        # Returning None is what score.py already treats as a failure. The
+        # difference is that this object counted it, so the caller can tell a
+        # judge failure from a real zero.
+        return None
+
+
+def _first_json_object(text: str) -> Any:
+    start = text.find("{")
+    end = text.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    for candidate in (text, text[start : end + 1]):
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def score(workspace: Path, bench: Path, *, model: str, project_id: str) -> dict:
+    sys.path.insert(0, str(bench))
+    import evaluation.config as config
+    import evaluation.score as scorer
+
+    # score_workspace refuses to build an agent unless these are present. They
+    # are never used, because the agent is replaced below.
+    for name in ("JUDGE_API_KEY", "JUDGE_API_BASE", "JUDGE_MODEL_NAME"):
+        os.environ.setdefault(name, "unused-local-judge")
+    config.JUDGE_MODEL_NAME = model
+
+    judge = VertexJudge(model=model, project_id=project_id)
+    scorer.LLMAgent = lambda **_: judge  # type: ignore[assignment]
+
+    # Serialise. Concurrency is the trap that fires most often, and a benchmark
+    # run that takes four hours can afford a scorer that takes three minutes.
+    def serial(inputs, fn, max_workers=None, use_tqdm=False):  # noqa: ARG001
+        return [fn(**item) for item in inputs]
+
+    scorer.multi_thread = serial  # type: ignore[assignment]
+
+    result = scorer.score_workspace(workspace)
+    result["judge_model"] = model
+    result["judge_calls"] = judge.calls
+    result["judge_failures"] = judge.failures
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--workspace", required=True, type=Path)
+    parser.add_argument("--bench", required=True, type=Path)
+    parser.add_argument("--model", default=DEFAULT_JUDGE_MODEL)
+    parser.add_argument(
+        "--project-id", default=os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
+    )
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args()
+
+    if not args.project_id:
+        print("Set ANTHROPIC_VERTEX_PROJECT_ID or pass --project-id.", file=sys.stderr)
+        return 2
+
+    result = score(args.workspace, args.bench, model=args.model, project_id=args.project_id)
+    if "error" in result:
+        print(f"scoring failed: {result['error']}", file=sys.stderr)
+        return 1
+
+    items = result.get("results", [])
+    failures = result.get("judge_failures", [])
+
+    print(f"judge:     {result['judge_model']}")
+    print(f"workspace: {args.workspace}")
+    print()
+    for item in items:
+        print(
+            f"  [{item.get('type','?'):>5}] w={item.get('weight',0):<5} "
+            f"score={item.get('score',0):>3}  {str(item.get('content',''))[:70]}"
+        )
+
+    # The check that matters. A judge failure reads as a zero, so a total quoted
+    # without this is not a measurement of the run.
+    if failures:
+        print()
+        print(f"REFUSING TO QUOTE A TOTAL: {len(failures)} judge call(s) failed.")
+        for reason in failures:
+            print(f"  - {reason}")
+        print("Every one of those is recorded as score 0 and is indistinguishable")
+        print("from a criterion the report genuinely missed. Fix and re-run.")
+        return 1
+
+    print()
+    print(f"TOTAL (judge {result['judge_model']}): {result.get('total_score', 0):.1f}")
+    print(f"items judged: {len(items)}   judge calls: {result.get('judge_calls', 0)}")
+
+    if args.out:
+        args.out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        print(f"written: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The previous two rounds (#160, #161) changed instructions and gates with **no scored run behind them**. This adds the instrument that closes that gap, and writes down what it cost to learn the first time.

## The three traps

`tools/score_rcb_run.py` drives ResearchClawBench's own `score_workspace`, so every number is that scorer's rather than a reimplementation. What it replaces is three defaults where the judge agent is built (`evaluation/score.py:229-238`), each of which turns a failed judge call into `{"score": 0, "reasoning": "Failed to parse scoring response."}` — **indistinguishable in the output from a criterion the report genuinely missed**.

| Stock default | Why it fails | Used here |
|:---|:---|:---|
| `max_tokens=500` | a reasoning judge spends the budget thinking and returns an empty body | 4096 |
| `time_limit=120` | too short for a multimodal call carrying a target image plus five agent images | 600 |
| `multi_thread(max_workers=16)` | concurrent multimodal calls were the actual cause of most failures | serial |

Scoring one run this way, **two of three items were judge failures: the honest total was 37.0 and the number on screen was 19.5.**

So the tool counts failed calls separately from scored ones and **refuses to print a total while any call failed**. A total computed over silent judge failures is not a measurement of the run, and the stock output gives no way to tell the two apart.

## The judge is part of the result

The reference judge is `gpt-5.1`. Without that key, Claude Opus through `AnthropicVertex` is a drop-in for `structai.LLMAgent` — `score.py` only ever calls the agent as `agent(prompt, image_paths=, return_example=, max_try=)` and expects a dict.

On identical artifacts, **Gemini 2.5 Flash scored 37.0 where Claude Opus scored 20.8**. Sixteen points that belong to the judge, not the run. A number quoted without naming its judge compares to nothing, so the tool prints it on every run and writes it into the result file.

## Docs

`docs/researchclawbench.md` gains a scoring section: the traps as a table, the judge spread, and what the 0–100 scale actually means — 50 is as good as the published paper, 1–10 is mentioned without a number, and a result the run produced but never wrote down scores zero with no partial credit. Plus the `report_text[:10000]` window that applies to image criteria only.

## Tests

Properties, not wording: each stock default is named in the source so it cannot be quietly reverted, a failed call returns `None` rather than `0`, unparseable and empty bodies both yield `None`, and the judge spread is recorded. Twelve tests. The tool itself is an instrument and is not collected as one.

1,666 tests green.

## Still open

A real end-to-end run is in flight now (Astronomy_001, opus, ~4h based on the last one). Until it finishes and is scored, #160 and #161 remain unvalidated against a real score — that is stated here rather than implied away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)