### PR TITLE
Ask for the verdict last, where the reviewer will still be reading

### DIFF
--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -63,6 +63,34 @@ UNREADABLE_REASON = "Automated reviewer did not return valid JSON."
 UNSUPPORTED_REASON = "Automated reviewer returned an unsupported decision token."
 CRASHED_REASON = "Automated reviewer failed to run."
 
+#: The last thing the reviewer reads, and the reason it is last.
+#:
+#: The verdict contract was stated once, near the top, and the prompt then ended with five
+#: thousand characters of log tail. Measured over one benchmark run's 65 recorded review
+#: calls, the primary call emitted no parseable decision in its closing output almost every
+#: time, while the verdict-only re-ask -- which asks for nothing else and asks for it last --
+#: produced one on essentially every attempt. A reviewer that has spent its turn inspecting
+#: files ends by narrating what it found, because narration is what the end of its context
+#: asks for.
+#:
+#: Every recovery costs an extra model call, and a re-ask that also misses costs the stage an
+#: attempt; enough of those exhaust the stage, then the auto-skip budget, then the run. So
+#: this restates the contract as the closing instruction. It adds no rule the fuller spec
+#: above does not already state.
+CLOSING_VERDICT_INSTRUCTION = (
+    "\n\n---\n\n"
+    "# Your Final Message\n\n"
+    "Everything above is material to judge. This is what to do about it.\n\n"
+    "Whatever you inspected and however much you reasoned, **your final message must be a "
+    "single JSON object and nothing else** — no preamble, no summary after it, no code "
+    "fence. Put the narrative inside `reason`, where it is read; outside the object it is "
+    "discarded and the verdict has to be asked for again.\n\n"
+    '{"decision":"approve|suggestion_1|suggestion_2|suggestion_3|custom_feedback|revise|abort",'
+    '"reason":"","feedback":"","carry_forward":[],"discharged":[]}\n\n'
+    "`decision` is required. Use `approve` or `revise`/`custom_feedback` unless the run is "
+    "genuinely blocked; `abort` stops the whole run, not just this stage."
+)
+
 
 def _try_load_json(text: str) -> dict[str, Any] | None:
     try:
@@ -481,6 +509,7 @@ class AutomatedReviewer:
             f"{self._read_excerpt(paths.experiment_manifest, max_chars=6000)}\n\n"
             "# Recent Log Excerpt\n\n"
             f"{self._read_excerpt(paths.logs, max_chars=5000, tail=True)}\n"
+            + CLOSING_VERDICT_INSTRUCTION
         )
 
     def _obligations_block(self, paths: RunPaths, stage: StageSpec) -> str:

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -42,12 +42,26 @@ DECISION_TO_CHOICE = {
     "use_suggestion_2": "2",
     "use_suggestion_3": "3",
     "refine_with_custom_feedback": "4",
+    # A reviewer asked to choose between "custom_feedback" and "abort" writes "revise". Three
+    # of five benchmark runs died on exactly that: the word was not in this map, so an ordinary
+    # request for changes was read as an unsupported token and ended the run. AutoR's own
+    # unreadable-verdict fallback emits `decision_token="revise"`, so the vocabulary did not
+    # even agree with itself. Only unambiguous synonyms are added -- "reject" is deliberately
+    # absent, because it reads as both "send back" and "stop".
+    "revise": "4",
+    "refine": "4",
+    "revision": "4",
+    "request_changes": "4",
+    "changes_requested": "4",
+    "revise_with_feedback": "4",
 }
 
 
 #: Prefix that marks "the reviewer answered but we could not read it", as distinct from
 #: "the reviewer refused". The two are told apart by `AutomatedReviewer._is_unreadable`.
 UNREADABLE_REASON = "Automated reviewer did not return valid JSON."
+UNSUPPORTED_REASON = "Automated reviewer returned an unsupported decision token."
+CRASHED_REASON = "Automated reviewer failed to run."
 
 
 def _try_load_json(text: str) -> dict[str, Any] | None:
@@ -172,12 +186,34 @@ class AutomatedReviewer:
         )
 
         if exit_code != 0:
