### PR TITLE
Stop one bad operator call and an empty stages/ deciding the report

### DIFF
--- a/src/rcb.py
+++ b/src/rcb.py
@@ -609,6 +609,41 @@ def _research_body(stage_markdown: str) -> str:
     return "\n".join(kept).strip()
 
 
+def unapproved_stage_bodies(paths: RunPaths) -> list[tuple[str, str]]:
+    """Recover the research an aborted run did but never got approved.
+
+    A run that clears no stage still leaves the work behind: the per-stage evolution
+    directory keeps the champion each stage converged on, and the raw attempts under
+    ``candidates/`` keep the rest. None of it is approved, so none of it reaches
+    ``stages/`` -- and the report was assembled from ``stages/`` alone, which is why eight
+    of forty benchmark runs shipped a 197-byte report while holding tens of kilobytes of
+    survey and five rendered figures on disk. Unapproved work is worth less than approved
+    work; it is not worth less than nothing, and the caller labels it as unapproved.
+
+    Champions are preferred over candidates because the champion *is* the best attempt the
+    ratchet found. A candidate is read only when a stage has no champion, and only its
+    single newest attempt, so a stage that failed six times contributes one section rather
+    than six near-duplicates of the same rejected draft.
+    """
+    if not paths.evolution_dir.exists():
+        return []
+
+    recovered: list[tuple[str, str]] = []
+    for stage_dir in sorted(p for p in paths.evolution_dir.iterdir() if p.is_dir()):
+        source = stage_dir / "champion.md"
+        if not source.exists():
+            candidates = sorted((stage_dir / "candidates").glob("attempt_*.md"))
+            if not candidates:
+                continue
+            source = candidates[-1]
+        body = _research_body(read_text(source))
+        if not body:
+            continue
+        title = _STAGE_SECTION_TITLES.get(stage_dir.name, stage_dir.name.replace("_", " ").title())
+        recovered.append((f"{title} (unapproved draft)", body))
+    return recovered
+
+
 def build_fallback_report(
     *,
     paths: RunPaths,
@@ -623,13 +658,35 @@ def build_fallback_report(
     also deliberately shaped like a research report rather than a run log — the stage files it
     draws on are full of approval-workflow headings that would otherwise be scored as content.
     """
+    approved: list[tuple[str, str]] = []
+    for stage_path in sorted(paths.stages_dir.glob("*.md")) if paths.stages_dir.exists() else []:
+        if stage_path.name.endswith(".tmp.md"):
+            continue
+        body = _research_body(read_text(stage_path))
+        if not body:
+            continue
+        title = _STAGE_SECTION_TITLES.get(stage_path.stem, stage_path.stem.replace("_", " ").title())
+        approved.append((title, body))
+
+    # Unapproved drafts are a strictly worse source, so they are only read when there is no
+    # approved stage at all -- never mixed in beside one.
+    recovered = [] if approved else unapproved_stage_bodies(paths)
+
     sections: list[str] = ["# Research Report", ""]
 
     if not pipeline_completed:
+        provenance = (
+            "This report was assembled from the stages that were completed."
+            if approved
+            else "No stage was approved, so the sections below are the best draft each stage "
+            "reached before the run stopped: they did not pass review, and every claim in "
+            "them is unverified."
+            if recovered
+            else "No stage produced output before the run stopped."
+        )
         sections.extend(
             [
-                "> **Incomplete run.** The research pipeline did not finish every stage. This report "
-                "was assembled from the stages that were completed.",
+                f"> **Incomplete run.** The research pipeline did not finish every stage. {provenance}",
                 "",
             ]
         )
@@ -641,18 +698,10 @@ def build_fallback_report(
             ]
         )
 
-    wrote_any = False
-    for stage_path in sorted(paths.stages_dir.glob("*.md")) if paths.stages_dir.exists() else []:
-        if stage_path.name.endswith(".tmp.md"):
-            continue
-        body = _research_body(read_text(stage_path))
-        if not body:
-            continue
-        title = _STAGE_SECTION_TITLES.get(stage_path.stem, stage_path.stem.replace("_", " ").title())
+    for title, body in approved or recovered:
         sections.extend([f"## {title}", "", body, ""])
-        wrote_any = True
 
-    if not wrote_any:
+    if not approved and not recovered:
         summaries = approved_stage_summaries(read_text(paths.memory)) if paths.memory.exists() else "None yet."
         sections.extend([summaries if summaries != "None yet." else "_No completed stage output was produced._", ""])
 
@@ -786,10 +835,21 @@ class ReportSynthesizer:
 
     Uses the same private invocation seam as :class:`src.approval_agent.AutomatedReviewer`,
     so it works with either operator backend without widening ``OperatorProtocol``.
+
+    The call is retried, because losing it is expensive and the runs that lose it are not a
+    random sample. Across forty benchmark runs a synthesized report scored 19.52 and the
+    deterministic fallback 7.50, so one unlucky operator invocation costs about twelve
+    points -- and synthesis runs at the end of a run that has just aborted, which is
+    exactly when the operator is most likely to fail. A single attempt made the worst
+    moment in the run decide the whole deliverable.
     """
 
-    def __init__(self, operator: Any) -> None:
+    #: Attempts at the synthesis call before giving up and letting the fallback stand.
+    MAX_ATTEMPTS = 3
+
+    def __init__(self, operator: Any, max_attempts: int = MAX_ATTEMPTS) -> None:
         self.operator = operator
+        self.max_attempts = max(1, int(max_attempts))
 
     def supported(self) -> bool:
         return all(
@@ -798,6 +858,26 @@ class ReportSynthesizer:
         )
 
     def __call__(self, *, paths: RunPaths, workspace: Path, figures: list[str]) -> str | None:
+        """Return the synthesized report, retrying a failed or thin attempt.
+
+        A thin answer is retried like a failed one: `export_run` discards anything under
+        ``MIN_REPORT_CHARS`` anyway, so returning it early just spends the remaining
+        attempts on nothing.
+        """
+        for attempt in range(1, self.max_attempts + 1):
+            report = self._attempt(paths=paths, workspace=workspace, figures=figures, attempt=attempt)
+            if report is not None and len(report.strip()) >= MIN_REPORT_CHARS:
+                return report
+        return None
+
+    def _attempt(
+        self,
+        *,
+        paths: RunPaths,
+        workspace: Path,
+        figures: list[str],
+        attempt: int = 1,
+    ) -> str | None:
         if not self.supported():
             return None
 
@@ -818,7 +898,7 @@ class ReportSynthesizer:
                 command=command,
                 cwd=cwd,
                 stage=REPORT_STAGE,
-                attempt_no=1,
+                attempt_no=attempt,
                 paths=paths,
                 mode="benchmark_report",
                 stdin_text=stdin_text,

--- a/tests/test_preregistration.py
+++ b/tests/test_preregistration.py
@@ -372,12 +372,16 @@ class PromptRenderingTest(PreregistrationTestCase):
 
         rendered = format_preregistration_for_prompt(prereg)
 
-        self.assertIn("H1", rendered)
+        self.assertIn("**H1**", rendered)
         self.assertIn("Decision rule:", rendered)
         self.assertIn("may not edit", rendered)
         self.assertIn("record it as refuted", rendered)
-        # Theoretical propositions and paper claims are not adjudicated here.
-        self.assertNotIn("T1", rendered)
+        # Theoretical propositions and paper claims are not adjudicated here. Both ids are
+        # matched as the prompt renders them, `**T1**`, rather than as bare substrings: the
+        # header carries an ISO timestamp, so a bare "T1" also matches the "…-11T10:…" in
+        # every prompt frozen between 10:00 and 19:59, and this test failed for ten hours
+        # of each day rather than when the behaviour it describes broke.
+        self.assertNotIn("**T1**", rendered)
 
 
 if __name__ == "__main__":

--- a/tests/test_rcb_report_source.py
+++ b/tests/test_rcb_report_source.py
@@ -1,0 +1,234 @@
+"""The report source decides the score, so both degraded paths are pinned here.
+
+Across forty ResearchClawBench runs a synthesized report scored 19.52 and the deterministic
+fallback 7.50 -- the same pipeline, the same artifacts, twelve points apart. Two defects
+produced that gap: synthesis was one operator call with no retry, taken at the end of a run
+that had just aborted; and the fallback read only ``stages/``, so a run that cleared no
+stage shipped 197 bytes while holding tens of kilobytes of drafts and five figures on disk.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.rcb import ReportSynthesizer, build_fallback_report, unapproved_stage_bodies
+from src.utils import MIN_REPORT_CHARS, build_run_paths, ensure_run_layout, write_text
+
+
+BODY = "Substantive finding with a number: the barrier is 0.42 eV. " * 60
+
+
+class RecoverUnapprovedWorkTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+
+    def _evolution(self, stage: str, *, champion: str | None = None, attempts: dict[str, str] | None = None) -> None:
+        stage_dir = self.paths.evolution_dir / stage
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        if champion is not None:
+            write_text(stage_dir / "champion.md", champion)
+        for name, text in (attempts or {}).items():
+            (stage_dir / "candidates").mkdir(parents=True, exist_ok=True)
+            write_text(stage_dir / "candidates" / name, text)
+
+    def test_a_champion_is_recovered(self) -> None:
+        self._evolution("01_literature_survey", champion=f"# Stage 01\n\n## Objective\n\n{BODY}")
+        recovered = unapproved_stage_bodies(self.paths)
+        self.assertEqual(len(recovered), 1)
+        self.assertIn("unapproved", recovered[0][0].lower())
+        self.assertIn("0.42 eV", recovered[0][1])
+
+    def test_the_champion_wins_over_the_candidates(self) -> None:
+        """The champion is what the ratchet converged on; a candidate is a rejected draft."""
+        self._evolution(
+            "01_literature_survey",
+            champion=f"# Stage 01\n\nCHAMPION {BODY}",
+            attempts={"attempt_01.md": f"# Stage 01\n\nCANDIDATE {BODY}"},
+        )
+        body = unapproved_stage_bodies(self.paths)[0][1]
+        self.assertIn("CHAMPION", body)
+        self.assertNotIn("CANDIDATE", body)
+
+    def test_only_the_newest_candidate_is_read_when_there_is_no_champion(self) -> None:
+        """Six failed attempts at one stage must not become six near-identical sections."""
+        self._evolution(
+            "02_hypothesis_generation",
+            attempts={
+                "attempt_01.md": f"# Stage 02\n\nFIRST {BODY}",
+                "attempt_02.md": f"# Stage 02\n\nSECOND {BODY}",
+                "attempt_03.md": f"# Stage 02\n\nTHIRD {BODY}",
+            },
+        )
+        recovered = unapproved_stage_bodies(self.paths)
+        self.assertEqual(len(recovered), 1)
+        self.assertIn("THIRD", recovered[0][1])
+        self.assertNotIn("FIRST", recovered[0][1])
+
+    def test_a_run_with_no_evolution_tree_recovers_nothing(self) -> None:
+        self.assertEqual(unapproved_stage_bodies(self.paths), [])
+
+    def test_workflow_scaffolding_is_stripped_from_a_draft_too(self) -> None:
+        """A recovered draft goes through the same filter as an approved stage summary."""
+        self._evolution(
+            "01_literature_survey",
+            champion=f"# Stage 01\n\n## Your Options\n\n1. Use suggestion 1\n6. Abort\n\n## Findings\n\n{BODY}",
+        )
+        body = unapproved_stage_bodies(self.paths)[0][1]
+        self.assertNotIn("Abort", body)
+        self.assertIn("0.42 eV", body)
+
+
+class FallbackUsesRecoveredWorkTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+
+    def _build(self, figures: list[str] | None = None) -> str:
+        return build_fallback_report(
+            paths=self.paths,
+            figures=figures or [],
+            pipeline_completed=False,
+            auto_skipped_stages=[],
+        )
+
+    def _champion(self, stage: str, text: str) -> None:
+        stage_dir = self.paths.evolution_dir / stage
+        stage_dir.mkdir(parents=True, exist_ok=True)
+        write_text(stage_dir / "champion.md", text)
+
+    def test_material_002_shipped_197_bytes_and_should_not_have(self) -> None:
+        """The exact benchmark failure: real drafts on disk, a stub report published."""
+        self._champion("01_literature_survey", f"# Stage 01\n\n## Objective\n\n{BODY}")
+        report = self._build(figures=["fig1_data_audit.png"])
+        self.assertGreater(len(report), MIN_REPORT_CHARS)
+        self.assertIn("0.42 eV", report)
+        self.assertNotIn("No completed stage output was produced", report)
+
+    def test_the_report_says_the_draft_was_never_approved(self) -> None:
+        """Passing unreviewed drafts off as findings would be the worse defect."""
+        self._champion("01_literature_survey", f"# Stage 01\n\n{BODY}")
+        report = self._build()
+        self.assertIn("No stage was approved", report)
+        self.assertIn("unverified", report)
+
+    def test_the_two_notices_do_not_contradict_each_other(self) -> None:
+        """It cannot claim assembly from completed stages when none completed."""
+        self._champion("01_literature_survey", f"# Stage 01\n\n{BODY}")
+        self.assertNotIn("assembled from the stages that were completed", self._build())
+
+    def test_an_approved_stage_is_never_mixed_with_a_draft(self) -> None:
+        write_text(self.paths.stages_dir / "01_literature_survey.md", f"# Stage 01\n\nAPPROVED {BODY}")
+        self._champion("01_literature_survey", f"# Stage 01\n\nDRAFT {BODY}")
+        report = self._build()
+        self.assertIn("APPROVED", report)
+        self.assertNotIn("DRAFT", report)
+        self.assertNotIn("unapproved draft", report)
+        self.assertIn("assembled from the stages that were completed", report)
+
+    def test_a_run_with_nothing_at_all_still_says_so(self) -> None:
+        report = self._build()
+        self.assertIn("No completed stage output was produced", report)
+
+    def test_figures_are_still_linked_after_a_draft_is_recovered(self) -> None:
+        self._champion("01_literature_survey", f"# Stage 01\n\n{BODY}")
+        report = self._build(figures=["fig1.png", "fig2.png"])
+        self.assertIn("![fig1](images/fig1.png)", report)
+        self.assertIn("![fig2](images/fig2.png)", report)
+
+
+class _Operator:
+    """Minimal stand-in for the operator seam ReportSynthesizer reaches through."""
+
+    def __init__(self, outcomes: list[str], report_path: Path) -> None:
+        self.outcomes = outcomes
+        self.report_path = report_path
+        self.attempts: list[int] = []
+
+    def _prepare_invocation(self, prompt_path, session_id, *, paths, resume):  # noqa: ANN001
+        return (["true"], str(prompt_path.parent), None)
+
+    def _run_streaming_command(self, *, command, cwd, stage, attempt_no, paths, mode, stdin_text):  # noqa: ANN001
+        self.attempts.append(attempt_no)
+        outcome = self.outcomes[min(len(self.attempts), len(self.outcomes)) - 1]
+        if outcome == "crash":
+            raise RuntimeError("operator died")
+        if outcome == "nonzero":
+            return (1, "", "", "s", {})
+        self.report_path.parent.mkdir(parents=True, exist_ok=True)
+        self.report_path.write_text(
+            "x" if outcome == "thin" else f"# Report\n\n{BODY}", encoding="utf-8"
+        )
+        return (0, "", "", "s", {})
+
+
+class SynthesisRetryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self.workspace = root / "ws"
+        self.paths = build_run_paths(root / "run_0001")
+        ensure_run_layout(self.paths)
+        self.report_path = self.workspace / "report" / "report.md"
+
+    def _run(self, outcomes: list[str], **kwargs) -> tuple[str | None, _Operator]:
+        operator = _Operator(outcomes, self.report_path)
+        result = ReportSynthesizer(operator, **kwargs)(
+            paths=self.paths, workspace=self.workspace, figures=[]
+        )
+        return result, operator
+
+    def test_a_first_call_that_works_is_not_repeated(self) -> None:
+        result, operator = self._run(["ok"])
+        self.assertIsNotNone(result)
+        self.assertEqual(operator.attempts, [1])
+
+    def test_a_failed_call_is_retried_rather_than_costing_the_report(self) -> None:
+        """The defect: one bad call at the end of an aborted run forfeited ~12 points."""
+        result, operator = self._run(["nonzero", "ok"])
+        self.assertIsNotNone(result)
+        self.assertEqual(operator.attempts, [1, 2])
+
+    def test_a_crash_is_retried_too(self) -> None:
+        result, operator = self._run(["crash", "ok"])
+        self.assertIsNotNone(result)
+        self.assertEqual(len(operator.attempts), 2)
+
+    def test_a_thin_answer_is_retried_because_export_would_discard_it(self) -> None:
+        result, operator = self._run(["thin", "ok"])
+        self.assertIsNotNone(result)
+        self.assertGreaterEqual(len(result.strip()), MIN_REPORT_CHARS)
+        self.assertEqual(operator.attempts, [1, 2])
+
+    def test_it_gives_up_and_lets_the_fallback_stand(self) -> None:
+        result, operator = self._run(["nonzero"])
+        self.assertIsNone(result)
+        self.assertEqual(len(operator.attempts), ReportSynthesizer.MAX_ATTEMPTS)
+
+    def test_each_retry_is_recorded_as_its_own_attempt(self) -> None:
+        """Sharing attempt_no=1 would overwrite the previous attempt's operator log."""
+        _result, operator = self._run(["nonzero", "nonzero", "ok"])
+        self.assertEqual(operator.attempts, [1, 2, 3])
+
+    def test_the_attempt_count_cannot_be_configured_to_zero(self) -> None:
+        _result, operator = self._run(["ok"], max_attempts=0)
+        self.assertEqual(operator.attempts, [1])
+
+    def test_an_unsupported_operator_is_not_retried(self) -> None:
+        class Bare:
+            pass
+
+        self.assertIsNone(
+            ReportSynthesizer(Bare())(paths=self.paths, workspace=self.workspace, figures=[])
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What the benchmark data says

Under ResearchClawBench's own `gpt-5.1` judge, over 40 tasks, the source of `report/report.md` predicts the score better than anything else in the run tree:

| report source | n | mean |
|---|---|---|
| `synthesized` | 18 | **19.52** |
| `fallback` | 18 | **7.50** |

Same pipeline, same artifacts, 12 points apart. (`agent` and `stage` — the Stage 07 gate-validated paths — won 0 of 40, because no run reached Stage 07.) Two separate defects decide which side of that line a run lands on.

## 1. Synthesis had no retry

One operator call, and `exit_code != 0 or not report_path.exists()` → fall back. That call runs at the very end of the run, which on an aborted run is exactly when the operator is least likely to answer, so the worst instant in the run decided the whole deliverable.

Now up to three attempts. A thin answer is retried like a failed one — `export_run` discards anything under `MIN_REPORT_CHARS` regardless, so returning it early just spent the remaining attempts on nothing. Each retry gets its own `attempt_no` so it does not overwrite the previous attempt's operator log.

## 2. The fallback read only `stages/`

`stages/` holds *approved* stage summaries. A run that cleared no stage published 197 bytes:

```
# Research Report

> **Incomplete run.** …
_No completed stage output was produced._
```

Material_002 shipped exactly that next to an **18,976-byte literature survey** and **five rendered figures** already on disk. Eight of the 40 runs did this and averaged **0.78**.

The fallback now recovers the per-stage evolution champion, or the newest candidate where a stage has none — so six failed attempts at one stage contribute one section, not six drafts of the same rejected text. Replayed against all eight real run trees:

| task | score | was | now |
|---|---|---|---|
| Information_001 | 0.0 | 197 B | 10,371 B |
| Information_002 | 0.0 | 197 B | 13,083 B |
| Material_002 | 0.0 | 197 B | 12,926 B |
| Material_003 | 1.5 | 197 B | 11,388 B |
| Math_001 | 0.0 | 197 B | 11,203 B |
| Math_002 | 0.0 | 197 B | 9,975 B |
| Physics_000 | 3.0 | 197 B | 12,746 B |
| Physics_001 | 1.8 | 197 B | 10,661 B |

All eight died in Stage 01, so what is recovered is a literature survey: this buys text credit for background and related work and gets the figures linked. It is not a substitute for results, and the scores will not jump to 19.5.

### Honesty

Unapproved work is worth less than approved work — not less than nothing. So it is read **only** when there is no approved stage at all, never mixed in beside one, and the report states on its face that the sections did not pass review and their claims are unverified. The incomplete-run notice is chosen to match: it no longer claims assembly "from the stages that were completed" when none were.

## Drive-by

`test_the_prompt_says_the_set_is_frozen_and_refutation_is_allowed` asserted a bare `"T1"` was absent from a rendered prompt whose header carries an ISO timestamp. `…-11T10:…` contains that substring, so the test failed for ten hours of every day rather than when the behaviour it describes broke. It now matches the id as the prompt renders it, `**T1**`.

## Tests

19 new tests in `tests/test_rcb_report_source.py`; full suite 1753 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)