### PR TITLE
Answer the task description item by item

### DIFF
--- a/src/operator.py
+++ b/src/operator.py
@@ -787,6 +787,19 @@ Original stderr:
                             "source_artifact": "results/fake_results.json",
                         }
                     ],
+                    "task_outputs": [
+                        {
+                            "stated": (
+                                "whatever the task description asked for — fake-operator mode "
+                                "does not read it"
+                            ),
+                            "covered_by": "not_attempted",
+                            "why_not": (
+                                "fake-operator mode exercises the workflow and measures "
+                                "nothing, so it answers no deliverable the task named."
+                            ),
+                        }
+                    ],
                 },
             )
 

--- a/src/prompts/03_study_design.md
+++ b/src/prompts/03_study_design.md
@@ -136,6 +136,14 @@ Rules:
   whether a reader can accept it from a number in the prose or needs to see it. Only the
   second kind gets a slot. A question no slot settles is one the prose has to carry alone, and
   that is often correct.
+- `task_outputs` answers the task description item by item. Read what the task says it
+  wants — many task descriptions carry a literal `Outputs:` sentence naming the constraints,
+  comparisons, distributions or tables expected — and list each one, with what in this plan
+  produces it: `figure:<slot>`, `number:<index>`, `prose`, or `not_attempted` with a reason.
+  This is the closest thing to a specification of the deliverable that exists, and a
+  deliverable the task named which the report never mentions is the cheapest thing there is
+  to lose. Splitting it finely is better than one line saying "everything".
+
 - Do not write `declared_at`, `digest` or `amendments` — the workflow manager stamps those on
   approval, and a later round amends this file rather than rewriting it.
 - **Produce no figure files at this stage.** This is a plan. The figures are drawn at Stage 06,

--- a/src/report_plan.py
+++ b/src/report_plan.py
@@ -197,6 +197,46 @@ class HeadlineNumber:
         }
 
 
+#: How a stated deliverable is accounted for. ``not_attempted`` is a real
+#: answer — a task can ask for something the data cannot support — but it has
+#: to be said rather than left out.
+COVERAGE_KINDS = ("figure", "number", "prose", "not_attempted")
+
+
+@dataclass(frozen=True)
+class TaskOutput:
+    """One deliverable the task asked for, and what in this plan produces it.
+
+    The task description is the only statement of what the run is for that the
+    run can read, and it is routinely explicit: 22 of the 40 ResearchClawBench
+    tasks carry a literal ``Outputs:`` sentence naming the constraints, the
+    comparisons and the distributions the study is expected to produce. Where a
+    deliverable is graded, that sentence is the closest thing to the grading
+    criteria that the run is allowed to see — the criteria themselves live with
+    the target study, which the run has no access to and must not be shown.
+
+    Reading it and answering it item by item is therefore the cheapest coverage
+    available, and nothing was doing it: the description reached every stage as
+    an undifferentiated goal blob.
+    """
+
+    stated: str
+    covered_by: str
+    why_not: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {"stated": self.stated, "covered_by": self.covered_by, "why_not": self.why_not}
+
+    @property
+    def kind(self) -> str:
+        return self.covered_by.split(":", 1)[0].strip().casefold()
+
+    @property
+    def target(self) -> str:
+        _, _, rest = self.covered_by.partition(":")
+        return rest.strip()
+
+
 @dataclass(frozen=True)
 class ReportPlan:
     figures: list[PlannedFigure]
@@ -206,6 +246,8 @@ class ReportPlan:
     #: Why this study's report carries no figure. Required only when ``figures``
     #: is empty, which three of the forty benchmark tasks genuinely are.
     no_figures_because: str = ""