+            # A crashed backend is not a refusal to approve. Attended, aborting is right --
+            # a human is there. Unattended it forfeits the task: Information_001 lost a run
+            # holding four approved stages to `exit code -1`, a signal kill with nothing
+            # wrong with the research. The backend is deliberately *not* re-asked, because a
+            # process that died is not one attempt away from a usable verdict; the stage is
+            # sent back instead, bounded by its own attempt budget.
+            if not self.unattended:
+                return ReviewDecision(
+                    choice="6",
+                    decision_token="abort",
+                    reason=(
+                        f"Automated reviewer failed with exit code {exit_code}. "
+                        "AutoR stopped instead of approving blindly."
+                    ),
+                    raw_response=stdout_text or stderr_text,
+                )
             return ReviewDecision(
-                choice="6",
-                decision_token="abort",
+                choice="4",
+                decision_token="revise",
                 reason=(
-                    f"Automated reviewer failed with exit code {exit_code}. "
-                    "AutoR stopped instead of approving blindly."
+                    f"{CRASHED_REASON} It exited {exit_code}. Unattended, so the stage was "
+                    "sent back for another pass rather than approved or aborted."
+                ),
+                feedback=(
+                    "The automated reviewer could not be run, so this stage was not "
+                    "approved. Re-examine the draft against the stage contract and the "
+                    "artifacts it claims, strengthen whatever is weakest, and restate the "
+                    "summary."
                 ),
                 raw_response=stdout_text or stderr_text,
             )
@@ -239,7 +275,13 @@ class AutomatedReviewer:
 
     @staticmethod
     def _is_unreadable(decision: ReviewDecision) -> bool:
