### PR TITLE
Read the verdict the reviewer actually emitted

### DIFF
--- a/main.py
+++ b/main.py
@@ -856,7 +856,7 @@ def resolve_search_context(ui: TerminalUI, *, mode: str, operator: str, codex_sa
 
 
 def configure_effort(manager, args, *, backend_name: str, model: str, ui: TerminalUI, fake_mode: bool,
-                     stage_timeout: int) -> None:
+                     stage_timeout: int, unattended: bool = False) -> None:
     """Turn on effort tiering, and give routine stages a cheap gate to use."""
     manager.rigor_level = getattr(args, "rigor", "")
     if not getattr(args, "effort_tiers", False):
@@ -877,8 +877,12 @@ def configure_effort(manager, args, *, backend_name: str, model: str, ui: Termin
         manager.solo_reviewer = manager.reviewer
     elif manager.reviewer is not None:
         # A panel is seated, so build the plain reviewer a routine stage falls back to.
+        # `unattended` is threaded in for the same reason create_reviewer takes it: attended
+        # is the constructor default, so the one construction that stays silent about it is
+        # the one reviewer in an unattended run that aborts on a transport failure.
         manager.solo_reviewer = AutomatedReviewer(
-            backend_name, model=model, fake_mode=fake_mode, ui=ui, stage_timeout=stage_timeout
+            backend_name, model=model, fake_mode=fake_mode, ui=ui,
+            stage_timeout=stage_timeout, unattended=unattended,
         )
 
 def create_crux_panel(args, *, backend_name: str, model: str, ui: TerminalUI):
@@ -1057,6 +1061,7 @@ def main() -> int:
         configure_effort(
             manager, args, backend_name=review_operator, model=review_model, ui=ui,
             fake_mode=args.fake_operator, stage_timeout=args.stage_timeout,
+            unattended=unattended,
         )
         completed = manager.resume_run(
             run_root,
@@ -1145,6 +1150,7 @@ def main() -> int:
     configure_effort(
         manager, args, backend_name=review_operator, model=review_model, ui=ui,
         fake_mode=args.fake_operator, stage_timeout=args.stage_timeout,
+        unattended=unattended,
     )
 
     goal = resolve_goal(args, unattended=unattended)

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -598,11 +598,16 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         from src.effort import EffortPlan
 
         manager.effort_plan = EffortPlan(enabled=True)
+        # `unattended=True` like every other reviewer this file builds. Without it the
+        # routine-tier fallback is the one reviewer in an unattended run that still treats a
+        # transport failure as grounds to abort, because attended is the constructor default
+        # and this was the only construction that did not say otherwise.
         manager.solo_reviewer = (
             reviewer if isinstance(reviewer, AutomatedReviewer)
             else AutomatedReviewer(review_backend, model=review_model,
                                    fake_mode=args.fake_operator, ui=ui,
-                                   stage_timeout=args.stage_timeout)
+                                   stage_timeout=args.stage_timeout,
+                                   unattended=True)
         )
 
     pipeline_completed = False

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -100,17 +100,75 @@ def _try_load_json(text: str) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def extract_json_payload(raw_response: str) -> dict[str, Any] | None:
+#: How far back from the end of a transcript to look for the verdict object, and how many
+#: candidate objects to try. The verdict is the backend's *final* message, so a bounded tail
+#: is enough, and the bound is what keeps a multi-megabyte transcript full of braces from
+#: turning the search into a quadratic scan.
+_VERDICT_SCAN_CHARS = 262_144
+_VERDICT_SCAN_CANDIDATES = 400
+
+
+def _last_object_with_key(text: str, key: str) -> dict[str, Any] | None:
+    """The last JSON object in ``text`` that carries ``key``, ignoring everything else.
+
+    A reviewing backend is an agent, not a formatter. It narrates ("I'll inspect the actual
+    artifacts before judging."), runs tools, and prints their output -- which routinely
+    includes JSON files it read -- before emitting the verdict as its final message. Every
+    other branch here assumes the response *is* the object, or contains exactly one: the
+    greedy ``(\\{.*\\})`` spans from the first brace anywhere in the transcript to the last
+    and yields something unparseable, and the fence branch happily returns the first fenced
+    block even when that is a data file rather than the verdict.
+
+    ``raw_decode`` is what makes this robust: it parses from a given offset and ignores
+    whatever follows, so a candidate is tested without needing to know where it ends, and
+    unbalanced quotes earlier in the transcript cannot desynchronise the search. Scanning
+    from the end means the verdict is found before any JSON the backend merely quoted.
+
+    This is not a loosening of the refusal. An answer with no object carrying ``key`` still
+    returns None and is still refused; the point is that a verdict which was right there in
+    the output stops being read as no verdict at all. In the 40-task ResearchClawBench run
+    that misread ended 12 of the runs, one of them discarding a draft that had passed both
+    gates with a perfect rubric score.
+    """
+    window_start = max(0, len(text) - _VERDICT_SCAN_CHARS)
+    positions = [m.start() + window_start for m in re.finditer(r"\{", text[window_start:])]
+    decoder = json.JSONDecoder()
+    for start in reversed(positions[-_VERDICT_SCAN_CANDIDATES:]):
+        try:
+            payload, _end = decoder.raw_decode(text, start)
+        except ValueError:
+            continue
+        if isinstance(payload, dict) and key in payload:
+            return payload
+    return None
+
+
+def extract_json_payload(raw_response: str, *, verdict_key: str | None = None) -> dict[str, Any] | None:
     """Recover a JSON object from whatever a backend actually printed.
 
     Shared with :mod:`src.router`, which asks a backend for a decision on the same
     terms. Two copies of this would drift on the day one backend starts wrapping
     its output differently, and the copy that was not updated would silently fall
     back to its refusal path instead of reading a decision that was right there.
+
+    ``verdict_key`` is the field that identifies the caller's object -- ``decision`` for a
+    review, ``target`` for a routing move. The two callers want different objects out of the
+    same transcript, so neither can be found by shape alone.
+
+    When it is given the search is *only* for an object carrying it, with no fall-through.
+    Falling through would hand the caller whatever other object the transcript happened to
+    contain -- a data file the backend quoted -- and the caller reads its own fields off
+    what it is given: ``feedback``, ``carry_forward`` and ``discharged`` would come from
+    that file, and the run would be refused for an unsupported decision token rather than
+    for the unreadable answer it actually got. An object that is not the verdict is not a
+    better answer than no verdict.
     """
     candidate = raw_response.strip()
     if not candidate:
         return None
+
+    if verdict_key:
+        return _last_object_with_key(candidate, verdict_key)
 
     direct = _try_load_json(candidate)
     if direct is not None:
@@ -543,7 +601,7 @@ class AutomatedReviewer:
         return truncate_text(text, max_chars=max_chars)
 
     def _parse_decision(self, raw_response: str, markdown: str = "") -> ReviewDecision:
-        payload = self._extract_json_payload(raw_response)
+        payload = self._extract_json_payload(raw_response, verdict_key="decision")
         if payload is None:
             return ReviewDecision(
                 choice="6",
@@ -585,8 +643,13 @@ class AutomatedReviewer:
             comments=comments,
         )
 
-    def _extract_json_payload(self, raw_response: str) -> dict[str, Any] | None:
-        return extract_json_payload(raw_response)
+    def _extract_json_payload(
+        self, raw_response: str, *, verdict_key: str | None = None
+    ) -> dict[str, Any] | None:
+        # No default key: this seam is also how src.ideation_panel reads proposal and scoring
+        # payloads off the same backend, and those objects carry `hypotheses` and `scores`
+        # rather than `decision`. Each caller names the field that identifies its own object.
+        return extract_json_payload(raw_response, verdict_key=verdict_key)
 
     def _try_load_json(self, text: str) -> dict[str, Any] | None:
         return _try_load_json(text)

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -107,6 +107,18 @@ def _try_load_json(text: str) -> dict[str, Any] | None:
 _VERDICT_SCAN_CHARS = 262_144
 _VERDICT_SCAN_CANDIDATES = 400
 
+#: How close to the end of the output the object has to *finish* to count as the verdict.
+#: Scanning from the end finds the verdict before anything the backend merely quoted -- but
+#: only while a verdict exists. When none does, the last quoted object is the last object,
+#: and the run tree the reviewer is told to inspect contains `round_decision.json`, whose
+#: top level really does carry a `decision` key. Reading that as a vote is approving
+#: blindly, which is the one thing this gate exists to prevent. The contract asks for the
+#: verdict as the final message with nothing after it, so requiring it to end near the end
+#: costs a compliant reviewer nothing and puts a quoted artifact mid-transcript out of
+#: reach. The slack is generous: a verdict carrying several carry_forward obligations runs
+#: to a few KB, and a sentence after it is tolerated rather than punished.
+_VERDICT_TAIL_CHARS = 16_384
+
 
 def _last_object_with_key(text: str, key: str) -> dict[str, Any] | None:
     """The last JSON object in ``text`` that carries ``key``, ignoring everything else.
@@ -133,12 +145,13 @@ def _last_object_with_key(text: str, key: str) -> dict[str, Any] | None:
     window_start = max(0, len(text) - _VERDICT_SCAN_CHARS)
     positions = [m.start() + window_start for m in re.finditer(r"\{", text[window_start:])]
     decoder = json.JSONDecoder()
+    tail_begins = len(text) - _VERDICT_TAIL_CHARS
     for start in reversed(positions[-_VERDICT_SCAN_CANDIDATES:]):
         try:
-            payload, _end = decoder.raw_decode(text, start)
+            payload, end = decoder.raw_decode(text, start)
         except ValueError:
             continue
-        if isinstance(payload, dict) and key in payload:
+        if isinstance(payload, dict) and key in payload and end >= tail_begins:
             return payload
     return None
 
@@ -358,6 +371,19 @@ class AutomatedReviewer:
         if on_unreadable is not None and self.unattended:
             return on_unreadable(raw_response)
         return self._unreadable_verdict(raw_response)
+
+    @staticmethod
+    def is_degraded_verdict(decision: ReviewDecision) -> bool:
+        """Whether this verdict is AutoR's own stand-in rather than a reviewer's judgement.
+
+        Unattended, an unreadable answer and a crashed backend both become choice "4" so the
+        stage is revised rather than the run abandoned. That is the right outcome and the
+        wrong provenance: the feedback attached is AutoR's, not a reviewer's, and anything
+        downstream that treats a refusal as something the reviewer *asked for* -- the review
+        policy most of all -- has to be able to tell the two apart. Public because the
+        distinction is only useful outside this class.
+        """
+        return decision.reason.startswith((UNREADABLE_REASON, UNSUPPORTED_REASON, CRASHED_REASON))
 
     @staticmethod
     def _is_unreadable(decision: ReviewDecision) -> bool:

--- a/src/deliberation.py
+++ b/src/deliberation.py
@@ -398,7 +398,13 @@ class CruxPanel:
                 label=f"crux_{voice.key}",
             )
             resolution.voice_calls += 1
-            payload = member._extract_json_payload(stdout_text) if exit_code == 0 else None  # noqa: SLF001
+            # `answer` is what makes an object a position; without it the voice is read off
+            # whatever JSON its transcript quoted and recorded as failed.
+            payload = (  # noqa: SLF001
+                member._extract_json_payload(stdout_text, verdict_key="answer")
+                if exit_code == 0
+                else None
+            )
             if not isinstance(payload, dict) or not str(payload.get("answer") or "").strip():
                 resolution.positions.append(
                     Position(voice=voice.key, title=voice.title, backend=member.backend_name,
@@ -532,7 +538,7 @@ class CruxPanel:
         resolution.voice_calls += 1
         if exit_code != 0:
             return
-        payload = member._extract_json_payload(stdout_text)  # noqa: SLF001
+        payload = member._extract_json_payload(stdout_text, verdict_key="answer")  # noqa: SLF001
         if not isinstance(payload, dict):
             return
         resolution.answer = str(payload.get("answer") or "").strip()

--- a/src/ideation_panel.py
+++ b/src/ideation_panel.py
@@ -447,7 +447,9 @@ class IdeationPanel:
             if exit_code != 0:
                 pool.unreachable.append(lens.key)
                 continue
-            payload = member._extract_json_payload(stdout_text)  # noqa: SLF001
+            payload = member._extract_json_payload(  # noqa: SLF001
+                stdout_text, verdict_key="hypotheses"
+            )
             if not isinstance(payload, dict):
                 pool.unreachable.append(lens.key)
                 continue
@@ -504,7 +506,7 @@ class IdeationPanel:
         )
         if exit_code != 0:
             return
-        payload = scorer._extract_json_payload(stdout_text)  # noqa: SLF001
+        payload = scorer._extract_json_payload(stdout_text, verdict_key="scores")  # noqa: SLF001
         if not isinstance(payload, dict) or not isinstance(payload.get("scores"), list):
             return
 

--- a/src/manager.py
+++ b/src/manager.py
@@ -2753,7 +2753,17 @@ class ResearchManager:
         if decision.feedback:
             log_body.append(f"feedback:\n{decision.feedback}")
         if decision.raw_response:
-            log_body.append("raw_response_excerpt:\n" + truncate_text(decision.raw_response, max_chars=2000))
+            # The tail, not the head. This excerpt is the only durable record of what the
+            # reviewer said, and it is read precisely when the verdict could not be: the
+            # contract puts the verdict in the final message, so keeping the first 2,000
+            # characters records the narration and drops the answer. On Material_002 the
+            # recorded excerpt was 2,002 characters of "I'll inspect the actual artifacts
+            # before judging." and an `ls` listing, containing not one `{`, while the
+            # verdict sat at the other end of the same string.
+            log_body.append(
+                "raw_response_excerpt (tail):\n"
+                + "..." + decision.raw_response.strip()[-2000:].lstrip()
+            )
         append_log_entry(paths.logs, f"{stage.slug} attempt {attempt_no} reviewer_choice", "\n".join(log_body))
         self._record_review_correction(
             paths=paths, stage=stage, attempt_no=attempt_no, decision=decision, suggestions=suggestions
@@ -2911,6 +2921,15 @@ class ResearchManager:
         asked for, so the rule is traceable to the decision that produced it.
         """
         if decision.choice not in {"1", "2", "3", "4"}:
+            return
+
+        # A reviewer that could not be read, or that crashed, did not demand a correction --
+        # unattended, both of those arrive here as choice "4" carrying AutoR's own synthetic
+        # feedback ("The automated reviewer could not be run..."). Recorded as a rule that
+        # text becomes a standing instruction injected into every later review in the run,
+        # so one transport failure permanently teaches the panel a lesson nobody taught it.
+        # Only a reviewer that actually read the stage and asked for something is teaching.
+        if AutomatedReviewer.is_degraded_verdict(decision):
             return
 
         if decision.choice in {"1", "2", "3"}:

--- a/src/rcb.py
+++ b/src/rcb.py
@@ -62,6 +62,7 @@ from .utils import (
     read_text,
     resolve_output_format,
     resolve_report_image,
+    stage_summary_files,
     truncate_text,
     write_text,
 )
@@ -688,9 +689,7 @@ def build_fallback_report(
     draws on are full of approval-workflow headings that would otherwise be scored as content.
     """
     approved: list[tuple[str, str]] = []
-    for stage_path in sorted(paths.stages_dir.glob("*.md")) if paths.stages_dir.exists() else []:
-        if stage_path.name.endswith(".tmp.md"):
-            continue
+    for stage_path in stage_summary_files(paths):
         body = _research_body(read_text(stage_path))
         if not body:
             continue

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -748,8 +748,12 @@ class ReviewPanel:
         return token in {"abstain", "abstention", "no_comment", "pass"}
 
     def _payload(self, raw_response: str) -> dict[str, Any] | None:
+        # `decision` identifies a seat's verdict, and without naming it the veto is read off
+        # whichever object the seat's transcript happened to contain first -- a data file it
+        # quoted. `blocking`, `concerns` and the abstention token all come from here, so a
+        # miss does not fail loudly: the seat is recorded as having raised nothing.
         member = next(iter(self._members.values()))
-        return member._extract_json_payload(raw_response)  # noqa: SLF001
+        return member._extract_json_payload(raw_response, verdict_key="decision")  # noqa: SLF001
 
     @staticmethod
     def _is_unanimous(verdicts: list[PanelVerdict]) -> bool:

--- a/src/router.py
+++ b/src/router.py
@@ -320,7 +320,10 @@ class StageRouter:
                 f"Routing backend exited {exit_code}.",
             )
             return None
-        return extract_json_payload(stdout_text)
+        # `target` is what identifies a routing move, the way `decision` identifies a review
+        # verdict: the backend is an agent whose stdout is a transcript, and the object it
+        # merely quoted from a file must not outrank the one it chose.
+        return extract_json_payload(stdout_text, verdict_key="target")
 
     def _archive_evidence(self, source: str, targets: list[str]) -> str:
         """What the archive can show about the moves on this menu, or nothing.

--- a/src/utils.py
+++ b/src/utils.py
@@ -1681,6 +1681,32 @@ def append_approved_stage_summary(memory_path: Path, stage: StageSpec, stage_mar
     write_text(memory_path, build_memory_text(user_goal, retained_entries, intake_summary=intake_summary))
 
 
+#: Names under ``stages/`` that are not a stage's summary. ``.tmp.md`` is the draft under
+#: review; ``.skip_stub.md`` is the audit record kept beside a *rescued* draft, saying the
+#: stage was auto-skipped. Both sit in the same directory as the summary and both end in
+#: ``.md``, so every reader that globs ``*.md`` has to exclude them or ship them as content.
+NON_SUMMARY_STAGE_SUFFIXES = (".tmp.md", ".skip_stub.md")
+
+
+def stage_summary_files(paths: RunPaths) -> list[Path]:
+    """Every stage summary under ``stages/``, and nothing else.
+
+    One function because two readers globbed this directory with different filters and both
+    were wrong the same way. ``.skip_stub.md`` is written only when a stage ran out of
+    attempts *and* its last draft passed both gates: the draft is promoted to the summary
+    and the stub is kept next to it for the audit trail. A reader that takes both gets the
+    stage's real research and, immediately after it, a section reading "This stage was
+    skipped (auto) and its work was never done" -- about the work sitting above it.
+    """
+    if not paths.stages_dir.exists():
+        return []
+    return sorted(
+        path
+        for path in paths.stages_dir.glob("*.md")
+        if not path.name.endswith(NON_SUMMARY_STAGE_SUFFIXES)
+    )
+
+
 def approved_stage_summaries(memory_text: str) -> str:
     marker = "## Approved Stage Summaries"
     if marker not in memory_text:

--- a/src/validity_review.py
+++ b/src/validity_review.py
@@ -25,6 +25,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime
 
+from .approval_agent import extract_json_payload
 from .terminal_ui import TerminalUI
 from .utils import (
     RunPaths,
@@ -438,19 +439,16 @@ class ValidityReviewer:
 
     @staticmethod
     def _extract_json(raw: str):
-        if not raw:
-            return None
-        text = raw.strip()
-        start = text.find("{")
-        end = text.rfind("}")
-        if start < 0 or end <= start:
-            return None
-        for candidate in (text, text[start : end + 1]):
-            try:
-                return json.loads(candidate)
-            except json.JSONDecodeError:
-                continue
-        return None
+        """The findings object, from a transcript that also contains other JSON.
+
+        This used to be a fourth private copy of the same idea, and the narrowest: it tried
+        the whole string and then ``text[first '{' : last '}']``. On an adversarial review
+        that read a JSON artifact before answering, that slice spans both objects and parses
+        as neither -- and this parser's failure is silent, because :meth:`_parse` returns an
+        empty list either way. The run then records that the validity reviewer attacked the
+        stage and raised nothing, which is the opposite of what happened.
+        """
+        return extract_json_payload(raw, verdict_key="findings")
 
     def _build_prompt(self, *, paths: RunPaths, stage: StageSpec, stage_markdown: str) -> str:
         def excerpt(path, limit: int = 6000) -> str:

--- a/src/writing_manifest.py
+++ b/src/writing_manifest.py
@@ -17,6 +17,7 @@ from .utils import (
     read_text,
     resolve_report_image,
     selected_output_format,
+    stage_summary_files,
 )
 
 
@@ -170,12 +171,10 @@ def _scan_dir(directory: Path) -> list[str]:
 
 
 def _collect_stage_summaries(paths: RunPaths) -> dict[str, str]:
-    summaries: dict[str, str] = {}
-    if paths.stages_dir.exists():
-        for stage_file in sorted(paths.stages_dir.glob("*.md")):
-            if not stage_file.name.endswith(".tmp.md"):
-                summaries[stage_file.stem] = str(stage_file.relative_to(paths.run_root))
-    return summaries
+    return {
+        stage_file.stem: str(stage_file.relative_to(paths.run_root))
+        for stage_file in stage_summary_files(paths)
+    }
 
 
 def generate_layout_review(paths: RunPaths) -> dict[str, object]:

--- a/tests/test_rcb_report_source.py
+++ b/tests/test_rcb_report_source.py
@@ -136,6 +136,40 @@ class FallbackUsesRecoveredWorkTest(unittest.TestCase):
         report = self._build()
         self.assertIn("No completed stage output was produced", report)
 
+    def test_the_skip_stub_sidecar_is_never_a_report_section(self) -> None:
+        """A rescued draft is promoted and the stub is kept beside it for the audit trail.
+
+        Both are `*.md` in `stages/`. A reader that takes both ships the stage's real
+        research and then, immediately below it, "This stage was skipped (auto) and its work
+        was never done" -- about the work directly above. Observed on the live re-runs:
+        Math_001 has 01_literature_survey.md holding a full survey next to
+        01_literature_survey.skip_stub.md saying it never happened.
+        """
+        write_text(self.paths.stages_dir / "01_literature_survey.md", f"# Stage 01\n\nRESCUED {BODY}")
+        write_text(
+            self.paths.stages_dir / "01_literature_survey.skip_stub.md",
+            "# Stage 01: Literature Survey\n\n## Key Results\n\n"
+            "- This stage was skipped (auto) and its work was never done.\n",
+        )
+        report = self._build()
+        self.assertIn("RESCUED", report)
+        self.assertNotIn("its work was never done", report)
+
+    def test_a_lone_skip_stub_does_not_block_champion_recovery(self) -> None:
+        """The sidecar is not a stage summary, so it cannot stand in for one."""
+        write_text(
+            self.paths.stages_dir / "01_literature_survey.skip_stub.md",
+            "# Stage 01\n\n- This stage was skipped (auto).\n",
+        )
+        self._champion("01_literature_survey", f"# Stage 01\n\nDRAFT {BODY}")
+        report = self._build()
+        self.assertIn("DRAFT", report)
+        self.assertIn("No stage was approved", report)
+
+    def test_a_draft_under_review_is_still_excluded(self) -> None:
+        write_text(self.paths.stages_dir / "01_literature_survey.tmp.md", f"# Stage 01\n\nUNDER_REVIEW {BODY}")
+        self.assertNotIn("UNDER_REVIEW", self._build())
+
     def test_figures_are_still_linked_after_a_draft_is_recovered(self) -> None:
         self._champion("01_literature_survey", f"# Stage 01\n\n{BODY}")
         report = self._build(figures=["fig1.png", "fig2.png"])

--- a/tests/test_review_policy.py
+++ b/tests/test_review_policy.py
@@ -200,6 +200,40 @@ class ManagerRecordingTest(PolicyTestBase):
     def test_an_approval_teaches_nothing(self) -> None:
         self.assertEqual(self._record("5", reason="looks good"), [])
 
+    def test_a_verdict_nobody_could_read_teaches_nothing(self) -> None:
+        """Unattended, an unreadable answer arrives here as choice "4" like a real refusal.
+
+        The feedback on it is AutoR's own stand-in text, not something a reviewer asked
+        for. Recorded as a rule it becomes a standing instruction injected into every later
+        review in the run -- one transport failure permanently teaching a lesson nobody
+        taught. Eleven of forty benchmark runs took this path.
+        """
+        from src.approval_agent import UNREADABLE_REASON
+
+        rules = self._record(
+            "4",
+            reason=UNREADABLE_REASON + " AutoR stopped instead of approving blindly.",
+            feedback="The automated reviewer could not be run, so this stage was not approved. "
+                     "Re-examine the draft against the stage contract.",
+        )
+        self.assertEqual(rules, [])
+
+    def test_a_crashed_reviewer_teaches_nothing(self) -> None:
+        from src.approval_agent import CRASHED_REASON
+
+        self.assertEqual(
+            self._record("4", reason=CRASHED_REASON + " It exited -1.", feedback=OTHER), []
+        )
+
+    def test_an_unsupported_token_teaches_nothing(self) -> None:
+        from src.approval_agent import UNSUPPORTED_REASON
+
+        self.assertEqual(self._record("4", reason=UNSUPPORTED_REASON, feedback=OTHER), [])
+
+    def test_a_real_refusal_still_teaches(self) -> None:
+        """The exemption is for degraded verdicts only, not for refusals generally."""
+        self.assertEqual(self._record("4", feedback=OTHER, reason="the ledger is wrong")[0].text, OTHER)
+
     def test_an_abort_teaches_nothing(self) -> None:
         self.assertEqual(self._record("6", reason="blocked"), [])
 

--- a/tests/test_verdict_extraction.py
+++ b/tests/test_verdict_extraction.py
@@ -108,6 +108,27 @@ class TheRefusalIsPreservedTest(unittest.TestCase):
     def test_truncated_json_is_refused(self) -> None:
         self.assertIsNone(extract_json_payload(NARRATION + VERDICT[:-20], verdict_key="decision"))
 
+    def test_a_quoted_artifact_mid_transcript_is_not_a_vote(self) -> None:
+        """`round_decision.json` in the run tree carries a top-level `decision` key.
+
+        The reviewer is told to inspect that tree. If it reads the file and then never
+        emits a verdict, the quoted object is the last decision-bearing object in the
+        output, and taking it would be approving blindly -- the one thing the gate exists
+        to prevent. The verdict has to be the final message, so it has to end near the end.
+        """
+        from src.approval_agent import _VERDICT_TAIL_CHARS
+
+        quoted = '{"decision":"approve","stage":"06_synthesis","round":2}'
+        raw = NARRATION + quoted + "\n" + ("I am still thinking about this. " * 1200)
+        self.assertGreater(len(raw) - len(NARRATION + quoted), _VERDICT_TAIL_CHARS)
+        self.assertIsNone(extract_json_payload(raw, verdict_key="decision"))
+
+    def test_a_real_verdict_after_a_quoted_artifact_still_wins(self) -> None:
+        raw = NARRATION + '{"decision":"abort","stage":"06_synthesis"}\nMy own verdict:\n' + VERDICT
+        payload = extract_json_payload(raw, verdict_key="decision")
+        assert payload is not None
+        self.assertEqual(payload["decision"], "approve")
+
 
 class RouterSharesTheFunctionTest(unittest.TestCase):
     """Two callers want different objects out of the same kind of transcript."""

--- a/tests/test_verdict_extraction.py
+++ b/tests/test_verdict_extraction.py
@@ -1,0 +1,192 @@
+"""The reviewing backend is an agent, so its stdout is a transcript, not an object.
+
+This is the defect that ended 12 of 40 ResearchClawBench runs. On Material_002 the reviewer
+inspected the artifacts, wrote "well past the bar for a literature survey", and emitted a
+verdict object as its final message. AutoR read the transcript, found no object it could
+parse, recorded
+
+    choice: 6
+    decision_token: abort
+    reason: Automated reviewer did not return valid JSON. AutoR stopped instead of approving blindly.
+
+and ended the run -- discarding `stages/01_literature_survey.tmp.md`, 18,976 bytes that had
+passed both gates with a rubric score of 1.0. The refusal itself is right; the premise was
+wrong. The verdict was in the output.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.approval_agent import AutomatedReviewer, extract_json_payload
+
+
+VERDICT = (
+    '{"decision":"approve","reason":"ledger integrity holds","feedback":"",'
+    '"carry_forward":[{"obligation":"settle experiment 3","target_stage":"03_study_design"}],'
+    '"discharged":[]}'
+)
+
+#: The literal opening of the transcript AutoR recorded for Material_002.
+NARRATION = (
+    "I'll inspect the actual artifacts before judging.\n"
+    "total 2408\n"
+    "drwxrwxr-x  9 robtang_google_com robtang_google_com    4096 Aug  6 14:53 .\n"
+    "-rw-rw-r--  1 robtang_google_com robtang_google_com     584 Aug  6 14:48 artifact_index.json\n\n"
+)
+
+#: A data file the reviewer read and echoed. This is what defeats the greedy brace branch:
+#: `(\{.*\})` spans from this object's first brace to the verdict's last one.
+QUOTED_DATA = '{"claims": [{"id": "C09", "source_ids": []}, {"id": "C10", "source_ids": ["S16"]}]}\n'
+
+
+class VerdictInATranscriptTest(unittest.TestCase):
+    def _decision(self, raw: str) -> str | None:
+        payload = extract_json_payload(raw, verdict_key="decision")
+        return None if payload is None else payload.get("decision")
+
+    def test_a_bare_object_still_works(self) -> None:
+        self.assertEqual(self._decision(VERDICT), "approve")
+
+    def test_narration_and_tool_output_before_the_verdict(self) -> None:
+        self.assertEqual(self._decision(NARRATION + VERDICT), "approve")
+
+    def test_material_002_the_transcript_also_quoted_a_json_file(self) -> None:
+        """The greedy `(\\{.*\\})` branch spans both objects and parses as neither."""
+        raw = NARRATION + "Let me read claims.json.\n" + QUOTED_DATA + "Now the verdict.\n" + VERDICT
+        self.assertEqual(self._decision(raw), "approve")
+
+    def test_a_sentence_after_the_verdict_does_not_hide_it(self) -> None:
+        self.assertEqual(self._decision(VERDICT + "\n\nHappy to expand on any of this."), "approve")
+
+    def test_a_fenced_data_block_does_not_outrank_the_real_verdict(self) -> None:
+        """The fence branch returns the *first* fenced object, which here is a data file."""
+        raw = "Here is what I read:\n```json\n" + QUOTED_DATA + "```\n" + VERDICT
+        self.assertEqual(self._decision(raw), "approve")
+
+    def test_a_fenced_verdict_is_still_found(self) -> None:
+        self.assertEqual(self._decision("Verdict:\n```json\n" + VERDICT + "\n```"), "approve")
+
+    def test_the_last_verdict_wins_when_the_backend_changes_its_mind(self) -> None:
+        raw = '{"decision":"revise","reason":"first pass"}\nOn reflection:\n' + VERDICT
+        self.assertEqual(self._decision(raw), "approve")
+
+    def test_nested_objects_inside_the_verdict_survive(self) -> None:
+        payload = extract_json_payload(NARRATION + VERDICT, verdict_key="decision")
+        assert payload is not None
+        self.assertEqual(payload["carry_forward"][0]["target_stage"], "03_study_design")
+
+    def test_an_unbalanced_quote_earlier_in_the_transcript_does_not_desynchronise(self) -> None:
+        """Tool output is arbitrary text; a stray quote must not swallow the verdict."""
+        raw = NARRATION + 'sed: -e expression #1, char 3: unterminated `s\' command\n' + VERDICT
+        self.assertEqual(self._decision(raw), "approve")
+
+    def test_a_verdict_split_by_a_blank_line_in_the_middle_is_still_one_object(self) -> None:
+        raw = NARRATION + '{"decision":"approve",\n\n  "reason":"fine"}'
+        self.assertEqual(self._decision(raw), "approve")
+
+
+class TheRefusalIsPreservedTest(unittest.TestCase):
+    """Reading a verdict that is there must not become approving one that is not."""
+
+    def test_a_transcript_with_no_verdict_is_still_refused(self) -> None:
+        self.assertIsNone(extract_json_payload(NARRATION + QUOTED_DATA, verdict_key="decision"))
+
+    def test_an_empty_response_is_refused(self) -> None:
+        self.assertIsNone(extract_json_payload("", verdict_key="decision"))
+        self.assertIsNone(extract_json_payload("   \n  ", verdict_key="decision"))
+
+    def test_prose_that_merely_says_approve_is_not_a_verdict(self) -> None:
+        """The object is the contract. An agent musing about approval has not voted."""
+        self.assertIsNone(
+            extract_json_payload("I would approve this stage. decision: approve", verdict_key="decision")
+        )
+
+    def test_an_object_without_the_key_does_not_masquerade_as_one(self) -> None:
+        self.assertIsNone(extract_json_payload('{"verdict":"approve"}', verdict_key="decision"))
+
+    def test_truncated_json_is_refused(self) -> None:
+        self.assertIsNone(extract_json_payload(NARRATION + VERDICT[:-20], verdict_key="decision"))
+
+
+class RouterSharesTheFunctionTest(unittest.TestCase):
+    """Two callers want different objects out of the same kind of transcript."""
+
+    def test_a_routing_move_is_found_by_its_own_key(self) -> None:
+        raw = 'I looked at the graph.\n{"nodes":[1,2]}\nMy move:\n{"target":"03_study_design","reason":"design first"}'
+        payload = extract_json_payload(raw, verdict_key="target")
+        assert payload is not None
+        self.assertEqual(payload["target"], "03_study_design")
+
+    def test_a_review_verdict_is_not_mistaken_for_a_routing_move(self) -> None:
+        self.assertIsNone(extract_json_payload(VERDICT, verdict_key="target"))
+
+    def test_omitting_the_key_keeps_the_original_behaviour(self) -> None:
+        """Callers with no identifying key still get the first parseable object."""
+        self.assertEqual(extract_json_payload(VERDICT), extract_json_payload(VERDICT, verdict_key="decision"))
+        self.assertEqual(extract_json_payload(QUOTED_DATA.strip())["claims"][0]["id"], "C09")
+
+
+class TheDecisionThatWasLostTest(unittest.TestCase):
+    """End to end: the transcript that ended 11 runs now promotes the stage.
+
+    `parse_with_retry` and the unattended send-back already stopped the *abort*, so these
+    runs would no longer die outright. They would still burn every attempt on re-asks of a
+    verdict that was readable all along, and end auto-skipped. This is the cause, not the
+    bleeding: the first parse succeeds and the stage is approved on attempt one.
+    """
+
+    def setUp(self) -> None:
+        self.reviewer = AutomatedReviewer("claude", model="opus", unattended=True)
+
+    def _decision(self, raw: str):
+        return self.reviewer._parse_decision(raw)  # noqa: SLF001
+
+    def test_the_transcript_now_yields_approve_and_promote(self) -> None:
+        decision = self._decision(NARRATION + QUOTED_DATA + "Verdict:\n" + VERDICT)
+        self.assertEqual(decision.choice, "5")
+        self.assertEqual(decision.decision_token, "approve")
+        self.assertFalse(self.reviewer._is_unreadable(decision))  # noqa: SLF001
+
+    def test_the_obligations_survive_the_transcript(self) -> None:
+        """carry_forward is where most of a review's value lives; it came from the verdict."""
+        decision = self._decision(NARRATION + QUOTED_DATA + VERDICT)
+        self.assertEqual(decision.carry_forward[0]["target_stage"], "03_study_design")
+
+    def test_a_revise_verdict_in_a_transcript_is_read_as_revise(self) -> None:
+        """Three of the twelve runs said revise, not approve. Both were lost the same way."""
+        raw = NARRATION + '{"decision":"revise","reason":"ledger has empty source_ids","feedback":"cite the spec"}'
+        decision = self._decision(raw)
+        self.assertEqual(decision.choice, "4")
+        self.assertEqual(decision.feedback, "cite the spec")
+
+    def test_a_transcript_with_no_verdict_is_still_unreadable(self) -> None:
+        decision = self._decision(NARRATION + QUOTED_DATA)
+        self.assertTrue(self.reviewer._is_unreadable(decision))  # noqa: SLF001
+
+    def test_a_quoted_data_file_is_never_read_as_the_verdict(self) -> None:
+        """Falling through to some other object would source feedback from a data file."""
+        decision = self._decision(NARRATION + QUOTED_DATA)
+        self.assertEqual(decision.carry_forward, [])
+        self.assertEqual(decision.feedback, "")
+
+
+class ScanIsBoundedTest(unittest.TestCase):
+    def test_a_megabyte_of_braces_before_the_verdict_still_resolves(self) -> None:
+        """A long transcript must not turn the search quadratic."""
+        noise = '{"row": %d}\n' % 1
+        raw = noise * 20000 + VERDICT
+        self.assertEqual(
+            extract_json_payload(raw, verdict_key="decision").get("decision"), "approve"
+        )
+
+    def test_a_verdict_beyond_the_scan_window_is_refused_rather_than_hung(self) -> None:
+        """Bounding the window is a real limit, so it is stated rather than assumed."""
+        from src.approval_agent import _VERDICT_SCAN_CHARS
+
+        raw = VERDICT + "x" * (_VERDICT_SCAN_CHARS + 1000)
+        self.assertIsNone(extract_json_payload(raw, verdict_key="decision"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The reviewer is an agent, not a formatter

It narrates, runs tools, and prints their output before emitting the verdict as its final message. AutoR parsed that whole transcript as if it were the object.

On **Material_002** the reviewer inspected the artifacts, wrote *"well past the bar for a literature survey"*, and emitted a complete verdict. AutoR recorded:

```
choice: 6
decision_token: abort
reason: Automated reviewer did not return valid JSON. AutoR stopped instead of approving blindly.
raw_response_excerpt:
I'll inspect the actual artifacts before judging.
total 2408
drwxrwxr-x  9 robtang_google_com ...
```

and ended the run — discarding `stages/01_literature_survey.tmp.md`, **18,976 bytes** that had passed both gates with a **rubric score of 1.0**.

## Forensics on all 12 zero-stage runs

| | |
|---|---|
| died on *"did not return valid JSON"* | **11 / 12** |
| held a draft scoring **1.0** on the rubric | 12 / 12 |
| reviewer **had** emitted a complete JSON verdict | 11 / 11 |
| its prose said *approve* / *revise* | 8 / 3 |
| mean score, these 12 | **0.91** |
| mean score, the other 28 | **19.84** |

**Earth_003 and Chemistry_003 carry the control inside the run.** An earlier attempt emitted the same prose-then-verdict shape wrapped in a ` ```json ` fence, matched the fence branch, and landed normally. The final attempt complied *more* closely with *"Return JSON only, with no prose outside the JSON object"* by dropping the fence — and that is what made its approval unreadable. The difference between a working review and a cancelled run was three backticks.

Why no branch found it: whole-string `json.loads` fails on a transcript; the fence branch returns the **first** fenced object, a data file the reviewer read; the greedy `(\{.*\})` anchors on the Read tool's own input JSON or a `tool_result` dump and spans to the end.

## The fix

Callers name the field that identifies their own object. The last object carrying it wins, found with `raw_decode` scanning backwards — robust to unbalanced quotes in earlier tool output, and it finds the verdict before any JSON the backend merely quoted.

| caller | key |
|---|---|
| `approval_agent` review | `decision` |
| `router` | `target` |
| `ideation_panel` | `hypotheses`, `scores` |
| `review_panel` | `decision` — `blocking`, `concerns`, abstention all come from here, so a miss silently erased a seat's veto |
| `deliberation` | `answer` — voices and chair; every voice recorded failed, budget spent |
| `validity_review` | `findings` — a fourth private copy, the narrowest; its failure is silent, so the run recorded that the adversarial reviewer attacked and raised nothing |

### The keyed search needed a bound of its own

Scanning from the end beats a quoted object — **only while a verdict exists**. When none does, the quoted one *is* the last one, and `round_decision.json` in the run tree the reviewer is told to inspect carries a top-level `decision` key. Reading that as a vote is approving blindly. The object must now also **finish within 16 KB of the end** — which the contract already asks for, and a quoted artifact mid-transcript cannot satisfy. My first draft of this fix had both this hole and a fall-through that would have handed the caller a data file to read `feedback` and `carry_forward` off; the tests caught both.

## Also fixed

- **A degraded verdict taught the run.** Unattended, unreadable/crashed arrives as choice `"4"` carrying AutoR's own stand-in feedback. That was promoted to a standing rule injected into every later review — one transport failure permanently teaching a lesson nobody taught.
- **The record kept the head.** `raw_response_excerpt` took the first 2,000 chars. It is read precisely when the verdict could not be, and the verdict is last: on Material_002 those 2,002 chars held narration and an `ls`, and not one `{`. Now the tail.
- **The routine-tier solo reviewer was built without `unattended=`**, in both `main.py` and `rcb_agent.py`, 70 lines below a panel construction that passes it with a comment explaining why. Attended is the default, so it was the one reviewer in an unattended run that still aborted on a transport failure.
- **`.skip_stub.md` shipped as a report section.** Two readers globbed `stages/*.md` and both missed it. It is the audit record kept beside a *rescued* draft, so taking it ships the stage's real research followed by "This stage was skipped (auto) and its work was never done" — about the work directly above. Live on the re-runs: Math_001 has a full literature survey next to a stub saying it never happened. One shared `stage_summary_files` now.

## Verification

Five re-runs launched this morning on the pre-fix code are live and have approved **zero** stages between them — every stage burned its attempts on re-asks and was auto-skipped, `did not return valid JSON` appearing 12 times in one log. `parse_with_retry` and the unattended send-back (#164/#169) stopped these runs dying outright; they never made the verdict readable. With this change the same transcript parses on the first attempt and returns `choice: 5` with its obligations intact.

Full suite **1820 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)