### PR TITLE
Score with the reference judge, and make the key uncommittable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ examples/
 agentspace/
 assets/paper_gallery_source/
 project/
+
+# Credentials. The judge key lives outside the tree by default (see
+# tools/score_rcb_run.py DEFAULT_KEY_FILE); this is belt and braces for a copy
+# that lands here by accident.
+api.txt
+*.key
+.env

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -419,10 +419,27 @@ is not a measurement of the run.
 
 ### The judge is part of the result
 
-The reference judge is `gpt-5.1` (`evaluation/.env.example`). Without that key, Claude
-Opus through `AnthropicVertex` is a drop-in for `structai.LLMAgent` — `score.py` only
-ever calls the agent as `agent(prompt, image_paths=, return_example=, max_try=)` and
-expects a dict.
+The reference judge is `gpt-5.1` (`evaluation/.env.example`), and it is what
+`score_rcb_run.py` uses by default:
+
+```bash
+# Reads the key from ~/api.txt. Never pass a key as an argument — it lands in the
+# shell history and in the process table.
+python3 tools/score_rcb_run.py --workspace <ws> --bench <bench>
+
+# No reference key available:
+python3 tools/score_rcb_run.py --workspace <ws> --bench <bench> --judge vertex
+```
+
+Either judge is a drop-in for `structai.LLMAgent` — `score.py` only ever calls the
+agent as `agent(prompt, image_paths=, return_example=, max_try=)` and expects a dict.
+
+The key is read from a file outside the repository. `DEFAULT_KEY_FILE` is
+`~/api.txt` deliberately: a default inside the tree is one `git add -A` away from a
+leak. Error text is redacted before printing, because an HTTP client's exception can
+carry the request that produced it and this output gets pasted into issues. A test
+scans every tracked file for a key-shaped literal, so a key pasted into a docstring
+or a fixture fails the suite rather than reaching a remote.
 
 On identical artifacts, **Gemini 2.5 Flash scored 37.0 where Claude Opus scored 20.8**.
 A sixteen-point spread is a property of the judge, not of the run, so a number quoted

