### PR TITLE
Stop the docs' counts from rotting, and repair the instrument that proved a claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ AutoR takes a different position: research is too important to hand over as a bl
 | Execution model | A coding agent as the execution layer, AutoR as the research control loop |
 | Control model | Human approval by default, with an optional strict reviewer-agent gate for unattended runs |
 | Research unit | A reproducible run under `runs/<run_id>/` |
-| Workflow shape | Nine stages as a **directed graph** the run navigates; the linear sequence is one path through it |
+| Workflow shape | Eight stages as a **directed graph** the run navigates — intake runs before the walk; the linear sequence is one path through it |
 | Improvement | On by default: drafts are measured and ratcheted, so a stage can only get better — and the score is blind to what the run concluded |
 | Quality bar | Artifact-backed outputs, not markdown-only summaries |
 | Recovery | Resume, redo-stage, rollback-stage, stage-local continuation |
@@ -118,7 +118,7 @@ It is:
 
 Latest mainline updates:
 
-- **2026-08-06**: **Recursive self-improvement is now the default.** The nine stages are a **directed graph** the run navigates: an analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it, and the move into Stage 07 stays closed until every hypothesis carries a verdict. The stage that just ran chooses the next move, among the ones AutoR's guards leave open. Every valid draft is scored against a rigour rubric read off disk and held to a champion ratchet, so the draft that gets promoted is the best one the run produced rather than the last one — that half costs nothing, because the rubric never calls a backend. Two improvement rounds per stage are budgeted on top, and a stage the rubric has nothing to say about spends none of them. A round that scores worse is reverted; a round that changes a hypothesis verdict is rejected outright. Each finished run records its route and measured fitness in a cross-run archive, which compares each graph edge against the decisions that were *offered* it and declined. The archive has no real runs in it yet — see [what has and has not been measured](docs/self-improvement.md#what-has-and-has-not-been-measured). Opt out with `--stage-graph linear`, `--routing off`, `--no-evolve`, `--no-archive`. See [Recursive Self-Improvement](docs/self-improvement.md).
+- **2026-08-06**: **Recursive self-improvement is now the default.** The eight stages are a **directed graph** the run navigates: an analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it, and the move into Stage 07 stays closed until every hypothesis carries a verdict. The stage that just ran chooses the next move, among the ones AutoR's guards leave open. Every valid draft is scored against a rigour rubric read off disk and held to a champion ratchet, so the draft that gets promoted is the best one the run produced rather than the last one — that half costs nothing, because the rubric never calls a backend. Two improvement rounds per stage are budgeted on top, and a stage the rubric has nothing to say about spends none of them. A round that scores worse is reverted; a round that changes a hypothesis verdict is rejected outright. Each finished run records its route and measured fitness in a cross-run archive, which compares each graph edge against the decisions that were *offered* it and declined. The archive has no real runs in it yet — see [what has and has not been measured](docs/self-improvement.md#what-has-and-has-not-been-measured). Opt out with `--stage-graph linear`, `--routing off`, `--no-evolve`, `--no-archive`. See [Recursive Self-Improvement](docs/self-improvement.md).
 - **2026-06-02**: Added a configurable Codex sandbox mode. Codex-backed runs still default to `workspace-write`, but users who intentionally need remote GPU or SSH execution can now opt into `--codex-sandbox danger-full-access`; the setting is persisted in `run_config.json` and preserved on resume.
 - **2026-05-10**: Refined the terminal-first run experience. Stage 00 now uses a dedicated clarification flow: the first intake pass asks the user questions one by one with selectable options, custom answers, and skip; the revised intake brief then uses a compact refine / approve / abort menu instead of showing the normal suggestion template. The terminal UI also keeps colored frames on wrapped body rows, handles long lines and wide characters more reliably, and the Codex backend now uses the current `--sandbox workspace-write` execution flag instead of the deprecated Codex CLI `--full-auto` flag.
 - **2026-04-20**: Added an optional `--full-auto` approval mode. The execution loop is unchanged, but the manual approval gate can now be replaced by a strict simulated reviewer agent backed by Claude or Codex, with reviewer settings persisted in `run_config.json`.
@@ -166,8 +166,8 @@ Most autoresearch systems optimize for autonomy. AutoR takes a different positio
 important to hand over as a blind end-to-end loop. The goal is not to remove humans from research.
 The goal is to give them a stronger execution system.
 
-AutoR runs a research project as eight stages wired into a directed graph: six forward edges are
-guarded by artifacts on disk, thirteen backward edges let a late finding send the run back — Stage 07
+AutoR runs a research project as eight stages wired into a directed graph: six of the eight forward
+edges are guarded by artifacts on disk, thirteen backward edges let a late finding send the run back — Stage 07
 can reopen the literature survey. Hypotheses are frozen and hashed when Stage 04 is approved, every
 one must be adjudicated at Stage 06 against a named result file, and every paper claim traced at
 Stage 07; a `supported` or `refuted` verdict resting on one run is refused unless the run records
@@ -180,14 +180,14 @@ gate, and by default that gate is you.
 
 | Move | What runs | Where |
 | --- | --- | --- |
-| **Propose** | Five proposers work from distinct lenses — mechanism, contrarian, adjacent field, null/artifact, regime — blind to each other; two statements whose Jaccard overlap reaches 0.5 collapse into one idea | [`ideation_panel.py`](src/ideation_panel.py) · 712L |
-| **Test** | Every baseline declares `why_competent` and a `tuning_budget` before it runs; the hypothesis set is frozen and hashed before any result exists, and a later change is legal only as a recorded amendment | [`experimental_protocol.py`](src/experimental_protocol.py) · 234L<br />[`preregistration.py`](src/preregistration.py) · 579L |
-| **Refute** | An adversarial pass asks why the result is wrong across ten named failure modes — confound, leakage, `metric_cherry_picking`, `effect_within_noise`, six more; a round can close as `converged`, `refine_design`, `new_hypothesis` or `abandon` | [`validity_review.py`](src/validity_review.py) · 512L<br />[`research_rounds.py`](src/research_rounds.py) · 320L |
-| **Critique** | Five seats review independently, cross-examine anonymised, then converge; a blocking objection is turned into a refusal in code against the panel's own chair, and a different model family audits the approval as a veto | [`review_panel.py`](src/review_panel.py) · 1223L<br />[`cross_reviewer.py`](src/cross_reviewer.py) · 239L |
-| **Iterate** | Every valid draft is scored against a rubric read off disk; the champion is kept and a losing polish round is reverted before anyone reads it; a draft that loses on the weighted total but is non-dominated on the criterion vector is kept anyway | [`rubric.py`](src/rubric.py) · 926L<br />[`evolution.py`](src/evolution.py) · 692L<br />[`pareto.py`](src/pareto.py) · 212L |
-| **Learn** | Each finished run records its route and measured fitness; a fitness comparison is keyed on the set of stages the run actually measured, so a run cannot score well by stopping early | [`archive.py`](src/archive.py) · 862L |
-| **Deliberate** | A stage that hits a genuine crux stops, names the question, and pulls in theorist / empiricist / critic / pragmatist plus an expert brief, then continues with an answer that names its own falsifier; budgeted, and measured against what the agent already believed | [`deliberation.py`](src/deliberation.py) · 640L |
-| **Localise** | A reviewer quotes the passage it objects to instead of refusing the whole stage; the revision is told to change only those spans and is diffed against them, so "preserve the correct parts" is measured rather than hoped for | [`stage_comments.py`](src/stage_comments.py) · 375L |
+| **Propose** | Five proposers work from distinct lenses — mechanism, contrarian, adjacent field, null/artifact, regime — blind to each other; two statements whose Jaccard overlap reaches 0.5 collapse into one idea | [`ideation_panel.py`](src/ideation_panel.py) |
+| **Test** | Every baseline declares `why_competent` and a `tuning_budget` before it runs; the hypothesis set is frozen and hashed before any result exists, and a later change is legal only as a recorded amendment | [`experimental_protocol.py`](src/experimental_protocol.py)<br />[`preregistration.py`](src/preregistration.py) |
+| **Refute** | An adversarial pass asks why the result is wrong across ten named failure modes — confound, leakage, `metric_cherry_picking`, `effect_within_noise`, six more; a round can close as `converged`, `refine_design`, `new_hypothesis` or `abandon` | [`validity_review.py`](src/validity_review.py)<br />[`research_rounds.py`](src/research_rounds.py) |
+| **Critique** | Five seats review independently, cross-examine anonymised, then converge; a blocking objection is turned into a refusal in code against the panel's own chair, and a different model family audits the approval as a veto | [`review_panel.py`](src/review_panel.py)<br />[`cross_reviewer.py`](src/cross_reviewer.py) |
+| **Iterate** | Every valid draft is scored against a rubric read off disk; the champion is kept and a losing polish round is reverted before anyone reads it; a draft that loses on the weighted total but is non-dominated on the criterion vector is kept anyway | [`rubric.py`](src/rubric.py)<br />[`evolution.py`](src/evolution.py)<br />[`pareto.py`](src/pareto.py) |
+| **Learn** | Each finished run records its route and measured fitness; a fitness comparison is keyed on the set of stages the run actually measured, so a run cannot score well by stopping early. No real observation has reached it yet — the archive is empty on a fresh install ([what has and has not been measured](docs/self-improvement.md#what-has-and-has-not-been-measured)) | [`archive.py`](src/archive.py) |
+| **Deliberate** | A stage that hits a genuine crux stops, names the question, and pulls in theorist / empiricist / critic / pragmatist plus an expert brief, then continues with an answer that names its own falsifier; budgeted, and measured against what the agent already believed | [`deliberation.py`](src/deliberation.py) |
+| **Localise** | A reviewer quotes the passage it objects to instead of refusing the whole stage; the revision is told to change only those spans and is diffed against them, so "preserve the correct parts" is measured rather than hoped for | [`stage_comments.py`](src/stage_comments.py) |
 
 Four of those eight are on for every run: **Test**, **Refute**, **Iterate** (`--evolve` defaults on)
 and **Learn**, which records on every run but only reaches a routing decision under
@@ -205,7 +205,7 @@ reaches the desk. The research unit is unchanged: one reproducible run under `ru
 isolated, resumable, with redo and rollback.
 
 Approved stage summaries are the only *free-text* memory. Every other cross-stage edge is a typed
-artifact with a declared reader: thirteen channels in
+artifact with a declared reader: sixteen typed channels in
 [`information_flow.py`](src/information_flow.py) each name the exact stage slugs that consume them,
 and the eight produced inside the walk name their producing stage as well. `obligations.json` and
 `review_policy.json` cross stages without touching a summary at all — both only behind an agent
@@ -235,10 +235,13 @@ the stage contract, and the effect on a scripted run was measured at the commit 
 | Share of stage output that was relay | 64% | 0% |
 | Assembled prompt text | 21,236 words | 20,353 words |
 
-Dated on purpose. The "after" column reproduces to the word at `dd54947` and no longer does at
-HEAD — the same measurement now gives 24,089 words, because eight PRs have since added context
-channels of their own. The relay heading is still gone; the 18% that came back is other people's
-work, not a regression of this one, and the honest form of a before/after is the commit it was taken
+Dated on purpose, and the recipe matters as much as the number: wrap `build_prompt`, sum
+`len(prompt.split())` over one `--fake-operator --full-auto` run, and hold the goal string fixed —
+the goal alone moves the total by a few hundred words, which is why an undated, un-recipe'd figure
+here is not re-derivable by anyone. Re-run at `be76a34` with one goal held constant, `dd54947` gives
+20,401 and HEAD gives 25,415: the assembled prompt is a quarter larger than when the relay heading
+came out. The relay heading is still gone; the growth is later work adding context channels of its
+own, not a regression of this one, and the honest form of a before/after is the commit it was taken
 at.
 
 The sharpest single case: the mutable Stage 02 hypotheses and the frozen preregistration were both
@@ -249,16 +252,19 @@ stops at `04_implementation`, where the freeze supersedes it
 
 The shape of the system, in counts you can re-derive from named symbols in the source: eight stages
 plus `FINISH`, six guarded forward edges (`_ADVANCE_GUARDS`), thirteen backward edges
-(`REVISIT_EDGES`), one conditional terminal (`TERMINAL_EDGES`), and fifteen typed information
+(`REVISIT_EDGES`), one conditional terminal (`TERMINAL_EDGES`), and sixteen typed information
 channels (`CHANNELS`) — twenty-two edges in the adaptive graph altogether. Alongside the gates that ask whether a file
-exists, **nine** `validate_*` functions ask whether a claim is warranted — count them with
-`grep -rn "^def validate_" src/`; they are named in full under
-[the stage contract](#-the-stage-contract-and-what-gets-validated).
+exists, seven `validate_*` functions form the scientific-validity chain and ask whether a *claim*
+is warranted; they are named in full under
+[the stage contract](#-the-stage-contract-and-what-gets-validated). (`validate_stage_artifacts`
+dispatches seventeen validators in total and `src/` defines twenty — the seven are the subset the
+code itself labels as the validity chain.)
 
 ## News
 
-- **2026-08-06** — Per-stage output is flat at 228-277 words where it used to grow 235 → 1,211,
-  relay is 0% where it was 64%, and assembled prompt text fell 21,823 → 20,353 words across a run.
+- **2026-08-06** — Per-stage output is flat at 228-292 words where it used to grow 235 → 1,211,
+  relay is 0% where it was 64%, and assembled prompt text fell by about 900 words across a run
+  (measured at `dd54947`; see [What changed, measured](#what-changed-measured) for the recipe).
   Behind those numbers: the stages became a directed graph with a router that must justify its move
   and is refused off-menu (`stage_graph.py`, `router.py`); every valid draft is scored and held to a
   champion ratchet (`rubric.py`, `evolution.py`, `pareto.py`); the cross-run archive keys every
@@ -338,7 +344,7 @@ scope. "Make each one refutable" is advice about a gate that now exists.
 - Python 3.10+
 - Claude CLI or Codex CLI available on `PATH` for real runs
 - Local TeX tools are only needed for `--output-format latex`; the default markdown output needs no TeX
-- `pip install google-genai` and a Gemini key in `GOOGLE_API_KEY` or `GEMINI_API_KEY` — needed by three paths, not only the diagram one: `--web-search gemini`, required where the backend's own `WebSearch` tool is disabled (`build_genai_client`, src/web_search.py:346, called at :482); the cross-model veto `--cross-review auto|gemini`, which builds the same client (src/cross_reviewer.py:108); and `--research-diagram`, which also reads `configs/diagram_config.yaml` (see `configs/diagram_config.template.yaml`)
+- `pip install google-genai` and a Gemini key in `GOOGLE_API_KEY` or `GEMINI_API_KEY` — needed by three paths, not only the diagram one: `--web-search gemini`, required where the backend's own `WebSearch` tool is disabled (`build_genai_client`, src/web_search.py); the cross-model veto `--cross-review auto|gemini`, which builds the same client (src/cross_reviewer.py); and `--research-diagram`, which also reads `configs/diagram_config.yaml` (see `configs/diagram_config.template.yaml`)
 - The SDK is **not** a default dependency. Without it the diagram step prints `Diagram generation failed: No module named 'google'` and the run continues; cross-review records itself unavailable rather than agreeing
 
 ### Common commands
@@ -379,7 +385,7 @@ scope. "Make each one refutable" is advice about a gate that now exists.
 
 Every flag, its default, and what is preserved on resume: **[docs/cli-reference.md](docs/cli-reference.md)**. Stage identifiers accept `03`, `3` or `03_study_design`; `--venue` defaults to `neurips_2025`.
 
-**Two flags in that table remove the human from the gate.** `resolve_unattended` returns `True` for both `--full-auto` and `--review-panel` (main.py:567-577), and `approval_mode = "agent" if (args.full_auto or args.review_panel)` (main.py:862). So both replace the approval menu with an agent reviewer, never block on terminal input, and auto-skip a stage that exhausts its retries, up to `--max-auto-skips` (default 3). Under a badge reading *Human approval required*, the flag that looks like more review is the flag that removes the reviewer. Three headline mechanisms — obligations, the standing review policy, the cross-model veto — also run only behind that agent gate. Manual approval is the default and remains the path for work you intend to publish.
+**Two flags in that table remove the human from the gate.** `resolve_unattended` returns `True` for both `--full-auto` and `--review-panel` (main.py), and `approval_mode = "agent" if (args.full_auto or args.review_panel)` (main.py). So both replace the approval menu with an agent reviewer, never block on terminal input, and auto-skip a stage that exhausts its retries, up to `--max-auto-skips` (default 3). Under a badge reading *Human approval required*, the flag that looks like more review is the flag that removes the reviewer. Three headline mechanisms — obligations, the standing review policy, the cross-model veto — also run only behind that agent gate. Manual approval is the default and remains the path for work you intend to publish.
 
 For Codex-backed runs, AutoR defaults to `--codex-sandbox workspace-write`. If a verified remote experiment needs SSH or external GPU access, use `--codex-sandbox danger-full-access` intentionally. This grants the Codex backend unrestricted local/remote execution ability, so it should not be the default for untrusted tasks.
 
@@ -408,15 +414,15 @@ python studio.py --runs-dir /path/to/runs       # override runs directory
 
 > The Studio API has **no authentication**. It binds to `127.0.0.1` by default; anything that can reach it can start runs, approve stages, and read every file under the runs directory. For remote access prefer an SSH tunnel over `--host 0.0.0.0`. See [SECURITY.md](SECURITY.md).
 
-One honest limit, then the walkthrough: the Studio's lazy-resume approve path picks the next stage arithmetically — the first stage with a higher number (src/backend/studio_runner.py:361-364) — and never consults the router, so graph routing and backward moves are a CLI capability today. Page-by-page walkthrough and the full HTTP API: **[docs/studio.md](docs/studio.md)**.
+One honest limit, then the walkthrough: the Studio's lazy-resume approve path picks the next stage arithmetically — the first stage with a higher number (src/backend/studio_runner.py) — and never consults the router, so graph routing and backward moves are a CLI capability today. Page-by-page walkthrough and the full HTTP API: **[docs/studio.md](docs/studio.md)**.
 
 ## How it works: the stage graph
 
 Eight stages are the nodes; a `finish` node closes the walk. Stage 00 intake is not one of
 them — it runs before the walk starts, and `_graph_entry_stage` → `_select_stages_for_run`
-(src/manager.py:507-510, 693-715) only ever yields the eight. Solid edges advance, dotted
+(`src/manager.py`) only ever yields the eight. Solid edges advance, dotted
 edges go back; `--stage-graph linear` is the solid edges alone, and the guards come off with
-the backward ones (`_advance_edges(guarded=False)`, src/stage_graph.py:535) — one edge out of
+the backward ones (`_advance_edges(guarded=False)`, src/stage_graph.py) — one edge out of
 each node leaves nothing to choose, so a guard there could only halt a run that the stage's
 own validation is about to fail anyway.
 
@@ -447,25 +453,25 @@ flowchart LR
 ```
 
 Six of the eight forward edges carry a guard, one per target stage
-(`_ADVANCE_GUARDS`, src/stage_graph.py:266-273); 01→02 and 08→`finish` are
+(`_ADVANCE_GUARDS`, src/stage_graph.py); 01→02 and 08→`finish` are
 unguarded. Thirteen dotted edges go back (`REVISIT_EDGES`). The longest is
 07→01: writing it up showed the finding relates to work the survey missed. The
 Stage 07 guard is the strictest — every preregistered empirical hypothesis needs a
 verdict **and** at least one figure under `workspace/figures`
-(`_guard_validity_chain`, :157-190).
+(`_guard_validity_chain`).
 
 **Who decides the move.** AutoR decides which moves are *admissible*, by evaluating
 each edge's guard against the artifacts on disk. With `--routing auto` (the default,
-src/utils.py:367) the agent chooses among them and states a reason; `--routing off`
+src/utils.py) the agent chooses among them and states a reason; `--routing off`
 always takes the graph's default. An off-menu choice — an unlisted target, or one
 with no stated reason — is refused, written to `evolution/routing_refusals.jsonl`
