### PR TITLE
Re-derive every measured claim in the docs, and stop three stages going unscored

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ It is:
 
 Latest mainline updates:
 
-- **2026-08-06**: **Recursive self-improvement is now the default.** The nine stages are a **directed graph** the run navigates: an analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it, and the move into Stage 07 stays closed until every hypothesis carries a verdict. The stage that just ran chooses the next move, among the ones AutoR's guards leave open. Every valid draft is scored against a rigour rubric read off disk and held to a champion ratchet, so the draft that gets promoted is the best one the run produced rather than the last one — that half costs nothing, because the rubric never calls a backend. Two improvement rounds per stage are budgeted on top, and a stage the rubric has nothing to say about spends none of them. A round that scores worse is reverted; a round that changes a hypothesis verdict is rejected outright. Each finished run records its route and measured fitness in a cross-run archive, which compares every graph edge against runs that reached the same node and did not take it. Opt out with `--stage-graph linear`, `--routing off`, `--no-evolve`, `--no-archive`. See [Recursive Self-Improvement](docs/self-improvement.md).
+- **2026-08-06**: **Recursive self-improvement is now the default.** The nine stages are a **directed graph** the run navigates: an analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it, and the move into Stage 07 stays closed until every hypothesis carries a verdict. The stage that just ran chooses the next move, among the ones AutoR's guards leave open. Every valid draft is scored against a rigour rubric read off disk and held to a champion ratchet, so the draft that gets promoted is the best one the run produced rather than the last one — that half costs nothing, because the rubric never calls a backend. Two improvement rounds per stage are budgeted on top, and a stage the rubric has nothing to say about spends none of them. A round that scores worse is reverted; a round that changes a hypothesis verdict is rejected outright. Each finished run records its route and measured fitness in a cross-run archive, which compares each graph edge against the decisions that were *offered* it and declined. The archive has no real runs in it yet — see [what has and has not been measured](docs/self-improvement.md#what-has-and-has-not-been-measured). Opt out with `--stage-graph linear`, `--routing off`, `--no-evolve`, `--no-archive`. See [Recursive Self-Improvement](docs/self-improvement.md).
 - **2026-06-02**: Added a configurable Codex sandbox mode. Codex-backed runs still default to `workspace-write`, but users who intentionally need remote GPU or SSH execution can now opt into `--codex-sandbox danger-full-access`; the setting is persisted in `run_config.json` and preserved on resume.
 - **2026-05-10**: Refined the terminal-first run experience. Stage 00 now uses a dedicated clarification flow: the first intake pass asks the user questions one by one with selectable options, custom answers, and skip; the revised intake brief then uses a compact refine / approve / abort menu instead of showing the normal suggestion template. The terminal UI also keeps colored frames on wrapped body rows, handles long lines and wide characters more reliably, and the Codex backend now uses the current `--sandbox workspace-write` execution flag instead of the deprecated Codex CLI `--full-auto` flag.
 - **2026-04-20**: Added an optional `--full-auto` approval mode. The execution loop is unchanged, but the manual approval gate can now be replaced by a strict simulated reviewer agent backed by Claude or Codex, with reviewer settings persisted in `run_config.json`.
@@ -167,7 +167,7 @@ important to hand over as a blind end-to-end loop. The goal is not to remove hum
 The goal is to give them a stronger execution system.
 
 AutoR runs a research project as eight stages wired into a directed graph: six forward edges are
-guarded by artifacts on disk, ten backward edges let a late finding send the run back — Stage 07
+guarded by artifacts on disk, thirteen backward edges let a late finding send the run back — Stage 07
 can reopen the literature survey. Hypotheses are frozen and hashed when Stage 04 is approved, every
 one must be adjudicated at Stage 06 against a named result file, and every paper claim traced at
 Stage 07; a `supported` or `refuted` verdict resting on one run is refused unless the run records
@@ -189,14 +189,17 @@ gate, and by default that gate is you.
 | **Deliberate** | A stage that hits a genuine crux stops, names the question, and pulls in theorist / empiricist / critic / pragmatist plus an expert brief, then continues with an answer that names its own falsifier; budgeted, and measured against what the agent already believed | [`deliberation.py`](src/deliberation.py) · 640L |
 | **Localise** | A reviewer quotes the passage it objects to instead of refusing the whole stage; the revision is told to change only those spans and is diffed against them, so "preserve the correct parts" is measured rather than hoped for | [`stage_comments.py`](src/stage_comments.py) · 375L |
 