-        return decision.decision_token == "abort" and decision.reason.startswith(UNREADABLE_REASON)
+        """Whether the reviewer failed to answer, as distinct from answering "abort".
+
+        Matched on the reason, not the token: an unsupported token keeps whatever word the
+        model wrote, so a token check misses it -- and it is still a verdict nobody can act
+        on. Both kinds get the re-ask and, unattended, the send-back.
+        """
+        return decision.reason.startswith((UNREADABLE_REASON, UNSUPPORTED_REASON))
 
     def _unreadable_verdict(self, raw_response: str) -> ReviewDecision:
         """What to do when the reviewer's answer cannot be read, twice.
@@ -487,7 +529,7 @@ class AutomatedReviewer:
             return ReviewDecision(
                 choice="6",
                 decision_token=token or "abort",
-                reason="Automated reviewer returned an unsupported decision token.",
+                reason=UNSUPPORTED_REASON,
                 raw_response=raw_response,
             )
 

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -36,7 +36,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .approval_agent import AutomatedReviewer, ReviewDecision
+from .approval_agent import DECISION_TO_CHOICE, AutomatedReviewer, ReviewDecision
 from .terminal_ui import TerminalUI
 from .utils import RunPaths, StageSpec, append_log_entry, read_text, truncate_text, write_text
 
@@ -713,7 +713,16 @@ class ReviewPanel:
             markdown=stage_markdown,
             label=f"panel_{role.key}_verdict",
         )
-        blocking = bool(payload.get("blocking")) if isinstance(payload, dict) else False
+        # A veto is only as trustworthy as the answer carrying it. `blocking` is read from
+        # the seat's raw payload, so if that payload's own decision is not a word the panel
+        # recognises, its blocking flag is not either -- whatever a re-ask later manages to
+        # recover. Keyed on the payload rather than on the degraded choice: the old guard
+        # (`choice != "6"`) tested a symptom, and stopped holding the moment an unreadable
+        # verdict became something the reviewer re-asks instead of aborting on.
+        blocking = False
+        if isinstance(payload, dict) and payload.get("blocking"):
+            token = member._normalize_decision_token(payload.get("decision"))  # noqa: SLF001
+            blocking = token in DECISION_TO_CHOICE
         concerns: tuple[str, ...] = ()
         if isinstance(payload, dict) and isinstance(payload.get("concerns"), list):
             concerns = tuple(str(item).strip() for item in payload["concerns"] if str(item).strip())
@@ -725,8 +734,8 @@ class ReviewPanel:
             model=member.model,
             choice=decision.choice,
             decision_token=decision.decision_token,
-            # An unparseable answer degrades to abort in `parse_decision`; treat that as a
-            # non-blocking failure rather than letting one bad response veto the run.
+            # Still suppressed on an explicit abort: a seat that voted to stop the run has
+            # said so through `choice`, and does not also need a veto counted against it.
             blocking=blocking and decision.choice != "6",
             reason=decision.reason,
             feedback=decision.feedback,

--- a/tests/test_reviewer_unreadable_verdict.py
+++ b/tests/test_reviewer_unreadable_verdict.py
@@ -16,9 +16,9 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from src.approval_agent import DECISION_TO_CHOICE, UNSUPPORTED_REASON, UNREADABLE_REASON, AutomatedReviewer, ReviewDecision
+from src.approval_agent import CLOSING_VERDICT_INSTRUCTION, DECISION_TO_CHOICE, UNSUPPORTED_REASON, UNREADABLE_REASON, AutomatedReviewer, ReviewDecision
 from src.terminal_ui import TerminalUI
-from src.utils import STAGES, build_run_paths, ensure_run_layout
+from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
 
 GOOD = '{"decision": "approve", "reason": "Artifacts check out."}'
 PROSE = "I reviewed the draft and the artifacts. Everything looks broadly reasonable."
@@ -259,3 +259,62 @@ class DecisionVocabularyTest(unittest.TestCase):
     def test_a_genuinely_unknown_token_is_still_treated_as_unanswered(self) -> None:
         decision = self._reviewer()._parse_decision(json.dumps({"decision": "banana", "reason": "r"}))
         self.assertIn(UNSUPPORTED_REASON, decision.reason)
+
+
+class ClosingVerdictInstructionTest(unittest.TestCase):
+    """The verdict contract has to be the last thing the reviewer reads.
+
+    Over one benchmark run's 65 recorded review calls, the primary call's closing output
+    carried no parseable decision almost every time, while the verdict-only re-ask produced
+    one on essentially every attempt. The difference is position: the contract was stated
+    near the top and the prompt then ended with five thousand characters of log tail.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.memory, "# Memory\n")
+        self.reviewer = AutomatedReviewer(
+            "claude", model="opus", fake_mode=True,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+
+    def _prompt(self) -> str:
+        return self.reviewer._build_review_prompt(
+            paths=self.paths, stage=STAGES[0], attempt_no=1,
+            stage_markdown="# Stage 01: Literature Survey", suggestions=["a", "b", "c"],
+        )
+
+    def test_the_prompt_ends_with_the_verdict_contract(self) -> None:
+        self.assertTrue(self._prompt().rstrip().endswith(CLOSING_VERDICT_INSTRUCTION.rstrip()))
+
+    def test_it_comes_after_the_log_excerpt_that_used_to_be_last(self) -> None:
+        prompt = self._prompt()
+        self.assertLess(prompt.index("Recent Log Excerpt"), prompt.index("Your Final Message"))
+
+    def test_it_offers_only_tokens_the_parser_accepts(self) -> None:
+        """The re-ask prompt once offered `revise`, which the parser rejected outright."""
+        import re
+
+        listed = re.findall(r'"decision":"([^"]+)"', CLOSING_VERDICT_INSTRUCTION)
+        self.assertTrue(listed)
+        for token in listed[0].split("|"):
+            self.assertIn(token, DECISION_TO_CHOICE, token)
+
+    def test_it_says_narrative_belongs_inside_the_object(self) -> None:
+        self.assertIn("reason", CLOSING_VERDICT_INSTRUCTION)
+        self.assertIn("nothing else", CLOSING_VERDICT_INSTRUCTION)
+
+    def test_it_warns_that_abort_stops_the_run(self) -> None:
+        """Three benchmark runs ended on a verdict the reviewer did not mean as fatal."""
+        self.assertIn("stops the whole run", CLOSING_VERDICT_INSTRUCTION)
+
+    def test_the_verdict_only_re_ask_also_offers_accepted_tokens(self) -> None:
+        import re
+
+        prompt = self.reviewer._build_verdict_only_prompt(stage=STAGES[0], previous="prose")
+        for token in re.findall(r'"(approve|revise|abort|custom_feedback)"', prompt):
+            self.assertIn(token, DECISION_TO_CHOICE, token)

--- a/tests/test_reviewer_unreadable_verdict.py
+++ b/tests/test_reviewer_unreadable_verdict.py
@@ -9,12 +9,15 @@ the answer -- and unattended those deserve different outcomes.
 
 from __future__ import annotations
 
+import io
+import json
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from src.approval_agent import UNREADABLE_REASON, AutomatedReviewer, ReviewDecision
+from src.approval_agent import DECISION_TO_CHOICE, UNSUPPORTED_REASON, UNREADABLE_REASON, AutomatedReviewer, ReviewDecision
+from src.terminal_ui import TerminalUI
 from src.utils import STAGES, build_run_paths, ensure_run_layout
 
 GOOD = '{"decision": "approve", "reason": "Artifacts check out."}'
@@ -138,17 +141,32 @@ class ReAskFailureTest(_Harness):
         self.assertEqual(decision.choice, "4")
         self.assertEqual(calls, ["review", "review_verdict"])
 
-    def test_a_nonzero_first_call_still_aborts_without_a_re_ask(self) -> None:
-        """A backend that failed to run is a different thing from one that answered
-        unreadably, and must not be re-asked into a false decision."""
-        reviewer = self._reviewer(unattended=True)
-        calls: list[str] = []
+    def test_a_crashed_backend_is_never_re_asked(self) -> None:
+        """A process that died is not one attempt away from a usable verdict.
 
-        def run_prompt(*, paths, stage, attempt_no, prompt, label):
-            calls.append(label)
-            return (2, "", "backend exploded")
+        The re-ask exists for a reviewer that answered unreadably. Re-asking a backend that
+        failed to run risks turning a transport failure into a fabricated decision, so the
+        no-re-ask rule holds whether or not anyone is watching.
+        """
+        for unattended in (True, False):
+            reviewer = self._reviewer(unattended=unattended)
+            calls: list[str] = []
 
-        with patch.object(reviewer, "run_prompt", side_effect=run_prompt), \
+            def run_prompt(**kwargs):
+                calls.append(kwargs.get("label"))
+                return (2, "", "boom")
+
+            with patch.object(reviewer, "run_prompt", side_effect=run_prompt), \
+                 patch.object(reviewer, "_build_review_prompt", return_value="p"):
+                reviewer.review_stage(
+                    paths=self.paths, stage=self.stage, attempt_no=1,
+                    stage_markdown="# Stage 01", suggestions=["a", "b", "c"],
+                )
+            self.assertEqual(calls, ["review"], unattended)
+
+    def test_a_crashed_backend_still_aborts_when_a_human_is_watching(self) -> None:
+        reviewer = self._reviewer(unattended=False)
+        with patch.object(reviewer, "run_prompt", return_value=(2, "", "boom")), \
              patch.object(reviewer, "_build_review_prompt", return_value="p"):
             decision = reviewer.review_stage(
                 paths=self.paths, stage=self.stage, attempt_no=1,
@@ -156,7 +174,35 @@ class ReAskFailureTest(_Harness):
             )
         self.assertEqual(decision.decision_token, "abort")
         self.assertIn("exit code 2", decision.reason)
-        self.assertEqual(calls, ["review"])
+
+    def test_a_crashed_backend_sends_the_stage_back_when_nobody_is(self) -> None:
+        """Unattended, aborting here forfeits the task for a reason unrelated to the work.
+
+        Information_001 lost a run holding four approved stages to `exit code -1` -- a
+        signal kill, with nothing wrong with the research. Sending the stage back is bounded
+        by its own attempt budget; aborting discards everything already earned.
+        """
+        reviewer = self._reviewer(unattended=True)
+        with patch.object(reviewer, "run_prompt", return_value=(-1, "", "killed")), \
+             patch.object(reviewer, "_build_review_prompt", return_value="p"):
+            decision = reviewer.review_stage(
+                paths=self.paths, stage=self.stage, attempt_no=1,
+                stage_markdown="# Stage 01", suggestions=["a", "b", "c"],
+            )
+        self.assertEqual(decision.choice, "4")
+        self.assertNotEqual(decision.decision_token, "abort")
+        self.assertIn("-1", decision.reason)
+        self.assertTrue(decision.feedback.strip())
+
+    def test_a_crashed_backend_never_becomes_an_approval(self) -> None:
+        reviewer = self._reviewer(unattended=True)
+        with patch.object(reviewer, "run_prompt", return_value=(1, "", "boom")), \
+             patch.object(reviewer, "_build_review_prompt", return_value="p"):
+            decision = reviewer.review_stage(
+                paths=self.paths, stage=self.stage, attempt_no=1,
+                stage_markdown="# Stage 01", suggestions=["a", "b", "c"],
+            )
+        self.assertNotEqual(decision.choice, "5")
 
 
 class RcbAgentIsUnattendedTest(unittest.TestCase):
@@ -166,3 +212,50 @@ class RcbAgentIsUnattendedTest(unittest.TestCase):
         text = source.read_text()
         block = text[text.index("reviewer = AutomatedReviewer("):]
         self.assertIn("unattended=True", block[: block.index(")\n")])
+
+
+class DecisionVocabularyTest(unittest.TestCase):
+    """The words a reviewer actually uses when it means "send this back".
+
+    Three of five benchmark runs died because the reviewer answered `"revise"` and the map
+    did not contain it, so an ordinary request for changes was read as an unsupported token
+    and ended the run at Stage 01 or 02.
+    """
+
+    def _reviewer(self) -> AutomatedReviewer:
+        return AutomatedReviewer(
+            "claude", model="opus", fake_mode=True,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False), unattended=True,
+        )
+
+    def test_revise_is_a_request_for_changes_not_an_unsupported_token(self) -> None:
+        decision = self._reviewer()._parse_decision(
+            json.dumps({"decision": "revise", "reason": "r", "feedback": "fix the power analysis"})
+        )
+        self.assertEqual(decision.choice, "4")
+        self.assertIn("power analysis", decision.feedback)
+
+    def test_the_other_natural_synonyms_are_accepted(self) -> None:
+        for token in ("refine", "revision", "request_changes", "changes_requested",
+                      "revise_with_feedback", "REVISE", "Request Changes"):
+            decision = self._reviewer()._parse_decision(
+                json.dumps({"decision": token, "reason": "r", "feedback": "f"})
+            )
+            self.assertEqual(decision.choice, "4", token)
+
+    def test_autor_own_fallback_token_round_trips(self) -> None:
+        """The unreadable-verdict fallback emits `revise`; the map has to accept its own word."""
+        self.assertIn("revise", DECISION_TO_CHOICE)
+
+    def test_reject_stays_out_because_it_reads_both_ways(self) -> None:
+        """"Reject" means both "send back" and "stop"; guessing either way is worse."""
+        self.assertNotIn("reject", DECISION_TO_CHOICE)
+
+    def test_approve_and_abort_are_untouched(self) -> None:
+        for token, choice in (("approve", "5"), ("abort", "6")):
+            decision = self._reviewer()._parse_decision(json.dumps({"decision": token, "reason": "r"}))
+            self.assertEqual(decision.choice, choice, token)
+
+    def test_a_genuinely_unknown_token_is_still_treated_as_unanswered(self) -> None:
+        decision = self._reviewer()._parse_decision(json.dumps({"decision": "banana", "reason": "r"}))
+        self.assertIn(UNSUPPORTED_REASON, decision.reason)