-(src/router.py:186), and replaced by the forward edge.
+(src/router.py), and replaced by the forward edge.
 
 Two design calls worth naming. Blocked moves are handed to the agent *with the
-reason they are blocked* (`StageGraph.moves`, :555) — the useful thing to say is not
+reason they are blocked* (`StageGraph.moves`) — the useful thing to say is not
 "you may go to 06" but "07 is closed because H2 has no verdict", and an agent that
 sees why writing is closed routes to the analysis that opens it. And a revisit whose
-justification repeats one already on the path is refused (`repeats_a_previous_reason`, :652): going again on the same grounds is a loop, not an iteration.
+justification repeats one already on the path is refused (`repeats_a_previous_reason`): going again on the same grounds is a loop, not an iteration.
 
 **A backward move is only ever a deliberate choice.** The default is always the
 forward edge, and when a guard has closed it the default advances anyway and lets
@@ -475,7 +481,7 @@ the gate. So a refusal, a routing failure, or a run nobody is steering all come 
 as the linear pipeline rather than as a stall.
 
 A stage is a node with a visit budget, not a position in a sequence:
-`DEFAULT_MAX_VISITS = 3` (:76, `--graph-max-visits`); `--graph-max-steps` bounds the whole walk at 20.
+`DEFAULT_MAX_VISITS = 3` (`--graph-max-visits`); `--graph-max-steps` bounds the whole walk at 20.
 
 ### The eight stages, and what you check at each
 
@@ -486,7 +492,7 @@ A stage is a node with a visit budget, not a position in a sequence:
 | `02_hypothesis_generation` | Convert the direction into typed, testable hypotheses and provisional paper claims. | A `- Decision rule:` line on every empirical hypothesis, stating in advance what would count as support and what would count as refutation (src/prompts/02_hypothesis_generation.md:52-58). These are the hypotheses frozen at 04 and adjudicated at 06. |
 | `03_study_design` | Turn the hypotheses into an executable plan and a declared protocol. | Datasets, metrics, ablations, budgets, failure criteria, machine-readable data artifacts — and a baseline set where every entry says `why_competent` and names its `tuning_budget`. |
 | `04_implementation` | Build the runnable code, configs, data preparation and sanity checks. | This is the freeze point: approving the stage hashes the hypothesis set into `workspace/notes/preregistration.json`. Check the set you are freezing, and do not approve skeletons. |
-| `05_experimentation` | Run the planned experiments and write machine-readable results. | The declared baselines and the seeds: a supported or refuted verdict off a single seed is refused unless the run states why one run settles it (`MIN_SEEDS_FOR_A_VERDICT = 2`, src/experimental_protocol.py:37). |
+| `05_experimentation` | Run the planned experiments and write machine-readable results. | The declared baselines and the seeds: a supported or refuted verdict off a single seed is refused unless the run states why one run settles it (`MIN_SEEDS_FOR_A_VERDICT = 2`, src/experimental_protocol.py). |
 | `06_analysis` | Interpret the results, produce figures, adjudicate every frozen hypothesis. | A verdict for each one, backed by a result file the validator can find. The forward edge stays closed until then. |
 | `07_writing` | Produce the deliverable: a markdown report with embedded figures, or a venue-aware LaTeX package with a compiled PDF. | That every claim traces. A `confirmatory` claim whose hypothesis is not in the supported set is already refused, so what is left to check is whether the exploratory ones are honestly labelled. |
 | `08_dissemination` | Package the run for review, release, reproduction or presentation. | Readiness notes, review materials, manifests and outward-facing deliverables exist. |
@@ -513,7 +519,7 @@ produces churn, so AutoR does not buy one. `--evolve-rounds 0` measures without
 polishing; `--no-evolve` restores the old behaviour entirely.
 
 One edge of that budget is worth knowing before you resume a run. `state()` rehydrates the
-champion and the Pareto frontier from disk and nothing else (src/evolution.py:204-243), so
+champion and the Pareto frontier from disk and nothing else (src/evolution.py), so
 `--resume-run` restarts `rounds_spent` and the patience counter at zero: the best draft
 survives the resume, the *spend cap* does not, and a stage resumed twice can buy the two
 rounds twice.
@@ -540,9 +546,9 @@ The division of labour is not "AutoR drives, the agent types": AutoR owns the me
 
 Every finished run is recorded into `~/.autor/archive` — the route it took, the rubric
 fitness it reached, and the set of stages it actually measured (`Archive.record_run`,
-src/archive.py:426, from `record_into_archive`, main.py:657). `edge_payoffs` compares runs
+src/archive.py, from `record_into_archive`, main.py). `edge_payoffs` compares runs
 that *took* an edge against runs that reached the same node and did not, and
-`propose_variant` (:512) turns a payoff that is believable — enough observations, and a
+`propose_variant` turns a payoff that is believable — enough observations, and a
 delta above `min_gain` — into a child variant that moves that one edge one step up or down
 the preference order.
 
@@ -551,19 +557,20 @@ declared, and never removes one: the guards are the correctness argument for let
 agent route at all, and the component that learns from outcomes is precisely the one that
 must not be able to weaken them. Promotion is as conservative — a challenger has to beat the
 incumbent *within every comparability basis* rather than on a pooled mean, because "runs
-that stopped early" is the cheapest composition for a topology to win on (`promote`, :661).
+that stopped early" is the cheapest composition for a topology to win on (`promote`).
 
 Two limits, stated here rather than left to be assumed:
 
 - **The archive records and proposes on every run; it steers only when you ask.** The
   proposed variant is written down and reported, but the topology a run walks comes from
-  the archive only under `--archive-steer` (main.py:792, 874). Without it, `resolve_graph`
+  the archive only under `--archive-steer` (`resolve_graph` in `main.py`). Without it, `resolve_graph`
   returns the declared topology unchanged.
 - **A payoff comparison cannot reach an edge nothing has taken.** No takers means no
   evidence in either direction, so such an edge is never proposed and never preferred — and
   the backward edges start unpreferred, so they are the ones this strands.