+    #: Every deliverable the task description states, and what produces it.
+    task_outputs: list[TaskOutput] = field(default_factory=list)
     amendments: list[dict[str, str]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
@@ -213,6 +255,7 @@ class ReportPlan:
             "declared_at": self.declared_at,
             "digest": self.digest,
             "no_figures_because": self.no_figures_because,
+            "task_outputs": [item.to_dict() for item in self.task_outputs],
             "amendments": [dict(item) for item in self.amendments],
             "figures": [item.to_dict() for item in self.figures],
             "headline_numbers": [item.to_dict() for item in self.headline_numbers],
@@ -289,6 +332,15 @@ def load_report_plan(paths: RunPaths) -> ReportPlan | None:
         declared_at=_text(payload.get("declared_at")),
         digest=_text(payload.get("digest")),
         no_figures_because=_text(payload.get("no_figures_because")),
+        task_outputs=[
+            TaskOutput(
+                stated=_text(item.get("stated")),
+                covered_by=_text(item.get("covered_by")),
+                why_not=_text(item.get("why_not")),
+            )
+            for item in _entries(payload, "task_outputs")
+            if isinstance(item, dict)
+        ],
         amendments=[dict(item) for item in _entries(payload, "amendments") if isinstance(item, dict)],
     )
 
@@ -408,6 +460,8 @@ def stamp_report_plan(paths: RunPaths, reason: str = "initial declaration") -> R
         stamped = ReportPlan(
             figures=plan.figures,
             headline_numbers=plan.headline_numbers,
+            no_figures_because=plan.no_figures_because,
+            task_outputs=plan.task_outputs,
             declared_at=declared_at,
             digest=current,
             amendments=amendments,
@@ -416,6 +470,8 @@ def stamp_report_plan(paths: RunPaths, reason: str = "initial declaration") -> R
         stamped = ReportPlan(
             figures=plan.figures,
             headline_numbers=plan.headline_numbers,
+            no_figures_because=plan.no_figures_because,
+            task_outputs=plan.task_outputs,
             declared_at=declared_at or _now(),
             digest=current,
             amendments=amendments,
@@ -424,6 +480,8 @@ def stamp_report_plan(paths: RunPaths, reason: str = "initial declaration") -> R
         stamped = ReportPlan(
             figures=plan.figures,
             headline_numbers=plan.headline_numbers,
+            no_figures_because=plan.no_figures_because,
+            task_outputs=plan.task_outputs,
             declared_at=declared_at or _now(),
             digest=current,
             amendments=[
@@ -513,6 +571,61 @@ def _allowed_figure_suffixes(output_format: str) -> set[str]:
     return set(FIGURE_SUFFIXES)
 
 
+def _task_output_problems(plan: "ReportPlan") -> list[str]:
+    """Every deliverable the task states is answered by something in the plan.
+
+    Structural only. Whether the agent read the task description correctly is a
+    review question — a gate cannot know what the description said without
+    parsing prose, and a gate that guessed would refuse correct plans. What it
+    can hold is that each stated deliverable was answered, that the answer
+    points at something that exists, and that a deliverable being skipped is
+    written down rather than dropped.
+    """
+    problems: list[str] = []
+    if not plan.task_outputs:
+        return [
+            "report_plan.json has no `task_outputs`. Read the task description, list every "
+            "deliverable it states — the constraints, comparisons, distributions or tables it "
+            "asks for — and say for each one what in this plan produces it. A deliverable the "
+            "task named and the report never mentions is the cheapest score there is to lose."
+        ]
+
+    slots = {item.slot for item in plan.figures}
+    numbers = range(len(plan.headline_numbers))
+    for index, output in enumerate(plan.task_outputs, start=1):
+        label = output.stated[:60] or f"task output {index}"
+        if not output.stated.strip():
+            problems.append(f"report_plan.json task output {index} states nothing.")
+            continue
+        if output.kind not in COVERAGE_KINDS:
+            problems.append(
+                f"report_plan.json task output {label!r} has covered_by "
+                f"{output.covered_by!r}; expected one of "
+                + ", ".join(f"`{kind}`" for kind in COVERAGE_KINDS)
+                + " (figure and number take a target, as `figure:1` or `number:0`)."
+            )
+            continue
+        if output.kind == "figure":
+            if not output.target.isdigit() or int(output.target) not in slots:
+                problems.append(
+                    f"report_plan.json task output {label!r} is covered by figure slot "
+                    f"{output.target!r}, which this plan does not declare."
+                )
+        elif output.kind == "number":
+            if not output.target.isdigit() or int(output.target) not in numbers:
+                problems.append(
+                    f"report_plan.json task output {label!r} is covered by headline number "
+                    f"{output.target!r}, which this plan does not declare."
+                )
+        elif output.kind == "not_attempted" and len(output.why_not.strip()) < MIN_BRANCH_CHARS:
+            problems.append(
+                f"report_plan.json leaves task output {label!r} unattempted without saying "
+                f"why, in at least {MIN_BRANCH_CHARS} characters. Not attempting something the "
+                "task asked for is a legitimate call and a reader has to be told it was a call."
+            )
+    return problems
+
+
 def validate_report_plan(
     paths: RunPaths,
     output_format: str = DEFAULT_OUTPUT_FORMAT,
@@ -542,6 +655,8 @@ def validate_report_plan(
     #: field. False means the plan is still being declared — the first Stage 03
     #: that writes it, or a re-attempt of that stage.
     declared = recorded_report_plan_stamp(paths) is not None
+
+    problems.extend(_task_output_problems(plan))
 
     if not figures:
         # A plan with no figures is unusual, not wrong. Measured over the 40

--- a/tests/prereg_support.py
+++ b/tests/prereg_support.py
@@ -82,6 +82,7 @@ def write_report_plan(
     source_artifact: str = "results/metrics.json",
     figures=None,
     headline_numbers=None,
+    task_outputs=None,
 ) -> None:
     """One planned figure, one headline number: the smallest plan the gate accepts.
 
@@ -120,6 +121,15 @@ def write_report_plan(
                         "quantity": "held-out accuracy, treatment vs baseline",
                         "unit": "percentage points",
                         "source_artifact": source_artifact,
+                    }
+                ],
+                "task_outputs": task_outputs
+                if task_outputs is not None
+                else [
+                    {
+                        "stated": "the held-out accuracy comparison the task asks for",
+                        "covered_by": "figure:1",
+                        "why_not": "",
                     }
                 ],
             }

--- a/tests/test_manager_smoke.py
+++ b/tests/test_manager_smoke.py
@@ -299,6 +299,13 @@ class ScriptedSmokeOperator:
                                 "source_artifact": "results/metrics.json",
                             }
                         ],
+                        "task_outputs": [
+                            {
+                                "stated": "the retrieval-on versus retrieval-off accuracy comparison",
+                                "covered_by": "figure:1",
+                                "why_not": "",
+                            }
+                        ],
                     }
                 ),
             )

--- a/tests/test_report_plan.py
+++ b/tests/test_report_plan.py
@@ -83,6 +83,16 @@ class ReportPlanTestCase(unittest.TestCase):
                     "source_artifact": "results/accuracy_by_length.json",
                 }
             ],
+            # Every plan answers the task description. Tests about figure counts
+            # override `figures`, not this, so the default has to cover slot 1 —
+            # which every default figure set includes.
+            "task_outputs": [
+                {
+                    "stated": "the accuracy comparison the task asks for",
+                    "covered_by": "figure:1",
+                    "why_not": "",
+                }
+            ],
         }
         payload.update(extra)
         write_text(self.paths.report_plan, json.dumps(payload))
@@ -916,3 +926,120 @@ class JudgeVisibleWindowTest(unittest.TestCase):
         from src.report_plan import JUDGE_VISIBLE_PREFIX_CHARS
 
         self.assertEqual(JUDGE_VISIBLE_PREFIX_CHARS, 10_000)
+
+
+class TaskOutputCoverageTest(ReportPlanTestCase):
+    """The task description is the only statement of intent the run may read.
+
+    22 of the 40 ResearchClawBench tasks carry a literal ``Outputs:`` sentence
+    naming the constraints, comparisons and distributions the study should
+    produce. The grading criteria themselves live with the target study, which
+    the run has no access to and must never be shown — but that sentence is the
+    closest legitimate proxy, and nothing was answering it item by item.
+    """
+
+    def test_a_plan_that_answers_every_stated_output_passes(self) -> None:
+        self.write_plan(
+            task_outputs=[
+                {"stated": "parameter constraints from model fitting", "covered_by": "figure:1"},
+                {"stated": "goodness-of-fit comparison", "covered_by": "number:0"},
+            ]
+        )
+        self.assertEqual([p for p in self.problems() if "task output" in p], [])
+
+    def test_a_plan_with_no_task_outputs_is_refused(self) -> None:
+        self.write_plan(task_outputs=[])
+        self.assertTrue(any("no `task_outputs`" in p for p in self.problems()))
+
+    def test_pointing_at_a_slot_that_does_not_exist_is_refused(self) -> None:
+        self.write_plan(task_outputs=[{"stated": "constraints", "covered_by": "figure:9"}])
+        self.assertTrue(any("which this plan does not declare" in p for p in self.problems()))
+
+    def test_pointing_at_a_headline_number_that_does_not_exist_is_refused(self) -> None:
+        self.write_plan(task_outputs=[{"stated": "constraints", "covered_by": "number:7"}])
+        self.assertTrue(any("which this plan does not declare" in p for p in self.problems()))
+
+    def test_prose_is_a_valid_answer(self) -> None:
+        """Not everything the task asks for needs a figure or a headline number."""
+        self.write_plan(task_outputs=[{"stated": "a discussion of limitations", "covered_by": "prose"}])
+        self.assertEqual([p for p in self.problems() if "task output" in p], [])
+
+    def test_not_attempting_something_is_allowed_when_said(self) -> None:
+        self.write_plan(
+            task_outputs=[
+                {
+                    "stated": "posterior distributions of the EDE parameters",
+                    "covered_by": "not_attempted",
+                    "why_not": "the supplied data carries only best-fit values, not chains",
+                }
+            ]
+        )
+        self.assertEqual([p for p in self.problems() if "task output" in p], [])
+
+    def test_not_attempting_something_silently_is_refused(self) -> None:
+        self.write_plan(
+            task_outputs=[{"stated": "posterior distributions", "covered_by": "not_attempted"}]
+        )
+        self.assertTrue(any("without saying why" in p for p in self.problems()))
+
+    def test_an_unknown_coverage_kind_is_refused(self) -> None:
+        self.write_plan(task_outputs=[{"stated": "constraints", "covered_by": "somehow"}])
+        self.assertTrue(any("expected one of" in p for p in self.problems()))
+
+    def test_the_gate_does_not_judge_whether_the_reading_was_right(self) -> None:
+        """Structural only.
+
+        A gate cannot know what the task description said without parsing prose,
+        and one that guessed would refuse correct plans. Whether the agent read
+        the description well is a review question.
+        """
+        self.write_plan(
+            task_outputs=[{"stated": "something the task never asked for", "covered_by": "figure:1"}]
+        )
+        self.assertEqual([p for p in self.problems() if "task output" in p], [])
+
+
+class StampCarriesEveryAuthoredFieldTest(ReportPlanTestCase):
+    """The manager rewrites the file on approval; anything it forgets is lost.
+
+    `task_outputs` and `no_figures_because` were both dropped by the stamp
+    because the three `ReportPlan(...)` reconstructions inside it listed fields
+    by hand. The agent wrote them, the manager silently erased them, and the
+    gate then refused the stage for not having what it had just deleted.
+    """
+
+    def test_stamping_preserves_task_outputs(self) -> None:
+        from src.report_plan import load_report_plan, stamp_report_plan
+
+        self.write_plan(
+            task_outputs=[{"stated": "the comparison", "covered_by": "figure:1"}]
+        )
+        stamp_report_plan(self.paths)
+        self.assertEqual(len(load_report_plan(self.paths).task_outputs), 1)
+
+    def test_stamping_preserves_the_no_figures_reason(self) -> None:
+        from src.report_plan import load_report_plan, stamp_report_plan
+
+        reason = "The result is one scalar limit; the prose states it with its interval."
+        self.write_plan(figures=[], no_figures_because=reason,
+                        task_outputs=[{"stated": "the limit", "covered_by": "number:0"}])
+        stamp_report_plan(self.paths)
+        self.assertEqual(load_report_plan(self.paths).no_figures_because, reason)
+
+    def test_every_dataclass_field_survives_a_stamp(self) -> None:
+        """The general form, so the next field added is covered without a new test."""
+        import dataclasses
+
+        from src.report_plan import ReportPlan, load_report_plan, stamp_report_plan
+
+        self.write_plan(task_outputs=[{"stated": "x", "covered_by": "figure:1"}])
+        before = load_report_plan(self.paths)
+        stamp_report_plan(self.paths)
+        after = load_report_plan(self.paths)
+        # declared_at, digest and amendments are what the stamp is *for*.
+        stamped = {"declared_at", "digest", "amendments"}
+        for f in dataclasses.fields(ReportPlan):
+            if f.name in stamped:
+                continue
+            with self.subTest(field=f.name):
+                self.assertEqual(getattr(after, f.name), getattr(before, f.name))

--- a/tests/test_report_plan_robustness.py
+++ b/tests/test_report_plan_robustness.py
@@ -75,6 +75,9 @@ class ReportPlanRobustnessTestCase(unittest.TestCase):
                 {
                     "figures": figures,
                     "headline_numbers": HEADLINE if headline_numbers is None else headline_numbers,
+                    "task_outputs": [
+                        {"stated": "the comparison the task asks for", "covered_by": "figure:1"}
+                    ],
                 }
             ),
         )


### PR DESCRIPTION
The task description is the only statement of what a run is for that the run can read — and it is routinely explicit. Parsing all 40 ResearchClawBench task descriptions, **22 carry a literal `Outputs:` sentence**:

> **Outputs:** Constraints on cosmological parameters (Ωm, H₀, σ₈, etc.) from model fitting, comparison of goodness-of-fit (Δχ²) for ΛCDM, EDE and w₀wₐ models, and posterior distributions of EDE parameters (f_EDE, log₁₀a_c).

That is a natural-language checklist. The graded criteria themselves live in `target_study/`, which the run has no access to and must never be shown — but this sentence is a legitimate input, and **nothing was answering it**. The description reached every stage as an undifferentiated goal blob.

## What this adds

`report_plan.json` gains `task_outputs`: every deliverable the description states, and what in this plan produces it.

```json
"task_outputs": [
  {"stated": "constraints on cosmological parameters from model fitting", "covered_by": "figure:1"},
  {"stated": "goodness-of-fit comparison across the three models",       "covered_by": "number:0"},
  {"stated": "posterior distributions of the EDE parameters",
   "covered_by": "not_attempted",
   "why_not": "the supplied data carries only best-fit values, not chains"}
]
```

Coverage stops being a guess about the rubric and becomes alignment with a specific paragraph.

## The gate is deliberately structural

It checks that each stated deliverable was answered, that the answer points at a slot or number the plan actually declares, and that skipping something is written down rather than dropped.

It does **not** judge whether the agent read the description correctly. A gate cannot know what the description said without parsing prose, and one that guessed would refuse correct plans. There is a test asserting that non-property explicitly: a plan answering something the task never asked for passes.

## A bug this surfaced

`stamp_report_plan` rebuilds `ReportPlan` in three places with the fields listed by hand, so it silently dropped `task_outputs` — and, **already on main**, `no_figures_because` from #160. The agent wrote the field, the manager erased it on approval, and the gate then refused the stage for missing what it had just deleted.

All three reconstructions now carry every authored field, and a test walks `dataclasses.fields(ReportPlan)` asserting each survives a stamp — so the next field added is covered without a new test. Mutation-checked: reverting the three carries fails 4 tests.

## Verification

1,687 tests green. A fake run keeps `task_outputs` through the stamp and completes every stage on the first attempt.

A real end-to-end run (Astronomy_001, opus) is still in flight; #160, #161 and this remain unvalidated against a real score until it finishes and is scored with `tools/score_rcb_run.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)