--- a/tests/test_score_rcb_run.py
+++ b/tests/test_score_rcb_run.py
@@ -129,3 +129,105 @@ class JudgeIsPartOfTheResultTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class NoSecretInTheRepositoryTest(unittest.TestCase):
+    """The judge key must never be committable.
+
+    A key pasted into a tool, a docstring or a test fixture is the ordinary way
+    this leaks — the file itself lives outside any repository, so the risk is
+    not the file, it is a copy of its contents ending up in one.
+    """
+
+    def test_the_tool_contains_no_key_shaped_literal(self) -> None:
+        import re
+
+        text = TOOL.read_text(encoding="utf-8")
+        # A long opaque token assigned to something, or an OpenAI-style key.
+        suspicious = re.findall(r"""(?:sk-[A-Za-z0-9_\-]{16,})""", text)
+        self.assertEqual(suspicious, [], "a key-shaped literal is in the tool")
+
+    def test_no_tracked_file_holds_a_key_shaped_literal(self) -> None:
+        import re
+        import subprocess
+
+        listing = subprocess.run(
+            ["git", "ls-files"], cwd=REPO_ROOT, capture_output=True, text=True, check=False
+        )
+        if listing.returncode != 0:  # pragma: no cover - not a git checkout
+            self.skipTest("not a git checkout")
+
+        pattern = re.compile(r"sk-[A-Za-z0-9_\-]{16,}")
+        offenders = []
+        for name in listing.stdout.split():
+            path = REPO_ROOT / name
+            if not path.is_file() or path.stat().st_size > 2_000_000:
+                continue
+            try:
+                body = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            if pattern.search(body):
+                offenders.append(name)
+        self.assertEqual(offenders, [], f"key-shaped literal in tracked files: {offenders}")
+
+    def test_the_key_file_default_is_outside_any_repository(self) -> None:
+        """A default inside the tree is one `git add -A` away from a leak."""
+        tool = _load()
+        default = tool.DEFAULT_KEY_FILE.resolve()
+        self.assertFalse(
+            str(default).startswith(str(REPO_ROOT.resolve()) + "/"),
+            f"the default key file {default} sits inside the repository",
+        )
+
+    def test_the_cli_refuses_to_take_a_key_as_an_argument(self) -> None:
+        """A key on the command line lands in shell history and the process table."""
+        text = TOOL.read_text(encoding="utf-8")
+        self.assertNotIn('"--api-key"', text)
+        self.assertNotIn("'--api-key'", text)
+        self.assertIn("--key-file", text)
+
+    def test_errors_are_redacted_before_they_are_printed(self) -> None:
+        tool = _load()
+        # Assembled rather than written out: a literal here would be found by
+        # the repository scan above, which is the point of that scan.
+        fake = "sk-" + ("abcdefghijkl" + "mnopqrstuvwxyz" + "012345")
+        leaked = f"AuthError: request failed with Bearer {fake}"
+        self.assertNotIn("mnopqrstuvwxyz", tool._redact(leaked))
+        self.assertIn("<redacted>", tool._redact(leaked))
+
+
+class ReferenceJudgeTest(unittest.TestCase):
+    """gpt-5.1 is what the benchmark scores with; anything else is not comparable."""
+
+    def setUp(self) -> None:
+        self.tool = _load()
+
+    def test_the_reference_judge_is_the_default(self) -> None:
+        text = TOOL.read_text(encoding="utf-8")
+        self.assertIn('default="reference"', text)
+        self.assertEqual(self.tool.REFERENCE_JUDGE_MODEL, "gpt-5.1")
+
+    def test_a_missing_key_file_says_what_to_do_rather_than_crashing(self) -> None:
+        from pathlib import Path
+
+        with self.assertRaises(SystemExit) as caught:
+            self.tool.read_api_key(Path("/nonexistent/api.txt"))
+        message = str(caught.exception)
+        self.assertIn("--judge vertex", message)
+        self.assertIn("Do not pass a key on the command line", message)
+
+    def test_the_key_reader_tolerates_the_shapes_a_file_arrives_in(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        for raw in ("token-value", "KEY=token-value", '"token-value"', "  token-value\n"):
+            with self.subTest(shape=raw):
+                with tempfile.TemporaryDirectory() as tmp:
+                    path = Path(tmp) / "api.txt"
+                    path.write_text(raw, encoding="utf-8")
+                    self.assertEqual(self.tool.read_api_key(path), "token-value")
+
+    def test_the_endpoint_is_not_treated_as_a_secret(self) -> None:
+        """An endpoint in source is fine; a key is not. Keep them distinguishable."""
+        self.assertTrue(self.tool.REFERENCE_JUDGE_ENDPOINT.startswith("https://"))

--- a/tools/score_rcb_run.py
+++ b/tools/score_rcb_run.py
@@ -55,7 +55,124 @@ JUDGE_TIME_LIMIT = 600
 #: Serial. The stock 16 is the trap that actually fires.
 JUDGE_WORKERS = 1
 
-DEFAULT_JUDGE_MODEL = "claude-opus-4-5@20251101"
+#: The judge ResearchClawBench itself scores with (`evaluation/.env.example`).
+#: Use it unless you cannot: judge choice moves the number by about sixteen
+#: points, so a run scored with anything else is not comparable to a published
+#: figure.
+REFERENCE_JUDGE_MODEL = "gpt-5.1"
+
+#: The OpenAI-compatible endpoint the reference judge is served from here. An
+#: endpoint is not a secret; the key that opens it is, and never appears in this
+#: file — see `read_api_key`.
+REFERENCE_JUDGE_ENDPOINT = "https://shi-lab-2-resource.services.ai.azure.com/openai/v1"
+
+#: Fallback when no reference key is available.
+FALLBACK_JUDGE_MODEL = "claude-opus-4-5@20251101"
+
+#: Where the key is read from. Outside any repository on purpose: a default
+#: inside the tree is one `git add -A` away from a leak.
+DEFAULT_KEY_FILE = Path.home() / "api.txt"
+
+
+def read_api_key(path: Path) -> str:
+    """The key, from a file that is never committed.
+
+    Tolerant about shape because the caller should never have to print the file
+    to find out what shape it is: a bare token, `KEY=token`, and a quoted value
+    all read the same. Nothing here echoes the value, and the only confirmation
+    that parsing worked is that a call succeeds.
+    """
+    if not path.is_file():
+        raise SystemExit(
+            f"No judge key at {path}. Put the reference judge's key there, or pass "
+            "--judge vertex to score with Claude instead. Do not pass a key on the "
+            "command line: it lands in the shell history and in the process table."
+        )
+    raw = path.read_text(encoding="utf-8").strip()
+    if "=" in raw and not raw.startswith("sk-"):
+        raw = raw.split("=", 1)[1]
+    return raw.strip().strip("\"'")
+
+
+def _redact(text: str) -> str:
+    """Strip anything key-shaped before it reaches an error message.
+
+    Error text from an HTTP client can carry the request that produced it, and
+    this output gets pasted into issues.
+    """
+    import re
+
+    return re.sub(r"(sk-|Bearer\s+)[A-Za-z0-9_\-\.]{12,}", r"\1<redacted>", text)
+
+
+def _response_text(response: Any) -> str:
+    """Pull the text out of a Responses API result, whatever shape it arrived in."""
+    text = getattr(response, "output_text", None)
+    if isinstance(text, str) and text.strip():
+        return text
+    parts: list[str] = []
+    for item in getattr(response, "output", []) or []:
+        for block in getattr(item, "content", []) or []:
+            value = getattr(block, "text", None)
+            if isinstance(value, str):
+                parts.append(value)
+    return "\n".join(parts)
+
+
+class ReferenceJudge:
+    """The gpt-5.1 judge, through the OpenAI-compatible Responses API.
+
+    Same contract as :class:`VertexJudge`: ``score.py`` only ever calls the
+    agent as ``agent(prompt, image_paths=, return_example=, max_try=)`` and
+    expects a dict back.
+    """
+
+    def __init__(self, *, model: str, endpoint: str, api_key: str) -> None:
+        from openai import OpenAI
+
+        self.model = model
+        self._client = OpenAI(base_url=endpoint, api_key=api_key)
+        self.calls = 0
+        self.failures: list[str] = []
+
+    def __call__(
+        self,
+        prompt: str,
+        image_paths: list[str] | None = None,
+        return_example: dict | None = None,
+        max_try: int = 2,
+        **_: Any,
+    ) -> dict | None:
+        import base64
+        import mimetypes
+
+        content: list[dict[str, Any]] = [{"type": "input_text", "text": prompt}]
+        for path in image_paths or []:
+            data = base64.b64encode(Path(path).read_bytes()).decode("ascii")
+            media_type = mimetypes.guess_type(path)[0] or "image/png"
+            content.append(
+                {"type": "input_image", "image_url": f"data:{media_type};base64,{data}"}
+            )
+
+        last = ""
+        for _attempt in range(max_try):
+            self.calls += 1
+            try:
+                response = self._client.responses.create(
+                    model=self.model, input=[{"role": "user", "content": content}]
+                )
+                text = _response_text(response)
+                parsed = _first_json_object(text)
+                if isinstance(parsed, dict) and "score" in parsed:
+                    return parsed
+                last = f"unparseable body ({len(text)} chars)"
+            except Exception as exc:  # noqa: BLE001 - the reason is what matters
+                last = _redact(f"{type(exc).__name__}: {exc}")
+        self.failures.append(last)
+        return None
+
+
+DEFAULT_JUDGE_MODEL = FALLBACK_JUDGE_MODEL
 
 
 class VertexJudge:
@@ -140,7 +257,7 @@ def _first_json_object(text: str) -> Any:
     return None
 
 
-def score(workspace: Path, bench: Path, *, model: str, project_id: str) -> dict:
+def score(workspace: Path, bench: Path, *, judge) -> dict:
     sys.path.insert(0, str(bench))
     import evaluation.config as config
     import evaluation.score as scorer
@@ -149,9 +266,8 @@ def score(workspace: Path, bench: Path, *, model: str, project_id: str) -> dict:
     # are never used, because the agent is replaced below.
     for name in ("JUDGE_API_KEY", "JUDGE_API_BASE", "JUDGE_MODEL_NAME"):
         os.environ.setdefault(name, "unused-local-judge")
-    config.JUDGE_MODEL_NAME = model
+    config.JUDGE_MODEL_NAME = judge.model
 
-    judge = VertexJudge(model=model, project_id=project_id)
     scorer.LLMAgent = lambda **_: judge  # type: ignore[assignment]
 
     # Serialise. Concurrency is the trap that fires most often, and a benchmark
@@ -162,7 +278,7 @@ def score(workspace: Path, bench: Path, *, model: str, project_id: str) -> dict:
     scorer.multi_thread = serial  # type: ignore[assignment]
 
     result = scorer.score_workspace(workspace)
-    result["judge_model"] = model
+    result["judge_model"] = judge.model
     result["judge_calls"] = judge.calls
     result["judge_failures"] = judge.failures
     return result
@@ -172,18 +288,48 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     parser.add_argument("--workspace", required=True, type=Path)
     parser.add_argument("--bench", required=True, type=Path)
-    parser.add_argument("--model", default=DEFAULT_JUDGE_MODEL)
+    parser.add_argument(
+        "--judge",
+        choices=("reference", "vertex"),
+        default="reference",
+        help=(
+            "reference = gpt-5.1, what the benchmark itself scores with. "
+            "vertex = Claude on Vertex, for when no reference key is available. "
+            "The choice is worth about sixteen points, so it is reported with the total."
+        ),
+    )
+    parser.add_argument("--model", default=None, help="Override the judge model id.")
+    parser.add_argument(
+        "--key-file",
+        type=Path,
+        default=DEFAULT_KEY_FILE,
+        help=(
+            f"File holding the reference judge's key (default {DEFAULT_KEY_FILE}). "
+            "Never pass the key itself: it would land in the shell history."
+        ),
+    )
+    parser.add_argument("--endpoint", default=REFERENCE_JUDGE_ENDPOINT)
     parser.add_argument(
         "--project-id", default=os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
     )
     parser.add_argument("--out", type=Path, default=None)
     args = parser.parse_args()
 
-    if not args.project_id:
-        print("Set ANTHROPIC_VERTEX_PROJECT_ID or pass --project-id.", file=sys.stderr)
-        return 2
+    if args.judge == "reference":
+        judge = ReferenceJudge(
+            model=args.model or REFERENCE_JUDGE_MODEL,
+            endpoint=args.endpoint,
+            api_key=read_api_key(args.key_file),
+        )
+    else:
+        if not args.project_id:
+            print("Set ANTHROPIC_VERTEX_PROJECT_ID or pass --project-id.", file=sys.stderr)
+            return 2
+        judge = VertexJudge(
+            model=args.model or FALLBACK_JUDGE_MODEL, project_id=args.project_id
+        )
 
-    result = score(args.workspace, args.bench, model=args.model, project_id=args.project_id)
+    result = score(args.workspace, args.bench, judge=judge)
     if "error" in result:
         print(f"scoring failed: {result['error']}", file=sys.stderr)
         return 1


### PR DESCRIPTION
`score_rcb_run.py` scored with Claude because no reference key was available. ResearchClawBench scores with **`gpt-5.1`** (`evaluation/.env.example`), and judge choice is worth about sixteen points — on identical artifacts Gemini 2.5 Flash gave 37.0 where Opus gave 20.8. A number from a different judge is not comparable to anything published, so the reference judge is now the default and Claude is the fallback (`--judge vertex`).

`ReferenceJudge` speaks the OpenAI-compatible Responses API and satisfies the same contract as the Vertex one: `score.py` only ever calls the agent as `agent(prompt, image_paths=, return_example=, max_try=)` and expects a dict back. Images go through as base64 `input_image` parts. Verified live — the judge returns well-formed JSON.

## Keeping the key out of the repository

This is most of the change.

| Measure | Why |
|:---|:---|
| `DEFAULT_KEY_FILE = ~/api.txt` | outside any checkout — a default inside the tree is one `git add -A` from a leak |
| no `--api-key` flag, only `--key-file` | a key on the command line lands in shell history and the process table |
| tolerant reader (bare token, `KEY=token`, quoted) | nobody should have to print the file to learn its shape; the only confirmation is that a call succeeds |
| `_redact()` on all error text | an HTTP client's exception can carry the request that produced it, and this output gets pasted into issues |
| a test scans **every tracked file** for a key-shaped literal | a key pasted into a docstring or fixture fails the suite instead of reaching a remote |
| `.gitignore`: `api.txt`, `*.key`, `.env` | belt and braces for a copy that lands here by accident |

The scan caught **its own fixture** on the first run — the fake key in the redaction test is now assembled from parts rather than written out, because a literal there is exactly what the scan exists to find. Mutation-checked: appending a key-shaped literal to the tool fails two tests.

Before committing, the staged diff and every tracked file were compared against the real key byte for byte, without printing either. Both clean.

1,743 tests green.

## Note

Mid-change I ran `git checkout -- tools/score_rcb_run.py` to undo a mutation probe and reverted the whole uncommitted file with it. Redone; the mutation probes here use a file copy instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)