-  `propose_exploration` and `unexplored_edges` (src/archive.py:595, :576) are written for
-  exactly that blind spot and have no production caller; see [Limits](#-limits).
+  `propose_exploration` and `unexplored_edges` (src/archive.py) are written for
+  exactly that blind spot, and `record_into_archive` reaches them only when `propose_variant`
+  declines — so exploration is the fallback, never the first choice.
 
 ### Obligations carried forward
 
@@ -645,7 +652,7 @@ Approvals teach nothing and are not recorded.
 `--full-auto` — equivalently `--approval-mode agent`, and implied by `--review-panel` — removes the human entirely, which is what benchmark harnesses and overnight sweeps need:
 
 - The reviewer agent decides every approval, including the Stage 00 intake flow.
-- `--unattended` on its own is only half of that. It stops AutoR blocking on stdin, but it does not install a reviewer: `approval_mode` stays `manual` (main.py:862), so the first approval menu raises `UnattendedInputError` instead of being decided. For a run with nobody at the terminal, pass `--full-auto`.
+- `--unattended` on its own is only half of that. It stops AutoR blocking on stdin, but it does not install a reviewer: `approval_mode` stays `manual` (main.py), so the first approval menu raises `UnattendedInputError` instead of being decided. For a run with nobody at the terminal, pass `--full-auto`.
 - The resource prompt is skipped even on a TTY. Pass resources with `--resources` instead.
 - A stage that exhausts its retry budget is auto-skipped rather than aborting the run, bounded by `--max-auto-skips` (default 3). The skip is promoted as an explicit skip summary so downstream stages know the work is missing.
 - Any interactive prompt still reachable raises `UnattendedInputError` instead of waiting on stdin — a prompt added later fails on its first unattended run rather than silently hanging an overnight job.
@@ -656,7 +663,7 @@ Approvals teach nothing and are not recorded.
 
 AutoR does not consider a run successful just because it generated a plausible markdown summary.
 
-**Required stage summary shape.** Seven headings, in this order — `REQUIRED_STAGE_HEADINGS` ([src/utils.py:144-152](src/utils.py)):
+**Required stage summary shape.** Seven headings, in this order — `REQUIRED_STAGE_HEADINGS` ([src/utils.py](src/utils.py)):
 
 ```md
 # Stage X: <name>
@@ -670,7 +677,7 @@ AutoR does not consider a run successful just because it generated a plausible m
 ## Your Options
 ```
 
-There was an eighth heading, retired in this branch: a section in which each stage restated the approved summaries of the stages before it. It made every node contractually required to relay its inbound edge. Stage output grew 235 → 1,211 words across a run and 64% of it was relay of context the stage had just been handed; without the section, relay is 0% and output is flat at 228-277 words per stage.
+There was an eighth heading, retired in this branch: a section in which each stage restated the approved summaries of the stages before it. It made every node contractually required to relay its inbound edge. Stage output grew 235 → 1,211 words across a run and 64% of it was relay of context the stage had just been handed; without the section, relay is 0% and output is flat at 228-292 words per stage.
 
 Also required, and checked: exactly 3 numbered refinement suggestions, exactly the fixed 6 user options, concrete file paths under `Files Produced`, and no `[In progress]`, `[Pending]`, `[TODO]` or `[TBD]` placeholders.
 
@@ -687,27 +694,27 @@ Also required, and checked: exactly 3 numbered refinement suggestions, exactly t
 | Stage 07+ (latex) | `main.tex` matching the venue, `sections/*.tex`, a bibliography, a compiled PDF, `build_log.txt`, `citation_verification.json`, `self_review.json`, `layout_review.json` |
 | Stage 08+ | Review and readiness assets under `workspace/reviews/` |
 
-Requirements are cumulative, and the stage that *produces* a class of artifact must produce it **during that stage's execution** — a re-run is not credited with the previous attempt's files. The cutoff is `stage_execution_started_at` feeding `recent_in` ([src/utils.py:1249-1261](src/utils.py)), and the rubric enforces the same rule independently in `_fresh_artifact_kinds` ([src/rubric.py:417](src/rubric.py)), so a Stage 07 draft cannot score on Stage 06's figures.
+Requirements are cumulative, and the stage that *produces* a class of artifact must produce it **during that stage's execution** — a re-run is not credited with the previous attempt's files. The cutoff is `stage_execution_started_at` feeding `recent_in` ([src/utils.py](src/utils.py)), and the rubric enforces the same rule independently in `_fresh_artifact_kinds` ([src/rubric.py](src/rubric.py)), so a Stage 07 draft cannot score on Stage 06's figures.
 
-**Validity gates.** The same function — `validate_stage_artifacts` ([src/utils.py:1232](src/utils.py)) — also runs seven validators that ask whether a *claim* is warranted rather than whether output exists: `validate_preregistration`, `validate_experimental_protocol`, `validate_hypothesis_outcomes`, `validate_outcome_statistics`, `validate_claim_provenance`, `validate_validity_response`, `validate_round_decision`. (Three of them do refuse on an absent file — the artifact they need is the record of the claim itself, so its absence *is* the unwarranted claim.) The code labels the split itself: "The scientific-validity chain, distinct from the artifact gates around it" ([src/utils.py:1292-1297](src/utils.py)). A run can fail because a claim is unwarranted, not only because a file is absent.
+**Validity gates.** The same function — `validate_stage_artifacts` ([src/utils.py](src/utils.py)) — also runs seven validators that ask whether a *claim* is warranted rather than whether output exists: `validate_preregistration`, `validate_experimental_protocol`, `validate_hypothesis_outcomes`, `validate_outcome_statistics`, `validate_claim_provenance`, `validate_validity_response`, `validate_round_decision`. (Three of them do refuse on an absent file — the artifact they need is the record of the claim itself, so its absence *is* the unwarranted claim.) The code labels the split itself: "The scientific-validity chain, distinct from the artifact gates around it" ([src/utils.py](src/utils.py)). A run can fail because a claim is unwarranted, not only because a file is absent.
 
 The complete gate, including every JSON schema that is parsed rather than merely counted, is in **[docs/stage-contract.md](docs/stage-contract.md)**.
 
 ## 🧠 Execution Model
 
-Context is composed per consumer, not per availability. A stage's inbound block is built by `render_inbound(ChannelContext(...), CHANNELS)` ([src/manager.py:2033-2039](src/manager.py)) from the fifteen typed channels in [src/information_flow.py](src/information_flow.py). Each channel declares `produced_by`, a `consumed_by` set of real stage slugs, and a `rationale`; `test_every_narrowing_is_argued_for` ([tests/test_information_flow.py:67](tests/test_information_flow.py)) fails a channel that withholds itself from a stage without saying why. Withholding has to be argued for, not just done.
+Context is composed per consumer, not per availability. A stage's inbound block is built by `render_inbound(ChannelContext(...), CHANNELS)` ([src/manager.py](src/manager.py)) from the sixteen typed channels in [src/information_flow.py](src/information_flow.py). Each channel declares `produced_by`, a `consumed_by` set of real stage slugs, and a `rationale`; `test_every_narrowing_is_argued_for` ([tests/test_information_flow.py](tests/test_information_flow.py)) fails a channel that withholds itself from a stage without saying why. Withholding has to be argued for, not just done.
 
 Three narrowings, because the abstraction is not the point:
 
 - the **artifact index** skips Stages 00-02 — they produce no data, results or figures, so the index is empty noise there
 - the **writing manifest** reaches Stage 07 alone
-- the mutable **Stage 02 hypotheses** stop at `04_implementation` ([src/information_flow.py:333-350](src/information_flow.py)), because the freeze at Stage 04's approval supersedes them. Before that edge was typed, the same H1 went into every prompt from Stage 05 on twice — one copy labelled editable, sitting next to the frozen one at exactly the stages where the freeze is the point.
+- the mutable **Stage 02 hypotheses** stop at `04_implementation` ([src/information_flow.py](src/information_flow.py)), because the freeze at Stage 04's approval supersedes them. Before that edge was typed, the same H1 went into every prompt from Stage 05 on twice — one copy labelled editable, sitting next to the frozen one at exactly the stages where the freeze is the point.
 
-`dependency_edges()` returns every `(producer, consumer, channel key)` triple, so the information topology can be printed and diffed rather than reconstructed from thirteen `if` statements. `_record_inbound_channels` ([src/manager.py:2900](src/manager.py)) writes the delivered channel keys per stage into the run log.
+`dependency_edges()` returns every `(producer, consumer, channel key)` triple, so the information topology can be printed and diffed rather than reconstructed from sixteen `if` statements. `_record_inbound_channels` ([src/manager.py](src/manager.py)) writes the delivered channel keys per stage into the run log.
 
-Honest scope: thirteen blocks are typed. Five more — `obligations_context`, `intake_context_text`, `web_search_context`, `approved_memory` and `handoff_context` — are still passed to `build_prompt` as ordinary arguments rather than declared as channels ([src/manager.py:2041-2069](src/manager.py)), so each one's delivery rule lives in `build_prompt` instead of next to a `consumed_by` set. Around them, `compose_stage_template` ([src/prompt_fragments.py](src/prompt_fragments.py)) assembles the stage's own instructions, the accepted-extension lists generated from the validators' constants rather than hand-copied, and the run-safety rules.
+Honest scope: sixteen blocks are typed. Five more — `obligations_context`, `intake_context_text`, `web_search_context`, `approved_memory` and `handoff_context` — are still passed to `build_prompt` as ordinary arguments rather than declared as channels ([src/manager.py](src/manager.py)), so each one's delivery rule lives in `build_prompt` instead of next to a `consumed_by` set. Around them, `compose_stage_template` ([src/prompt_fragments.py](src/prompt_fragments.py)) assembles the stage's own instructions, the accepted-extension lists generated from the validators' constants rather than hand-copied, and the run-safety rules.
 
-One duplication has already been cut: `build_prompt` withholds the handoff when approved memory is non-empty ([src/utils.py:807-811](src/utils.py)). The handoff was a strict subset of memory, so sending both put ~350 words of verbatim duplicate into every prompt from Stage 04 on. Assembled prompts across a run: 21,823 → 20,353 words.
+One duplication has already been cut: `build_prompt` withholds the handoff when approved memory is non-empty ([src/utils.py](src/utils.py)). The handoff was a strict subset of memory, so sending both put ~350 words of verbatim duplicate into every prompt from Stage 04 on. Assembled prompts across a run at `dd54947`: 21,236 → 20,353 words.
 
 The assembled prompt is written to `runs/<run_id>/prompt_cache/`, per-stage session IDs to `runs/<run_id>/operator_state/`, and the selected CLI backend is invoked in live streaming mode. Alongside the prompt, AutoR installs an agent skill pack from [src/skills/](src/skills) into `runs/<run_id>/.claude/skills/` — the operator's working directory — so the agent can *pull* long-form craft guidance when it needs it. A skill costs nothing in the prompts that do not use it.
 
@@ -750,7 +757,7 @@ Important behavior:
 
 ## 📂 Run Layout
 
-Every run lives entirely inside its own directory. The tree is `build_run_paths` ([src/utils.py:232-273](src/utils.py)).
+Every run lives entirely inside its own directory. The tree is `build_run_paths` ([src/utils.py](src/utils.py)).
 
 ```text
 runs/<run_id>/
@@ -772,45 +779,45 @@ runs/<run_id>/
     └── reviews/     validity_review_<stage>.json, panel/
 ```
 
-`evolution/` sits outside `workspace/` on purpose, and the dataclass records the reason: it is "a record of how the run reached its answer, not part of the answer, and a benchmark export that swept it up would ship the losing drafts alongside the report" ([src/utils.py:92-96](src/utils.py)).
+`evolution/` sits outside `workspace/` on purpose, and the dataclass records the reason: it is "a record of how the run reached its answer, not part of the answer, and a benchmark export that swept it up would ship the losing drafts alongside the report" ([src/utils.py](src/utils.py)).
 
 **Workspace semantics.** `literature/` reading notes, survey tables, benchmark notes · `code/` runnable code, scripts, configs, implementations · `data/` machine-readable datasets, manifests, processed splits · `results/` metrics, predictions, ablations, plus the standardized `experiment_manifest.json` · `report/` the markdown deliverable, `report.md` and the PNGs it embeds under `images/` · `writing/` LaTeX sources, sections, tables, bibliography (latex mode) · `figures/` plots and paper figures · `artifacts/` review JSON, build metadata, compiled PDFs, packaged deliverables · `notes/` the frozen files of the validity chain plus supporting notes · `reviews/` adversarial validity reviews, panel transcripts, readiness reviews.
 
-Outside `workspace/`: `memory.md` is the approved free-text cross-stage memory; `handoff/<slug>.md` is the second free-text carrier, each approved summary trimmed to Objective / Key Results / Files Produced (`write_stage_handoff`, [src/utils.py:1628](src/utils.py)) and sent only on a continuation attempt or when memory is still empty; every other cross-stage edge is a typed channel or a JSON artifact. `run_manifest.json` is the lifecycle state that resume, redo and rollback read; `artifact_index.json` indexes `data/`, `results/` and `figures/`; `prompt_cache/` holds the exact prompt of every attempt and repair.
+Outside `workspace/`: `memory.md` is the approved free-text cross-stage memory; `handoff/<slug>.md` is the second free-text carrier, each approved summary trimmed to Objective / Key Results / Files Produced (`write_stage_handoff`, [src/utils.py](src/utils.py)) and sent only on a continuation attempt or when memory is still empty; every other cross-stage edge is a typed channel or a JSON artifact. `run_manifest.json` is the lifecycle state that resume, redo and rollback read; `artifact_index.json` indexes `data/`, `results/` and `figures/`; `prompt_cache/` holds the exact prompt of every attempt and repair.
 
 ## 🏗️ Architecture
 
 ```mermaid
 flowchart LR
-    C[information_flow.py<br/>13 typed channels] --> M
+    C[information_flow.py<br/>16 typed channels] --> M
     M[manager.py<br/>walks the stage graph] --> W[walk<br/>stage_graph · router]
     M --> G[gates<br/>preregistration · experimental_protocol · validity_review]
     M --> I[improvement<br/>rubric · evolution · pareto · archive]
     M --> R[review<br/>review_panel · cross_reviewer · obligations · review_policy]
 ```
 
-| Module | Lines | What it owns |
-| --- | ---: | --- |
-| [main.py](main.py) | 1188 | CLI entry: start, resume, `--redo-stage`, `--rollback-stage`, and the archive record at the end of a run |
-| [src/manager.py](src/manager.py) | 3753 | Walks the stage graph until it reaches finish or nothing is open — plus the router call, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto and the inbound-channel record |
-| [src/utils.py](src/utils.py) | 2360 | Stage metadata, run paths, prompt assembly, markdown validation, the artifact gates and the validity-chain wiring |
-| [src/review_panel.py](src/review_panel.py) | 1273 | The deliberating panel; a blocking objection is enforced in code against its own chair |
-| [src/rubric.py](src/rubric.py) | 936 | The rigour score over a draft and the artifacts it names. Never calls a backend |
-| [src/archive.py](src/archive.py) | 974 | Cross-run routes and edge payoffs, keyed on a comparability basis; variant proposal and promotion |
-| [src/stage_graph.py](src/stage_graph.py) | 1000 | Stages as nodes: six guarded forward edges, thirteen backward edges, a conditional terminal, a per-stage visit budget |
-| [src/ideation_panel.py](src/ideation_panel.py) | 733 | Divergent Stage 02 proposers across five lenses, deduplicated into a candidate pool |
-| [src/evolution.py](src/evolution.py) | 727 | The champion ratchet: budgeted polish rounds, reverted when they do not improve |
-| [src/preregistration.py](src/preregistration.py) | 579 | Freeze, amend, adjudicate, trace |
-| [src/validity_review.py](src/validity_review.py) | 512 | The adversarial pass after Stages 05 and 06 |
-| [src/information_flow.py](src/information_flow.py) | 522 | Fifteen typed information channels, each with declared readers |
-| [src/router.py](src/router.py) | 533 | The agent's choice among admissible moves; an off-menu choice is refused and logged |
-| [src/research_rounds.py](src/research_rounds.py) | 411 | Stages 03-06 as a repeatable round, bounded by `--max-rounds` |
-| [src/obligations.py](src/obligations.py) | 306 | What a later stage still owes; only a reviewer can discharge it |
-| [src/cross_reviewer.py](src/cross_reviewer.py) | 239 | A second opinion from a different model family. Veto only, never an override |
-| [src/experimental_protocol.py](src/experimental_protocol.py) | 234 | Declared baselines, seeds and dispersion, fixed before the result exists |
-| [src/pareto.py](src/pareto.py) | 212 | Non-dominated drafts kept beside the champion, and the pair worth merging |
-| [src/review_policy.py](src/review_policy.py) | 212 | Standing review rules learned from this run's own corrections |
-| [src/prompt_fragments.py](src/prompt_fragments.py) | 104 | Shared prompt blocks generated from the validators' own constants |
+| Module | What it owns |
+| --- | --- |
+| [main.py](main.py) | CLI entry: start, resume, `--redo-stage`, `--rollback-stage`, and the archive record at the end of a run |
+| [src/manager.py](src/manager.py) | Walks the stage graph until it reaches finish or nothing is open — plus the router call, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto and the inbound-channel record |
+| [src/utils.py](src/utils.py) | Stage metadata, run paths, prompt assembly, markdown validation, the artifact gates and the validity-chain wiring |
+| [src/review_panel.py](src/review_panel.py) | The deliberating panel; a blocking objection is enforced in code against its own chair |
+| [src/rubric.py](src/rubric.py) | The rigour score over a draft and the artifacts it names. Never calls a backend |
+| [src/archive.py](src/archive.py) | Cross-run routes and edge payoffs, keyed on a comparability basis; variant proposal and promotion |
+| [src/stage_graph.py](src/stage_graph.py) | Stages as nodes: six guarded forward edges, thirteen backward edges, a conditional terminal, a per-stage visit budget |
+| [src/ideation_panel.py](src/ideation_panel.py) | Divergent Stage 02 proposers across five lenses, deduplicated into a candidate pool |
+| [src/evolution.py](src/evolution.py) | The champion ratchet: budgeted polish rounds, reverted when they do not improve |
+| [src/preregistration.py](src/preregistration.py) | Freeze, amend, adjudicate, trace |
+| [src/validity_review.py](src/validity_review.py) | The adversarial pass after Stages 05 and 06 |
+| [src/information_flow.py](src/information_flow.py) | Sixteen typed information channels, each with declared readers |
+| [src/router.py](src/router.py) | The agent's choice among admissible moves; an off-menu choice is refused and logged |
+| [src/research_rounds.py](src/research_rounds.py) | Stages 03-06 as a repeatable round, bounded by `--max-rounds` |
+| [src/obligations.py](src/obligations.py) | What a later stage still owes; only a reviewer can discharge it |
+| [src/cross_reviewer.py](src/cross_reviewer.py) | A second opinion from a different model family. Veto only, never an override |
+| [src/experimental_protocol.py](src/experimental_protocol.py) | Declared baselines, seeds and dispersion, fixed before the result exists |
+| [src/pareto.py](src/pareto.py) | Non-dominated drafts kept beside the champion, and the pair worth merging |
+| [src/review_policy.py](src/review_policy.py) | Standing review rules learned from this run's own corrections |
+| [src/prompt_fragments.py](src/prompt_fragments.py) | Shared prompt blocks generated from the validators' own constants |
 
 Supporting modules: [operator.py](src/operator.py) and [operator_codex.py](src/operator_codex.py) (the Claude and Codex CLI adapters — stage session state, live streaming, resume fallback), [approval_agent.py](src/approval_agent.py), [intake.py](src/intake.py), [manifest.py](src/manifest.py), [artifact_index.py](src/artifact_index.py), [experiment_manifest.py](src/experiment_manifest.py), [evidence_ledger.py](src/evidence_ledger.py), [hypothesis_manifest.py](src/hypothesis_manifest.py), [writing_manifest.py](src/writing_manifest.py), [bootstrap.py](src/bootstrap.py) and [project_bootstrap.py](src/project_bootstrap.py), [platform/foundry.py](src/platform/foundry.py), [run_skills.py](src/run_skills.py), [prompts/](src/prompts), [skills/](src/skills), and [backend/](src/backend) + [frontend/](src/frontend) for the Studio.
 
@@ -833,21 +840,22 @@ The [docs/](docs/) directory is the reference documentation. This README is the 
 | [Studio Guide & API](docs/studio.md) | The browser workspace and its complete HTTP API. |
 | [ResearchClawBench](docs/researchclawbench.md) | Running with no human in the loop: unattended execution, the benchmark adapter and its output contract, and Gemini-backed web search. |
 | [ResearchClawBench Landscape](docs/researchclawbench-landscape.md) | How EvoScientist, ARIS Codex and MIRA actually score on the benchmark, which reported numbers reproduce, and the baseline any result must be quoted against. |
-| [Architecture](docs/architecture.md) | Layers, the module map with line counts, the stage walk, prompt assembly by typed channel, recovery, extension points. |
+| [Architecture](docs/architecture.md) | Layers, the module map, the stage walk, prompt assembly by typed channel, recovery, extension points. |
 | [Development](docs/development.md) | Dev setup, tests, CI, conventions, and recipes for adding a stage, venue, or backend. |
 | [Troubleshooting](docs/troubleshooting.md) | Symptom-to-fix for the errors AutoR actually raises. |
 | [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Code of Conduct](CODE_OF_CONDUCT.md) | How to land a change; the security model, the sandbox trade-offs and how to report a vulnerability; community expectations. |
 
 ## 🚧 Limits
 
-Six things the mechanisms above do not close. Each is also the next thing worth building, named at the code that would have to change.
+Seven things the mechanisms above do not close. Each is also the next thing worth building, named at the code that would have to change.
 
-- **The archive's explore proposer does not run.** `propose_exploration` and `unexplored_edges` ([src/archive.py](src/archive.py):595, :576) have no production caller: `record_into_archive` calls `propose_variant` alone ([main.py](main.py):687), and every other reference is in `tests/test_archive_exploration.py`. `propose_variant` reads only believable payoffs, and an edge nobody has taken has no payoff in either direction — so a never-taken backward edge stays untaken.
-- **A crashed adversarial pass is indistinguishable from a clean result.** `_write_review(..., failed=True)` records `reviewer_failed: true` ([src/validity_review.py](src/validity_review.py):405) and no production code reads that flag. Zero findings and a reviewer that never returned are the same input to `validate_validity_response`: nothing owed, gate open.
-- **Attribution stops at the log.** `_record_inbound_channels` ([src/manager.py](src/manager.py):2900) writes which channels reached each stage, but `RunRecord` ([src/archive.py](src/archive.py):113-125) has no channel field, so "this edge helped" cannot yet become "this information helped".
-- **The self-measurement files have no reader in code.** `panel_effect.json` is read only by the function that appends to it, and the adoption marks `measure_adoption` writes back into `idea_pool.json` change no later decision. Both files exist to say when a feature did not earn its cost, and the party they say it to is you.
-- **Most of the recursion is opt-in or partial.** `--max-rounds` defaults to 1 ([main.py](main.py):128), so a round that asks to go back is recorded with `acted_on: false` and a budget note, and the run continues to writing anyway ([src/manager.py](src/manager.py):2741-2755); the archive steers the topology only under `--archive-steer`; and `REVIEWED_STAGE_NUMBERS = (5, 6)` ([src/validity_review.py](src/validity_review.py):42), so nothing attacks Stage 07 or 08.
-- **Studio does not route.** Its lazy-resume approve path picks the next stage by stage number ([src/backend/studio_runner.py](src/backend/studio_runner.py):361-364) and never consults the router, so graph routing is a CLI capability today.
+- **Nothing in this section has been measured on a real run.** The cross-run archive holds zero real observations and the paired-trial mechanism has never completed a trial — six pairs attempted on 2026-08-11 produced 46 attempts and zero recorded runs, every one refused by a Vertex quota. Every number quoted anywhere in these docs comes from a `--fake-operator` run, which measures the script. See [what has and has not been measured](docs/self-improvement.md#what-has-and-has-not-been-measured).
+- **Exploration is a fallback, not a policy.** `propose_exploration` ([src/archive.py](src/archive.py)) runs only when `propose_variant` declines ([main.py](main.py)), so the archive spends a run on curiosity only when it has no believable payoff to act on. Since it has never held a real observation, that is currently every run — the wiring is exercised, the judgement behind it never has been.
+- **A crashed adversarial pass is indistinguishable from a clean result.** `_write_review(..., failed=True)` records `reviewer_failed: true` ([src/validity_review.py](src/validity_review.py)) and no production code reads that flag. Zero findings and a reviewer that never returned are the same input to `validate_validity_response`: nothing owed, gate open.
+- **Attribution stops at the log.** `_record_inbound_channels` ([src/manager.py](src/manager.py)) writes which channels reached each stage, but `RunRecord` ([src/archive.py](src/archive.py)) has no channel field, so "this edge helped" cannot yet become "this information helped".
+- **The self-measurement files feed a report, not a decision.** `src/scorecard.py` reads all five ledgers — `panel_effect.json` among them — and renders a per-feature verdict, but nothing inside a run acts on it: the adoption marks `measure_adoption` writes back into `idea_pool.json` change no later decision. The files exist to say when a feature did not earn its cost, and the party they say it to is you.
+- **Most of the recursion is opt-in or partial.** `--max-rounds` defaults to 1 ([main.py](main.py)), so a round that asks to go back is recorded with `acted_on: false` and a budget note, and the run continues to writing anyway ([src/manager.py](src/manager.py)); the archive steers the topology only under `--archive-steer`; and `REVIEWED_STAGE_NUMBERS = (5, 6)` ([src/validity_review.py](src/validity_review.py)), so nothing attacks Stage 07 or 08.
+- **Studio does not route.** Its lazy-resume approve path picks the next stage by stage number ([src/backend/studio_runner.py](src/backend/studio_runner.py)) and never consults the router, so graph routing is a CLI capability today.
 
 **Intentionally out of scope**: generic multi-agent orchestration, database-backed runtime state, concurrent stage execution, heavyweight platform abstractions, dashboard-first productization.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ survives a crash because it was never anywhere else.
 **No conversation crosses a stage boundary.** Stage 05 cannot see Stage 03's
 session. What crosses is `memory.md` — the approved stage summaries — plus
 `handoff/<slug>.md`, the same summaries cut down to Objective / Key Results /
-Files Produced (`write_stage_handoff`, `src/utils.py:1628`), plus thirteen typed
+Files Produced (`write_stage_handoff`, `src/utils.py`), plus sixteen typed
 channels in [`src/information_flow.py`](../src/information_flow.py), each of
 which declares which stages read it. Memory and the handoff are the free text;
 everything else that crosses a boundary is a typed channel or a JSON artifact.
@@ -31,14 +31,14 @@ Approval stays load-bearing because it is what puts a summary into memory and
 what triggers the preregistration freeze; a refused stage propagates neither.
 
 **Two different kinds of check, deliberately separated.**
-`validate_stage_artifacts` ([`src/utils.py`](../src/utils.py):1232-1490) runs
+`validate_stage_artifacts` ([`src/utils.py`](../src/utils.py)) runs
 artifact gates — this file exists, is parseable, is fresh, cross-references
 correctly — and then runs seven validity-chain validators that ask whether a
 claim is warranted: `validate_preregistration`,
 `validate_experimental_protocol`, `validate_hypothesis_outcomes`,
 `validate_outcome_statistics`, `validate_claim_provenance`,
 `validate_validity_response`, `validate_round_decision`. The code labels the
-split itself at `src/utils.py:1292-1297`. A run can fail because a claim is
+split itself at `src/utils.py`. A run can fail because a claim is
 unwarranted, not only because a file is absent.
 
 **Nothing that measures may also approve.** The rubric scores, the evolution
@@ -106,22 +106,22 @@ counted below are the panel, the rubric, the archive and the graph.
 
 ### The walk
 
-| Module | Lines | Responsibility |
-| --- | --- | --- |
-| [`src/manager.py`](../src/manager.py) | 2955 | `ResearchManager` — "walk the stage graph until it reaches `finish` or nothing is open" (`:412`). Owns intake, the attempt loop, prompt assembly, validation dispatch, the approval menu, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto, the inbound-channel record, repair, resume, redo and rollback. |
-| [`src/stage_graph.py`](../src/stage_graph.py) | 724 | Eight stages plus `FINISH` as a directed graph. Six of the seven forward edges carry a guard (`_ADVANCE_GUARDS`, `:266-273`) evaluated against artifacts on disk; `REVISIT_EDGES` (`:301-359`) adds ten backward moves; `DEFAULT_MAX_VISITS = 3` (`:76`) is a per-node budget. `moves()` (`:555`) returns blocked edges *with* the reason they are blocked, and `repeats_a_previous_reason()` (`:652`) refuses a revisit already justified on the same grounds. |
-| [`src/router.py`](../src/router.py) | 385 | Picks among admissible moves and records why. `--routing auto` asks only where more than one move is live. A choice outside the menu is refused, appended to `evolution/routing_refusals.jsonl` (`:186`), and replaced by the forward edge. |
-| [`src/research_rounds.py`](../src/research_rounds.py) | 320 | Stages 03-06 as a repeatable round. Stage 06 records `converged`, `refine_design`, `new_hypothesis` or `abandon`; `converged` with nothing supported is refused unless the round declares `negative_result` (`:161`). Bounded by `--max-rounds`, which defaults to 1. |
-| [`src/terminal_ui.py`](../src/terminal_ui.py) | | All terminal rendering: banners, stage panels, backend event streams, display-width-aware markdown wrapping, keyboard-selectable menus. The manager never writes to stdout directly. |
+| Module | Responsibility |
+| --- | --- |
+| [`src/manager.py`](../src/manager.py) | `ResearchManager` — "walk the stage graph until it reaches `finish` or nothing is open". Owns intake, the attempt loop, prompt assembly, validation dispatch, the approval menu, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto, the inbound-channel record, repair, resume, redo and rollback. |
+| [`src/stage_graph.py`](../src/stage_graph.py) | Eight stages plus `FINISH` as a directed graph. Six of the eight forward edges carry a guard (`_ADVANCE_GUARDS`) evaluated against artifacts on disk; `REVISIT_EDGES` adds thirteen backward moves and `TERMINAL_EDGES` one conditional terminal, twenty-two edges in all; `DEFAULT_MAX_VISITS = 3` is a per-node budget. `moves()` returns blocked edges *with* the reason they are blocked, and `repeats_a_previous_reason()` refuses a revisit already justified on the same grounds. |
+| [`src/router.py`](../src/router.py) | Picks among admissible moves and records why. `--routing auto` asks only where more than one move is live. A choice outside the menu is refused, appended to `evolution/routing_refusals.jsonl`, and replaced by the forward edge. |
+| [`src/research_rounds.py`](../src/research_rounds.py) | Stages 03-06 as a repeatable round. Stage 06 records `converged`, `refine_design`, `new_hypothesis` or `abandon`; `converged` with nothing supported is refused unless the round declares `negative_result`. Bounded by `--max-rounds`, which defaults to 1. |
+| [`src/terminal_ui.py`](../src/terminal_ui.py) | All terminal rendering: banners, stage panels, backend event streams, display-width-aware markdown wrapping, keyboard-selectable menus. The manager never writes to stdout directly. |
 
 ### Gates
 
-| Module | Lines | Responsibility |
-| --- | --- | --- |
-| [`src/utils.py`](../src/utils.py) | 2214 | The contract layer. `STAGES`, `RunPaths`/`build_run_paths`, `REQUIRED_STAGE_HEADINGS`, `FIXED_STAGE_OPTIONS`, prompt assembly, `validate_stage_markdown`, `validate_stage_artifacts`, memory rendering, handoff read/write, venue resolution, `run_config.json` I/O, and every default the CLI overrides. |
-| [`src/preregistration.py`](../src/preregistration.py) | 579 | Freezes and hashes the hypothesis set before results exist, adjudicates every frozen hypothesis at Stage 06 against a named result artifact, and traces every manuscript claim back to a supported hypothesis at Stage 07. A post-freeze change is legal only as an `amend_preregistration` (`:234`) amendment carrying the previous digest. |
-| [`src/experimental_protocol.py`](../src/experimental_protocol.py) | 234 | Declares the primary metric, the seed count and each baseline's `why_competent` and `tuning_budget` before the experiments run. `MIN_SEEDS_FOR_A_VERDICT = 2` (`:37`) refuses a supported/refuted verdict resting on one run unless the run says why one run settles it. |
-| [`src/validity_review.py`](../src/validity_review.py) | 512 | The adversarial pass after Stages 05 and 06 (`REVIEWED_STAGE_NUMBERS`, `:42`). Asks why the result is wrong across ten named failure modes rather than whether the stage is complete, and requires the next stage to answer every finding. Has no authority to approve or reject. |
+| Module | Responsibility |
+| --- | --- |
+| [`src/utils.py`](../src/utils.py) | The contract layer. `STAGES`, `RunPaths`/`build_run_paths`, `REQUIRED_STAGE_HEADINGS`, `FIXED_STAGE_OPTIONS`, prompt assembly, `validate_stage_markdown`, `validate_stage_artifacts`, memory rendering, handoff read/write, venue resolution, `run_config.json` I/O, and every default the CLI overrides. |
+| [`src/preregistration.py`](../src/preregistration.py) | Freezes and hashes the hypothesis set before results exist, adjudicates every frozen hypothesis at Stage 06 against a named result artifact, and traces every manuscript claim back to a supported hypothesis at Stage 07. A post-freeze change is legal only as an `amend_preregistration` amendment carrying the previous digest. |
+| [`src/experimental_protocol.py`](../src/experimental_protocol.py) | Declares the primary metric, the seed count and each baseline's `why_competent` and `tuning_budget` before the experiments run. `MIN_SEEDS_FOR_A_VERDICT = 2` refuses a supported/refuted verdict resting on one run unless the run says why one run settles it. |
+| [`src/validity_review.py`](../src/validity_review.py) | The adversarial pass after Stages 05 and 06 (`REVIEWED_STAGE_NUMBERS`). Asks why the result is wrong across ten named failure modes rather than whether the stage is complete, and requires the next stage to answer every finding. Has no authority to approve or reject. |
 | [`src/manifest.py`](../src/manifest.py) | | `run_manifest.json`: stage lifecycle, status transitions, rollback and stale marking, memory rebuild from approved entries. |
 | [`src/artifact_index.py`](../src/artifact_index.py) | | Scans `data/`, `results/`, `figures/`; infers or reads declared schemas; writes `artifact_index.json`. |
 | [`src/experiment_manifest.py`](../src/experiment_manifest.py) | | Builds and validates `results/experiment_manifest.json` as a view over the artifact index. |
@@ -131,30 +131,30 @@ counted below are the panel, the rubric, the archive and the graph.
 
 ### Improvement
 
-| Module | Lines | Responsibility |
-| --- | --- | --- |
-| [`src/rubric.py`](../src/rubric.py) | 926 | Eight weighted criteria read off disk with no backend call (`CRITERIA`, `:135-143`), including `reproducibility` (3.0), which walks the same validity chain the gate walks, and `commitment` (1.5), which counts hedge patterns. Verdicts are read only through `_verdict_blind_outcomes` (`:260`), so the score carries no gradient toward changing an answer. |
-| [`src/evolution.py`](../src/evolution.py) | 692 | The champion ratchet. `consider()` (`:248`) scores each valid draft; `_revert()` (`:383`) copies the champion back over a losing polish round before the reviewer sees it; a round whose `verdict_digest` moved is rejected whatever it scored (`:306-327`); a human-directed revision is exempt (`:288-304`). `measure=True`, `rounds=2` by default (`:97`, `:102`). |
-| [`src/pareto.py`](../src/pareto.py) | 212 | Keeps drafts that are non-dominated on the criterion vector even when they lose on the weighted total (`frontier`, `:74`). `complementary_pair` (`:153`) names the two whose merge has the most headroom — the only place two drafts are combined rather than ranked. |
-| [`src/archive.py`](../src/archive.py) | 784 | Cross-run record under `~/.autor/archive`. `record_run` (`:426`) stores route, edges and per-stage fitness; `edge_payoffs` compares runs that took an edge against runs that reached the same node and did not; `propose_variant` (`:512`) reorders priorities and can never open, add or remove a guard. Promotion requires a win within every `comparability_basis` (`:91`), so halting early cannot raise mean fitness. |
+| Module | Responsibility |
+| --- | --- |
+| [`src/rubric.py`](../src/rubric.py) | Eight weighted criteria read off disk with no backend call (`CRITERIA`), including `reproducibility` (3.0), which walks the same validity chain the gate walks, and `commitment` (1.5), which counts hedge patterns. Verdicts are read only through `_verdict_blind_outcomes`, so the score carries no gradient toward changing an answer. |
+| [`src/evolution.py`](../src/evolution.py) | The champion ratchet. `consider()` scores each valid draft; `_revert()` copies the champion back over a losing polish round before the reviewer sees it; a round whose `verdict_digest` moved is rejected whatever it scored; a human-directed revision is exempt. `measure=True`, `rounds=2` by default. |
+| [`src/pareto.py`](../src/pareto.py) | Keeps drafts that are non-dominated on the criterion vector even when they lose on the weighted total (`frontier`). `complementary_pair` names the two whose merge has the most headroom — the only place two drafts are combined rather than ranked. |
+| [`src/archive.py`](../src/archive.py) | Cross-run record under `~/.autor/archive`. `record_run` stores route, edges and per-stage fitness; `edge_payoffs` compares runs that took an edge against runs that reached the same node and did not; `propose_variant` reorders priorities and can never open, add or remove a guard. Promotion requires a win within every `comparability_basis`, so halting early cannot raise mean fitness. |
 
 ### Review
 
-| Module | Lines | Responsibility |
-| --- | --- | --- |
+| Module | Responsibility |
+| --- | --- |
 | [`src/approval_agent.py`](../src/approval_agent.py) | | `AutomatedReviewer` — the strict reviewer agent that stands in for the human gate under `--full-auto`. Returns a `ReviewDecision`, and renders the standing rules and open obligations into its own prompt. |
-| [`src/review_panel.py`](../src/review_panel.py) | 1223 | Five seats. Round 1 is independent; a cross-examination round runs only if that round was not unanimous, up to `--panel-rounds` (default 2, `:513`); then the chair synthesizes one decision. The Adversarial Reviewer's exposure is `"none"` (`:256`); peers are anonymised in round 2 (`:893`); abstention is a first-class verdict (`:325`); an unreachable member breaks unanimity rather than counting as agreement (`_is_unanimous`, `:723`); `_enforce_blocking_objections` (`:783`) converts a chair's approval into a refusal in code. `record_panel_effect` (`:1143`) accumulates the chair's round-1 solo verdict as the panel's own control arm. |
-| [`src/cross_reviewer.py`](../src/cross_reviewer.py) | 239 | A second opinion from a different model family, applied only to approvals. A veto, never an override; an auditor that errors or returns unparseable output is recorded `unavailable` (`:60`, `:111-134`), never as agreement. |
-| [`src/review_policy.py`](../src/review_policy.py) | 212 | Corrections the reviewer demanded become standing rules in `runs/<id>/review_policy.json` (`policy_path`, `:103`) and are rendered into every later review prompt. Per-run: nothing carries a rule into the next run. |
-| [`src/obligations.py`](../src/obligations.py) | 306 | What an approving reviewer says a later stage still owes. Written to `runs/<id>/obligations.json` (`:160`), injected into that stage's prompt *and* its review, discharged only by a reviewer (`discharge_obligations`, `:226`), with deferrals counted rather than silent (`note_deferrals`, `:249`). |
-| [`src/ideation_panel.py`](../src/ideation_panel.py) | 712 | Stage 02 divergence: five proposer lenses, Jaccard deduplication, scoring into a candidate pool the stage chooses from. Decides nothing. `measure_adoption` (`:604`) marks afterwards which pooled candidates the approved stage actually built on. |
+| [`src/review_panel.py`](../src/review_panel.py) | Five seats. Round 1 is independent; a cross-examination round runs only if that round was not unanimous, up to `--panel-rounds` (default 2); then the chair synthesizes one decision. The Adversarial Reviewer's exposure is `"none"`; peers are anonymised in round 2; abstention is a first-class verdict; an unreachable member breaks unanimity rather than counting as agreement (`_is_unanimous`); `_enforce_blocking_objections` converts a chair's approval into a refusal in code. `record_panel_effect` accumulates the chair's round-1 solo verdict as the panel's own control arm. |
+| [`src/cross_reviewer.py`](../src/cross_reviewer.py) | A second opinion from a different model family, applied only to approvals. A veto, never an override; an auditor that errors or returns unparseable output is recorded `unavailable`, never as agreement. |
+| [`src/review_policy.py`](../src/review_policy.py) | Corrections the reviewer demanded become standing rules in `runs/<id>/review_policy.json` (`policy_path`) and are rendered into every later review prompt. Per-run: nothing carries a rule into the next run. |
+| [`src/obligations.py`](../src/obligations.py) | What an approving reviewer says a later stage still owes. Written to `runs/<id>/obligations.json`, injected into that stage's prompt *and* its review, discharged only by a reviewer (`discharge_obligations`), with deferrals counted rather than silent (`note_deferrals`). |
+| [`src/ideation_panel.py`](../src/ideation_panel.py) | Stage 02 divergence: five proposer lenses, Jaccard deduplication, scoring into a candidate pool the stage chooses from. Decides nothing. `measure_adoption` marks afterwards which pooled candidates the approved stage actually built on. |
 
 ### Context and inputs
 
-| Module | Lines | Responsibility |
-| --- | --- | --- |
-| [`src/information_flow.py`](../src/information_flow.py) | 395 | Thirteen typed channels (`CHANNELS`, `:240-395`). Each declares `produced_by`, a `consumed_by` set of real stage slugs, and a rationale for every narrowing. `render_inbound()` composes a stage's context per consumer; `dependency_edges()` prints the producer→consumer topology. |
-| [`src/prompt_fragments.py`](../src/prompt_fragments.py) | 104 | The rules every stage prompt shares, held once. `compose_stage_template` (`:97`) orders them: the stage's own instructions, then the output-format rules that constrain them, then `RUN_SAFETY`. |
+| Module | Responsibility |
+| --- | --- |
+| [`src/information_flow.py`](../src/information_flow.py) | Sixteen typed channels (`CHANNELS`). Each declares `produced_by`, a `consumed_by` set of real stage slugs, and a rationale for every narrowing. `render_inbound()` composes a stage's context per consumer; `dependency_edges()` prints the producer→consumer topology. |
+| [`src/prompt_fragments.py`](../src/prompt_fragments.py) | The rules every stage prompt shares, held once. `compose_stage_template` orders them: the stage's own instructions, then the output-format rules that constrain them, then `RUN_SAFETY`. |
 | [`src/intake.py`](../src/intake.py) | | Stage 00: clarification-question parsing, resource classification and ingestion, `intake_context.json`. Runs before the graph walk begins. |
 | [`src/bootstrap.py`](../src/bootstrap.py) | | `--paper-corpus`: scans your prior papers (PDF/LaTeX/BibTeX) into a researcher profile, citation neighborhood, and style profile. |
 | [`src/project_bootstrap.py`](../src/project_bootstrap.py) | | `--project-root`: scans an existing repository, assesses per-stage completion, recommends a re-entry stage. |
@@ -184,7 +184,7 @@ counted below are the panel, the rubric, the archive and the graph.
 | --- | --- |
 | [`src/backend/studio_http.py`](../src/backend/studio_http.py) | `ThreadingHTTPServer` request router, static asset serving, SSE for the Notebook. Stdlib `http.server` only. |
 | [`src/backend/studio_service.py`](../src/backend/studio_service.py) | The service layer: project index, run summaries, stage documents, file tree, paper preview, version history, iteration planning. |
-| [`src/backend/studio_runner.py`](../src/backend/studio_runner.py) | Drives real `ResearchManager` runs in a background thread under the Studio's approval gate. Its lazy-resume approve path picks the next stage by stage number (`:361-364`) rather than asking the router, so graph routing is a CLI capability today. |
+| [`src/backend/studio_runner.py`](../src/backend/studio_runner.py) | Drives real `ResearchManager` runs in a background thread under the Studio's approval gate. Its lazy-resume approve path picks the next stage by stage number rather than asking the router, so graph routing is a CLI capability today. |
 | [`src/backend/sessions.py`](../src/backend/sessions.py) | Per-stage trace events for the live view; parses `logs_raw.jsonl` into renderable events. |
 | [`src/backend/notebook.py`](../src/backend/notebook.py) | The Notebook view's Claude conversation over a run. |
 | [`src/frontend/static/`](../src/frontend/static) | The single-page UI: `index.html`, `app.js`, `notebook.js`, `styles.css`. No build step, no framework. |
@@ -198,7 +198,7 @@ shims that re-export from `src/backend/`. New code should import from
 ## The walk
 
 Stage 00 intake runs before the walk. `_graph_entry_stage` →
-`_select_stages_for_run` (`src/manager.py:693-715`) yields only `STAGES`, so
+`_select_stages_for_run` (`src/manager.py`) yields only `STAGES`, so
 the graph has eight nodes plus `FINISH`, not nine.
 
 ```mermaid
@@ -223,7 +223,7 @@ flowchart TD
     L --> E
 ```
 
-Three things bypass the router at the jump seam (`src/manager.py:440-465`):
+Three things bypass the router at the jump seam (`src/manager.py`):
 `/back <stage>`, a rollback after retry exhaustion, and a round that decided to
 refine its design or change its hypothesis. All are already-made moves by the
 time the walk sees them, and all are recorded on the route as revisits.
@@ -235,9 +235,9 @@ Context is composed **per consumer, not per availability**.
 
 1. `compose_stage_template` — the stage template from `src/prompts/<slug>.md`,
    the shared output-format fragments, and `RUN_SAFETY`.
-2. `render_inbound(ChannelContext(...), CHANNELS)` (`src/manager.py:2033-2039`)
+2. `render_inbound(ChannelContext(...), CHANNELS)` (`src/manager.py`)
    — the typed channels whose `consumed_by` includes this stage. The delivered
-   keys are written to the run log by `_record_inbound_channels` (`:2900`).
+   keys are written to the run log by `_record_inbound_channels`.
 3. The stage-summary contract — the required heading order, the six fixed
    options, three refinement suggestions — and the execution-discipline rules.
 4. `user_input.txt`.
@@ -248,8 +248,8 @@ Context is composed **per consumer, not per availability**.
 7. Refinement feedback, or — on a continuation attempt — the current draft, the
    workspace, and, from attempt 3 on, the previous validation errors.
 
-Steps 3-7 are `build_prompt` (`src/utils.py:753`); a continuation attempt takes
-`build_continuation_prompt` (`:820`) instead, which always sends the handoff
+Steps 3-7 are `build_prompt` (`src/utils.py`); a continuation attempt takes
+`build_continuation_prompt` instead, which always sends the handoff
 because it sends no memory at all.
 
 Three channel narrowings worth knowing, because they are what "typed" buys:
@@ -259,11 +259,11 @@ reaches Stage 07 alone; and the mutable Stage 02 hypotheses stop at
 
 Five blocks are still passed as arguments rather than declared as channels:
 `obligations_context`, `intake_context_text`, `web_search_context`,
-`approved_memory` and `handoff_context` (`src/manager.py:2041-2069`). Their
+`approved_memory` and `handoff_context` (`src/manager.py`). Their
 delivery rules therefore sit inside `build_prompt` instead of next to a
 `consumed_by` set — which is where the one rule that matters lives:
 `build_prompt` withholds the handoff when memory is non-empty
-(`src/utils.py:807`), because the handoff is a strict subset of memory and
+(`src/utils.py`), because the handoff is a strict subset of memory and
 sending both put ~350 words of verbatim duplicate into every prompt from Stage
 04 on.
 
@@ -322,7 +322,7 @@ A separate mechanism handles a **resume failure**: if the backend reports that
 a session ID no longer exists, the operator detects it from the error text and
 falls back to a fresh session rather than failing the stage.
 
-After `MAX_STAGE_ATTEMPTS` (5, `src/utils.py:13`) AutoR stops and offers you
+After `MAX_STAGE_ATTEMPTS` (5, `src/utils.py`) AutoR stops and offers you
 skip, roll back, or abort. Under `--full-auto` the stage is auto-skipped
 instead, bounded by `--max-auto-skips`. It never silently gives up and it never
 silently continues.
@@ -342,7 +342,7 @@ on each. `memory.md` is rebuilt from the approved entries that survive.
 
 Staleness is recorded rather than enforced: a stale stage is visibly marked,
 and re-running it clears the mark. Rollback is also the mechanism the run uses
-on itself — `_rollback_and_jump` (`src/manager.py:2585`) is how a research
+on itself — `_rollback_and_jump` (`src/manager.py`) is how a research
 round that decided `refine_design` gets back to Stage 03, and how a cross-model
 veto reopens a stage that was already approved.
 
@@ -354,12 +354,12 @@ The Studio is not a second system. It drives the same `ResearchManager` over
 the same run directories, writing the same files.
 
 | | Terminal | Studio |
-| --- | --- | --- |
+| --- | --- |
 | Backends | Claude, Codex | Claude only |
 | Approval | six-option menu | Approve button / feedback box |
 | Live output | streamed to the terminal | session trace from `logs_raw.jsonl` |
 | Restart safety | resume by `run_id` | lazy-resume on the next approve/feedback |
-| Next stage | `router.choose` among admissible moves | next stage number (`studio_runner.py:361-364`) |
+| Next stage | `router.choose` among admissible moves | next stage number (`studio_runner.py`) |
 | Extra state | none | `.autor/projects.json`, `<run>/sessions/`, `<run>/notebook/` |
 
 You can start a run in the terminal and inspect it in the Studio, or the
@@ -372,7 +372,7 @@ reverse. The run directory is the contract between them.
 Ordered by how much of the system you have to understand first.
 
 | To change… | Edit | Code change needed |
-| --- | --- | --- |
+| --- | --- |
 | What a stage asks the agent to do | `src/prompts/<slug>.md` | none |
 | A rule every stage prompt shares | `src/prompt_fragments.py` | none |
 | Craft guidance an agent can pull mid-stage | a new `src/skills/<name>/SKILL.md` | none |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -190,7 +190,7 @@ approval. See [Stage Contract](stage-contract.md#2-the-artifact-gate).
 | `--panel-models ROLE=MODEL...` | — | Assign a model per seat, as `role=model` or `role=backend:model` (`pi=opus skeptic=codex:default`). Heterogeneity is the lever with the best evidence behind it. |
 | `--persona PATH` | — | Markdown description of the researcher the panel stands in for, injected into every seat so they hold one consistent bar. |
 | `--cross-review {auto,gemini,off}` | `auto` | Independent second opinion on each approval, from a different model family. It can veto an approval it cannot defend and can never override a refusal, so it only makes the gate stricter. `auto` enables it when a Gemini backend is configured. Only meaningful with an agent approval gate. |
-| `--cross-review-model MODEL` | `gemini-3.1-pro-preview` | Model for the cross-model reviewer (`DEFAULT_CROSS_REVIEW_MODEL`, `src/cross_reviewer.py:45`). |
+| `--cross-review-model MODEL` | `gemini-3.1-pro-preview` | Model for the cross-model reviewer (`DEFAULT_CROSS_REVIEW_MODEL`, `src/cross_reviewer.py`). |
 
 A blocking objection from any member cannot be approved over — the chair's approval is
 converted to a refinement in code. Each run also writes
@@ -302,11 +302,11 @@ mechanism and the reasoning behind each refusal.
 | `--archive PATH` | `~/.autor/archive` | Where the cross-run archive lives. Each finished run records its route and measured fitness, and each edge is compared against runs that reached the same node and did not take it. Recording only. |
 | `--no-archive` | off | Do not record this run in the archive. |
 | `--archive-steer` / `--no-archive-steer` | **off** | Let the archive choose the topology this run uses, rather than only recording what it did. A run silently using a different topology from the one asked for is not a surprise a research tool gets to spring on anyone; turn this on once `--archive-report` shows the archive has something to say. A learned prior only reorders which move is preferred — it can never open a guarded edge. Preserved on resume. |
-| `--archive-report` | off | Print what the archive has learned, and exit. |
+| `--archive-report` | off | Print what the archive has learned, and exit. On a fresh install this is an empty table, and that is the honest state rather than a bug: no real run has ever been recorded into one. See [what has and has not been measured](self-improvement.md#what-has-and-has-not-been-measured). |
 | `--trial ID` | — | Tag this run as one arm of a paired trial. Two runs of the **same goal** sharing a `--trial` ID, with the same `--capability` and different `--arm` labels, become a pair; the statistic is the within-pair difference, which cancels goal difficulty. Requires `--capability` and `--arm` — a partial tag is refused, because a run tagged with only some of them can never be paired. |
 | `--capability NAME` | — | What the trial is testing, e.g. `effort_tiers`. Runs pair only within one capability. |
 | `--arm LABEL` | — | Which side of the pair, e.g. `off` / `on`. `off`, `control`, `baseline` and `0` are recognised as the control when the report has to guess. |
-| `--trial-report` | off | Print what the paired trials show, and exit: mean within-pair difference, an exact two-sided sign-flip p, the smallest p the sample size could have produced, and the per-criterion decomposition. See [Recursive Self-Improvement](self-improvement.md#5-paired-trials--does-any-of-this-help). |
+| `--trial-report` | off | Print what the paired trials show, and exit: mean within-pair difference, an exact two-sided sign-flip p, the smallest p the sample size could have produced, and the per-criterion decomposition. See [Recursive Self-Improvement](self-improvement.md#5-paired-trials--does-any-of-this-help). No trial has ever completed: the last attempt, on 2026-08-11, recorded zero runs against a quota wall. |
 | `--max-rounds N` | `1` | How many times Stages 03-06 may run. A round ends when Stage 06 records `converged`, `refine_design`, `new_hypothesis` or `abandon`. The default keeps the single-pass behaviour: the decision is still recorded, so a one-round run says whether it converged or merely stopped, but a round that asks to go back is recorded with `acted_on: false` and the run continues. Raise it to let a refuted hypothesis lead to a second round. |
 
 ### Optional enhancements

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,7 +40,7 @@ pip install google-genai pyyaml
 ## Tests
 
 ```bash
-# Everything (~10s, 234 tests)
+# Everything (~65s, 1786 tests)
 python -m unittest discover -s tests -p "test_*.py"
 
 # Verbose
@@ -50,7 +50,7 @@ python -m unittest discover -s tests -p "test_*.py" -v
 python -m unittest tests.test_manager_smoke
 
 # One test
-python -m unittest tests.test_manager_smoke.ManagerSmokeTest.test_full_run
+python -m unittest tests.test_manager_smoke.ManagerSmokeTests.test_manager_run_completes_full_eight_stage_smoke
 ```
 
 Tests are stdlib `unittest`. They create temporary run directories, drive the

--- a/docs/scorecard.md
+++ b/docs/scorecard.md
@@ -27,13 +27,19 @@ sentence as the reason.
 
 ---
 
-## Three verdicts, and the distinction that matters
+No feature has yet been measured on a real backend run — every verdict in the examples below
+comes from a scripted `--fake-operator` run. See
+[what has and has not been measured](self-improvement.md#what-has-and-has-not-been-measured).
+
+## Five verdicts, and the distinction that matters
 
 | Verdict | Meaning |
 | --- | --- |
 | `keep` | Enabled, measured, and the measurement says it changed an outcome. |
 | `drop` | Enabled, measured, and it changed nothing. |
 | `unproven` | Enabled, but the measurement could not run. |
+| `unused` | Never enabled. Reported as not enabled, and it appears in no section. |
+| `unreadable` | The ledger exists but cannot be parsed. Never reported as a null. |
 
 **`unproven` is not a pass.** A feature lands here when there was no baseline to compare
 against — the ideation panel whose Stage 02 was never approved, the crux panel that was

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -395,11 +395,22 @@ Three further refusals hold this together:
   `C(a+b,a)` labellings, so no result can go below `2/C(a+b,a)`. Three a side bottoms
   out at `p = 0.10`; against a family the size of the adaptive graph's edge set the
   corrected threshold needs six. `minimum_arms_for` computes it, and the family is
-  the number of contrasts the archive actually holds rather than a written-down
-  constant — the graph has gone from eighteen edges to twenty-two, and a fixed
-  divisor would have under-corrected from the first edge added. The previous value was three, with a
-  docstring about intent, which meant the archive was licensing topology changes at a
-  sample size where the arithmetic forbids the claim.
+  computed rather than written down — the graph has gone from eighteen edges to
+  twenty-two, and a fixed divisor would have under-corrected from the first edge
+  added. The previous value was three, with a docstring about intent, which meant the
+  archive was licensing topology changes at a sample size where the arithmetic forbids
+  the claim.
+
+  Two families, not one, and the difference is deliberate. `min_observations` is
+  derived against the whole declared edge family — `len(REVISIT_EDGES) + len(STAGES)`,
+  twenty-one today — because the sample size has to be fixed before anyone looks. The
+  per-row believability threshold is corrected only for the contrasts the archive
+  actually holds, which on a young archive is a much weaker correction. That is the
+  right shape (you cannot be penalised for comparisons you did not make) but it is not
+  the same divisor, and the two should not be described with one phrase. The margin on
+  the first is thinner than it looks: `minimum_arms_for(0.05, family=f)` is 6 for every
+  `f` from 7 to 23 and becomes 7 at 24, so three more edges would raise the bar with no
+  other change.
 - **A p-value is never reported without the floor its sample size could attain.**
   *Did not show an effect* and *could not have shown one* print identically as "not
   significant" and mean opposite things.
@@ -543,6 +554,38 @@ attached: the criterion weights per stage, the composition gap, the 0/400 reach 
 learned priority, the permutation floors. All of these come from running the code —
 mostly with `--fake-operator`, which measures the harness rather than any research —
 and every one can be re-derived from the commands named beside it.
+
+One of them is worth singling out because it is the strongest negative result here.
+`tools/archive_sample_complexity.py` drives the *real* graph and the *real*
+`edge_payoffs` under a forward-only routing policy and asks how many edges become
+believable. The answer is zero at every sample size it sweeps — N = 5, 10, 25, 50,
+100, 200, 500, 1000, with `P(at least one believable) = 0.00` at each. That is not
+"we have not collected enough runs yet"; it is a property of the estimator and the
+policy together, and it is why `propose_exploration` exists. The instrument had
+itself stopped running at some point — `RunRecord` gained a required field and it
+crashed on its first record — which is the reason a fast construction check now
+guards it.
+
+The same sweep says something less comfortable about the other end. Under a policy
+that *does* explore, clearing the believability gate is not the same as picking the
+right edge. Planting a true effect on two edges and asking what `propose_variant`
+would then propose:
+
+| Runs in the archive | It proposes something | The edge it picks has no real effect |
+| --- | --- | --- |
+| 10 | 0% | — |
+| 25 | 34% | **77%** |
+| 50 | 80% | 7% |
+| 100 | 100% | 0% |
+
+(at `sd_run = 0.0027`, the run-to-run spread of `mean_fitness`; the pattern holds
+across a sweep from 0.0027 to 0.08, and gets worse as the spread grows — at 0.08 the
+picked edge is still a null one 57% of the time at N = 100.) `min_observations = 6`
+is a per-edge false-positive control and it is doing its job; it is not, and was
+never, a guarantee that the *best* of the surviving edges is a real one. The window
+between "the archive starts having opinions" and "the archive is right" is roughly
+25 to 50 runs wide, and it is the direct argument for `--archive-steer` defaulting
+off rather than a matter of taste.
 
 **Not measured.** Whether any of this makes research better.
 

--- a/main.py
+++ b/main.py
@@ -815,9 +815,13 @@ def record_into_archive(
             # has taken has no payoff in either direction. That closes the loop the
             # archive exists for: the graph's 13 backward edges are never taken, so
             # they never become believable, so nothing ever proposes taking them.
-            # Measured on the shipped archive: 583 recorded runs, every one of them
-            # the plain forward line, 0 believable edges — and 0 at any N under a
-            # forward-only policy, not merely a large N.
+            #
+            # It is 0 believable edges at any N, not merely at a large one, and that
+            # is a property of the shipped code rather than of one archive file:
+            # `tools/archive_sample_complexity.py` drives the real graph and the real
+            # `edge_payoffs` under a forward-only policy and reports 0 believable
+            # edges with P(>=1) = 0.00 at N = 5, 10, 25, 50, 100, 200, 500 and 1000.
+            # Re-run it; do not take a run count on trust.
             #
             # `propose_exploration` is the written entry into that blind spot and
             # had no caller. Reaching it only when the evidence-driven proposer

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -66,10 +66,11 @@ CRASHED_REASON = "Automated reviewer failed to run."
 #: The last thing the reviewer reads, and the reason it is last.
 #:
 #: The verdict contract was stated once, near the top, and the prompt then ended with five
-#: thousand characters of log tail. Measured over one benchmark run's 65 recorded review
-#: calls, the primary call emitted no parseable decision in its closing output almost every
-#: time, while the verdict-only re-ask -- which asks for nothing else and asks for it last --
-#: produced one on essentially every attempt. A reviewer that has spent its turn inspecting
+#: thousand characters of log tail. Measured over one ResearchClawBench run's recorded review
+#: calls -- a population that is not vendored here and so cannot be re-derived from this repo --
+#: the primary call emitted no parseable decision in its closing output almost every time, while
+#: the verdict-only re-ask, which asks for nothing else and asks for it last, produced one on
+#: essentially every attempt. A reviewer that has spent its turn inspecting
 #: files ends by narrating what it found, because narration is what the end of its context
 #: asks for.
 #:

--- a/src/archive.py
+++ b/src/archive.py
@@ -84,8 +84,9 @@ ARCHIVE_VERSION = "1"
 DEFAULT_MIN_OBSERVATIONS = minimum_arms_for(ALPHA, family=len(REVISIT_EDGES) + len(STAGES))
 
 #: Mean fitness a challenger must beat the incumbent by. Roughly the size of one
-#: criterion moving a quarter of its range on a seven-criterion rubric; below that
-#: the archive would promote noise.
+#: criterion moving a quarter of its range on the eight-criterion rubric: the lightest
+#: criterion carries 1.5 of 18, so a quarter of its range is 0.25 * 1.5/18 = 0.021.
+#: Below that the archive would promote noise.
 DEFAULT_MIN_GAIN = 0.02
 
 #: Weight on an unproven variant when sampling a parent. Pure fitness-proportional
@@ -506,8 +507,9 @@ class Archive:
         # a twice-resumed run three times. Duplicates are free observations: they
         # push `taken_runs` and `skipped_runs` past `min_observations` without any
         # new evidence, which is the one number standing between a coincidence and a
-        # topology change. Measured on the archive this repo's own review left
-        # behind: 415 rows, 327 distinct runs.
+        # topology change. No archive is vendored here, so the ratio is not a fixed
+        # figure to quote — measure your own with
+        # ``wc -l runs.jsonl`` against the count of distinct ``run_id`` values.
         deduped: dict[str, RunRecord] = {}
         for record in records:
             deduped[record.run_id] = record

--- a/src/inference.py
+++ b/src/inference.py
@@ -65,8 +65,9 @@ class TestResult:
 
         Both halves are required. Without the second, an archive comparing *n* edges
         reports the best of *n* at an uncorrected threshold, which is the
-        multiple-comparisons mistake in its purest form: with twenty edges and no
-        effect anywhere, the chance that at least one clears 0.05 is about 64%.
+        multiple-comparisons mistake in its purest form: against the twenty-one-member
+        family :data:`~src.archive.DEFAULT_MIN_OBSERVATIONS` is derived over, with no
+        effect anywhere, the chance that at least one clears 0.05 is about 66%.
         """
         corrected = alpha / max(family, 1)
         return self.p_value <= corrected and self.floor <= corrected

--- a/src/information_flow.py
+++ b/src/information_flow.py
@@ -8,12 +8,15 @@ from here on".
 
 Three things follow from writing the dependency down instead of approximating it.
 
-**The prompt stops carrying what a stage does not read.** Measured on a real run
-before this change, the Stage 02 hypothesis context and the frozen
-preregistration were both injected from Stage 05 onward — the same H1, twice,
-one of them labelled editable. That is not only 148 wasted words; it puts a
-mutable copy of the hypotheses next to the frozen one at exactly the stages
-where the freeze is the point.
+**The prompt stops carrying what a stage does not read.** Before this change the
+Stage 02 hypothesis context and the frozen preregistration were both injected
+from Stage 05 onward — the same H1, twice, one of them labelled editable. The
+wasted words were the smaller half of it: it put a mutable copy of the
+hypotheses next to the frozen one at exactly the stages where the freeze is the
+point. What survives as a checkable statement is the topology, not the word
+count — ``hypotheses.consumed_by`` now stops at ``04_implementation`` and no
+longer intersects ``preregistration.consumed_by``, asserted in
+``tests/test_information_flow.py``.
 
 **Attribution becomes possible.** ``src.archive`` learns which *moves* pay.
 A move carries a payload; until the payload has a name, "this edge helped"
@@ -21,7 +24,7 @@ cannot become "this information helped".
 
 **The graph is inspectable.** ``dependency_edges()`` returns the producer →
 consumer pairs, so the information topology can be printed, tested, and diffed
-rather than reconstructed by reading thirteen ``if`` statements.
+rather than reconstructed by reading sixteen ``if`` statements.
 
 A channel is deliberately allowed to have no producer (``produced_by=None``):
 run configuration, the researcher profile and the deliverable contract come

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -264,8 +264,10 @@ DEFAULT_PANEL: tuple[PanelRole, ...] = (
 #: a document, and `paper-writing` / `venue-checklist` are bound to no seat at all. It is out
 #: of :data:`DEFAULT_PANEL` because nothing filters the roster by stage yet, so seating it
 #: would buy one extra model call at all nine gates for a mandate that exists at two. Seating
-#: it by default is a one-line change here plus the two roster counts in
-#: ``tests/test_review_panel.py`` and the seat table in ``docs/review-panel.md``.
+#: it by default is not the one-line change it looks like: measured by making it, 18 of the 47
+#: tests in ``tests/test_review_panel.py`` fail, because their scripted reviewers supply exactly
+#: five responses and the sixth seat gets "No scripted response left". The roster count there and
+#: the seat table in ``docs/review-panel.md`` move with it.
 OPTIONAL_ROLES: tuple[PanelRole, ...] = (
     PanelRole(
         key="reader",

--- a/src/scorecard.py
+++ b/src/scorecard.py
@@ -13,7 +13,8 @@ made exactly this the point of its design: what settled the question was one com
 So this reads every ledger a run produced and answers the only question that matters when the
 run is over — **which of these should I have turned on?**
 
-Three verdicts, and the distinction between the last two is the whole point:
+Five verdicts. Three of them describe a feature that ran, and the distinction between the
+last two of those is the whole point:
 
 ``keep``
     Enabled, measured, and the measurement says it changed an outcome.
@@ -22,6 +23,11 @@ Three verdicts, and the distinction between the last two is the whole point:
 ``unproven``
     Enabled, but the measurement could not run — no baseline to compare against, or the run
     ended before the comparison was possible. **Not the same as "it worked."**
+
+``unused``
+    Never switched on. Reported as not enabled, and it appears in no section.
+``unreadable``
+    The ledger exists but cannot be parsed. Reported as unreadable, never as a null.
 
 A feature that was never switched on is reported as unused rather than as a failure, and a
 ledger that cannot be read is reported as unreadable rather than as an absence of effect.

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -134,10 +134,12 @@ class ArchiveTests(unittest.TestCase):
         """The Goodhart hole this closes, measured on real scores.
 
         A stage's score is a weighted mean over the criteria that apply to it, and
-        later stages face strictly more of them. On a real completed run, mean
-        fitness over stages 01-02 is 0.986 against 0.822 over all eight. Pool those
-        and "stop early" is worth eight times what a promotion needs — so the
-        archive would find it, and promote whatever topology halts soonest.
+        later stages face no fewer of them — 01 and 02 face the same set, and so do
+        05 through 08, but the count rises twice on the way. On a scripted
+        `--fake-operator` run, mean fitness over stages 01-02 is 0.973 against 0.817
+        over all eight. Pool those and "stop early" is worth nearly eight times what
+        a promotion needs — so the archive would find it, and promote whatever
+        topology halts soonest.
         """
         short = RunRecord(
             run_id="short", variant_id="baseline", rubric_version=RUBRIC_VERSION,
@@ -372,7 +374,11 @@ class ArchiveTests(unittest.TestCase):
         three a side could never have licensed a claim at any threshold anyone would
         use, whatever the effect size.
         """
-        self.assertGreaterEqual(DEFAULT_MIN_OBSERVATIONS, 6)
+        # Equality, not a floor. `minimum_arms_for(0.05, family=f)` is 6 for every
+        # family from 7 to 23 and becomes 7 at 24, so the graph is three edges away
+        # from silently needing a seventh observation a side. A `>= 6` assertion
+        # would not notice that happening.
+        self.assertEqual(DEFAULT_MIN_OBSERVATIONS, 6)
         self.assertGreater(unpaired_floor(3, 3), 0.05)
 
         self.archive._save_variants([BASELINE_VARIANT, Variant("challenger", "adaptive")])

--- a/tests/test_archive_evidence.py
+++ b/tests/test_archive_evidence.py
@@ -1,7 +1,8 @@
 """What the archive is allowed to say inside a routing prompt.
 
 The archive's learned value reached nothing: 0 of 400 measured node-comparisons
-changed `default_move`, because it filters to forward edges and every node has one.
+changed `default_move`, because it filters to forward edges and at most one of them
+is ever live at a node.
 Three independent reviews refused the obvious fix — wiring the statistic into
 `default_move` — on the grounds that it would put an unrandomised, guard-selected,
 n=3 number in charge of what the run does at the moment a guard has just failed.

--- a/tests/test_archive_exploration_wiring.py
+++ b/tests/test_archive_exploration_wiring.py
@@ -6,10 +6,16 @@ nobody has taken has no payoff in either direction, so it never becomes
 believable, so nothing ever proposes taking it — and the archive can only learn
 about edges the agent already chose on its own.
 
-Measured on the shipped archive: 583 recorded runs, every one the plain forward
-line, 0 backward edges taken, 0 believable edges. And 0 at any N under a
-forward-only policy — not a large N, an infinite one. `propose_exploration`
-exists to break that and was never called outside its own tests.
+It is 0 believable edges at any N under a forward-only policy — not a large N, an
+infinite one — and `tools/archive_sample_complexity.py` measures exactly that
+against the real graph and the real `edge_payoffs`: P(>=1 believable) = 0.00 at
+every N it sweeps, up to 1000 runs. `propose_exploration` exists to break that and
+was never called outside its own tests.
+
+The instrument had itself rotted quietly: `RunRecord` gained a required `bypassed`
+field and the tool crashed on its first record, which the old version of this test
+could not notice because it only checked that the file mentioned the right symbol
+names. It now builds a record.
 """
 
 from __future__ import annotations
@@ -76,9 +82,19 @@ class ExplorationIsReachableTest(unittest.TestCase):
         )
 
     def test_the_reason_is_recorded_next_to_the_call(self) -> None:
-        """The measurement that justifies wiring this is not obvious from the code."""
+        """The measurement that justifies wiring this is not obvious from the code.
+
+        This used to assert a run count appeared in `main.py`. A literal population
+        size is the wrong thing to pin: it came from a file nobody else has, two
+        other copies of it in this repo disagreed with it, and it would have stayed
+        green forever. What the comment owes the reader is the *instrument*.
+        """
         text = (REPO_ROOT / "main.py").read_text(encoding="utf-8")
-        self.assertIn("583", text, "the measured evidence for wiring this is not written down")
+        self.assertIn(
+            "archive_sample_complexity",
+            text,
+            "the comment must name the instrument that measured this, not a bare number",
+        )
 
 
 class SampleComplexityToolTest(unittest.TestCase):
@@ -90,6 +106,28 @@ class SampleComplexityToolTest(unittest.TestCase):
         text = tool.read_text(encoding="utf-8")
         for symbol in ("edge_payoffs", "believable", "StageGraph"):
             self.assertIn(symbol, text, f"the tool does not exercise the real {symbol}")
+
+    def test_the_tool_can_still_build_a_record(self) -> None:
+        """A silent crash on line one is how it stopped being an instrument.
+
+        Cheap on purpose: the sweep itself takes minutes, but constructing one
+        `RunRecord` through the tool's own factory is instant and is the thing that
+        breaks when the dataclass gains a field.
+        """
+        import importlib.util
+        import random
+
+        spec = importlib.util.spec_from_file_location(
+            "_asc", REPO_ROOT / "tools" / "archive_sample_complexity.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        rng = random.Random(0)
+        edges, visited = module.walk(rng, revisit_p=0.15, weighting="uniform")
+        record = module.make_record(rng, 0, edges, visited)
+        self.assertEqual(record.topology, "adaptive")
+        self.assertTrue(record.stage_fitness)
 
     def test_the_tool_is_not_collected_as_a_test(self) -> None:
         """It is an instrument; it takes minutes and asserts nothing."""

--- a/tests/test_decisions.py
+++ b/tests/test_decisions.py
@@ -19,6 +19,9 @@ from src.decisions import (
     format_offered_payoffs,
     offered_payoffs,
 )
+from src.archive import DEFAULT_MIN_OBSERVATIONS
+from src.stage_graph import REVISIT_EDGES
+from src.utils import STAGES
 from src.inference import (
     minimum_arms_for,
     paired_floor,
@@ -173,16 +176,22 @@ class InferenceTests(unittest.TestCase):
         self.assertTrue(result.believable())
 
     def test_the_family_correction_is_applied(self) -> None:
-        """With eighteen edges and no effect anywhere, the chance one clears an
-        uncorrected 0.05 is about 60%. The best of many is not one test."""
+        """Against the family the archive corrects over and no effect anywhere, the
+        chance one clears an uncorrected 0.05 is about 66%. The best of many is not
+        one test."""
         result = unpaired_permutation([0.9] * 6, [0.1] * 6)
         self.assertTrue(result.believable(family=1))
         self.assertFalse(result.believable(family=100))
 
     def test_the_derived_minimum_matches_the_arithmetic(self) -> None:
-        size = minimum_arms_for(0.05, family=18)
-        self.assertLessEqual(unpaired_floor(size, size), 0.05 / 18)
-        self.assertGreater(unpaired_floor(size - 1, size - 1), 0.05 / 18)
+        # The family the archive actually corrects over, computed the same way it is
+        # in `src.archive`. Pinning a literal here would keep passing after the graph
+        # grew, which is the failure this whole module exists to make impossible.
+        family = len(REVISIT_EDGES) + len(STAGES)
+        size = minimum_arms_for(0.05, family=family)
+        self.assertEqual(size, DEFAULT_MIN_OBSERVATIONS)
+        self.assertLessEqual(unpaired_floor(size, size), 0.05 / family)
+        self.assertGreater(unpaired_floor(size - 1, size - 1), 0.05 / family)
 
     def test_an_identical_pair_of_arms_is_not_significant(self) -> None:
         self.assertEqual(unpaired_permutation([0.5] * 4, [0.5] * 4).p_value, 1.0)

--- a/tests/test_doc_counts.py
+++ b/tests/test_doc_counts.py
@@ -1,0 +1,160 @@
+"""Counts written into prose, checked against the symbols they claim to count.
+
+Three sweeps of the docs in one week found the same class of defect each time: a
+sentence says "thirteen typed channels", someone adds a channel, and the sentence
+stays green because prose has no compiler. The counts that rotted were not obscure —
+they were the ones the README leads with, and one of them contradicted a second copy
+of itself four hundred lines further down.
+
+Two rules, both cheap:
+
+**A spelled-out count next to a countable noun must equal the symbol.** The scan is
+deliberately narrow — a fixed list of (phrase, live value) pairs — because a general
+"find every number in the docs" check would be all false positives. Adding a row here
+is how a new claim gets protected.
+
+**A doc may not cite a line number in this repo's own source.** Of the forty-four
+`file.py:NNN` references the docs carried before this test existed, twelve of twelve
+spot-checked pointed at the wrong line, and two of the survivors were right by
+coincidence — one landed on a blank line, another on a closing bracket. A line number
+rots on the next edit to the file above it, which is a guarantee of decay, not a risk
+of it. Symbol names do not rot: `grep` finds them wherever they moved. External repos
+are exempt, because the doc cannot re-derive those and the reader is being pointed at
+a pinned artifact rather than at moving code.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+from src.information_flow import CHANNELS
+from src.rubric import CRITERIA
+from src.stage_graph import _ADVANCE_GUARDS, REVISIT_EDGES, StageGraph
+from src.utils import STAGES
+
+REPO = Path(__file__).resolve().parent.parent
+
+NUMBER_WORDS = {
+    1: "one", 2: "two", 3: "three", 4: "four", 5: "five", 6: "six", 7: "seven",
+    8: "eight", 9: "nine", 10: "ten", 11: "eleven", 12: "twelve", 13: "thirteen",
+    14: "fourteen", 15: "fifteen", 16: "sixteen", 17: "seventeen", 18: "eighteen",
+    19: "nineteen", 20: "twenty", 21: "twenty-one", 22: "twenty-two",
+    23: "twenty-three", 24: "twenty-four", 25: "twenty-five",
+}
+
+
+def spelled(value: int) -> str:
+    return NUMBER_WORDS[value]
+
+
+def _adaptive_edges() -> int:
+    return len(StageGraph.adaptive().edges)
+
+
+def _forward_edges() -> int:
+    return sum(1 for edge in StageGraph.adaptive().edges if edge.kind != "revisit")
+
+
+#: ``(noun, live value)``. Every spelled-out numeral immediately before *noun* in a
+#: tracked document must equal *value*. The noun is matched case-insensitively and
+#: must be the whole phrase, so "typed channels" does not also catch "channels".
+COUNTED_NOUNS: tuple[tuple[str, int], ...] = (
+    ("typed channels", len(CHANNELS)),
+    ("typed information channels", len(CHANNELS)),
+    ("backward edges", len(REVISIT_EDGES)),
+    ("backward moves", len(REVISIT_EDGES)),
+    ("dotted edges", len(REVISIT_EDGES)),
+    ("edges in the adaptive graph", _adaptive_edges()),
+    ("forward edges", _forward_edges() - 1),  # the abandonment terminal aside
+    ("guarded forward edges", len(_ADVANCE_GUARDS)),
+)
+
+TRACKED_DOCS = ("README.md", "docs/architecture.md", "docs/self-improvement.md")
+
+#: Line references outside this repo's own tree. The reader is being sent to a pinned
+#: artifact somewhere else, which this repo cannot re-derive and does not churn.
+EXTERNAL_REFERENCE_PREFIXES = ("evaluation/",)
+
+
+class CountsInProseMatchTheSymbolTests(unittest.TestCase):
+    def test_every_spelled_out_count_matches_its_symbol(self) -> None:
+        wrong: list[str] = []
+        for name in TRACKED_DOCS:
+            text = (REPO / name).read_text(encoding="utf-8")
+            for noun, value in COUNTED_NOUNS:
+                # The noun may be broken across a line in the source markdown, so
+                # every space in it matches any run of whitespace. Without this the
+                # scan silently skips exactly the wrapped sentences, which is where
+                # the first three stale counts were found.
+                spaced = r"\s+".join(re.escape(word) for word in noun.split())
+                pattern = re.compile(
+                    r"\b([A-Za-z]+(?:-[a-z]+)?)\s+" + spaced + r"\b", re.IGNORECASE
+                )
+                for match in pattern.finditer(text):
+                    word = match.group(1).lower()
+                    if word not in NUMBER_WORDS.values():
+                        continue
+                    if word != spelled(value):
+                        line = text[: match.start()].count("\n") + 1
+                        wrong.append(
+                            f"{name}:{line} says '{match.group(0)}' but the symbol "
+                            f"counts {value} ({spelled(value)})"
+                        )
+        self.assertEqual(wrong, [], "\n".join(wrong))
+
+    def test_the_criteria_count_is_stated_correctly(self) -> None:
+        text = (REPO / "docs/self-improvement.md").read_text(encoding="utf-8")
+        self.assertIn(f"{spelled(len(CRITERIA)).capitalize()} criteria", text)
+
+    def test_the_stage_count_is_stated_correctly(self) -> None:
+        text = (REPO / "README.md").read_text(encoding="utf-8")
+        self.assertIn(f"{spelled(len(STAGES))} stages", text.lower())
+
+    def test_the_mermaid_diagram_draws_every_backward_edge(self) -> None:
+        """A count elsewhere in the file does not fix a picture that is missing edges.
+
+        The README's graph diagram drew ten dotted edges while `REVISIT_EDGES` had
+        thirteen, so the three that were missing — 02→01, 03→02, 06→04 — were absent
+        from the only place a reader looks for the shape.
+        """
+        text = (REPO / "README.md").read_text(encoding="utf-8")
+        blocks = re.findall(r"```mermaid\n(.*?)```", text, re.DOTALL)
+        dotted = sum(block.count("-.->") for block in blocks)
+        self.assertEqual(
+            dotted,
+            len(REVISIT_EDGES),
+            f"the diagram draws {dotted} backward edges, REVISIT_EDGES has "
+            f"{len(REVISIT_EDGES)}",
+        )
+
+
+class DocsDoNotCiteLineNumbersTests(unittest.TestCase):
+    def test_no_doc_cites_a_line_number_in_this_repo(self) -> None:
+        offenders: list[str] = []
+        for path in sorted(REPO.glob("*.md")) + sorted((REPO / "docs").glob("*.md")):
+            text = path.read_text(encoding="utf-8")
+            for match in re.finditer(r"([A-Za-z_][\w/]*\.py):(\d+)(?:-\d+)?", text):
+                target = match.group(1)
+                if target.startswith(EXTERNAL_REFERENCE_PREFIXES):
+                    continue
+                if not _is_in_this_repo(target):
+                    continue
+                line = text[: match.start()].count("\n") + 1
+                offenders.append(
+                    f"{path.relative_to(REPO)}:{line} cites {match.group(0)} — "
+                    "name the symbol instead; line numbers rot on the next edit"
+                )
+        self.assertEqual(offenders, [], "\n".join(offenders))
+
+
+def _is_in_this_repo(reference: str) -> bool:
+    if (REPO / reference).exists():
+        return True
+    name = Path(reference).name
+    return any((REPO / "src").rglob(name)) or (REPO / name).exists()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stage_graph.py
+++ b/tests/test_stage_graph.py
@@ -122,8 +122,10 @@ class WhatEdgePriorityActuallyReachesTests(unittest.TestCase):
     `Variant.edge_priority` is the whole output of the cross-run learner, and the
     honest statement of its reach is narrow: it orders the move table the agent is
     shown, and that is currently all of it. `default_move` filters to forward edges
-    before ranking and every shipped node has exactly one, so no assignment of
-    priorities changes what a run does when nobody is steering.
+    before ranking, and at most one is ever live at a node: seven of the eight have a
+    single forward edge, and 06_analysis's second — the abandonment terminal — is shut
+    unless a round concluded `abandon` and preempts everything else when it is open. So
+    no assignment of priorities changes what a run does when nobody is steering.
 
     Both halves are asserted on purpose. A test that only pinned "no difference"
     would stay green if someone deleted `default_move` entirely; pinning that the

--- a/tools/archive_sample_complexity.py
+++ b/tools/archive_sample_complexity.py
@@ -114,11 +114,13 @@ def walk(rng: random.Random, *, revisit_p: float, weighting: str, abandon_p: flo
 def make_record(rng: random.Random, index: int, edges, visited, *, sigma: float = 0.06) -> RunRecord:
     """One archived row. ``sigma`` is the run-to-run spread of a stage score.
 
-    Measured on the only real archive available (568 runs, all fake-operator, so
-    all on scripted content): the spread of ``mean_fitness`` across runs is 0.0027
-    and the spread of stage scores *within* a run is 0.11. The first is far too
-    small to stand in for live runs on different goals and the second is far too
-    large, so :func:`precision_sweep` sweeps the range rather than picking one.
+    No archive is vendored with this repo, so ``sigma`` cannot be read off one. On
+    the author's own archive — every row of it ``--fake-operator``, so all on
+    scripted content — the spread of ``mean_fitness`` across runs was 0.0027 and the
+    spread of stage scores *within* a run 0.11. The first is far too small to stand
+    in for live runs on different goals and the second far too large, so
+    :func:`precision_sweep` sweeps the range instead of picking one. Point this at
+    your own ``~/.autor/archive/runs.jsonl`` to re-derive both.
     """
     lift = sum(TRUE_EFFECT.get(key, 0.0) for key in edges)
     base = 0.75 + lift
@@ -137,6 +139,7 @@ def make_record(rng: random.Random, index: int, edges, visited, *, sigma: float 
         steps=len(visited),
         revisits=sum(v for k, v in edges.items() if KIND.get(k) == "revisit"),
         agent_directed=0,
+        bypassed=0,
         recorded_at="t",
     )
 
@@ -146,7 +149,7 @@ def make_record(rng: random.Random, index: int, edges, visited, *, sigma: float 
 # ---------------------------------------------------------------------------
 
 POLICIES = {
-    "always forward (matches all 513 real runs)": dict(revisit_p=0.00, weighting="uniform"),
+    "always forward (every recorded run so far)": dict(revisit_p=0.00, weighting="uniform"),
     "occasional revisit p=0.05, uniform": dict(revisit_p=0.05, weighting="uniform"),
     "occasional revisit p=0.15, uniform": dict(revisit_p=0.15, weighting="uniform"),
     "agent-chosen p=0.15, prefers cheap": dict(revisit_p=0.15, weighting="local"),
@@ -174,7 +177,7 @@ def main() -> None:
     for label, kwargs in POLICIES.items():
         print(f"--- {label}")
         print(f"{'N':>6} {'believable (median)':>20} {'of which revisit':>17} "
-              f"{'P(>=1)':>8} {'P(all 10 revisit)':>18}")
+              f"{'P(>=1)':>8} {f'P(all {len(REVISITS)} revisit)':>18}")
         for n in SAMPLE_SIZES:
             totals, revisit_totals, any_hit, all_hit = [], [], 0, 0
             for rep in range(REPLICATES):
@@ -220,7 +223,8 @@ def precision_sweep() -> None:
     print(f"policy p=0.30 uniform; true effect only on "
           f"{', '.join(sorted(TRUE_EFFECT))}; min_gain={DEFAULT_MIN_GAIN}")
     print("sd_run is the run-to-run spread of `mean_fitness`, the quantity min_gain is")
-    print("compared against. 0.0027 is the measured value on the real 568-run archive.")
+    print("compared against. 0.0027 is the spread measured on the author's own archive,")
+    print("every row of which is --fake-operator; there is no vendored archive to re-derive it from.")
     print(f"{'sd_run':>7} {'N':>6} {'P(propose)':>11} {'P(picks a null edge)':>21} "
           f"{'P(wrong sign|real)':>19}")
     for sd_run in (0.0027, 0.010, 0.020, 0.040, 0.080):


### PR DESCRIPTION
Every measured claim re-derived against HEAD. Three were not stale numbers but wrong statements, and one of the tools the docs cite as evidence had stopped running without anything noticing.

## The instrument had rotted

`tools/archive_sample_complexity.py` is what justifies wiring `propose_exploration`. `RunRecord` gained a required `bypassed` field and the tool crashed on its first record. The wiring test only checked that the file *mentioned* the right symbol names, so nothing saw it.

Repaired, it confirms the claim far better than the run count it replaced:

```
--- always forward (every recorded run so far)
     N  believable (median)  of which revisit   P(>=1)
     5                  0.0               0.0     0.00
    25                  0.0               0.0     0.00
   100                  0.0               0.0     0.00
  1000                  0.0               0.0     0.00
```

Zero at every N — a property of the estimator and the policy together, not "we need more runs". That is re-derivable by anyone; "583 recorded runs" was not.

### And a finding no doc carried

Clearing the believability gate is not the same as picking the right edge. Plant a true effect on two edges and ask what `propose_variant` proposes:

| Runs in the archive | It proposes something | The edge it picks has no real effect |
| --- | --- | --- |
| 10 | 0% | — |
| 25 | 34% | **77%** |
| 50 | 80% | 7% |
| 100 | 100% | 0% |

`min_observations = 6` is a per-edge false-positive control doing its job; it was never a guarantee that the *best* of the survivors is real. The window between "the archive starts having opinions" and "the archive is right" is about 25–50 runs wide — the direct argument for `--archive-steer` defaulting off.

## Claims that were wrong, not stale

| Claim | Reality |
| --- | --- |
| "the explore proposer has no production caller" (said twice) | `main.py` calls it, and `tests/test_archive_exploration_wiring.py` exists to keep it wired |
| "`panel_effect.json` is read only by the function that appends to it" | `src/scorecard.py` reads all five ledgers and renders a verdict |
| "**nine** `validate_*` functions — count them with `grep -rn '^def validate_' src/`" | the grep returns **20**, the section it points at names **7**, and 9 matches no rule. Three numbers for one quantity in one document |
| "Three verdicts" (`docs/scorecard.md`, `src/scorecard.py`) | five; the other two are described sixteen lines further down |
| "seating the Area Chair is a one-line change" | measured by making it: **18 of 47** tests in that file fail |
| `docs/development.md`'s one-test command | errors out — the class was renamed |
| "Six of the seven forward edges carry a guard … ten backward moves" | six of eight, thirteen backward |

## Populations nobody can reproduce

415 rows / 327 runs (`src/archive.py`), 583 runs (`main.py`), 513 and 568 (the instrument), 65 review calls (`src/approval_agent.py`), 148 wasted words (`src/information_flow.py`). No archive is vendored, so none is re-derivable, and they disagree with each other. Each replaced with the qualitative claim plus a recipe, or with the instrument.

## Counts refreshed

`CHANNELS` reached 16 — the README's "fifteen", which last week's sweep had just corrected, went stale again inside one merge (#175 added a channel). Also: the mermaid label, `docs/architecture.md`'s "thirteen typed channels", the "sixteen `if` statements", per-stage output `228-277` → `228-292`, and the composition table re-measured on HEAD (0.973 / 0.904 / 0.817, and all eight stages are scored again now that #174 split measuring from polishing).

The prompt-size claim now ships its recipe, because it needs one: wrap `build_prompt`, sum `len(prompt.split())`, and **hold the goal string fixed** — the goal alone moves the total by several hundred words. Measured that way with one goal held constant, `dd54947` gives 20,401 and HEAD gives 25,415.

## Two gates, so there is no fourth sweep

- **`tests/test_doc_counts.py`** — every spelled-out count checked against the live symbol (matching across line wraps, which is where the first three stale counts hid), the mermaid diagram checked for every backward edge, and no doc may cite a line number in this repo's own source. Five mutations kill it: reverting a wrapped count, reverting a single-line count, re-adding a line ref, breaking a count in `architecture.md`, and adding a channel to the code.
- The wiring test now **builds a `RunRecord` through the instrument's own factory** — instant, and it is exactly what breaks when the dataclass gains a field. Verified by removing `bypassed=0` again.

Also pinned: `DEFAULT_MIN_OBSERVATIONS` with `assertEqual`, not `>=`. It is 6 for every family from 7 to 23 and becomes **7 at 24** — three more edges would silently raise the bar. And `tests/test_decisions.py` now computes the family the way `src/archive.py` does instead of pinning `18`, a divisor nothing in the tree has used since #157.

## What was dropped

Line numbers: 44 of them, 12 of 12 spot-checked wrong, two survivors right by coincidence (one landed on a blank line, another on a closing bracket). Line-count columns: 12 of 12 stale, and the one hand-refreshed last week was wrong again within a single merge. Both are decoration whose failure mode is silent.

## What I checked and left alone

`docs/star-activity-notice.md`'s "12 contributors" — git shows 17 distinct author *names* by that date, but several are the same person under two handles, and GitHub counts accounts. Not the same quantity, so not a defect.

## Testing

1792 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)