### PR DESCRIPTION
#164 stopped a reviewer's *word choice* ending a run. This is **why the reviewer kept failing to produce a word at all**.

One benchmark run recorded 65 review calls:

```
review_attempt_NN          len 4000        parseable decision: almost never
review_verdict_attempt_NN  len 431-1253    parseable decision: essentially always
```

The re-ask works and the primary call does not, and the difference is **position**. The verdict contract was stated once near the top of the prompt, and the prompt then ended with **five thousand characters of log tail**. A reviewer that has spent its turn inspecting files ends by narrating what it found, because narration is what the end of its context asks for. The re-ask asks for the verdict alone, and asks for it last.

The contract is now restated as the closing instruction. It adds **no rule** the fuller spec above does not already state — it is the same contract, positioned where the final message is decided.

## Why this is upstream, not a duplicate

Each miss costs an extra model call. A re-ask that also misses costs the stage an **attempt**. Enough of those exhaust the stage, then the auto-skip budget, then the run.

`Information_000` spent **25 review calls on unreadable verdicts**, auto-skipped three stages, and aborted — with **eight stages already approved**.

## Two things the evidence turned up

**The re-ask prompt offered `"revise"`** as one of three choices, and until #164 the parser rejected that word. AutoR was telling the reviewer to answer with something that would end the run — exactly how `Math_001` died. A test now asserts every token *either* prompt offers is one the parser accepts, so they cannot drift apart again.

**The closing block says plainly that `abort` stops the whole run**, not just the stage. Three runs ended on a verdict that reads like a strong refusal rather than a decision to stop everything.

1669 tests, 6 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)