### PR TITLE
Stop the result panel saying a call both failed and succeeded

### DIFF
--- a/src/terminal_ui.py
+++ b/src/terminal_ui.py
@@ -511,8 +511,18 @@ class TerminalUI:
         session_id = str(payload.get("session_id") or "unknown")
         title = "Claude Finished" if not is_error else "Claude Failed"
         color = self.FG_GREEN if not is_error else self.FG_RED
+        # The two fields come from different places and can disagree: a stream cut
+        # mid-response arrives as `is_error: true` with `subtype: "success"`,
+        # because the CLI did finish emitting. Rendering them independently
+        # produced the panel "Claude Failed / Status: success", which is the worst
+        # possible thing to read when reconstructing an unattended run hours later
+        # — it says both that the call failed and that it did not. Say which field
+        # is which instead of picking one.
+        status = subtype or ("error" if is_error else "success")
+        if is_error and subtype and subtype != "error":
+            status = f"{subtype} (the backend still flagged this call as failed)"
         body = [
-            f"Status     : {subtype or ('error' if is_error else 'success')}",
+            f"Status     : {status}",
             f"Turns      : {turns}",
             f"Duration   : {duration_ms / 1000:.1f}s",
             f"Session ID : {session_id}",

--- a/tests/test_result_panel.py
+++ b/tests/test_result_panel.py
@@ -1,0 +1,70 @@
+"""The result panel must not say a call both failed and succeeded.
+
+`is_error` and `subtype` come from different places in the CLI's stream-json and
+can disagree: a response cut mid-stream arrives as `is_error: true` with
+`subtype: "success"`, because the CLI did finish emitting. Rendered
+independently that produced
+
+    | Claude Failed          |
+    | Status     : success   |
+
+which is the worst thing to read when reconstructing an unattended run hours
+after it stopped — it asserts both that the call failed and that it did not.
+Encountered for real while diagnosing an aborted four-hour benchmark run.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+
+from src.terminal_ui import TerminalUI
+
+
+def _render(payload: dict) -> str:
+    stream = io.StringIO()
+    ui = TerminalUI(output_stream=stream)
+    ui._render_result_event(payload)  # noqa: SLF001
+    return stream.getvalue()
+
+
+class ResultPanelTest(unittest.TestCase):
+    def test_a_clean_success_reads_as_one(self) -> None:
+        text = _render({"subtype": "success", "is_error": False, "num_turns": 3})
+        self.assertIn("Claude Finished", text)
+        self.assertIn("success", text)
+        self.assertNotIn("flagged", text)
+
+    def test_a_clean_failure_reads_as_one(self) -> None:
+        text = _render({"subtype": "error", "is_error": True})
+        self.assertIn("Claude Failed", text)
+        self.assertNotIn("flagged", text)
+
+    def test_a_disagreement_is_stated_rather_than_resolved_silently(self) -> None:
+        """The real case: stream cut mid-response."""
+        text = _render({"subtype": "success", "is_error": True, "num_turns": 32})
+        self.assertIn("Claude Failed", text)
+        self.assertIn("success", text, "the backend's own subtype is still worth showing")
+        self.assertIn("flagged this call as failed", text)
+
+    def test_a_missing_subtype_falls_back_to_the_error_flag(self) -> None:
+        self.assertIn("error", _render({"is_error": True}))
+        self.assertIn("success", _render({"is_error": False}))
+
+    def test_the_panel_never_shows_an_unqualified_success_on_a_failed_call(self) -> None:
+        """The property, independent of wording."""
+        for subtype in ("success", "completed", "done"):
+            with self.subTest(subtype=subtype):
+                text = _render({"subtype": subtype, "is_error": True})
+                status_line = next(
+                    line for line in text.splitlines() if "Status" in line
+                )
+                self.assertNotEqual(
+                    status_line.split(":", 1)[1].strip().rstrip("|").strip(),
+                    subtype,
+                    "a failed call renders a bare success status",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found while reconstructing why a four-hour unattended benchmark run stopped. The log held:

```
+------------------------------------------+
| Claude Failed                            |
|------------------------------------------|
| Status     : success                     |
| Turns      : 32                          |
| Duration   : 233.9s                      |
+------------------------------------------+
```

`is_error` and `subtype` come from different places in the CLI's stream-json and can disagree. A response cut mid-stream arrives as `is_error: true` with `subtype: "success"` — the CLI *did* finish emitting. `_render_result_event` took the title from one field and the Status line from the other, so the panel asserted both that the call failed and that it did not.

That is the worst thing to read hours after an unattended run stopped, which is exactly when this panel gets read. The Status line now carries both facts when they disagree rather than silently picking one.

Five tests, including one that holds the property independently of the wording: a failed call never renders a bare success status, for any subtype the backend might send. Mutation-checked — removing the disagreement branch fails four of them.

1,734 tests green.

## Context

The run that surfaced this aborted at Stage 04 on `API Error: Connection closed mid-response`, because the reviewer's exit code was non-zero. That part is **already fixed on main** — `if exit_code != 0` gained an `unattended` branch that sends the stage back instead of forfeiting the run. My run was on `39ed8db`, which predates it. Not a new bug; noted here so the log excerpt above is not mistaken for one.

The run has been restarted on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)