-Three of those six are on for every run: **Test**, **Refute**, and **Iterate** (`--evolve` defaults
-on). **Propose** needs `--ideation-panel`; **Critique** needs `--review-panel` and `--cross-review`;
-**Learn** records on every run but only reorders the graph under `--archive-steer`.
+Four of those eight are on for every run: **Test**, **Refute**, **Iterate** (`--evolve` defaults on)
+and **Learn**, which records on every run but only reaches a routing decision under
+`--archive-steer`. **Propose** needs `--ideation-panel`; **Critique** needs `--review-panel` and
+`--cross-review`; **Deliberate** needs `--deliberation`. **Localise** runs whenever a reviewer
+quotes a passage. The `--rigor` dial sets several of these together and defaults to `standard`,
+which turns effort tiering on.
 
 **AutoR does not run itself.** Manual approval is the default — `approval_mode` is `manual` unless a
 flag opts out ([`main.py`](main.py)) — and `--full-auto`, `--review-panel` and `--approval-mode
-agent` are those flags. Five of the six moves above can only score, refuse, revert or re-order;
-none of them can approve a stage. The sixth, the review panel, *is* an approval gate, and it exists
+agent` are those flags. Seven of the eight moves above can only score, refuse, revert or re-order;
+none of them can approve a stage. The eighth, the review panel, *is* an approval gate, and it exists
 only on the runs where you hand it the gate. Recursion did not change who decides; it changed what
 reaches the desk. The research unit is unchanged: one reproducible run under `runs/<run_id>/`,
 isolated, resumable, with redo and rollback.
@@ -204,7 +207,7 @@ isolated, resumable, with redo and rollback.
 Approved stage summaries are the only *free-text* memory. Every other cross-stage edge is a typed
 artifact with a declared reader: thirteen channels in
 [`information_flow.py`](src/information_flow.py) each name the exact stage slugs that consume them,
-and the seven produced inside the walk name their producing stage as well. `obligations.json` and
+and the eight produced inside the walk name their producing stage as well. `obligations.json` and
 `review_policy.json` cross stages without touching a summary at all — both only behind an agent
 approval gate.
 
@@ -223,13 +226,20 @@ frozen hypothesis carries a verdict (`_guard_validity_chain`, [`stage_graph.py`]
 ## What changed, measured
 
 Every node used to be contractually required to restate its inbound edge. That heading is gone from
-the stage contract, and the effect on a real run is the cheapest evidence in this document:
+the stage contract, and the effect on a scripted run was measured at the commit that removed it
+(`dd54947`):
 
-| Measured across one run | Before | After |
+| Measured across one `--fake-operator` run, at `dd54947` | Before | After |
 | --- | --- | --- |
-| Words a node emits | grew 235 → 1,211 | flat, 228-277 per stage |
+| Words a node emits | grew 235 → 1,211 | flat, 228-292 per stage |
 | Share of stage output that was relay | 64% | 0% |
-| Assembled prompt text | 21,823 words | 20,353 words |
+| Assembled prompt text | 21,236 words | 20,353 words |
+
+Dated on purpose. The "after" column reproduces to the word at `dd54947` and no longer does at
+HEAD — the same measurement now gives 24,089 words, because eight PRs have since added context
+channels of their own. The relay heading is still gone; the 18% that came back is other people's
+work, not a regression of this one, and the honest form of a before/after is the commit it was taken
+at.
 
 The sharpest single case: the mutable Stage 02 hypotheses and the frozen preregistration were both
 delivered from Stage 05 on — the same hypothesis twice, one copy labelled editable, sitting next to
@@ -238,9 +248,11 @@ stops at `04_implementation`, where the freeze supersedes it
 ([`information_flow.py`](src/information_flow.py)).
 
 The shape of the system, in counts you can re-derive from named symbols in the source: eight stages
-plus `FINISH`, six guarded forward edges (`_ADVANCE_GUARDS`), ten backward edges (`REVISIT_EDGES`),
-thirteen typed information channels (`CHANNELS`). Alongside the 27 stage gates that ask whether a
-file exists, seven validators ask whether a claim is warranted; they are named in full under
+plus `FINISH`, six guarded forward edges (`_ADVANCE_GUARDS`), thirteen backward edges
+(`REVISIT_EDGES`), one conditional terminal (`TERMINAL_EDGES`), and fifteen typed information
+channels (`CHANNELS`) — twenty-two edges in the adaptive graph altogether. Alongside the gates that ask whether a file
+exists, **nine** `validate_*` functions ask whether a claim is warranted — count them with
+`grep -rn "^def validate_" src/`; they are named in full under
 [the stage contract](#-the-stage-contract-and-what-gets-validated).
 
 ## News
@@ -419,12 +431,15 @@ flowchart LR
     S7 -->|report_exists| S8[08 Dissemination]
     S8 --> Z([finish])
 
+    S2 -.->|the gap it rests on is not a gap| S1
+    S3 -.->|a hypothesis cannot be brought to a decision| S2
     S4 -.->|not executable as specified| S3
     S5 -.->|implementation is at fault| S4
     S5 -.->|comparison cannot distinguish| S3
     S6 -.->|results insufficient to decide| S5
     S6 -.->|confound the results cannot repair| S3
     S6 -.->|evidence refutes, and points somewhere| S2
+    S6 -.->|the numbers are wrong, not disappointing| S4
     S7 -.->|claim has no analysis behind it| S6
     S7 -.->|needs a result never produced| S5
     S7 -.->|the survey missed related work| S1
@@ -433,7 +448,7 @@ flowchart LR
 
 Six of the eight forward edges carry a guard, one per target stage
 (`_ADVANCE_GUARDS`, src/stage_graph.py:266-273); 01→02 and 08→`finish` are
-unguarded. Ten dotted edges go back (`REVISIT_EDGES`, :301-359). The longest is
+unguarded. Thirteen dotted edges go back (`REVISIT_EDGES`). The longest is
 07→01: writing it up showed the finding relates to work the survey missed. The
 Stage 07 guard is the strictest — every preregistered empirical hypothesis needs a
 verdict **and** at least one figure under `workspace/figures`
@@ -659,7 +674,7 @@ There was an eighth heading, retired in this branch: a section in which each sta
 
 Also required, and checked: exactly 3 numbered refinement suggestions, exactly the fixed 6 user options, concrete file paths under `Files Produced`, and no `[In progress]`, `[Pending]`, `[TODO]` or `[TBD]` placeholders.
 
-**Artifact gates.** 27 of them start by asking whether a file is there — and the rows below that say
+**Artifact gates.** Most start by asking whether a file is there — and the rows below that say
 "valid", "resolving" or "matching" then parse it:
 
 | Stage | Required non-toy output |
@@ -674,13 +689,13 @@ Also required, and checked: exactly 3 numbered refinement suggestions, exactly t
 
 Requirements are cumulative, and the stage that *produces* a class of artifact must produce it **during that stage's execution** — a re-run is not credited with the previous attempt's files. The cutoff is `stage_execution_started_at` feeding `recent_in` ([src/utils.py:1249-1261](src/utils.py)), and the rubric enforces the same rule independently in `_fresh_artifact_kinds` ([src/rubric.py:417](src/rubric.py)), so a Stage 07 draft cannot score on Stage 06's figures.
 
-**Validity gates.** The same function — `validate_stage_artifacts` ([src/utils.py:1232](src/utils.py)) — also runs seven validators that never ask whether a file exists: `validate_preregistration`, `validate_experimental_protocol`, `validate_hypothesis_outcomes`, `validate_outcome_statistics`, `validate_claim_provenance`, `validate_validity_response`, `validate_round_decision`. The code labels the split itself: "The scientific-validity chain, distinct from the artifact gates around it" ([src/utils.py:1292-1297](src/utils.py)). A run can fail because a claim is unwarranted, not only because a file is absent.
+**Validity gates.** The same function — `validate_stage_artifacts` ([src/utils.py:1232](src/utils.py)) — also runs seven validators that ask whether a *claim* is warranted rather than whether output exists: `validate_preregistration`, `validate_experimental_protocol`, `validate_hypothesis_outcomes`, `validate_outcome_statistics`, `validate_claim_provenance`, `validate_validity_response`, `validate_round_decision`. (Three of them do refuse on an absent file — the artifact they need is the record of the claim itself, so its absence *is* the unwarranted claim.) The code labels the split itself: "The scientific-validity chain, distinct from the artifact gates around it" ([src/utils.py:1292-1297](src/utils.py)). A run can fail because a claim is unwarranted, not only because a file is absent.
 
 The complete gate, including every JSON schema that is parsed rather than merely counted, is in **[docs/stage-contract.md](docs/stage-contract.md)**.
 
 ## 🧠 Execution Model
 
-Context is composed per consumer, not per availability. A stage's inbound block is built by `render_inbound(ChannelContext(...), CHANNELS)` ([src/manager.py:2033-2039](src/manager.py)) from the thirteen typed channels in [src/information_flow.py](src/information_flow.py). Each channel declares `produced_by`, a `consumed_by` set of real stage slugs, and a `rationale`; `test_every_narrowing_is_argued_for` ([tests/test_information_flow.py:67](tests/test_information_flow.py)) fails a channel that withholds itself from a stage without saying why. Withholding has to be argued for, not just done.
+Context is composed per consumer, not per availability. A stage's inbound block is built by `render_inbound(ChannelContext(...), CHANNELS)` ([src/manager.py:2033-2039](src/manager.py)) from the fifteen typed channels in [src/information_flow.py](src/information_flow.py). Each channel declares `produced_by`, a `consumed_by` set of real stage slugs, and a `rationale`; `test_every_narrowing_is_argued_for` ([tests/test_information_flow.py:67](tests/test_information_flow.py)) fails a channel that withholds itself from a stage without saying why. Withholding has to be argued for, not just done.
 
 Three narrowings, because the abstraction is not the point:
 
@@ -776,20 +791,20 @@ flowchart LR
 
 | Module | Lines | What it owns |
 | --- | ---: | --- |
-| [main.py](main.py) | 965 | CLI entry: start, resume, `--redo-stage`, `--rollback-stage`, and the archive record at the end of a run |
-| [src/manager.py](src/manager.py) | 2955 | Walks the stage graph until it reaches finish or nothing is open — plus the router call, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto and the inbound-channel record |
-| [src/utils.py](src/utils.py) | 2214 | Stage metadata, run paths, prompt assembly, markdown validation, the artifact gates and the validity-chain wiring |
-| [src/review_panel.py](src/review_panel.py) | 1223 | The deliberating panel; a blocking objection is enforced in code against its own chair |
-| [src/rubric.py](src/rubric.py) | 926 | The rigour score over a draft and the artifacts it names. Never calls a backend |
-| [src/archive.py](src/archive.py) | 784 | Cross-run routes and edge payoffs, keyed on a comparability basis; variant proposal and promotion |
-| [src/stage_graph.py](src/stage_graph.py) | 724 | Stages as nodes: six guarded forward edges, ten backward edges, a per-stage visit budget |
-| [src/ideation_panel.py](src/ideation_panel.py) | 712 | Divergent Stage 02 proposers across five lenses, deduplicated into a candidate pool |
-| [src/evolution.py](src/evolution.py) | 692 | The champion ratchet: budgeted polish rounds, reverted when they do not improve |
+| [main.py](main.py) | 1188 | CLI entry: start, resume, `--redo-stage`, `--rollback-stage`, and the archive record at the end of a run |
+| [src/manager.py](src/manager.py) | 3753 | Walks the stage graph until it reaches finish or nothing is open — plus the router call, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto and the inbound-channel record |
+| [src/utils.py](src/utils.py) | 2360 | Stage metadata, run paths, prompt assembly, markdown validation, the artifact gates and the validity-chain wiring |
+| [src/review_panel.py](src/review_panel.py) | 1273 | The deliberating panel; a blocking objection is enforced in code against its own chair |
+| [src/rubric.py](src/rubric.py) | 936 | The rigour score over a draft and the artifacts it names. Never calls a backend |
+| [src/archive.py](src/archive.py) | 974 | Cross-run routes and edge payoffs, keyed on a comparability basis; variant proposal and promotion |
+| [src/stage_graph.py](src/stage_graph.py) | 1000 | Stages as nodes: six guarded forward edges, thirteen backward edges, a conditional terminal, a per-stage visit budget |
+| [src/ideation_panel.py](src/ideation_panel.py) | 733 | Divergent Stage 02 proposers across five lenses, deduplicated into a candidate pool |
+| [src/evolution.py](src/evolution.py) | 727 | The champion ratchet: budgeted polish rounds, reverted when they do not improve |
 | [src/preregistration.py](src/preregistration.py) | 579 | Freeze, amend, adjudicate, trace |
 | [src/validity_review.py](src/validity_review.py) | 512 | The adversarial pass after Stages 05 and 06 |
-| [src/information_flow.py](src/information_flow.py) | 395 | Thirteen typed information channels, each with declared readers |
-| [src/router.py](src/router.py) | 385 | The agent's choice among admissible moves; an off-menu choice is refused and logged |
-| [src/research_rounds.py](src/research_rounds.py) | 320 | Stages 03-06 as a repeatable round, bounded by `--max-rounds` |
+| [src/information_flow.py](src/information_flow.py) | 522 | Fifteen typed information channels, each with declared readers |
+| [src/router.py](src/router.py) | 533 | The agent's choice among admissible moves; an off-menu choice is refused and logged |
+| [src/research_rounds.py](src/research_rounds.py) | 411 | Stages 03-06 as a repeatable round, bounded by `--max-rounds` |
 | [src/obligations.py](src/obligations.py) | 306 | What a later stage still owes; only a reviewer can discharge it |
 | [src/cross_reviewer.py](src/cross_reviewer.py) | 239 | A second opinion from a different model family. Veto only, never an override |
 | [src/experimental_protocol.py](src/experimental_protocol.py) | 234 | Declared baselines, seeds and dispersion, fixed before the result exists |

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -59,7 +59,7 @@ Nodes are stages. Edges are the moves allowed between them.
 | Topology | Edges | Behaviour |
 | --- | --- | --- |
 | `linear` (default) | one advance edge out of each node | identical to the sequence AutoR has always run |
-| `adaptive` | the advance edges plus ten backward moves | the run can return to an earlier stage when a later one shows it has to |
+| `adaptive` | the advance edges, the abandonment terminal, and thirteen backward moves | the run can return to an earlier stage when a later one shows it has to |
 
 The backward edges exist for named research conditions, not as an error path:
 
@@ -318,12 +318,20 @@ the numbers that justified it are in its note.
 
 **What a priority actually reaches, stated honestly.** It orders the move table the
 routing agent is shown, and at present that is the whole of it. It does *not* change
-what a run does when nobody is steering: `default_move` filters to forward edges
-before ranking and every node has exactly one, so no assignment of priorities
-changes the walk. Measured over 50 random assignments across all 8 nodes: 0/400
-default moves move, 195/400 menu orderings do. Both halves are pinned by tests —
-the second because a test that only asserted "no difference" would stay green if
-the mechanism were deleted entirely.
+what a run does when nobody is steering.
+
+`default_move` ranks only forward edges, and at most one of them is ever live at a
+node: seven of the eight have a single forward edge, and Stage 06 has two — the
+advance into writing and the abandonment terminal — of which the terminal is shut
+unless a round concluded `abandon`, and preempts everything else when it is open.
+So a priority never decides between two available forward moves.
+
+Measured over 50 random priority assignments across all 8 nodes: **0/400** default
+moves change. That half is exact and holds at every seed tried. The menu ordering
+does change — around 250 of 400 — but the figure is seed-dependent and no single
+integer is a stable statement of it, so the test asserts only that it is non-zero.
+Both halves are pinned, the second because a test asserting "no difference" alone
+would stay green if the mechanism were deleted entirely.
 
 So the archive's influence today is advisory: it changes what the agent sees first,
 not what happens if the agent is not asked. That is a smaller claim than "the
@@ -333,22 +341,32 @@ the estimator underneath is worth acting on.
 
 ### The composition of a run is not allowed to be the improvement
 
-A stage's score is a weighted mean over the criteria that apply to it, and later
-stages face strictly more of them — Stage 02 is scored on five criteria worth 11,
-Stage 06 on eight worth 18, including `numeric_fidelity`, the hardest. So the *set
-of stages a run reached* is a free parameter of the objective.
+A stage's score is a weighted mean over the criteria that apply to it, and the late
+stages face more of them — Stage 02 is scored on five criteria worth 11, Stage 06 on
+eight worth 18, including `numeric_fidelity`, the hardest. (Not *strictly* more at
+every step: 01 and 02 face the same set, and so do 05 through 08. The count is
+non-decreasing and it rises twice.) So the *set of stages a run reached* is a free
+parameter of the objective.
 
-On a real completed run the gap is not subtle:
+On a scripted `--fake-operator` run — the only composition that can be re-derived on
+demand, and one whose scores measure the script rather than any research — the gap
+is not subtle:
 
 | Run reached | Mean fitness |
 | --- | --- |
-| stages 01-02 | 0.986 |
-| stages 01-04 | 0.913 |
-| all eight | 0.822 |
+| stages 01-02 | 0.973 |
+| stages 01-04 | 0.904 |
+| all eight | 0.817 |
 
-Pool those and **"stop early" is worth eight times what a promotion needs**. The
-archive would have found it, and promoted whichever topology halted soonest — a
-system whose measured self-improvement consists of producing less.
+Pool those and **"stop early" is worth nearly eight times what a promotion needs**
+(0.156 against a `min_gain` of 0.02). The archive would have found it, and promoted
+whichever topology halted soonest — a system whose measured self-improvement
+consists of producing less.
+
+Re-derive with `--fake-operator --full-auto` and read `evolution/summary.json`. The
+figures moved slightly from the ones first published here, entirely in `grounding`;
+the rubric-v2 change that excluded AutoR's own bookkeeping from `artifact_breadth`
+moved none of them on this fixture.
 
 The fix is a *comparability basis*: the rubric version plus the exact set of stages
 measured. Two runs may only be contrasted within a basis, per-basis contrasts are
@@ -375,8 +393,11 @@ Three further refusals hold this together:
 - **Below `min_observations` on each side, nothing is acted on — and that bound is
   now derived.** An exact two-sided permutation test over arms of *a* and *b* has
   `C(a+b,a)` labellings, so no result can go below `2/C(a+b,a)`. Three a side bottoms
-  out at `p = 0.10`; against the adaptive graph's edge family the corrected threshold
-  needs six. `minimum_arms_for` computes it. The previous value was three, with a
+  out at `p = 0.10`; against a family the size of the adaptive graph's edge set the
+  corrected threshold needs six. `minimum_arms_for` computes it, and the family is
+  the number of contrasts the archive actually holds rather than a written-down
+  constant — the graph has gone from eighteen edges to twenty-two, and a fixed
+  divisor would have under-corrected from the first edge added. The previous value was three, with a
   docstring about intent, which meant the archive was licensing topology changes at a
   sample size where the arithmetic forbids the claim.
 - **A p-value is never reported without the floor its sample size could attain.**
@@ -407,10 +428,12 @@ generating the observations that would overturn it.
 
 Nothing, until `--archive-steer`. And then only this: **show the agent the numbers.**
 
-The learned value reached nothing before. Measured over 50 random priority
-assignments across all 8 nodes: 0/400 `default_move` answers change, 207/400 menu
-orderings do — `default_move` filters to forward edges and every node has exactly
-one, so a learned priority could only ever reorder rows in a table.
+The learned value reached nothing before: over 50 random priority assignments
+across all 8 nodes, **0/400** `default_move` answers change. At most one forward
+edge is ever live at a node, so a learned priority could only reorder rows in a
+table — which it does, at a seed-dependent rate around 250/400. The measurement and
+its explanation are the same one given [above](#4-the-cross-run-archive); this
+section is what was done about it.
 
 Wiring the statistic into `default_move` was the obvious fix and three independent
 reviews refused it, for the same reason: it would put an unrandomised,
@@ -506,6 +529,41 @@ The rubric score, which is a proxy for rigour and not a measure of insight. A
 capability can raise it without making the research better, and can make the
 research better without raising it. The decomposition and the shape counts are there
 so a reader can argue with the number instead of accepting it.
+
+---
+
+## What has and has not been measured
+
+The mechanisms above are argued for from first principles and defended by unit
+tests. That is not the same as evidence that they improve a research output, and
+this section exists so a reader can tell the two apart.
+
+**Measured, and re-derivable on demand.** Everything in this document with a number
+attached: the criterion weights per stage, the composition gap, the 0/400 reach of a
+learned priority, the permutation floors. All of these come from running the code —
+mostly with `--fake-operator`, which measures the harness rather than any research —
+and every one can be re-derived from the commands named beside it.
+
+**Not measured.** Whether any of this makes research better.
+
+- **The cross-run archive has zero real runs.** Every number it can produce today
+  comes from synthetic records in the test suite. `--archive-report` on a fresh
+  install prints an empty table, and that is the honest state: the estimator, the
+  believability gate and the promotion rule are all implemented and none of them has
+  ever been fed a real observation.
+- **The paired-trial mechanism has never completed a trial.** Six pairs were
+  attempted on 2026-08-11 — the same goal twice, `--evolve-rounds 0` against `2`,
+  strictly one run at a time with backoff. The result was 46 attempts and **zero
+  recorded runs**, every one failing on Vertex quota (`RESOURCE_EXHAUSTED` for
+  `anthropic-claude-sonnet-4-5`, 218 errors). A rate-limited run auto-skips its
+  stages, and a skipped stage is never scored, so nothing reached the archive. The
+  blocker is infrastructure, not the mechanism — but the mechanism is unproven on
+  real data either way.
+
+So when this document says a capability *is* better, it is describing an argument.
+When it says a capability *measures* better, it means the rubric, on a scripted run.
+Nothing here yet says a capability produced better research, and the paired trial is
+the thing that would.
 
 ---
 

--- a/src/archive.py
+++ b/src/archive.py
@@ -71,8 +71,11 @@ ARCHIVE_VERSION = "1"
 #:
 #: Derived, not chosen. An exact two-sided permutation test over arms of size *a*
 #: and *b* has ``C(a+b, a)`` labellings, so no result can go below ``2/C(a+b,a)``:
-#: three a side bottoms out at 0.10, and against the eighteen edges of the adaptive
-#: graph the corrected threshold is ``0.05/18 = 0.0028``, which needs six.
+#: three a side bottoms out at 0.10, and against a family the size of the adaptive
+#: graph's edge set the corrected threshold needs six. The family is computed rather
+#: than written down: the graph has grown from eighteen edges to twenty-two since
+#: this line was first written, and a hard-coded divisor would have under-corrected
+#: silently from the moment an edge was added.
 #:
 #: The previous value was three, with a docstring saying "three is not enough to be
 #: sure and is enough to stop acting on a single lucky run" — a sentence about
@@ -101,13 +104,13 @@ def comparability_basis(
 ) -> str:
     """The key two runs must share before their fitness may be compared at all.
 
-    A stage's score is a weighted mean over the criteria that apply to it, and later
-    stages face strictly more of them: Stage 02 is scored on five criteria worth 11,
+    A stage's score is a weighted mean over the criteria that apply to it, and the
+    late stages face more of them: Stage 02 is scored on five criteria worth 11,
     Stage 06 on eight worth 18, including `numeric_fidelity`, which is the hardest.
     So the *set of stages a run reached* is a free parameter of the objective. On a
-    real completed run the difference is not subtle — mean fitness over stages 01-02
-    is 0.986 against 0.822 over all eight, a gap eight times the margin a promotion
-    needs.
+    scripted `--fake-operator` run the difference is not subtle — mean fitness over
+    stages 01-02 is 0.973 against 0.817 over all eight, a gap nearly eight times the
+    margin a promotion needs.
 
     Left alone, that makes "stop early" the cheapest available improvement, and the
     archive would find it: a topology variant whose runs halt at Stage 03 would be

--- a/src/inference.py
+++ b/src/inference.py
@@ -9,9 +9,15 @@ comparison at three-a-side could attain even in principle.
 It can attain 0.10. An exact two-sided permutation test over ``a`` and ``b``
 observations has ``C(a+b, a)`` distinct labellings, of which two are the extremes,
 so no result can go below ``2 / C(a+b, a)``. Three against three bottoms out at
-0.10; against a family of eighteen edges, ``0.05 / 18 = 0.0028`` needs six a side.
-The archive was licensing topology changes at a sample size where the arithmetic
-forbids the claim.
+0.10; against a family the size of the adaptive graph's edge set, the corrected
+threshold needs six a side. The archive was licensing topology changes at a sample
+size where the arithmetic forbids the claim.
+
+The family is not a constant and the docstrings here no longer name one. `Archive`
+corrects against the number of contrasts it actually has in hand, which grows as the
+graph does — the adaptive topology went from eighteen edges to twenty-two while this
+module was being written, and a hard-coded eighteen would have quietly under-
+corrected from then on.
 
 The distinction this module exists to keep visible is between **did not show an
 effect** and **could not have shown one**. They print identically as "not
@@ -57,10 +63,10 @@ class TestResult:
     def believable(self, *, alpha: float = ALPHA, family: int = 1) -> bool:
         """Significant *and* attainably so, at a threshold corrected for the family.
 
-        Both halves are required. Without the second, an archive comparing eighteen
-        edges reports the best of eighteen at an uncorrected threshold, which is the
-        multiple-comparisons mistake in its purest form: with eighteen edges and no
-        effect anywhere, the chance that at least one clears 0.05 is about 60%.
+        Both halves are required. Without the second, an archive comparing *n* edges
+        reports the best of *n* at an uncorrected threshold, which is the
+        multiple-comparisons mistake in its purest form: with twenty edges and no
+        effect anywhere, the chance that at least one clears 0.05 is about 64%.
         """
         corrected = alpha / max(family, 1)
         return self.p_value <= corrected and self.floor <= corrected
@@ -98,7 +104,8 @@ def minimum_arms_for(alpha: float, *, family: int = 1) -> int:
 
     The number to quote when refusing to act. "Not enough runs" invites the reading
     that some unspecified amount more would do; "six a side is the arithmetic floor
-    for eighteen edges at 0.05" is actionable.
+    for a family this size at 0.05" is actionable — so pass the family you are
+    actually correcting against rather than a number from a docstring.
     """
     corrected = alpha / max(family, 1)
     for size in range(1, 40):

--- a/src/manager.py
+++ b/src/manager.py
@@ -941,15 +941,38 @@ class ResearchManager:
         except Exception as exc:  # noqa: BLE001 - measurement must not derail the stage
             append_log_entry(paths.logs, f"{stage.slug} anchored_revision_failed", str(exc))
 
-    def _evolution_applies(self, stage: StageSpec) -> bool:
+    def _evolution_measures(self, stage: StageSpec) -> bool:
+        """Whether this stage is scored and ratcheted at all.
+
+        Free — the rubric reads the run off disk and never calls a backend — so the
+        only reason to withhold it is a caller who asked for the old behaviour.
+
+        Separate from :meth:`_evolution_polishes`, and it was not. One gate did
+        both, and since `--rigor standard` turns effort tiering on by default, a
+        default run silently stopped scoring its three routine stages: 04, 05 and 08
+        produced no ledger row, no champion and no entry in `evolution/summary.json`.
+        Two things followed that nobody asked for. The archive's fitness became a
+        mean over five stages rather than eight — and `comparability_basis` is keyed
+        on the measured set, so the change was invisible rather than wrong. And the
+        champion ratchet stopped protecting exactly the stages a cheap tier is most
+        likely to damage: a directed revision to a routine stage could make it worse
+        with nothing comparing the two, which is the one thing the ratchet exists to
+        prevent.
+
+        Withholding the *rounds* from routine stages is the intent and is what the
+        old docstring described. Withholding the measurement was a side effect.
+        """
+        assert self.evolution is not None
+        return self.evolution.config.applies_to(stage)
+
+    def _evolution_polishes(self, stage: StageSpec) -> bool:
         """Whether this stage may spend polish rounds.
 
         A polish round is a full stage execution — the most expensive thing the loop does. A
         stage whose decisions are already made has nothing to polish toward, so withholding
         the rounds there is what turns tiering from a label into a reallocation.
         """
-        assert self.evolution is not None
-        if not self.evolution.config.applies_to(stage):
+        if not self._evolution_measures(stage):
             return False
         if self.effort_plan.enabled and not self.concentration.polish_routine:
             return not self.effort_plan.is_routine(stage)
@@ -2302,7 +2325,7 @@ class ResearchManager:
                 continue
 
             # The draft is valid. Measure it, and decide whether it may stand.
-            if self.evolution is not None and self._evolution_applies(stage):
+            if self.evolution is not None and self._evolution_measures(stage):
                 self.concentration.note_round(self.effort_plan.tier_for(stage))
                 outcome = self.evolution.consider(
                     paths=paths,
@@ -2321,7 +2344,9 @@ class ResearchManager:
                     f"[{outcome.score.total:.3f}]",
                     level="success" if outcome.improved else "info",
                 )
-                if self.evolution.should_continue(paths, stage):
+                # Measuring happened above regardless; the *rounds* are what a
+                # routine tier withholds.
+                if self._evolution_polishes(stage) and self.evolution.should_continue(paths, stage):
                     directive = self.evolution.next_directive(paths, stage)
                     if directive:
                         self.evolution.begin_round(paths, stage)

--- a/tests/test_effort.py
+++ b/tests/test_effort.py
@@ -449,24 +449,41 @@ class ConcentrationIntegrationTests(unittest.TestCase):
         manager.effort_plan = EffortPlan(enabled=enabled)
         return manager, paths
 
+    def test_a_routine_stage_is_still_measured(self) -> None:
+        """Tiering withholds the rounds, not the score.
+
+        One gate used to do both, and since `--rigor standard` turns tiering on by
+        default a default run silently stopped scoring Stages 04, 05 and 08 — no
+        ledger row, no champion, no entry in `evolution/summary.json`. Measured: 5 of
+        8 stages scored on an otherwise ordinary run.
+
+        Two things followed. The archive's fitness became a mean over five stages,
+        and `comparability_basis` keys on the measured set, so the change was
+        invisible rather than wrong. And the champion ratchet stopped protecting
+        exactly the stages a cheap tier is most likely to damage.
+        """
+        manager, _paths = self._manager_and_paths()
+        self.assertFalse(manager._evolution_polishes(STAGE_04))
+        self.assertTrue(manager._evolution_measures(STAGE_04))
+
     def test_a_routine_stage_is_denied_the_polish_rounds(self) -> None:
         manager, _paths = self._manager_and_paths()
         # A polish round is a full stage execution — the most expensive thing the loop does.
-        self.assertFalse(manager._evolution_applies(STAGE_04))
-        self.assertTrue(manager._evolution_applies(STAGE_03))
+        self.assertFalse(manager._evolution_polishes(STAGE_04))
+        self.assertTrue(manager._evolution_polishes(STAGE_03))
 
     def test_tiering_off_leaves_polish_on_every_stage(self) -> None:
         manager, _paths = self._manager_and_paths(enabled=False)
-        self.assertTrue(manager._evolution_applies(STAGE_04))
-        self.assertTrue(manager._evolution_applies(STAGE_03))
+        self.assertTrue(manager._evolution_polishes(STAGE_04))
+        self.assertTrue(manager._evolution_polishes(STAGE_03))
 
     def test_a_promoted_stage_regains_its_polish_rounds(self) -> None:
         manager, _paths = self._manager_and_paths()
-        self.assertFalse(manager._evolution_applies(STAGE_04))
+        self.assertFalse(manager._evolution_polishes(STAGE_04))
         for _ in range(PROMOTE_AFTER_FAILURES):
             manager.effort_plan.note_failure(STAGE_04)
         # Promotion is not just a label: the resources follow it.
-        self.assertTrue(manager._evolution_applies(STAGE_04))
+        self.assertTrue(manager._evolution_polishes(STAGE_04))
 
     def test_a_routine_stage_runs_on_the_cheaper_operator(self) -> None:
         manager, _paths = self._manager_and_paths()

--- a/tests/test_preregistration.py
+++ b/tests/test_preregistration.py
@@ -377,7 +377,11 @@ class PromptRenderingTest(PreregistrationTestCase):
         self.assertIn("may not edit", rendered)
         self.assertIn("record it as refuted", rendered)
         # Theoretical propositions and paper claims are not adjudicated here.
-        self.assertNotIn("T1", rendered)
+        # `**T1**`, not `T1`. The bare substring also matches the `T` separator in the
+        # frozen-at timestamp — `2026-08-11T10:25:09` contains `T1` — so this assertion
+        # was red between 10:00 and 19:59 and green the rest of the day. The renderer
+        # emits identifiers as `- **T1**: ...`, so match what it actually writes.
+        self.assertNotIn("**T1**", rendered)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The docs quote numbers from measurements taken at the time they were written. Thirty PRs later most had drifted, one **contradicted itself inside a single file**, and several were never true. Every claim here was re-derived by running the code at `0c10cf4`.

Two of the findings are code bugs, not doc bugs.

## A gate was silently swallowing measurement

`--rigor standard` — the default — turns effort tiering on. One gate decided both whether a stage may spend polish rounds **and** whether it is scored at all. So a default run stopped scoring its routine stages:

```
stages measured on an ordinary run: 5 of 8
missing: 04_implementation, 05_experimentation, 08_dissemination
        (no ledger row, no champion, no summary.json entry)
