### PR TITLE
Stop reporting a dead panel as a panel that found nothing

### DIFF
--- a/docs/deliberation.md
+++ b/docs/deliberation.md
@@ -114,8 +114,42 @@ panel asked it writes essays.
 
 Every position from every voice is kept, including the ones the resolution rejected.
 
+## When no voice answers
+
+A panel that could not be convened and a panel that convened and added nothing are different
+outcomes, and for one live run they were reported with the same sentence.
+
+Vertex had exhausted the quota for the reviewer's base model while the run's own operator sat
+on a different, healthy one. All four voices failed. The ledger said:
+
+> 1 crux(es) escalated at 4 calls; no working answer was offered to compare against.
+
+**That is false.** The agent's `working_answer` was a thousand characters long. What was
+missing was the panel. Reading only the summary would send someone to tighten the escalation
+prompt — fixing a problem that does not exist, while the outage goes unnoticed.
+
+So the ledger now separates the two:
+
+| Situation | What the verdict says |
+|:---|:---|
+| Every voice failed, every crux | *not one panel could be convened … it was never tried* |
+| Every voice failed on some cruxes | *N never reached a panel … the remaining M are the only ones this run can speak to* |
+| Some voices failed, the panel still sat | the ordinary verdict, plus the unreachable count |
+| No voice failed, no answer emerged | unchanged — this is a real outcome |
+
+The distinction the code turns on is `all` versus `any`. *Every* voice failing means no panel;
+*a* voice failing means a smaller panel that still deliberated, and writing that off would
+subtract a real result from the evidence.
+
+The run is **not** stopped. Deliberation is an optional aid and a stage keeping its own answer
+is legitimate degradation — unlike a stage operator that cannot be reached, where the run has
+no findings at all and [stops](backend-health.md). The requirement here is visibility, not
+refusal.
+
 ## Limits worth knowing
 
+- **A dead panel is silent unless you read the ledger.** The run completes and the report is
+  real research; only `deliberations.json` records that no crux was ever argued.
 - **The agent chooses what is hard, and it may choose badly.** It can escalate a question it
   had already settled, or fail to escalate the one that mattered. The `confirmed` count catches
   the first; nothing catches the second.

--- a/docs/ideation-panel.md
+++ b/docs/ideation-panel.md
@@ -120,7 +120,12 @@ review panel, which pays per gate.
 ## Limits worth knowing
 
 - **The pool is material, not a dependency.** A panel that cannot be reached logs the failure
-  and Stage 02 generates hypotheses the ordinary way.
+  and Stage 02 generates hypotheses the ordinary way. When *every* proposer fails the verdict
+  says so rather than reporting "no candidate hypotheses survived" — an empty pool from
+  proposers that ran is a result, an empty pool from proposers that never ran is an outage, and
+  the same sentence for both hides one behind the other. See
+  [the deliberation note](deliberation.md#when-no-voice-answers) for the live run this came
+  from.
 - **Scoring is one call over the whole pool**, not independent critics per candidate. It orders
   material a later reader judges anyway; paying per candidate would spend more on ranking the
   pool than on generating it.

--- a/src/deliberation.py
+++ b/src/deliberation.py
@@ -269,9 +269,24 @@ class Resolution:
             "dissent": self.dissent,
             "voice_calls": self.voice_calls,
             "distinct_answers": self.distinct_answers,
+            "unreachable": self.unreachable,
             "changed_the_answer": self.changed_the_answer,
             "verdict": self.verdict(),
         }
+
+    @property
+    def unreachable(self) -> int:
+        """Voices whose backend never answered.
+
+        Kept separate from "the voice answered and said nothing useful". A panel that could
+        not be convened and a panel that convened and added nothing are different outcomes,
+        and reporting them with one sentence hides an outage behind a research finding.
+        """
+        return sum(1 for position in self.positions if position.failed)
+
+    @property
+    def all_voices_unreachable(self) -> bool:
+        return bool(self.positions) and self.unreachable == len(self.positions)
 
     @property
     def distinct_answers(self) -> int:
@@ -286,8 +301,21 @@ class Resolution:
 
     def verdict(self) -> str:
         """Whether stopping to think was worth the calls it cost."""
+        if self.all_voices_unreachable:
+            return (
+                f"No voice could be reached ({self.unreachable} of {len(self.positions)} "
+                "failed); the panel never sat. The stage keeps its own answer, and this crux "
+                "went un-deliberated rather than being settled."
+            )
         if not self.answer:
-            return "The deliberation produced no answer; the stage keeps its own."
+            unreachable = (
+                f" {self.unreachable} of {len(self.positions)} voice(s) could not be reached."
+                if self.unreachable
+                else ""
+            )
+            return (
+                "The deliberation produced no answer; the stage keeps its own." + unreachable
+            )
         if self.changed_the_answer is False:
             return (
                 f"The panel reached the same answer the agent already had, at {self.voice_calls} "
@@ -610,22 +638,47 @@ def record_resolution(paths: RunPaths, stage: StageSpec, resolution: Resolution)
     return ledger
 
 
+def _entry_was_never_deliberated(entry: dict[str, Any]) -> bool:
+    """True when every voice on this crux failed, so no panel actually sat."""
+    positions = entry.get("positions")
+    if not isinstance(positions, list) or not positions:
+        return False
+    return all(isinstance(p, dict) and p.get("failed") is True for p in positions)
+
+
 def _summary(entries: list[dict[str, Any]]) -> dict[str, Any]:
     calls = sum(int(entry.get("voice_calls") or 0) for entry in entries)
     changed = sum(1 for entry in entries if entry.get("changed_the_answer") is True)
     unchanged = sum(1 for entry in entries if entry.get("changed_the_answer") is False)
+    never_sat = sum(1 for entry in entries if _entry_was_never_deliberated(entry))
     return {
         "cruxes_raised": len(entries),
         "changed_the_agents_answer": changed,
         "confirmed_the_agents_answer": unchanged,
+        "never_deliberated": never_sat,
         "voice_calls": calls,
-        "verdict": _summary_verdict(len(entries), changed, unchanged, calls),
+        "verdict": _summary_verdict(len(entries), changed, unchanged, calls, never_sat),
     }
 
 
-def _summary_verdict(total: int, changed: int, unchanged: int, calls: int) -> str:
+def _summary_verdict(
+    total: int, changed: int, unchanged: int, calls: int, never_sat: int = 0
+) -> str:
     if total == 0:
         return "No cruxes were raised."
+    if never_sat == total:
+        return (
+            f"{total} crux(es) escalated at {calls} calls, and not one panel could be "
+            "convened — every voice's backend failed. This says nothing about whether "
+            "deliberation helps; it was never tried. Check the backend before reading "
+            "any deliberation result from this run."
+        )
+    if never_sat:
+        return (
+            f"{total} crux(es) escalated at {calls} calls, of which {never_sat} never "
+            "reached a panel because every voice's backend failed. The remaining "
+            f"{total - never_sat} are the only ones this run can speak to."
+        )
     if unchanged and not changed:
         return (
             f"{total} crux(es) escalated at {calls} calls, and the panel confirmed the agent's "

--- a/src/ideation_panel.py
+++ b/src/ideation_panel.py
@@ -209,6 +209,10 @@ class IdeaPool:
                 distinct=len(distinct),
                 added=len(added),
                 calls=self.proposer_calls,
+                unreachable=len(self.unreachable),
+                seated=len(self.unreachable) + len(self.abstentions) + len(
+                    {c.proposer for c in self.candidates}
+                ),
                 adoption_measured=self.adoption_measured,
                 adopted=sum(1 for c in distinct if c.adopted),
                 adopted_from_others=sum(1 for c in added if c.adopted),
@@ -230,6 +234,8 @@ def _pool_verdict(
     distinct: int,
     added: int,
     calls: int,
+    unreachable: int = 0,
+    seated: int = 0,
     adoption_measured: bool = False,
     adopted: int = 0,
     adopted_from_others: int = 0,
@@ -242,8 +248,23 @@ def _pool_verdict(
     speculative candidates that require expert validation". Until Stage 02 has actually been
     approved this can only report the first claim, and it says which one it is making.
     """
+    # ``unreachable`` being truthy already carries the "at least one seat" case, so a
+    # missing ``seated`` (older records predate the count) still reads as a total outage
+    # rather than being silently downgraded.
+    if unreachable and unreachable >= seated:
+        return (
+            f"No proposer could be reached ({unreachable} of {seated} failed); the panel "
+            "never sat. The stage proceeds without a pool, and this run says nothing about "
+            "whether widening the candidate pool helps — it was never tried."
+        )
+
     if distinct == 0:
-        return "No candidate hypotheses survived; the stage proceeds without a pool."
+        reached = (
+            f" {unreachable} of {seated} proposer(s) could not be reached." if unreachable else ""
+        )
+        return (
+            "No candidate hypotheses survived; the stage proceeds without a pool." + reached
+        )
 
     if added == 0:
         widened = (

--- a/tests/fixtures/deliberation_all_voices_unreachable.json
+++ b/tests/fixtures/deliberation_all_voices_unreachable.json
@@ -1,0 +1,61 @@
+{
+  "request": {
+    "question": "For a three-way comparison of LASSO, ridge and elastic net on selection stability, what should count as 'variable j was selected' for ridge, which never sets a coefficient to zero? Specifically: should the primary estimand be (a) top-k support with k matched per-resample to the lasso's cardinality, (b) rank agreement only, with no notion of a selected set, or (c) an absolute threshold on |beta-hat|?",
+    "why_it_matters": "The whole study is a comparison of between-regularizer disagreement against within-regularizer bootstrap noise. Ridge's native selection frequency is identically 1.0 for every variable, so under any naive support-based estimand ridge is trivially the 'most stable' method and the headline comparison ",
+    "working_answer": "Co-primary, not a single choice. (1) Matched-cardinality top-k support: on each bootstrap resample, k is the number of nonzeros the LASSO selected on that same resample, and the top-k rule is applied identically to all three estimators. This keeps set cardinality constant across methods within a res",
+    "help_wanted": "both",
+    "stage_slug": "01_literature_survey",
+    "already_considered": [
+      "Absolute threshold on |beta-hat|: rejected as primary. The shipped features have unit L2 norm rather than unit variance, so coefficient magnitudes sit on a scale with no interpretable cutoff, and the threshold can be tuned to produce any answer. Retained only as a declared sensitivity analysis."
+    ]
+  },
+  "positions": [
+    {
+      "voice": "theorist",
+      "title": "Theorist",
+      "backend": "claude",
+      "model": "sonnet",
+      "answer": "",
+      "argument": "",
+      "against_self": "",
+      "failed": true
+    },
+    {
+      "voice": "empiricist",
+      "title": "Empiricist",
+      "backend": "claude",
+      "model": "sonnet",
+      "answer": "",
+      "argument": "",
+      "against_self": "",
+      "failed": true
+    },
+    {
+      "voice": "critic",
+      "title": "Critic",
+      "backend": "claude",
+      "model": "sonnet",
+      "answer": "",
+      "argument": "",
+      "against_self": "",
+      "failed": true
+    },
+    {
+      "voice": "pragmatist",
+      "title": "Pragmatist",
+      "backend": "claude",
+      "model": "sonnet",
+      "answer": "",
+      "argument": "",
+      "against_self": "",
+      "failed": true
+    }
+  ],
+  "answer": "",
+  "reason": "",
+  "falsifier": "",
+  "dissent": "",
+  "voice_calls": 4,
+  "changed_the_answer": null,
+  "verdict": "The deliberation produced no answer; the stage keeps its own."
+}

--- a/tests/test_panel_unreachable.py
+++ b/tests/test_panel_unreachable.py
@@ -1,0 +1,185 @@
+"""A panel that could not be convened is not a panel that found nothing.
+
+Both distinctions in this file were found by running AutoR against a live backend rather than
+by reading the code. Vertex had exhausted the quota for the reviewer's base model while the
+run's own operator was on a different, healthy one, so every deliberation voice failed while
+the stage itself sailed on. The ledger then reported:
+
+    "1 crux(es) escalated at 4 calls; no working answer was offered to compare against."
+
+That sentence is false. The agent's ``working_answer`` was a 1,000-character answer; what was
+missing was the *panel*. Reading only the summary would have sent someone to tighten the
+escalation prompt, fixing a problem that did not exist while the outage went unnoticed.
+
+The captured payload is checked in verbatim as a fixture. A fixture invented after the fact
+would only encode what I already believed the failure looked like.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from src.deliberation import Position, Resolution, CruxRequest, _summary
+from src.ideation_panel import _pool_verdict
+
+FIXTURE = Path(__file__).parent / "fixtures" / "deliberation_all_voices_unreachable.json"
+
+
+def _position(voice: str, *, failed: bool, answer: str = "") -> Position:
+    return Position(
+        voice=voice,
+        title=voice.title(),
+        backend="claude",
+        model="sonnet",
+        answer=answer,
+        failed=failed,
+    )
+
+
+class RealCapturedOutageTest(unittest.TestCase):
+    """The exact ledger entry the live run produced."""
+
+    def setUp(self) -> None:
+        self.entry = json.loads(FIXTURE.read_text())
+
+    def test_the_captured_entry_really_is_a_total_outage(self) -> None:
+        # Guards the fixture itself: if someone regenerates it from a healthy run the
+        # tests below would pass for the wrong reason.
+        self.assertTrue(self.entry["positions"])
+        self.assertTrue(all(p["failed"] for p in self.entry["positions"]))
+        self.assertTrue(self.entry["request"]["working_answer"].strip())
+
+    def test_summary_does_not_blame_the_agent_for_the_backend(self) -> None:
+        verdict = _summary([self.entry])["verdict"]
+        self.assertNotIn("no working answer was offered", verdict)
+
+    def test_summary_names_the_outage(self) -> None:
+        summary = _summary([self.entry])
+        self.assertEqual(summary["never_deliberated"], 1)
+        self.assertIn("every voice's backend failed", summary["verdict"])
+
+    def test_summary_refuses_to_read_as_evidence_about_deliberation(self) -> None:
+        # The whole point of the ledger is to say whether stopping to think paid off.
+        # On a run where it never happened, it has to decline to answer.
+        verdict = _summary([self.entry])["verdict"]
+        self.assertIn("it was never tried", verdict)
+
+
+class ResolutionVerdictTest(unittest.TestCase):
+    def _resolution(self, positions: list[Position], **kw) -> Resolution:
+        return Resolution(
+            request=CruxRequest(question="q" * 40, working_answer="my current best answer"),
+            positions=positions,
+            voice_calls=len(positions),
+            **kw,
+        )
+
+    def test_all_voices_failed_says_the_panel_never_sat(self) -> None:
+        res = self._resolution([_position(v, failed=True) for v in ("a", "b", "c")])
+        self.assertTrue(res.all_voices_unreachable)
+        self.assertEqual(res.unreachable, 3)
+        self.assertIn("No voice could be reached", res.verdict())
+
+    def test_partial_outage_is_reported_but_not_as_a_dead_panel(self) -> None:
+        res = self._resolution(
+            [_position("a", failed=True), _position("b", failed=False, answer="use top-k")]
+        )
+        self.assertFalse(res.all_voices_unreachable)
+        self.assertIn("1 of 2 voice(s) could not be reached", res.verdict())
+
+    def test_a_reachable_panel_that_answered_nothing_is_unchanged(self) -> None:
+        # The pre-existing sentence has to survive. A panel that sat, spoke, and produced
+        # no usable answer is a real outcome and must not be relabelled as an outage.
+        res = self._resolution([_position("a", failed=False), _position("b", failed=False)])
+        self.assertEqual(res.unreachable, 0)
+        self.assertEqual(
+            res.verdict(), "The deliberation produced no answer; the stage keeps its own."
+        )
+
+    def test_no_positions_at_all_is_not_an_outage(self) -> None:
+        # A crux that was never dispatched has no positions. Claiming every voice failed
+        # would invent an outage out of an empty list.
+        res = self._resolution([])
+        self.assertFalse(res.all_voices_unreachable)
+
+    def test_unreachable_count_reaches_the_serialized_record(self) -> None:
+        res = self._resolution([_position("a", failed=True), _position("b", failed=True)])
+        self.assertEqual(res.to_dict()["unreachable"], 2)
+
+
+class MixedLedgerTest(unittest.TestCase):
+    def _entry(self, *, failed: bool, changed: bool | None) -> dict:
+        return {
+            "positions": [{"failed": failed}, {"failed": failed}],
+            "voice_calls": 2,
+            "changed_the_answer": changed,
+        }
+
+    def test_one_outage_among_several_is_subtracted_not_averaged(self) -> None:
+        verdict = _summary(
+            [self._entry(failed=True, changed=None), self._entry(failed=False, changed=True)]
+        )["verdict"]
+        self.assertIn("1 never reached a panel", verdict)
+        self.assertIn("1 are the only ones this run can speak to", verdict)
+
+    def test_one_failed_voice_does_not_write_off_a_panel_that_sat(self) -> None:
+        # The asymmetry that matters: *every* voice failing means no panel; *a* voice
+        # failing means a smaller panel that still deliberated. Counting the second as
+        # an outage would subtract a real result from the evidence.
+        entry = {
+            "positions": [{"failed": True}, {"failed": False}, {"failed": False}],
+            "voice_calls": 3,
+            "changed_the_answer": True,
+        }
+        summary = _summary([entry])
+        self.assertEqual(summary["never_deliberated"], 0)
+        self.assertIn("the panel changed the answer on 1", summary["verdict"])
+
+    def test_a_healthy_ledger_keeps_its_original_verdict(self) -> None:
+        verdict = _summary([self._entry(failed=False, changed=False)])["verdict"]
+        self.assertIn("confirmed the agent's own answer every time", verdict)
+
+    def test_the_genuine_missing_working_answer_case_still_reports_itself(self) -> None:
+        # The sentence being defended against a false positive is still needed for the
+        # case it was written for: voices reached, no baseline to compare against.
+        verdict = _summary([self._entry(failed=False, changed=None)])["verdict"]
+        self.assertIn("no working answer was offered", verdict)
+
+    def test_an_entry_with_no_positions_key_is_not_an_outage(self) -> None:
+        verdict = _summary([{"voice_calls": 2, "changed_the_answer": None}])["verdict"]
+        self.assertIn("no working answer was offered", verdict)
+
+
+class IdeationPoolVerdictTest(unittest.TestCase):
+    def test_every_proposer_unreachable_says_the_panel_never_sat(self) -> None:
+        verdict = _pool_verdict(distinct=0, added=0, calls=4, unreachable=4, seated=4)
+        self.assertIn("No proposer could be reached", verdict)
+        self.assertIn("it was never tried", verdict)
+
+    def test_an_empty_pool_from_reachable_proposers_keeps_its_sentence(self) -> None:
+        verdict = _pool_verdict(distinct=0, added=0, calls=4, unreachable=0, seated=4)
+        self.assertEqual(
+            verdict, "No candidate hypotheses survived; the stage proceeds without a pool."
+        )
+
+    def test_a_partial_outage_with_survivors_is_not_a_dead_panel(self) -> None:
+        verdict = _pool_verdict(distinct=3, added=2, calls=4, unreachable=1, seated=4)
+        self.assertNotIn("never sat", verdict)
+        self.assertIn("2 of 3 distinct hypotheses", verdict)
+
+    def test_a_partial_outage_with_an_empty_pool_still_names_the_failures(self) -> None:
+        verdict = _pool_verdict(distinct=0, added=0, calls=4, unreachable=2, seated=4)
+        self.assertIn("No candidate hypotheses survived", verdict)
+        self.assertIn("2 of 4 proposer(s) could not be reached", verdict)
+
+    def test_unknown_seat_count_does_not_swallow_a_real_outage(self) -> None:
+        # Older records predate the seated count. An outage must not be silently
+        # downgraded just because the denominator is missing.
+        verdict = _pool_verdict(distinct=0, added=0, calls=4, unreachable=3, seated=0)
+        self.assertIn("No proposer could be reached", verdict)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found by running AutoR against a live backend, not by reading the code. Second live-run defect in a row, and this one is worse than [#163](https://github.com/tangxiangru/AutoR/pull/163) because it is a lie told by the instrument built to prevent exactly this.

## What the ledger said

Vertex had exhausted the quota for the reviewer's base model while the run's own operator sat on a different, healthy one. All four deliberation voices failed. `deliberations.json`:

```json
{ "cruxes_raised": 1, "changed_the_agents_answer": 0, "confirmed_the_agents_answer": 0,
  "voice_calls": 4,
  "verdict": "1 crux(es) escalated at 4 calls; no working answer was offered to compare against." }
```

**That sentence is false.** `request.working_answer` in the same file is a thousand characters long. What was missing was the panel:

```json
"positions": [
  {"voice": "theorist",   "model": "sonnet", "answer": "", "failed": true},
  {"voice": "empiricist", "model": "sonnet", "answer": "", "failed": true},
  {"voice": "critic",     "model": "sonnet", "answer": "", "failed": true},
  {"voice": "pragmatist", "model": "sonnet", "answer": "", "failed": true}
]
```

`_summary_verdict` fell through to its last branch, which is reached whenever `changed == 0 and unchanged == 0`. That happens both when the agent offered no baseline *and* when the panel produced nothing — and it blames the agent either way. The per-position `failed` flags were recorded and then never read.

**Reading only the summary would send someone to tighten the escalation prompt** — fixing a problem that does not exist, while the outage goes unnoticed. That is a worse failure than being silent.

## The distinction

| Situation | Verdict now |
|:---|:---|
| Every voice failed, every crux | *not one panel could be convened … it was never tried* |
| Every voice failed on some cruxes | *N never reached a panel … the remaining M are the only ones this run can speak to* |
| Some voices failed, panel still sat | ordinary verdict + the unreachable count |
| No voice failed, no answer emerged | **unchanged** — a real outcome |

The rule turns on `all` versus `any`. *Every* voice failing means no panel; *a* voice failing means a smaller panel that still deliberated, and writing that off would subtract a real result from the evidence.

`ideation_panel.py` had the same shape — `"No candidate hypotheses survived; the stage proceeds without a pool."` for an empty pool whether the proposers ran or never answered. It tracked `unreachable` in the dict but never passed it to the verdict sentence.

`review_panel.py` already handled this correctly and is untouched; this brings the other two to parity.

## The run is not stopped

Deliberation is an optional aid, and a stage keeping its own answer is legitimate degradation — unlike a stage *operator* that cannot be reached, where the run has no findings at all and #163 stops it. **The requirement here is visibility, not refusal.** Aborting a run because an optional thinking aid was unreachable would be the same over-correction #163's false-positive analysis warned against.

## Verification

1,706 tests, 19 new. The fixture is the captured payload from the live run, **verbatim**, with one test asserting the fixture really is a total outage so a future regeneration from a healthy run cannot make the others pass for the wrong reason.

| Mutant | Killed |
|:---|:---|
| drop the never-sat branch | 1 |
| `all` → `any` in the outage test | 1 |
| never-sat detector always False | 4 |
| empty-positions guard removed | 1 |
| ideation outage branch removed | 2 |
| ideation `>=` → `>` | 1 |
| ideation partial-outage suffix dropped | 1 |

**`all` → `any` first survived.** Every mixed-ledger test used a uniform `failed` value across positions, so `all` and `any` agreed on every input — the case the rule exists for was untested. Added it; it now kills.

One mutant survived legitimately: `max(seated, 1)` → `seated`. The truthiness check already guarantees `unreachable >= 1`, so the `max` was dead. Removed rather than tested around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)