### PR TITLE
Reuse a settled crux instead of re-arguing it

### DIFF
--- a/docs/deliberation.md
+++ b/docs/deliberation.md
@@ -114,6 +114,37 @@ panel asked it writes essays.
 
 Every position from every voice is kept, including the ones the resolution rejected.
 
+## A crux asked twice is one crux
+
+The same live run put the **identical** question to the panel on two consecutive attempts of
+one stage — byte-for-byte the same string, four voice calls each, and `cruxes_raised: 2`.
+
+The cause is structural, not a model quirk. A stage that fails its gate is sent back with the
+state it already had, regenerates its escalation from that state, and asks the same thing
+again. With the default `--max-deliberations 3` the budget is gone after three attempts of a
+single stage, and a genuinely new crux in Stage 04 is then refused.
+
+So before deliberating, the ledger is checked for the same question:
+
+- **Already answered** → the stored answer is handed straight back. No panel, no budget, no
+  second entry in the ledger. Re-asking a settled question is the stage failing to notice it
+  has the answer, not the run needing more thinking.
+- **Asked before but never answered** → the panel is called again. A panel that could not be
+  reached last time may be reachable now, and one outage should not permanently silence a crux.
+
+`REPEAT_THRESHOLD` is 0.6, calibrated against real questions rather than guessed:
+
+| Pair | Similarity |
+|:---|---:|
+| verbatim re-escalation across attempts *(the observed failure)* | 1.00 |
+| paraphrase of the same question | 0.34 |
+| narrowed follow-up that builds on the answer — a **new** crux | 0.21 |
+| a different crux from the same stage | 0.06 |
+
+0.6 sits well above the paraphrase, deliberately. Suppressing a deliberation the agent actually
+needed costs correctness; re-arguing a paraphrase costs four calls. **The threshold is set to
+fail in the cheap direction**, which means a heavy paraphrase will still be re-argued.
+
 ## When no voice answers
 
 A panel that could not be convened and a panel that convened and added nothing are different

--- a/src/deliberation.py
+++ b/src/deliberation.py
@@ -612,6 +612,58 @@ def format_resolution_for_prompt(resolutions: list[Resolution]) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
+#: How alike two crux questions must read before the second is treated as a repeat.
+#: Calibrated on the questions from a live run rather than guessed:
+#:
+#:     verbatim re-escalation across attempts   1.00   <- the observed failure
+#:     paraphrase of the same question          0.34
+#:     narrowed follow-up that builds on the    0.21
+#:       answer, i.e. a genuinely new crux
+#:     a different crux from the same stage     0.06
+#:
+#: 0.6 sits well above the paraphrase, which is deliberate. Suppressing a deliberation
+#: the agent actually needed costs correctness; paying four calls to re-argue a paraphrase
+#: costs four calls. The threshold is set to fail in the cheap direction.
+REPEAT_THRESHOLD = 0.6
+
+
+def read_ledger(paths: RunPaths) -> list[dict[str, Any]]:
+    """Every crux this run has already put to a panel. Empty when there is no ledger yet."""
+    path = paths.reviews_dir / LEDGER_FILENAME
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(read_text(path))
+    except (OSError, json.JSONDecodeError):
+        return []
+    entries = payload.get("deliberations") if isinstance(payload, dict) else None
+    return [entry for entry in entries if isinstance(entry, dict)] if isinstance(entries, list) else []
+
+
+def settled_answer(entries: list[dict[str, Any]], request: CruxRequest) -> dict[str, Any] | None:
+    """An earlier deliberation of the same question that actually produced an answer.
+
+    A stage that fails its gate is sent back, regenerates its escalation from the same state,
+    and asks the identical question again. Re-running the panel on a question it has already
+    settled spends the budget re-deriving an answer already on disk, and the ledger then counts
+    it as a second crux — inflating the very number that is supposed to say how much thinking
+    the run needed.
+
+    Returns None when the question is new, or when the earlier attempt produced nothing: a
+    panel that could not be reached last time may be reachable now, and that retry is fair.
+    """
+    from .ideation_panel import similarity
+
+    for entry in reversed(entries):
+        prior = entry.get("request")
+        if not isinstance(prior, dict) or not str(entry.get("answer") or "").strip():
+            continue
+        question = str(prior.get("question") or "")
+        if question and similarity(question, request.question) >= REPEAT_THRESHOLD:
+            return entry
+    return None
+
+
 def record_resolution(paths: RunPaths, stage: StageSpec, resolution: Resolution) -> dict[str, Any]:
     """Persist the crux, every position, and whether escalating changed anything."""
     path = paths.reviews_dir / LEDGER_FILENAME