```

Two consequences nobody asked for. The archive's fitness became a mean over five stages — and `comparability_basis` keys on the measured set, so the change was *invisible* rather than wrong. And the champion ratchet stopped protecting exactly the stages a cheap tier is most likely to damage: a directed revision to a routine stage could make it worse with nothing comparing the two.

Split into `_evolution_measures` (free, always) and `_evolution_polishes` (tiering-aware) — which is what the old docstring already said the gate was for.

## A test that was red for ten hours a day

`assertNotIn("T1", rendered)` also matches the `T` separator in `2026-08-11T10:25:09`:

| hour | fails? |
| --- | --- |
| 09:xx | no |
| 10:xx – 19:xx | **yes** |
| 20:xx | no |

The renderer emits `- **T1**:`. The assertion now matches that, and mutation-checking confirms it still fails if a theoretical proposition is rendered. **main was red on a schedule.**

## Claims corrected

| Claim | Was | Is |
| --- | --- | --- |
| menu-order reach | 195/400 *and* 207/400 (same measurement, two paragraphs) | ~250/400, and **seed-dependent** — no integer is stable |
| `default_move` reach | 0/400 | 0/400 ✓ exact, holds at every seed |
| why 0/400 holds | "every node has exactly one forward edge" | false — Stage 06 has two |
| edge family | "eighteen edges" ×4 places | 22, and the code corrects against a *dynamic* count |
| backward edges | ten | thirteen |
| information channels | thirteen | fifteen |
| producing channels | seven | eight |
| `validate_*` functions | seven | nine |
| architecture table line counts | — | 12 stale, most by 20-40% |
| mermaid diagram | 10 dotted edges | 13 (02→01, 03→02, 06→04 were missing) |
| composition table | 0.986 / 0.913 / 0.822 | 0.973 / 0.904 / 0.817 |
| "eight times what a promotion needs" | 8× | 7.8× |
| "on a real completed run" | — | it was a `--fake-operator` run |
| "later stages face strictly more criteria" | — | not strict: 01=02, and 05=06=07=08 |
| "27 stage gates" | — | matches no counting rule at any commit; removed |

The before/after word counts are now dated to the commit they were taken at (`dd54947`). The "before" reproduces nowhere; the "after" has grown 18% since — from other people's channels, not a regression of that change — and the honest form of a before/after is the commit it was taken at.

## And what has never been measured

A new section, because a reader could not tell *"this mechanism works and here is what it found"* from *"this has never been fed anything"*:

- **The archive has zero real runs.** Every number it can produce comes from synthetic test records.
- **The paired-trial mechanism has never completed a trial.** Six pairs attempted 2026-08-11 → 46 attempts, **zero recorded runs**, all failing on Vertex quota (218 `RESOURCE_EXHAUSTED`). A rate-limited run auto-skips its stages, and a skipped stage is never scored.

## Testing

1744 pass. Was 1743 with 1 failure — the time-dependent one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)