--- a/src/manager.py
+++ b/src/manager.py
@@ -125,11 +125,14 @@ from .terminal_ui import TerminalUI
 from .platform.foundry import generate_paper_package, generate_release_package
 from .deliberation import (
     CruxPanel,
+    Resolution,
     clear_requests,
     escalation_offer,
     format_resolution_for_prompt,
+    read_ledger,
     read_requests,
     record_resolution,
+    settled_answer,
 )
 from .effort import (
     Concentration,
@@ -1005,7 +1008,34 @@ class ResearchManager:
         clear_requests(paths)
 
         resolutions = []
+        already = read_ledger(paths)
         for request in requests:
+            settled = settled_answer(already, request)
+            if settled is not None:
+                # Hand the stored answer back rather than re-deriving it. The panel is not
+                # called, the budget is not touched, and the ledger is not given a second
+                # crux to count -- re-asking a settled question is the stage failing to
+                # notice it has the answer, not the run needing more deliberation.
+                append_log_entry(
+                    paths.logs,
+                    f"{stage.slug} crux_already_settled",
+                    f"question: {request.question}\nReused the answer from an earlier "
+                    f"attempt; the panel was not reconvened.",
+                )
+                self.ui.show_status(
+                    "This crux was already settled on an earlier attempt; reusing that answer.",
+                    level="info",
+                )
+                resolutions.append(
+                    Resolution(
+                        request=request,
+                        answer=str(settled.get("answer") or ""),
+                        reason=str(settled.get("reason") or ""),
+                        falsifier=str(settled.get("falsifier") or ""),
+                        dissent=str(settled.get("dissent") or ""),
+                    )
+                )
+                continue
             if self.crux_panel.budget_left == 0:
                 append_log_entry(
                     paths.logs,

--- a/tests/test_crux_repeat.py
+++ b/tests/test_crux_repeat.py
@@ -1,0 +1,252 @@
+"""A crux asked twice is one crux.
+
+A live run put the identical question to the panel on two consecutive stage attempts. Both
+escalations were byte-for-byte the same string, both spent four voice calls, and the ledger
+recorded ``cruxes_raised: 2`` -- inflating the one number that is supposed to say how much
+deliberation the run actually needed.
+
+The cause is structural rather than a model quirk. A stage that fails its gate is sent back
+with the same state it had before, regenerates its escalation from that state, and asks the
+same thing again. With ``--max-deliberations 3`` the budget is exhausted after three attempts
+of a single stage, and a genuinely new crux in Stage 04 is then refused.
+
+The threshold is calibrated in ``REPEAT_THRESHOLD``'s comment against questions from that run.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+import json
+from pathlib import Path
+
+from src.deliberation import (
+    REPEAT_THRESHOLD,
+    CruxRequest,
+    Position,
+    Resolution,
+    read_ledger,
+    record_resolution,
+    settled_answer,
+)
+from src.ideation_panel import similarity
+from src.utils import build_run_paths, resolve_stage
+
+QUESTION = (
+    "For a three-way comparison of LASSO, ridge and elastic net on selection stability, what "
+    "should count as 'variable j was selected' for ridge, which never sets a coefficient to "
+    "zero? Specifically: should the primary estimand be (a) top-k support with k matched "
+    "per-resample to the lasso's cardinality, (b) rank agreement only, with no notion of a "
+    "selected set, or (c) an absolute threshold on |beta-hat|?"
+)
+FOLLOW_UP = (
+    "We settled on matched-cardinality top-k for ridge. Should k be matched per-resample to "
+    "the lasso, or fixed at the full-sample lasso cardinality?"
+)
+UNRELATED = (
+    "How should the penalty parameter be chosen for each regularizer -- one nested CV per "
+    "bootstrap resample, or a single penalty fixed on the full sample and reused?"
+)
+
+
+def _entry(question: str, *, answer: str) -> dict:
+    return {"request": {"question": question}, "answer": answer}
+
+
+class SettledAnswerTest(unittest.TestCase):
+    def test_the_verbatim_repeat_from_the_live_run_is_recognised(self) -> None:
+        found = settled_answer(
+            [_entry(QUESTION, answer="Use matched-cardinality top-k.")],
+            CruxRequest(question=QUESTION),
+        )
+        self.assertIsNotNone(found)
+        self.assertEqual(found["answer"], "Use matched-cardinality top-k.")
+
+    def test_an_unanswered_earlier_attempt_does_not_block_a_retry(self) -> None:
+        # The live run's two entries both had an empty answer because every voice failed.
+        # A panel that could not be reached last time may be reachable now; suppressing the
+        # retry would mean one outage permanently silences a crux.
+        self.assertIsNone(
+            settled_answer([_entry(QUESTION, answer="")], CruxRequest(question=QUESTION))
+        )
+
+    def test_a_whitespace_only_answer_is_not_an_answer(self) -> None:
+        self.assertIsNone(
+            settled_answer([_entry(QUESTION, answer="   \n ")], CruxRequest(question=QUESTION))
+        )
+
+    def test_a_different_crux_from_the_same_stage_is_not_a_repeat(self) -> None:
+        self.assertIsNone(
+            settled_answer([_entry(QUESTION, answer="an answer")], CruxRequest(question=UNRELATED))
+        )
+
+    def test_a_narrowed_follow_up_is_a_new_question_not_a_repeat(self) -> None:
+        # The boundary that matters. A follow-up that builds on the answer shares vocabulary
+        # with the original but asks something the original did not settle. Treating it as a
+        # repeat would hand back an answer that does not address it.
+        self.assertIsNone(
+            settled_answer([_entry(QUESTION, answer="an answer")], CruxRequest(question=FOLLOW_UP))
+        )
+
+    def test_the_threshold_sits_above_the_follow_up_with_room(self) -> None:
+        # Pins the calibration rather than the number: the rule only holds while the
+        # follow-up scores clearly below the threshold.
+        self.assertLess(similarity(QUESTION, FOLLOW_UP) + 0.2, REPEAT_THRESHOLD)
+        self.assertGreaterEqual(similarity(QUESTION, QUESTION), REPEAT_THRESHOLD)
+
+    def test_the_most_recent_settled_answer_wins(self) -> None:
+        found = settled_answer(
+            [_entry(QUESTION, answer="first"), _entry(QUESTION, answer="second")],
+            CruxRequest(question=QUESTION),
+        )
+        self.assertEqual(found["answer"], "second")
+
+    def test_a_malformed_entry_is_skipped_not_raised(self) -> None:
+        self.assertIsNone(
+            settled_answer(
+                [{"request": "not a dict", "answer": "x"}, {"answer": "y"}],
+                CruxRequest(question=QUESTION),
+            )
+        )
+
+    def test_an_empty_ledger_settles_nothing(self) -> None:
+        self.assertIsNone(settled_answer([], CruxRequest(question=QUESTION)))
+
+
+class ReadLedgerTest(unittest.TestCase):
+    def test_a_missing_ledger_is_empty_not_an_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(read_ledger(build_run_paths(Path(tmp))), [])
+
+    def test_a_corrupt_ledger_is_empty_not_an_error(self) -> None:
+        # A run must not die because a JSON file it writes for its own bookkeeping got
+        # truncated. Losing the dedup is the correct cost.
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = build_run_paths(Path(tmp))
+            paths.reviews_dir.mkdir(parents=True, exist_ok=True)
+            (paths.reviews_dir / "deliberations.json").write_text("{not json")
+            self.assertEqual(read_ledger(paths), [])
+
+    def test_a_ledger_with_a_non_list_body_is_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = build_run_paths(Path(tmp))
+            paths.reviews_dir.mkdir(parents=True, exist_ok=True)
+            (paths.reviews_dir / "deliberations.json").write_text('{"deliberations": "nope"}')
+            self.assertEqual(read_ledger(paths), [])
+
+    def test_a_recorded_resolution_round_trips_and_short_circuits_the_repeat(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = build_run_paths(Path(tmp))
+            paths.reviews_dir.mkdir(parents=True, exist_ok=True)
+            stage = resolve_stage("01")
+            record_resolution(
+                paths,
+                stage,
+                Resolution(
+                    request=CruxRequest(question=QUESTION, stage_slug=stage.slug),
+                    positions=[Position(voice="theorist", title="T", backend="claude",
+                                        model="sonnet", answer="top-k")],
+                    answer="Use matched-cardinality top-k.",
+                    voice_calls=4,
+                ),
+            )
+            entries = read_ledger(paths)
+            self.assertEqual(len(entries), 1)
+            self.assertIsNotNone(settled_answer(entries, CruxRequest(question=QUESTION)))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ManagerReusesASettledCruxTest(unittest.TestCase):
+    """The behaviour change: the panel is not reconvened, and the budget is not touched."""
+
+    def _manager(self):
+        import io
+        from unittest.mock import MagicMock
+        from src.manager import ResearchManager
+        from src.terminal_ui import TerminalUI
+        from src.utils import ensure_run_config, ensure_run_layout, write_text
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        runs_dir = Path(tmp.name) / "runs"
+        runs_dir.mkdir()
+        paths = build_run_paths(runs_dir / "20260101_000000")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Goal")
+        write_text(paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025")
+        operator = MagicMock()
+        operator.model, operator.backend_name = "sonnet", "claude"
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=runs_dir,
+            operator=operator,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        panel = MagicMock()
+        panel.budget_left = 3
+        manager.crux_panel = panel
+        return manager, paths, panel
+
+    def _raise_crux(self, paths, question: str) -> None:
+        from src.deliberation import REQUEST_FILENAME
+        from src.utils import write_text
+
+        write_text(
+            paths.notes_dir / REQUEST_FILENAME,
+            json.dumps({"question": question, "working_answer": "my best guess"}),
+        )
+
+    def _settle(self, paths, answer: str) -> None:
+        record_resolution(
+            paths,
+            resolve_stage("01"),
+            Resolution(request=CruxRequest(question=QUESTION), answer=answer, voice_calls=4),
+        )
+
+    def test_the_panel_is_not_reconvened_for_a_question_already_answered(self) -> None:
+        manager, paths, panel = self._manager()
+        self._settle(paths, "Use matched-cardinality top-k.")
+        self._raise_crux(paths, QUESTION)
+
+        feedback = manager._settle_cruxes(paths, resolve_stage("01"), 2)
+
+        panel.deliberate.assert_not_called()
+        self.assertIsNotNone(feedback)
+        self.assertEqual(len(manager._crux_resolutions), 1)
+        self.assertEqual(
+            manager._crux_resolutions[0].answer, "Use matched-cardinality top-k."
+        )
+
+    def test_the_reused_answer_does_not_add_a_second_crux_to_the_ledger(self) -> None:
+        # The count the live run inflated. Reusing must not look like more deliberation.
+        manager, paths, panel = self._manager()
+        self._settle(paths, "Use matched-cardinality top-k.")
+        self._raise_crux(paths, QUESTION)
+
+        manager._settle_cruxes(paths, resolve_stage("01"), 2)
+
+        self.assertEqual(len(read_ledger(paths)), 1)
+
+    def test_a_new_question_still_reaches_the_panel(self) -> None:
+        manager, paths, panel = self._manager()
+        self._settle(paths, "Use matched-cardinality top-k.")
+        self._raise_crux(paths, UNRELATED)
+        panel.deliberate.return_value = None
+
+        manager._settle_cruxes(paths, resolve_stage("01"), 2)
+
+        panel.deliberate.assert_called_once()
+
+    def test_an_unanswered_earlier_crux_still_reaches_the_panel(self) -> None:
+        manager, paths, panel = self._manager()
+        self._settle(paths, "")
+        self._raise_crux(paths, QUESTION)
+        panel.deliberate.return_value = None
+
+        manager._settle_cruxes(paths, resolve_stage("01"), 2)
+
+        panel.deliberate.assert_called_once()


### PR DESCRIPTION
Second finding from the same live run as [#167](https://github.com/tangxiangru/AutoR/pull/167).

## What happened

The stage put the **identical** question to the panel on two consecutive attempts:

```json
"summary": { "cruxes_raised": 2, "voice_calls": 8, ... }
```

Both `request.question` strings are byte-for-byte the same. Eight voice calls, one question.

The cause is structural rather than a model quirk. A stage that fails its gate is sent back with the state it already had, regenerates its escalation from that state, and asks the same thing again. Nothing in `_settle_cruxes` looks at what the run has already deliberated.

**The resource this wastes is the exact one the feature is rationed on.** With the default `--max-deliberations 3`, three failed attempts of a single stage exhaust the budget, and a genuinely new crux in Stage 04 is then refused — the run spends its entire thinking allowance re-asking one question and has nothing left for the one that mattered.

It also corrupts the ledger's own number: `cruxes_raised: 2` overstates how much deliberation the run needed, which is the statistic the whole falsifiability apparatus exists to report honestly.

## The rule

| Prior state of the same question | Now |
|:---|:---|
| Already answered | stored answer handed straight back — no panel, no budget, no second ledger entry |
| Asked before, never answered | panel called again |

The second row is deliberate. Both entries in the observed run had an empty answer because every voice had failed (that is #167). A panel unreachable on attempt 1 may be reachable on attempt 2, and **one outage should not permanently silence a crux.**

## The threshold is calibrated, not guessed

`REPEAT_THRESHOLD = 0.6`, measured against real questions from the run:

| Pair | Similarity |
|:---|---:|
| verbatim re-escalation across attempts *(the observed failure)* | 1.00 |
| paraphrase of the same question | 0.34 |
| narrowed follow-up that builds on the answer — a **new** crux | 0.21 |
| a different crux from the same stage | 0.06 |

The hard boundary is paraphrase (0.34) against follow-up (0.21) — only 0.13 apart, and Jaccard over content words is noisy there. So 0.6 sits well above both.

**That means a heavy paraphrase is still re-argued, on purpose.** Suppressing a deliberation the agent actually needed costs correctness; re-arguing a paraphrase costs four calls. The threshold fails in the cheap direction, and the doc says so rather than implying the rule is tight.

A test pins the calibration (`similarity(question, follow_up) + 0.2 < REPEAT_THRESHOLD`) rather than the literal number, so the rule breaks loudly if `similarity` is ever retuned.

## Verification

1,723 tests, 17 new.

| Mutant | Killed |
|:---|:---|
| short-circuit removed, panel reconvened *(the original bug)* | 2 |
| reuse the answer but call the panel anyway | 2 |
| ledger always read as empty | 2 |
| answered-check dropped — an unanswered crux blocks its own retry | 2 |
| threshold → 0.2, a follow-up reads as a repeat | 2 |
| threshold → 1.01, nothing is ever a repeat | 4 |
| `reversed()` dropped, the oldest answer wins | 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)