### PR TITLE
Rebuild the documentation against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@
 
 <p align="center">
   <strong>Start here:</strong>
+  <a href="docs/framework.md">The Framework</a> ·
   <a href="docs/tutorial_en.md">English Guide</a> ·
   <a href="docs/tutorial_zh.md">中文教程</a> ·
   <a href="docs/">Full Documentation</a>
 </p>
 
 <p align="center">
-<<<<<<< HEAD
-=======
   <img src="assets/examples/example_fig6_two_layer.png" alt="AutoR example figure" width="92%" />
 </p>
 
@@ -32,133 +31,21 @@
 
 > AutoR is not a chat demo, not a generic agent framework, and not a markdown-only research toy.
 >
-> It is a structured research harness over a coding agent execution layer:
-> **AI handles execution, humans own the direction, and every run becomes an inspectable research artifact on disk.**
+> It is a structured research harness over a coding-agent execution layer:
+> **the agent handles execution, the human owns the direction, and every run becomes an inspectable
+> research artifact on disk.**
 
-> New users should start with the step-by-step guides:
-> [English Guide](docs/tutorial_en.md) or [中文教程](docs/tutorial_zh.md).
+**[docs/framework.md](docs/framework.md)** is the single document that describes what this system is:
+its implementation, its modules, what is new in it, and what it contributes. This README is the
+overview and the operating manual.
 
-## 📖 Overview
+## Contents
 
-Most autoresearch systems optimize for autonomy.
-
-AutoR takes a different position: research is too important to hand over as a blind end-to-end loop. The goal is not to remove humans from research. The goal is to give them a stronger execution system.
-
-### ✨ At a Glance
-
-| Dimension | AutoR |
-| --- | --- |
-| Execution model | A coding agent as the execution layer, AutoR as the research control loop |
-| Control model | Human approval by default, with an optional strict reviewer-agent gate for unattended runs |
-| Research unit | A reproducible run under `runs/<run_id>/` |
-| Workflow shape | Nine stages as a **directed graph** the run navigates; the linear sequence is one path through it |
-| Improvement | On by default: drafts are measured and ratcheted, so a stage can only get better — and the score is blind to what the run concluded |
-| Quality bar | Artifact-backed outputs, not markdown-only summaries |
-| Recovery | Resume, redo-stage, rollback-stage, stage-local continuation |
-
-### 🔦 Highlights
-
-| Layer | Highlight | What AutoR actually does |
-| --- | --- | --- |
-| Big idea | **Human-centered research execution** | AutoR is not an autonomous scientist. AI handles execution; humans retain approval and direction at every stage boundary. |
-| Big idea | **The stages are a graph, not a list** | Analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it. AutoR computes which moves are open by checking artifacts on disk; the agent chooses among those and says why. [Details](docs/self-improvement.md) |
-| Big idea | **Improvement that is measured, not hoped for** | A refinement round is scored against a rigour rubric read off disk. The best-scoring draft is what gets promoted; a round that scores worse is reverted. A stage can only improve. |
-| Big idea | **Self-improvement that cannot p-hack** | The fitness function is blind to what the run concluded — a refuted hypothesis with clean evidence outscores a supported one resting on an assertion — and any round that moves a hypothesis verdict is rejected outright. |
-| Big idea | **The harness learns across runs** | An optional archive compares each graph edge against runs that reached the same node and did not take it, and reorders which move is preferred. It can never open a guarded edge. |
-| Big idea | **Research loop over agent loop** | The system manages stage progression, validation, repair, recovery, and human checkpoints above the lower-level agent execution loop. |
-| Big idea | **Every run is a reproducible research artifact** | Each run leaves behind prompts, logs, approved summaries, code, data, figures, writing sources, and packaged outputs under `runs/<run_id>/`. |
-| Big idea | **Verifiable outputs, not paper-shaped theater** | The workflow is judged by inspectable artifacts and human approval, not by whether a generated document merely looks polished. |
-| Useful feature | **Structured literature organization** | Survey notes, bibliographies, related-work tables, and reading artifacts stay under `workspace/literature/` instead of disappearing into chat history. |
-| Useful feature | **Automated experiment manifests** | Machine-readable experiment and result files make runs inspectable, comparable, and reusable downstream. |
-| Useful feature | **Citation verification and writing checks** | Writing expects citation verification, figure-link checks, and self-review artifacts before Stage 07 is considered complete. |
-| Useful feature | **Artifact indexing across stages** | `artifact_index.json` and related manifests help later stages find data, results, and figures without guessing from filenames. |
-| Useful feature | **Obligations carried forward** | An approving reviewer records what a later stage still owes; the debt is injected into that stage and its review, and only a reviewer can discharge it. |
-| Useful feature | **Cross-model review veto** | When the reviewer approves, a different model family audits that approval and can send the stage back. A veto, never an override, so it can only tighten the gate. |
-| Useful feature | **Self-improving review policy** | Every correction the reviewer demands becomes a standing rule checked on all later stages, recorded in an auditable `review_policy.json` with the stage and attempt that produced it. |
-| Useful feature | **Resume, redo, and rollback controls** | Long research runs can continue in place, retry a stage, or roll downstream state back without starting over. |
-| Useful feature | **Deliberating review panel** | Instead of one reviewer agent at the approval gate, `--review-panel` seats a PI, domain expert, methodologist, reproducibility engineer and adversarial reviewer who review independently, cross-examine, then converge — and a blocking objection cannot be approved over. Each run measures the panel against its own single-pass baseline and reports when it did not earn its cost. |
-| Useful feature | **Divergent ideation panel** | `--ideation-panel` widens Stage 02 with proposers working from distinct lenses - mechanism, contrarian, adjacent field, null/artifact, regime - deduplicated and scored into a candidate pool the stage chooses from. It decides nothing, and reports when the extra proposers added nothing. |
-| Useful feature | **Anchored review comments** | A reviewer can quote the passage it objects to instead of refusing the whole stage. The revision is told to change only those spans, and is then diffed against them — so "preserve the correct parts" is measured rather than hoped for. |
-| Useful feature | **Selective deep thinking** | Most steps are execution. With `--deliberation` a stage that hits a genuine crux can stop, name the question, and pull in a panel of theorist / empiricist / critic / pragmatist plus an expert brief — then carry on with an answer that names its own falsifier. Budgeted, and measured against what the agent already believed. |
-| Useful feature | **Effort tiers** | `--effort-tiers` runs each stage as routine or deliberative rather than treating them alike — a lean prompt and a single reviewer where the decisions are already made, the full apparatus where something is genuinely undecided. Each stage sets the next one's tier, and a routine stage that keeps failing is promoted automatically. Polish rounds and the strong model are then concentrated on the deliberative steps rather than spread evenly. |
-| Useful feature | **One dial** | `--rigor {fast,standard,thorough,max}` decides how much optional machinery a run uses, ordered by what each costs and what evidence there is for it. Individual switches remain as overrides in both directions. |
-| Useful feature | **Run scorecard** | Every optional feature measures itself; at the end of a run `workspace/reviews/scorecard.md` reads all of those ledgers together and says which ones earned their cost and which flags to turn off — keeping "could not be measured" separate from "changed nothing". |
-| Useful feature | **Two output formats** | Stage 07 writes a benchmark-ready markdown report (`report/report.md` + PNG figures) by default, or a venue-aware LaTeX paper package with a compiled PDF via `--output-format latex`. |
-
-In practice, that means AutoR is useful not only because of the high-level framing, but also because it handles real research chores: literature organization, experiment manifests, citation verification, artifact indexing, manuscript packaging, and recoverable long-running workflows.
-
-### ✅ What AutoR Guarantees
-
-- By default, human approval is required before the workflow advances.
-- An optional reviewer agent can simulate that gate for unattended runs, but the human-centered default remains manual review.
-- Approved summaries become the only cross-stage memory.
-- Every run is isolated, resumable, and auditable.
-- Later stages must produce real artifacts, not only prose.
-- A coding agent is the execution layer; AutoR is the research control loop above it.
-
-### 🤔 Why AutoR?
-
-Many systems aim to generate research outputs that *look* ready.
-
-AutoR takes a harder path:
-
-- it requires real experiments
-- it enforces artifact validation
-- it keeps humans in control
-
-So the question is not:
-
-> Does it look ready?
-
-It is:
-
-> Can you verify every part of it?
-
-## 📰 News
-
-Latest mainline updates:
-
-- **2026-08-06**: **Recursive self-improvement is now the default.** The nine stages are a **directed graph** the run navigates: an analysis that exposes a design flaw can send the run back to Stage 03 instead of writing up around it, and the move into Stage 07 stays closed until every hypothesis carries a verdict. The stage that just ran chooses the next move, among the ones AutoR's guards leave open. Every valid draft is scored against a rigour rubric read off disk and held to a champion ratchet, so the draft that gets promoted is the best one the run produced rather than the last one — that half costs nothing, because the rubric never calls a backend. Two improvement rounds per stage are budgeted on top, and a stage the rubric has nothing to say about spends none of them. A round that scores worse is reverted; a round that changes a hypothesis verdict is rejected outright. Each finished run records its route and measured fitness in a cross-run archive, which compares each graph edge against the decisions that were *offered* it and declined. The archive has no real runs in it yet — see [what has and has not been measured](docs/self-improvement.md#what-has-and-has-not-been-measured). Opt out with `--stage-graph linear`, `--routing off`, `--no-evolve`, `--no-archive`. See [Recursive Self-Improvement](docs/self-improvement.md).
-- **2026-06-02**: Added a configurable Codex sandbox mode. Codex-backed runs still default to `workspace-write`, but users who intentionally need remote GPU or SSH execution can now opt into `--codex-sandbox danger-full-access`; the setting is persisted in `run_config.json` and preserved on resume.
-- **2026-05-10**: Refined the terminal-first run experience. Stage 00 now uses a dedicated clarification flow: the first intake pass asks the user questions one by one with selectable options, custom answers, and skip; the revised intake brief then uses a compact refine / approve / abort menu instead of showing the normal suggestion template. The terminal UI also keeps colored frames on wrapped body rows, handles long lines and wide characters more reliably, and the Codex backend now uses the current `--sandbox workspace-write` execution flag instead of the deprecated Codex CLI `--full-auto` flag.
-- **2026-04-20**: Added an optional `--full-auto` approval mode. The execution loop is unchanged, but the manual approval gate can now be replaced by a strict simulated reviewer agent backed by Claude or Codex, with reviewer settings persisted in `run_config.json`.
-- **2026-04-19**: Merged **AutoR Studio** into main: a local browser workspace for the same run-based workflow, with live stage monitoring, human review, restart-safe recovery, paper preview, version history, and a Notebook view. The browser UI shares the same run directories and artifact model as the terminal workflow and is currently Claude-backed.
-- **2026-04-18**: Fixed a stage-summary recovery bug so local normalization now restores the required `Decision Ledger` section and validates draft outputs against the correct `.tmp.md` path. Added stage recovery controls that let operators `/skip` the current stage, `/back <stage>` to an earlier stage, or choose skip / roll back directly after retry exhaustion.
-- **2026-04-15**: Added minimal `--operator codex` support alongside Claude, persisted the selected execution backend in `run_config.json`, and improved terminal rendering for backend JSON streams.
-- **2026-04-13**: Added literature evidence ledgers and citation verification outputs, introduced typed hypothesis manifests, hardened experiment manifest parsing, and added regression coverage for research diagram injection.
-- **2026-04-10**: Added a decision ledger for human approvals and refined the public showcase gallery so research artifacts are presented more clearly.
-- **2026-04-08**: Documented optional `--research-diagram` dependencies and tightened the README positioning around human-centered, artifact-backed research execution.
-
-## 🌟 Showcase
-
-AutoR already has a full example run used throughout the repository: `runs/20260330_101222`.
-
-### 🧪 Example Run Snapshot
-
-| What the run produced | What it demonstrates |
-| --- | --- |
-| [example_paper.pdf](assets/examples/example_paper.pdf) | A compiled manuscript artifact within a broader research package |
-| Executable research code | The run is not just a writing pipeline |
-| Machine-readable datasets and result files | Claims are backed by inspectable experiment outputs |
-| Real figures used in the research package | The run produces publication-style visuals, not placeholders |
-| Review and dissemination materials | The workflow continues past writing into release readiness |
-
-Highlighted outcomes from that run:
-
-- `AGSNv2` reached **36.21 ± 1.08** on Actor.
-- The system produced a full research package with real figures, writing sources, and auditable artifacts.
-- The final run preserved the full human-in-the-loop approval trail.
-
-### 🖥️ Terminal Experience
-
-AutoR is designed for terminal-first execution, but the interaction layer is not limited to raw logs and plain prompts. The current UI supports banner-style startup, colored stage panels, parsed backend event streams, display-width-aware markdown wrapping, keyboard-selectable menus, and a Stage 00 clarification flow suitable for demos and recordings.
-
-<p align="center">
->>>>>>> dd3d62c (Spend effort where the research needs it, not evenly)
-  <img src="assets/terminal.png" alt="AutoR terminal UI" width="92%" />
-</p>
-
----
+[What AutoR is](#what-autor-is) · [Quick start](#quick-start) · [The stage graph](#how-it-works-the-stage-graph) ·
+[The rigor dial](#the-rigor-dial) · [Self-improvement rounds](#self-improvement-rounds) ·
+[Review](#review-five-kinds-of-critic) · [The stage contract](#the-stage-contract-and-what-gets-validated) ·
+[Execution model](#execution-model) · [Run layout](#run-layout) · [Architecture](#architecture) ·
+[Benchmarks](#benchmarks) · [Documentation](#documentation) · [Limits](#limits) · [License](#license)
 
 ## What AutoR is
 
@@ -166,46 +53,48 @@ Most autoresearch systems optimize for autonomy. AutoR takes a different positio
 important to hand over as a blind end-to-end loop. The goal is not to remove humans from research.
 The goal is to give them a stronger execution system.
 
-AutoR runs a research project as eight stages wired into a directed graph: six forward edges are
-guarded by artifacts on disk, thirteen backward edges let a late finding send the run back — Stage 07
-can reopen the literature survey. Hypotheses are frozen and hashed when Stage 04 is approved, every
-one must be adjudicated at Stage 06 against a named result file, and every paper claim traced at
-Stage 07; a `supported` or `refuted` verdict resting on one run is refused unless the run records
-why one run settles it. An adversarial reviewer attacks Stage 05's results and Stage 06's analysis,
-and the stage after each must answer every finding in writing or the gate refuses it. Drafts are
-scored and a refinement that does not improve is reverted. Every stage still stops at an approval
-gate, and by default that gate is you.
+AutoR runs a research project as **eight stages wired into a directed graph**. Six of the forward
+edges are guarded by artifacts on disk; **thirteen backward edges** let a late finding send the run
+back — Stage 07 can reopen the literature survey. Hypotheses are frozen and hashed when Stage 04 is
+approved, every one must be adjudicated at Stage 06 against a named result file that exists, and
+every paper claim traced at Stage 07; a `supported` or `refuted` verdict resting on a single seed is
+refused unless the run records why one run settles it. An adversarial reviewer attacks Stage 05's
+results and Stage 06's analysis, and the stage after each must answer every finding in writing or the
+gate refuses it. Drafts are scored and a refinement that does not improve is reverted. Every stage
+still stops at an approval gate, and by default that gate is you.
 
-"Recursive" is eight mechanisms, each of them a file you can open:
+### "Recursive" is eight mechanisms, each of them a file you can open
 
 | Move | What runs | Where |
 | --- | --- | --- |
-| **Propose** | Five proposers work from distinct lenses — mechanism, contrarian, adjacent field, null/artifact, regime — blind to each other; two statements whose Jaccard overlap reaches 0.5 collapse into one idea | [`ideation_panel.py`](src/ideation_panel.py) · 712L |
-| **Test** | Every baseline declares `why_competent` and a `tuning_budget` before it runs; the hypothesis set is frozen and hashed before any result exists, and a later change is legal only as a recorded amendment | [`experimental_protocol.py`](src/experimental_protocol.py) · 234L<br />[`preregistration.py`](src/preregistration.py) · 579L |
-| **Refute** | An adversarial pass asks why the result is wrong across ten named failure modes — confound, leakage, `metric_cherry_picking`, `effect_within_noise`, six more; a round can close as `converged`, `refine_design`, `new_hypothesis` or `abandon` | [`validity_review.py`](src/validity_review.py) · 512L<br />[`research_rounds.py`](src/research_rounds.py) · 320L |
-| **Critique** | Five seats review independently, cross-examine anonymised, then converge; a blocking objection is turned into a refusal in code against the panel's own chair, and a different model family audits the approval as a veto | [`review_panel.py`](src/review_panel.py) · 1223L<br />[`cross_reviewer.py`](src/cross_reviewer.py) · 239L |
-| **Iterate** | Every valid draft is scored against a rubric read off disk; the champion is kept and a losing polish round is reverted before anyone reads it; a draft that loses on the weighted total but is non-dominated on the criterion vector is kept anyway | [`rubric.py`](src/rubric.py) · 926L<br />[`evolution.py`](src/evolution.py) · 692L<br />[`pareto.py`](src/pareto.py) · 212L |
-| **Learn** | Each finished run records its route and measured fitness; a fitness comparison is keyed on the set of stages the run actually measured, so a run cannot score well by stopping early | [`archive.py`](src/archive.py) · 862L |
-| **Deliberate** | A stage that hits a genuine crux stops, names the question, and pulls in theorist / empiricist / critic / pragmatist plus an expert brief, then continues with an answer that names its own falsifier; budgeted, and measured against what the agent already believed | [`deliberation.py`](src/deliberation.py) · 640L |
-| **Localise** | A reviewer quotes the passage it objects to instead of refusing the whole stage; the revision is told to change only those spans and is diffed against them, so "preserve the correct parts" is measured rather than hoped for | [`stage_comments.py`](src/stage_comments.py) · 375L |
+| **Propose** | Five proposers work from distinct lenses — mechanism, contrarian, adjacent field, null/artifact, regime — blind to each other; two statements whose Jaccard overlap reaches 0.5 collapse into one idea | [`ideation_panel.py`](src/ideation_panel.py) · 735 L |
+| **Test** | Every baseline declares `why_competent` and a `tuning_budget` before it runs; the hypothesis set is frozen and hashed before any result exists, and a later change is legal only as a recorded amendment | [`experimental_protocol.py`](src/experimental_protocol.py) · 234 L<br />[`preregistration.py`](src/preregistration.py) · 579 L |
+| **Refute** | An adversarial pass asks why the result is wrong across ten named failure modes — confound, leakage, `metric_cherry_picking`, `effect_within_noise`, six more; a round can close as `converged`, `refine_design`, `new_hypothesis` or `abandon` | [`validity_review.py`](src/validity_review.py) · 510 L<br />[`research_rounds.py`](src/research_rounds.py) · 411 L |
+| **Critique** | Five seats review independently, cross-examine anonymised, then converge; a blocking objection is turned into a refusal in code against the panel's own chair, and a different model family audits the approval as a veto | [`review_panel.py`](src/review_panel.py) · 1277 L<br />[`cross_reviewer.py`](src/cross_reviewer.py) · 239 L |
+| **Iterate** | Every valid draft is scored against a rubric read off disk; the champion is kept and a losing polish round is reverted before anyone reads it; a draft that loses on the weighted total but is non-dominated on the criterion vector is kept anyway | [`rubric.py`](src/rubric.py) · 936 L<br />[`evolution.py`](src/evolution.py) · 727 L<br />[`pareto.py`](src/pareto.py) · 212 L |
+| **Learn** | Each finished run records its route and measured fitness; a fitness comparison is keyed on the set of stages the run actually measured, so a run cannot score well by stopping early | [`archive.py`](src/archive.py) · 974 L<br />[`decisions.py`](src/decisions.py) · 269 L |
+| **Deliberate** | A stage that hits a genuine crux stops, names the question, and pulls in theorist / empiricist / critic / pragmatist plus an expert brief, then continues with an answer that names its own falsifier; budgeted, and measured against what the agent already believed | [`deliberation.py`](src/deliberation.py) · 751 L |
+| **Localise** | A reviewer quotes the passage it objects to instead of refusing the whole stage; the revision is told to change only those spans and is diffed against them, so "preserve the correct parts" is measured rather than hoped for | [`stage_comments.py`](src/stage_comments.py) · 375 L |
 
-Four of those eight are on for every run: **Test**, **Refute**, **Iterate** (`--evolve` defaults on)
-and **Learn**, which records on every run but only reaches a routing decision under
-`--archive-steer`. **Propose** needs `--ideation-panel`; **Critique** needs `--review-panel` and
-`--cross-review`; **Deliberate** needs `--deliberation`. **Localise** runs whenever a reviewer
-quotes a passage. The `--rigor` dial sets several of these together and defaults to `standard`,
-which turns effort tiering on.
+**What a default run (`--rigor standard`) actually uses.** **Test**, **Refute**, **Iterate** and
+**Learn** are on: the validity chain is unconditional at every rigor level including `fast`,
+`--evolve` defaults on, and the archive records every run — though it only *steers* under
+`--archive-steer`. **Localise** runs whenever a reviewer quotes a passage, which requires an agent
+reviewer. **Propose** and **Deliberate** need `--rigor thorough`; **Critique**'s panel needs
+`--rigor max` and its cross-model veto is live on the `rcb_agent.py` path only. See
+[the rigor dial](#the-rigor-dial) for the exact mapping.
 
-**AutoR does not run itself.** Manual approval is the default — `approval_mode` is `manual` unless a
-flag opts out ([`main.py`](main.py)) — and `--full-auto`, `--review-panel` and `--approval-mode
-agent` are those flags. Seven of the eight moves above can only score, refuse, revert or re-order;
-none of them can approve a stage. The eighth, the review panel, *is* an approval gate, and it exists
-only on the runs where you hand it the gate. Recursion did not change who decides; it changed what
-reaches the desk. The research unit is unchanged: one reproducible run under `runs/<run_id>/`,
-isolated, resumable, with redo and rollback.
+**AutoR does not run itself.** Manual approval is the default: `approval_mode` is `manual` unless a
+flag opts out. Seven of the eight moves above can only score, refuse, revert or re-order; none of
+them can approve a stage. The eighth, the review panel, *is* an approval gate, and it exists only on
+the runs where you hand it the gate. Recursion did not change who decides; it changed what reaches
+the desk. The research unit is unchanged: one reproducible run under `runs/<run_id>/`, isolated,
+resumable, with redo and rollback.
 
-Approved stage summaries are the only *free-text* memory. Every other cross-stage edge is a typed
-artifact with a declared reader: thirteen channels in
+### The one thing the docs will not claim
+
+Approved stage summaries are the only *free-text* cross-stage memory. Every other cross-stage edge is
+a typed artifact with a declared reader: **sixteen channels** in
 [`information_flow.py`](src/information_flow.py) each name the exact stage slugs that consume them,
 and the eight produced inside the walk name their producing stage as well. `obligations.json` and
 `review_policy.json` cross stages without touching a summary at all — both only behind an agent
@@ -223,60 +112,715 @@ The answer is the validity chain — freeze at Stage 04, adjudicate at Stage 06,
 ([`preregistration.py`](src/preregistration.py)) — and the edge into writing stays shut until every
 frozen hypothesis carries a verdict (`_guard_validity_chain`, [`stage_graph.py`](src/stage_graph.py)).
 
-## What changed, measured
+### The shape of the system, in counts you can re-derive
 
-Every node used to be contractually required to restate its inbound edge. That heading is gone from
-the stage contract, and the effect on a scripted run was measured at the commit that removed it
-(`dd54947`):
+Every number below comes from a named symbol in the source. Re-derive them; that is the point of
+naming them.
 
-| Measured across one `--fake-operator` run, at `dd54947` | Before | After |
+| Count | Symbol | Value |
+| --- | --- | ---: |
+| Stages (nodes in the walk) | `STAGES`, [src/utils.py](src/utils.py) | 8 |
+| Guarded forward edges | `_ADVANCE_GUARDS`, [src/stage_graph.py](src/stage_graph.py) | 6 |
+| Backward edges | `REVISIT_EDGES` | 13 |
+| Conditional terminal edges | `TERMINAL_EDGES` | 1 |
+| Edges in the default (`adaptive`) graph | `StageGraph.adaptive()` | 22 |
+| Edges in `--stage-graph linear` | `StageGraph.linear()` | 9 |
+| Typed information channels | `CHANNELS`, [src/information_flow.py](src/information_flow.py) | 16 |
+| `validate_*` functions the stage gate calls | `validate_stage_artifacts`, [src/utils.py](src/utils.py) | 17 |
+| Required stage-summary headings | `REQUIRED_STAGE_HEADINGS` | 7 |
+| Rubric criteria (weighted, backend-free) | `CRITERIA`, [src/rubric.py](src/rubric.py) | 8 |
+| Flags on `main.py` / `rcb_agent.py` | `parse_args` | 61 / 37 |
+| Python modules / lines / tests | the tree | 150 / 62 k / 1820 |
+
+`python -m unittest discover -s tests -p "test_*.py"` runs **1820 tests in ~70 s** across 83 test
+modules, with no third-party dependency.
+
+## Quick start
+
+### Prerequisites
+
+- Python 3.10+
+- Claude CLI or Codex CLI on `PATH` for real runs
+- Local TeX tools only for `--output-format latex`; the default markdown output needs no TeX
+- `pip install google-genai` plus a key in `GOOGLE_API_KEY` or `GEMINI_API_KEY` — needed by three
+  paths, not only the diagram one: `--web-search gemini`, required where the backend's own
+  `WebSearch` tool is disabled (`build_genai_client`, [src/web_search.py](src/web_search.py)); the
+  cross-model veto `--cross-review auto|gemini` ([src/cross_reviewer.py](src/cross_reviewer.py)); and
+  `--research-diagram`, which also reads `configs/diagram_config.yaml`
+- The SDK is **not** a default dependency. Without it the diagram step prints
+  `Diagram generation failed: No module named 'google'` and the run continues; cross-review records
+  itself unavailable rather than agreeing
+
+### Common commands
+
+| Goal | Command |
+| --- | --- |
+| Start a run (the goal is prompted for if omitted) | `python main.py --goal "Your research goal here"` |
+| Start with preloaded resources | `python main.py --goal "..." --resources paper.pdf refs.bib data.csv` |
+| Run a local smoke test without a real agent backend | `python main.py --fake-operator --goal "Smoke test"` |
+| Run with the automated reviewer gate | `python main.py --full-auto --goal "..."` |
+| Choose how much optional machinery to run | `python main.py --rigor thorough --goal "..."` |
+| Give the panel a researcher persona to stand in for | `python main.py --review-panel --persona docs/persona-example.md --goal "..."` |
+| Seat the panel across different models | `python main.py --review-panel --panel-models pi=opus skeptic=codex:default --goal "..."` |
+| Seat the optional Area Chair as a sixth reviewer | `python main.py --review-panel --panel-roles pi domain method repro skeptic reader --goal "..."` |
+| Keep the strong model for the steps that matter | `python main.py --effort-tiers --model opus --routine-model sonnet --goal "..."` |
+| Choose the execution backend and model | `python main.py --operator claude --model opus` or `python main.py --operator codex --model default` |
+| Choose the reviewer backend separately | `python main.py --full-auto --review-operator claude --review-model opus` |
+| Allow Codex-backed SSH / remote GPU execution | `python main.py --operator codex --codex-sandbox danger-full-access --goal "..."` |
+| Produce a LaTeX paper package instead of a markdown report | `python main.py --output-format latex --goal "..."` |
+| Stop once the report is written, skipping dissemination | `python main.py --final-stage 07_writing --goal "..."` |
+| Choose a writing venue profile | `python main.py --venue neurips_2025` · `--venue nature` · `--venue jmlr` |
+| Resume the latest run | `python main.py --resume-run latest` |
+| Redo a stage inside the same run | `python main.py --resume-run 20260329_210252 --redo-stage 03` |
+| Roll back to a stage inside the same run | `python main.py --resume-run 20260329_210252 --rollback-stage 03` |
+| Re-enter an existing project instead of starting over | `python main.py --project-root ~/code/my-project --goal "..."` |
+| Seed the run from your own prior papers | `python main.py --paper-corpus ~/papers --goal "..."` |
+| Store runs on another disk | `python main.py --runs-dir /mnt/big-disk/runs --goal "..."` |
+| Raise the per-attempt ceiling for long training runs | `python main.py --stage-timeout 43200 --goal "..."` |
+| Give a stubborn stage more retries | `python main.py --max-attempts 10 --goal "..."` |
+| Let Stages 03-06 run as a repeatable round (default 1) | `python main.py --max-rounds 2 --goal "..."` |
+| Escalate a crux to a four-voice panel | `python main.py --deliberation --max-deliberations 3 --goal "..."` |
+| Widen Stage 02 with divergent proposers | `python main.py --ideation-panel --ideas-per-proposer 3 --goal "..."` |
+| Skip the intake stage | `python main.py --skip-intake --goal "..."` |
+| Add a generated method diagram to the paper | `python main.py --research-diagram --goal "..."` |
+| Search the web where the agent's own `WebSearch` is disabled | `python main.py --web-search gemini --goal "..."` |
+| Tag this run as one arm of a paired trial | `python main.py --trial t1 --capability review_panel --arm on --goal "..."` |
+| Read the paired-trial analysis and exit | `python main.py --trial-report` |
+| Benchmark AutoR on ResearchClawBench | `python rcb_agent.py --workspace <WORKSPACE>` |
+| Score a finished benchmark run with the reference judge | `python tools/score_rcb_run.py --workspace <WORKSPACE> --bench <BENCH>` |
+
+Every flag, its default, and what is preserved on resume:
+**[docs/cli-reference.md](docs/cli-reference.md)**. Stage identifiers accept `03`, `3` or
+`03_study_design`; `--venue` defaults to `neurips_2025`.
+
+> **Four paths remove the human from the gate**, not two. `resolve_unattended` returns `True` for
+> `--unattended`, `--full-auto`, `--review-panel` *and* `--approval-mode agent`, and `approval_mode`
+> becomes `agent` for `--full-auto` or `--review-panel`. Because `--rigor` is resolved **before**
+> `resolve_unattended` runs, a plain `--rigor max` sets `review_panel = True` and silently converts an
+> interactive run into an unattended agent-gated one. Under a badge reading *Human approval required*,
+> the flag that looks like more review is the flag that removes the reviewer. Three headline
+> mechanisms — obligations, the standing review policy, the cross-model veto — also run only behind
+> that agent gate, as do anchored comments. Manual approval is the default and remains the path for
+> work you intend to publish.
+
+For Codex-backed runs AutoR defaults to `--codex-sandbox workspace-write`. If a verified remote
+experiment needs SSH or external GPU access, use `--codex-sandbox danger-full-access`
+intentionally: it grants the Codex backend unrestricted local and remote execution, so it should not
+be the default for untrusted tasks.
+
+```bash
+# Self-improvement is on by default: navigate the graph, score every draft, keep the
+# best, and record the route in ~/.autor/archive.
+python main.py --goal "..."
+python main.py --archive-report                   # what the archive has learned so far
+python main.py --goal "..." --evolve-rounds 4     # spend more on improvement
+python main.py --goal "..." --evolve-rounds 0     # measure and ratchet, no extra passes
+python main.py --goal "..." --archive-steer       # let the archive pick the topology
+
+# Opt out entirely: the strict 01-through-08 sequence, last draft wins.
+python main.py --goal "..." --stage-graph linear --routing off --no-evolve --no-archive
+```
+
+### Studio (browser UI)
+
+A local web UI over the same Claude-backed runs: create a project, watch stages execute, approve or
+send feedback, read the compiled paper. It needs the Claude CLI on `PATH` to start a run.
+
+```bash
+python studio.py                                # http://127.0.0.1:8000/studio/
+python studio.py --host 0.0.0.0 --port 8765     # bind externally, see the warning below
+python studio.py --runs-dir /path/to/runs       # override runs directory
+```
+
+> The Studio API has **no authentication**. It binds to `127.0.0.1` by default; anything that can
+> reach it can start runs, approve stages, and read every file under the runs directory. For remote
+> access prefer an SSH tunnel over `--host 0.0.0.0`. See [SECURITY.md](SECURITY.md).
+
+One honest limit, then the walkthrough: the Studio's lazy-resume approve path picks the next stage
+arithmetically — the first stage with a higher number
+([src/backend/studio_runner.py](src/backend/studio_runner.py)) — and never consults the router, so
+graph routing and backward moves are a CLI capability today. Page-by-page walkthrough and the full
+HTTP API: **[docs/studio.md](docs/studio.md)**.
+
+## How it works: the stage graph
+
+Eight stages are the nodes; a `finish` node closes the walk. Stage 00 intake is not one of them — it
+runs before the walk starts, and `_graph_entry_stage` → `_select_stages_for_run`
+([src/manager.py](src/manager.py)) only ever yield the eight. Solid edges advance, dotted edges go
+back. `--stage-graph linear` is the eight advance edges plus the conditional terminal — nine in all —
+and the guards come off with the backward ones (`_advance_edges(guarded=False)`): one edge out of
+each node leaves nothing to choose, so a guard there could only halt a run that the stage's own
+validation is about to fail anyway.
+
+```mermaid
+flowchart LR
+    S1[01 Literature] --> S2[02 Hypotheses]
+    S2 -->|has_hypotheses| S3[03 Design]
+    S3 -->|design_artifacts| S4[04 Implementation]
+    S4 -->|runnable_code| S5[05 Experiments]
+    S5 -->|results_exist| S6[06 Analysis]
+    S6 -->|validity_chain| S7[07 Writing]
+    S7 -->|report_exists| S8[08 Dissemination]
+    S8 --> Z([finish])
+    S6 -.->|round abandoned| Z
+
+    S2 -.->|the gap it rests on is not a gap| S1
+    S3 -.->|a hypothesis cannot be brought to a decision| S2
+    S4 -.->|not executable as specified| S3
+    S5 -.->|implementation is at fault| S4
+    S5 -.->|comparison cannot distinguish| S3
+    S6 -.->|results insufficient to decide| S5
+    S6 -.->|confound the results cannot repair| S3
+    S6 -.->|evidence refutes, and points somewhere| S2
+    S6 -.->|the numbers are wrong, not disappointing| S4
+    S7 -.->|claim has no analysis behind it| S6
+    S7 -.->|needs a result never produced| S5
+    S7 -.->|the survey missed related work| S1
+    S8 -.->|deliverable is not what a reader needs| S7
+```
+
+Six of the eight forward edges carry a guard, one per target stage (`_ADVANCE_GUARDS`); 01→02 and
+08→`finish` are unguarded. Thirteen dotted edges go back (`REVISIT_EDGES`) — the longest is 07→01:
+writing it up showed the finding relates to work the survey missed. One conditional terminal
+(`TERMINAL_EDGES`, carried by *both* topologies) lets an abandoned round finish from Stage 06. The
+Stage 07 guard is the strictest: every preregistered empirical hypothesis needs a verdict **and** at
+least one figure under `workspace/figures` (`_guard_validity_chain`).
+
+**Who decides the move.** AutoR decides which moves are *admissible*, by evaluating each edge's guard
+against the artifacts on disk. With `--routing auto` (the default, `DEFAULT_ROUTING_MODE`) the agent
+chooses among them and states a reason; `--routing off` always takes the graph's default. An
+off-menu choice — an unlisted target, or one with no stated reason — is refused, written to
+`evolution/routing_refusals.jsonl` ([src/router.py](src/router.py)), and replaced by the forward edge.
+
+Two design calls worth naming. Blocked moves are handed to the agent *with the reason they are
+blocked* (`StageGraph.moves`) — the useful thing to say is not "you may go to 06" but "07 is closed
+because H2 has no verdict", and an agent that sees why writing is closed routes to the analysis that
+opens it. And a revisit whose justification repeats one already on the path is refused
+(`repeats_a_previous_reason`): going again on the same grounds is a loop, not an iteration.
+
+**A backward move is only ever a deliberate choice.** The default is always the forward edge, and
+when a guard has closed it the default advances anyway and lets the stage's own validation — still
+refusing a Stage 07 that writes up unadjudicated hypotheses — be the gate it always was. A guard is a
+routing preference; the gate is the gate. So a refusal, a routing failure, or a run nobody is
+steering all come out as the linear pipeline rather than as a stall.
+
+A stage is a node with a visit budget, not a position in a sequence: `DEFAULT_MAX_VISITS = 3`
+(`--graph-max-visits`); `DEFAULT_MAX_STEPS = 20` bounds the whole walk (`--graph-max-steps`).
+
+### The eight stages, and what you check at each
+
+| Stage | Role | What the human is checking |
 | --- | --- | --- |
-| Words a node emits | grew 235 → 1,211 | flat, 228-292 per stage |
-| Share of stage output that was relay | 64% | 0% |
-| Assembled prompt text | 21,236 words | 20,353 words |
+| `00_intake` (before the walk) | Align the goal, resources, constraints, target venue and success criteria. | Answer the clarification questions, add the missing constraints, and narrow the project until it is executable. |
+| `01_literature_survey` | Build the related-work base, organize the evidence, identify the real gap. | Reject shallow paper lists; require task framing, benchmarks, baselines, differences, and structured literature files with a cross-referenced `sources.json`/`claims.json`. |
+| `02_hypothesis_generation` | Convert the direction into typed, testable hypotheses and provisional paper claims. | A `- Decision rule:` line on every empirical hypothesis, stating in advance what would count as support and what would count as refutation. These are the hypotheses frozen at 04 and adjudicated at 06. |
+| `03_study_design` | Turn the hypotheses into an executable plan, a declared protocol and a committed report plan. | Datasets, metrics, ablations, budgets, failure criteria, machine-readable data artifacts, a baseline set where every entry states `why_competent` and its `tuning_budget` — and the figures the report will carry, each naming the claim it supports. |
+| `04_implementation` | Build the runnable code, configs, data preparation and sanity checks. | This is the freeze point: approving the stage hashes the hypothesis set into `workspace/notes/preregistration.json`. Check the set you are freezing, and do not approve skeletons. |
+| `05_experimentation` | Run the planned experiments and write machine-readable results. | The declared baselines and the seeds: a supported or refuted verdict off a single seed is refused unless the run states why one run settles it (`MIN_SEEDS_FOR_A_VERDICT = 2`). |
+| `06_analysis` | Interpret the results, produce figures, adjudicate every frozen hypothesis. | A verdict for each one, backed by a result file the validator can find. The forward edge stays closed until then. |
+| `07_writing` | Produce the deliverable: a markdown report with embedded figures, or a venue-aware LaTeX package with a compiled PDF. | That every claim traces, and that the report answers what the task actually asked. A `confirmatory` claim whose hypothesis is not in the supported set is already refused, so what is left to check is whether the exploratory ones are honestly labelled. |
+| `08_dissemination` | Package the run for review, release, reproduction or presentation. | Readiness notes, review materials, manifests and outward-facing deliverables exist. |
 
-Dated on purpose. The "after" column reproduces to the word at `dd54947` and no longer does at
-HEAD — the same measurement now gives 24,089 words, because eight PRs have since added context
-channels of their own. The relay heading is still gone; the 18% that came back is other people's
-work, not a regression of this one, and the honest form of a before/after is the commit it was taken
-at.
+## The rigor dial
 
-The sharpest single case: the mutable Stage 02 hypotheses and the frozen preregistration were both
-delivered from Stage 05 on — the same hypothesis twice, one copy labelled editable, sitting next to
-the frozen one at exactly the stages where the freeze is the point. The `hypotheses` channel now
-stops at `04_implementation`, where the freeze supersedes it
-([`information_flow.py`](src/information_flow.py)).
+`--rigor` is the single source of truth for which optional machinery a run uses. The table is
+generated from `_LEVEL_FEATURES` in [src/rigor.py](src/rigor.py); an explicit `--flag` / `--no-flag`
+always beats the level, which is why those switches use `BooleanOptionalAction` with `default=None`.
 
-The shape of the system, in counts you can re-derive from named symbols in the source: eight stages
-plus `FINISH`, six guarded forward edges (`_ADVANCE_GUARDS`), thirteen backward edges
-(`REVISIT_EDGES`), one conditional terminal (`TERMINAL_EDGES`), and fifteen typed information
-channels (`CHANNELS`) — twenty-two edges in the adaptive graph altogether. Alongside the gates that ask whether a file
-exists, **nine** `validate_*` functions ask whether a claim is warranted — count them with
-`grep -rn "^def validate_" src/`; they are named in full under
-[the stage contract](#-the-stage-contract-and-what-gets-validated).
+| `--rigor` | `--effort-tiers` | `--deliberation` | `--ideation-panel` | `--review-panel` |
+| --- | :---: | :---: | :---: | :---: |
+| `fast` | – | – | – | – |
+| `standard` *(default)* | **on** | – | – | – |
+| `thorough` | **on** | **on** | **on** | – |
+| `max` | **on** | **on** | **on** | **on** |
 
-## News
+Two consequences worth stating out loud:
 
-- **2026-08-06** — Per-stage output is flat at 228-277 words where it used to grow 235 → 1,211,
-  relay is 0% where it was 64%, and assembled prompt text fell 21,823 → 20,353 words across a run.
-  Behind those numbers: the stages became a directed graph with a router that must justify its move
-  and is refused off-menu (`stage_graph.py`, `router.py`); every valid draft is scored and held to a
-  champion ratchet (`rubric.py`, `evolution.py`, `pareto.py`); the cross-run archive keys every
-  fitness comparison on the stages a run actually measured (#137); plus a deliberating review panel
-  (#126), research rounds (#127), a cross-model veto (#128), a divergent ideation panel (#131),
-  obligations carried forward (#132), self-improvement on by default (#134),
-  shared prompt fragments (#136) and typed information edges (`dd54947`). Opt out with
-  `--stage-graph linear`, `--routing off`, `--no-evolve`, `--no-archive`; details in [Recursive Self-Improvement](docs/self-improvement.md).
-- **2026-06-02** — `--codex-sandbox danger-full-access` for runs that intentionally need remote GPU or SSH execution. Codex still defaults to `workspace-write`, and the setting persists in `run_config.json`.
-- **2026-05-10** — Stage 00 clarification flow: questions asked one at a time with selectable options, custom answers and skip, then a compact refine / approve / abort menu on the revised brief.
-- **2026-04-20** — `--full-auto`: the manual approval gate can be replaced by a strict reviewer agent, with reviewer settings persisted in `run_config.json`.
-- **2026-04-19** — AutoR Studio merged into main: a local browser workspace over the same run directories, with live stage monitoring, review, restart-safe recovery, paper preview and a Notebook view.
-- **2026-04-13** — Literature evidence ledgers and citation verification outputs, typed hypothesis manifests, and hardened experiment-manifest parsing.
+- **Effort tiers are on by default.** A default run therefore routes `04_implementation`,
+  `05_experimentation` and `08_dissemination` to a lean prompt and a single reviewer
+  (`DEFAULT_TIERS`, [src/effort.py](src/effort.py)). Under `--rigor max` the seated panel does not
+  sit at those three gates unless you also pass `--no-effort-tiers`.
+- **`--rigor max` makes the run unattended**, because it implies `--review-panel`. See the note
+  under [Common commands](#common-commands).
+
+The scientific-validity chain is *not* on this dial. It is unconditional at every level, `fast`
+included.
+
+## Self-improvement rounds
+
+Every valid stage draft is measured against a rigour rubric read off disk — do the paths it names
+resolve, do the numbers it reports appear in a results file, did it produce artifacts during *this*
+execution, is the decision ledger four different things rather than one sentence four times. Eight
+weighted criteria, `RUBRIC_VERSION = "2"`:
+
+| Criterion | Weight | From | What it measures |
+| --- | ---: | :---: | --- |
+| `grounding` | 3.0 | 01 | References that resolve — every path the draft names exists on disk |
+| `numeric_fidelity` | 3.0 | 05 | Reported numbers trace to a results file |
+| `reproducibility` | 3.0 | 01 | The machine-readable validity chain is present and parses |
+| `contract` | 2.0 | 01 | Contract compliance in substance, not just in headings |
+| `artifact_breadth` | 2.0 | 03 | Artifacts produced *this* stage, across the classes the role calls for |
+| `quantification` | 2.0 | 04 | Findings carrying numbers rather than adjectives |
+| `traceability` | 1.5 | 01 | The decision ledger is four different things, not one sentence four times |
+| `commitment` | 1.5 | 01 | Reports work, not intentions |
+
+`min_stage` exists so a criterion that cannot apply is not scored zero: Stage 01 has no experiment
+manifest to produce, and grading it as if it failed to produce one would make every early stage look
+worse than every late one — which would make the ratchet prefer late drafts for a reason unconnected
+to quality.
+
+**Measuring is free and always on.** The rubric reads the run off disk and never calls a backend, so
+the property it buys costs nothing: the draft that gets promoted is the best one the run produced,
+not the last one. That is the half that was missing before — AutoR could iterate, but "later" was the
+only ordering it had, so a refinement that dropped a resolving reference was promoted on exactly the
+same terms as one that fixed something.
+
+**Improvement rounds are the half that costs**, and they are budgeted separately from
+`--max-attempts`, which bounds a stage that is *failing* rather than one being improved. Two per
+stage by default, and a stage whose rubric has no shortfall worth acting on spends none of them — a
+round aimed at a criterion already at full marks produces churn, so AutoR does not buy one.
+`--evolve-rounds 0` measures without polishing; `--no-evolve` restores the old behaviour entirely.
+
+One edge of that budget is worth knowing before you resume a run. `state()` rehydrates the champion
+and the Pareto frontier from disk and nothing else ([src/evolution.py](src/evolution.py)), so
+`--resume-run` restarts `rounds_spent` and the patience counter at zero: the best draft survives the
+resume, the *spend cap* does not, and a stage resumed twice can buy the two rounds twice.
+
+A round that scores worse is reverted, so a stage can only improve. A round that changes a hypothesis
+verdict is rejected outright, whatever it scored — the rubric is blind to what the run concluded,
+which removes the incentive, and the `verdict_drift` check removes the possibility. A revision a
+*human* asked for always stands, whatever it measures. The ratchet governs AutoR's own rounds, not
+the direction it is given.
+
+Full mechanism, and the reasoning behind each refusal, in
+[docs/self-improvement.md](docs/self-improvement.md).
+
+### The archive: which moves paid, across runs
+
+Every finished run is recorded into `~/.autor/archive` — the route it took, the rubric fitness it
+reached, and the set of stages it actually measured (`Archive.record_run`, from `record_into_archive`
+in [main.py](main.py)). `edge_payoffs` compares runs that *took* an edge against runs that were
+**offered** it and declined ([src/decisions.py](src/decisions.py)), and `propose_variant` turns a
+payoff that is believable — enough observations, and a delta above `min_gain` — into a child variant
+that moves that one edge one step up or down the preference order. When no payoff is believable,
+`propose_exploration` proposes an unexplored edge instead, so an edge nobody has taken is not
+stranded forever.
+
+A variant is only a reordering. It never opens a guarded edge, never adds one that was not declared,
+and never removes one: the guards are the correctness argument for letting an agent route at all, and
+the component that learns from outcomes is precisely the one that must not be able to weaken them.
+Promotion is as conservative — a challenger has to beat the incumbent *within every comparability
+basis* rather than on a pooled mean, because "runs that stopped early" is the cheapest composition
+for a topology to win on.
+
+**The archive records and proposes on every run; it steers only when you ask.** The proposed variant
+is written down and reported, but the topology a run walks comes from the archive only under
+`--archive-steer`. Without it, `resolve_graph` returns the declared topology unchanged.
+
+### Paired trials
+
+`--trial ID --capability NAME --arm LABEL` tags a run as one arm of a paired A/B trial in the
+archive; `--trial-report` prints the within-pair rubric difference with an **exact sign-flip
+p-value** and the smallest p-value that sample size could possibly reach
+([src/trials.py](src/trials.py), [src/inference.py](src/inference.py)). Below
+`MIN_PAIRS_FOR_SIGNIFICANCE = 6` a trial is labelled `underpowered` rather than reported as a null.
+
+This is the apparatus for answering "does this mechanism help?", not the answer. No paired trial has
+been run yet. Read [docs/self-improvement.md](docs/self-improvement.md#what-has-and-has-not-been-measured)
+before quoting anything from it.
+
+## Review: five kinds of critic
+
+Only two of the five are the approval gate. The other three cannot approve anything.
+
+| Kind | What it is | Can it approve? |
+| --- | --- | --- |
+| **Solo reviewer** ([`approval_agent.py`](src/approval_agent.py)) | A coding agent with file tools returning one of six choices as JSON, through a parser that re-asks once and then falls back | **Yes** — this is the gate under `--full-auto` |
+| **Review panel** ([`review_panel.py`](src/review_panel.py)) | Five role-differentiated seats review blind, cross-examine anonymised peers, then a chair synthesizes | **Yes** — this is the gate under `--review-panel` |
+| **Cross-model veto** ([`cross_reviewer.py`](src/cross_reviewer.py)) | A different model family audits an *approval* only | No — veto only |
+| **Adversarial validity review** ([`validity_review.py`](src/validity_review.py)) | Runs *after* Stages 05 and 06 are approved with the opposite instruction: "explain why this result is wrong" | No — it creates debts the next stage must answer |
+| **Crux panel** ([`deliberation.py`](src/deliberation.py)) | The executing agent raises a question; four voices answer it while arguing against themselves | No — it is not a reviewer of a stage at all |
+
+**The panel's teeth are mechanical.** If any final-round seat carries `blocking: true` and the chair
+returned "approve", `_enforce_blocking_objections()` rewrites the approval into a refinement and
+records `chair_overridden`. It is enforced in code precisely because the chair is a model that can be
+argued out of a prompt-level rule. Blocking is read from the seat's own payload and only counts when
+that payload's `decision` token is legible, so a seat whose verdict was unreadable cannot veto.
+
+**Every panel run carries its own control arm.** The chair's round-1 verdict is one model, one call,
+no peer input; `panel_effect.json` accumulates solo-vs-panel across the run and writes a verdict
+sentence deliberately phrased to be unflattering — *"it did not earn that cost; consider dropping the
+panel"* — when that is the truth. The same is true of the ideation panel, anchored comments, crux
+deliberation and effort tiers; [`scorecard.py`](src/scorecard.py) reads all five ledgers at the end of
+every run and writes `workspace/reviews/scorecard.md`, keeping "could not be measured" separate from
+"changed nothing".
+
+**Two ledgers run underneath.** `review_policy.json` turns every refusal into a standing rule injected
+into every later solo review, deduplicated on normalized text so a reviewer restating one complaint
+cannot manufacture the appearance of learning. `obligations.json` lets an approving reviewer attach a
+debt to a later stage — *"fine, but you owe me a power analysis at design time"* — which only a later
+reviewer may discharge; deferral is counted and shown, never silent.
+
+**Anchored comments make a refusal local.** A reviewer quotes the exact passage it objects to
+(minimum 12 characters, and an unfindable quote is dropped as `unanchored` rather than sent), the
+revision is told to leave everything else byte-identical, and the next draft is diffed against the
+quotes so collateral rewriting is counted rather than assumed away.
+
+Full seat charters, the deliberation protocol and the measurement design:
+[docs/review-panel.md](docs/review-panel.md), [docs/deliberation.md](docs/deliberation.md),
+[docs/stage-comments.md](docs/stage-comments.md), [docs/scorecard.md](docs/scorecard.md).
+
+## The stage contract and what gets validated
+
+AutoR does not consider a run successful just because it generated a plausible markdown summary.
+
+**Required stage summary shape.** Seven headings, in this order — `REQUIRED_STAGE_HEADINGS`:
+
+```md
+# Stage X: <name>
+
+## Objective
+## What I Did
+## Key Results
+## Files Produced
+## Decision Ledger
+## Suggestions for Refinement
+## Your Options
+```
+
+Also required, and checked: exactly 3 numbered refinement suggestions, exactly the fixed 6 user
+options, concrete file paths under `Files Produced`, and no `[In progress]`, `[Pending]`, `[TODO]` or
+`[TBD]` placeholders.
+
+**Artifact gates.** Most start by asking whether a file is there — the rows that say "valid",
+"resolving" or "matching" then parse it.
+
+| Stage | Required non-toy output |
+| --- | --- |
+| Stage 01 | A cross-referenced evidence ledger: `sources.json` and `claims.json`, where every cited `source_id` resolves |
+| Stage 03+ | Machine-readable data under `workspace/data/`, plus a `report_plan.json` committing to the figures and headline numbers the report will carry |
+| Stage 05+ | Machine-readable results under `workspace/results/`, plus a valid `experiment_manifest.json` |
+| Stage 06+ | Real figure files under `workspace/figures/`, and every planned figure's `source_artifact` resolving to a non-empty file |
+| Stage 07+ (markdown) | `report/report.md` with resolving figure references, between `min_report_figures` and 5 figures under `report/images/`, `deliverables_coverage.json`, `citation_verification.json`, `self_review.json`, `report_review.json` |
+| Stage 07+ (latex) | `main.tex` matching the venue, `sections/*.tex`, a bibliography, a compiled PDF, `build_log.txt`, `citation_verification.json`, `self_review.json`, `layout_review.json` |
+| Stage 08+ | Review and readiness assets under `workspace/reviews/` |
+
+Requirements are cumulative, and the stage that *produces* a class of artifact must produce it
+**during that stage's execution** — a re-run is not credited with the previous attempt's files. The
+cutoff is `stage_execution_started_at` feeding `recent_in`, and the rubric enforces the same rule
+independently in `_fresh_artifact_kinds`, so a Stage 07 draft cannot score on Stage 06's figures.
+
+`min_report_figures` is a `run_config.json` field with no CLI flag, clamped to `[1, 5]`. It is 1 for
+an ordinary run and **3** for a ResearchClawBench run (`BENCHMARK_MIN_REPORT_FIGURES`).
+
+**Validity gates.** The same function — `validate_stage_artifacts` ([src/utils.py](src/utils.py)) —
+also runs the validators that ask whether a *claim* is warranted rather than whether output exists.
+Seventeen `validate_*` functions are reachable from it in all:
+
+| Fires at | Validator | Refuses when |
+| --- | --- | --- |
+| 01 | `validate_literature_evidence` | A claim cites a `source_id` that is not in `sources.json` |
+| 03+ | `validate_report_plan` | The plan has no task outputs, non-contiguous slots, a slot with no supported claim, or headline numbers without a quantity, unit and source |
+| 05+ | `validate_preregistration` | Nothing is frozen, an empirical hypothesis has no decision rule, or the manifest changed with no amendment on record |
+| 05+ | `validate_experimental_protocol` | No primary metric, `planned_seeds < 1`, or a baseline missing `why_competent` / `tuning_budget` |
+| 05+ | `validate_experiment_manifest` | The manifest does not parse into the declared shape |
+| 06+ | `validate_hypothesis_outcomes` | A frozen hypothesis has no verdict, a verdict adjudicates something unpreregistered, or a `supported`/`refuted` verdict cites an evidence path that does not exist |
+| 06+ | `validate_outcome_statistics` | A verdict has no `n_seeds`, an unrecognised `dispersion_type`, a single seed with no justification, or `dispersion_type: none` with two or more seeds |
+| 06+ | `validate_report_plan_sources` | A planned figure or headline number's `source_artifact` is missing or empty |
+| 06, 07 | `validate_validity_response` | The stage did not answer every adversarial finding from the one before it, with a status, a ≥40-character explanation, and evidence when it claims `addressed` |
+| 06 | `validate_round_decision` | A round closes as `converged` with no supported hypothesis and no `negative_result: true` |
+| 07+ | `validate_claim_provenance` | A manuscript claim is `confirmatory` on a hypothesis that is not `supported`, or cites no evidence file that exists |
+| 07 md | `validate_markdown_report` | The report is under 1200 characters, carries placeholder text, references an image that does not resolve, or publishes fewer than `min_report_figures` |
+| 07 md | `validate_report_plan_coverage` | A planned figure was never published or never referenced, or every slot was dropped |
+| 07 md | `validate_deliverables_coverage` | The report does not answer a demanding sentence of the task statement, or a coverage entry quotes something that is not verbatim in the task |
+| 07 md | `validate_report_review` | The AutoR-generated triage artifact is malformed |
+| 07 latex | `validate_layout_review` | The LaTeX build triage artifact is malformed |
+| 07+ | `validate_citation_verification` | The self-report has no status, a non-integer citation count, or an empty claim-coverage list |
+
+The code labels the split itself: *"the scientific-validity chain, distinct from the artifact gates
+around it"*. A run can fail because a claim is unwarranted, not only because a file is absent. The
+06→07 router edge is closed on top of that, in the `adaptive` topology only.
+
+**A gate that is honest about what it does not check.** `validate_preregistration` compares the
+*manifest's* digest to the recorded `source_digest`; it does not recompute the digest of the frozen
+file itself. Editing `preregistration.json` in place, leaving the manifest alone, passes. The honest
+claim is that a manifest rewrite is detected, not that the frozen file is tamper-proof.
+
+The complete gate, including every JSON schema that is parsed rather than merely counted, is in
+**[docs/stage-contract.md](docs/stage-contract.md)**.
+
+## Execution model
+
+Context is composed per consumer, not per availability. A stage's inbound block is built by
+`render_inbound(ChannelContext(...), CHANNELS)` from the **sixteen** typed channels in
+[src/information_flow.py](src/information_flow.py). Each channel declares `produced_by`, a
+`consumed_by` set of real stage slugs, and a `rationale`;
+`test_every_narrowing_is_argued_for` ([tests/test_information_flow.py](tests/test_information_flow.py))
+fails a channel that withholds itself from a stage without saying why. Withholding has to be argued
+for, not just done.
+
+Three narrowings, because the abstraction is not the point:
+
+- the **artifact index** skips Stages 00-02 — they produce no data, results or figures, so the index
+  is empty noise there
+- the **writing manifest** reaches Stage 07 alone
+- the mutable **Stage 02 hypotheses** stop at `04_implementation`, because the freeze at Stage 04's
+  approval supersedes them. Before that edge was typed, the same H1 went into every prompt from
+  Stage 05 on twice — one copy labelled editable, sitting next to the frozen one at exactly the
+  stages where the freeze is the point.
+
+`dependency_edges()` returns every `(producer, consumer, channel key)` triple, so the information
+topology can be printed and diffed rather than reconstructed from a pile of `if` statements.
+`_record_inbound_channels` writes the delivered channel keys per stage into the run log.
+
+Honest scope: sixteen blocks are typed. Six more — `obligations_context`, `intake_context_text`,
+`web_search_context`, `approved_memory`, `handoff_context`, and the `# What the Task Asks For` block
+that `build_prompt` composes inline from
+[`format_deliverables_for_prompt`](src/deliverables.py) — are still delivered by `build_prompt`
+itself rather than declared as channels, so each one's delivery rule lives there instead of next to a
+`consumed_by` set. Around them, `compose_stage_template`
+([src/prompt_fragments.py](src/prompt_fragments.py)) assembles the stage's own instructions, the
+accepted-extension lists generated from the validators' constants rather than hand-copied, and the
+run-safety rules.
+
+The assembled prompt is written to `runs/<run_id>/prompt_cache/`, per-stage session IDs to
+`runs/<run_id>/operator_state/`, and the selected CLI backend is invoked in live streaming mode.
+Alongside the prompt, AutoR installs an agent skill pack from [src/skills/](src/skills) into
+`runs/<run_id>/.claude/skills/` — the operator's working directory — so the agent can *pull*
+long-form craft guidance when it needs it. Six skills ship today: `citation-discipline`,
+`latex-repair`, `paper-writing`, `reproducibility-check`, `result-table`, `venue-checklist`. A skill
+costs nothing in the prompts that do not use it.
+
+<details>
+<summary><strong>Claude CLI invocation</strong></summary>
+
+First attempt for a stage:
+
+```bash
+claude --model <model> \
+  --permission-mode bypassPermissions \
+  --dangerously-skip-permissions \
+  --session-id <stage_session_id> \
+  -p @runs/<run_id>/prompt_cache/<stage>_attempt_<nn>.prompt.md \
+  --output-format stream-json \
+  --verbose
+```
+
+Continuation attempt for the same stage replaces `--session-id` with `--resume`.
+
+`_build_cli_command` ([src/operator.py](src/operator.py)) additionally inserts
+`--mcp-config <run>/operator_state/mcp_config.json` whenever the MCP web-search server is active, and
+`--tools <tools>` when a tool restriction is set.
+
+</details>
+
+**Web search where the backend has none.** Some deployments disable the agent's built-in `WebSearch`
+tool. `--web-search gemini` starts a stdlib JSON-RPC MCP stdio server
+([src/mcp_web_search.py](src/mcp_web_search.py)) that exposes one tool,
+`mcp__autor-search__web_search`, backed by Gemini with grounded search, and passes it to the CLI via
+`--mcp-config`. `assess_search_readiness()` refuses to promise a capability the environment cannot
+deliver: a hard blocker (no key, no SDK) is reported before the run starts rather than discovered at
+Stage 01.
+
+Important behaviour:
+
+- refinement attempts reuse the same stage conversation whenever possible
+- streamed agent output is shown live in the terminal
+- raw stream-json output is captured in `logs_raw.jsonl`
+- if resume fails, AutoR can fall back to a fresh session
+- if stage markdown is incomplete, AutoR can repair or normalize it locally before failing the stage
+- a backend that is unreachable is classified by [src/backend_health.py](src/backend_health.py) and
+  surfaces as `run.backend_unavailable`, so "the model was down" never reads as "the research failed"
+
+## Run layout
+
+Every run lives entirely inside its own directory. The tree is `build_run_paths`
+([src/utils.py](src/utils.py)).
+
+```text
+runs/<run_id>/
+├── user_input.txt      memory.md             run_config.json
+├── run_manifest.json   artifact_index.json   intake_context.json
+├── obligations.json    review_policy.json    # both per-run; nothing crosses runs
+├── report_plan_stamp.json                    # AutoR's copy, outside workspace/ on purpose
+├── logs.txt            logs_raw.jsonl
+├── prompt_cache/       operator_state/       handoff/        stages/
+├── .claude/skills/     # the skill pack, pulled on demand by the agent
+├── evolution/          # champion drafts, improvement_ledger.jsonl, summary.json,
+│                       # stage_graph.json, routing_refusals.jsonl
+└── workspace/
+    ├── literature/  code/  data/  figures/  report/  writing/
+    ├── bootstrap/   profile/
+    ├── notes/       preregistration.json, hypothesis_manifest.json, experimental_protocol.json,
+    │                report_plan.json, research_rounds.json, round_decision.json,
+    │                deliberation_request.json
+    ├── results/     experiment_manifest.json, hypothesis_outcomes.json
+    ├── artifacts/   claim_provenance.json, deliverables_coverage.json, citation_verification.json,
+    │                self_review.json, report_review.json | layout_review.json, compiled PDFs
+    └── reviews/     validity_review_<stage>.json, validity_response_<stage>.json,
+                     comment_ledger.json, deliberations.json, scorecard.md, panel/
+```
+
+`evolution/` sits outside `workspace/` on purpose, and the dataclass records the reason: it is *"a
+record of how the run reached its answer, not part of the answer, and a benchmark export that swept
+it up would ship the losing drafts alongside the report"*. `report_plan_stamp.json` is outside
+`workspace/` for the same class of reason: the agent must not be able to backdate its own declaration.
+
+The only state AutoR writes outside a run directory is the cross-run archive at `~/.autor/archive`
+(`--archive`, `--no-archive`).
+
+**Workspace semantics.** `literature/` reading notes, survey tables, benchmark notes · `code/`
+runnable code, scripts, configs · `data/` machine-readable datasets, manifests, processed splits ·
+`results/` metrics, predictions, ablations, plus the standardized `experiment_manifest.json` ·
+`report/` the markdown deliverable, `report.md` and the PNGs it embeds under `images/` · `writing/`
+LaTeX sources, sections, tables, bibliography · `figures/` plots and paper figures · `artifacts/`
+review JSON, build metadata, compiled PDFs, packaged deliverables · `notes/` the frozen files of the
+validity chain plus supporting notes · `reviews/` adversarial validity reviews, panel transcripts,
+self-measurement ledgers, the run scorecard.
+
+Outside `workspace/`: `memory.md` is the approved free-text cross-stage memory; `handoff/<slug>.md`
+is the second free-text carrier, each approved summary trimmed to Objective / Key Results / Files
+Produced and sent only on a continuation attempt or when memory is still empty. Every other
+cross-stage edge is a typed channel or a JSON artifact. `run_manifest.json` is the lifecycle state
+that resume, redo and rollback read; `prompt_cache/` holds the exact prompt of every attempt,
+repair, review, panel seat and crux voice.
+
+Full file-by-file reference: **[docs/run-artifacts.md](docs/run-artifacts.md)**.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    P[rigor.py · effort.py<br/>policy: what machinery runs] --> M
+    C[information_flow.py<br/>16 typed channels] --> M
+    M[manager.py<br/>walks the stage graph] --> W[walk<br/>stage_graph · router]
+    M --> G[gates<br/>utils · preregistration · experimental_protocol<br/>report_plan · deliverables · validity_review]
+    M --> I[improvement<br/>rubric · evolution · pareto]
+    M --> R[review<br/>approval_agent · review_panel · cross_reviewer<br/>obligations · review_policy · stage_comments]
+    M --> S[self-measurement<br/>scorecard · archive · decisions · trials · inference]
+    M --> X[execution<br/>operator · operator_codex · web_search · backend_health]
+```
+
+| Module | Lines | What it owns |
+| --- | ---: | --- |
+| [src/manager.py](src/manager.py) | 3772 | Walks the stage graph until it reaches finish or nothing is open — plus the router call, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto, the crux settlement and the inbound-channel record |
+| [src/utils.py](src/utils.py) | 2386 | Stage metadata, run paths, prompt assembly, markdown validation, the artifact gates and the validity-chain wiring |
+| [src/operator.py](src/operator.py) | 1630 | The Claude CLI adapter: stage session state, live streaming, resume fallback, MCP config, skill pack install |
+| [src/review_panel.py](src/review_panel.py) | 1277 | The deliberating panel; a blocking objection is enforced in code against its own chair |
+| [main.py](main.py) | 1194 | CLI entry: 61 flags, start, resume, `--redo-stage`, `--rollback-stage`, the archive record and the reports that print and exit |
+| [src/report_plan.py](src/report_plan.py) | 1103 | Figures and headline numbers committed at Stage 03, stamped outside the workspace, enforced at 03, 06 and 07 |
+| [src/rcb.py](src/rcb.py) | 1037 | The ResearchClawBench adapter core: workspace layout, goal construction, report synthesis, figure publication, export |
+| [src/stage_graph.py](src/stage_graph.py) | 1000 | Stages as nodes: six guarded forward edges, thirteen backward edges, a conditional terminal, a per-stage visit budget |
+| [src/archive.py](src/archive.py) | 974 | Cross-run routes and edge payoffs keyed on a comparability basis; variant proposal, exploration and promotion |
+| [src/rubric.py](src/rubric.py) | 936 | The rigour score over a draft and the artifacts it names. Never calls a backend |
+| [src/web_search.py](src/web_search.py) | 904 | Gemini-backed search, readiness assessment, MCP config construction |
+| [src/deliberation.py](src/deliberation.py) | 751 | The crux panel: four voices, each arguing against itself, resolved into an answer that names its own falsifier |
+| [src/ideation_panel.py](src/ideation_panel.py) | 735 | Divergent Stage 02 proposers across five lenses, deduplicated into a candidate pool |
+| [src/evolution.py](src/evolution.py) | 727 | The champion ratchet: budgeted polish rounds, reverted when they do not improve, rejected on verdict drift |
+| [src/writing_manifest.py](src/writing_manifest.py) | 698 | The Stage 07 inventory plus the AutoR-owned triage artifact for each output format |
+| [src/approval_agent.py](src/approval_agent.py) | 686 | The solo approval gate, its six-choice vocabulary and its unreadable-verdict fallback |
+| [src/preregistration.py](src/preregistration.py) | 579 | Freeze, amend, adjudicate, trace |
+| [src/information_flow.py](src/information_flow.py) | 553 | Sixteen typed information channels, each with declared readers and a written rationale |
+| [src/router.py](src/router.py) | 536 | The agent's choice among admissible moves; an off-menu choice is refused and logged |
+| [src/validity_review.py](src/validity_review.py) | 510 | The adversarial pass after Stages 05 and 06, and the response gate that follows it |
+| [src/research_rounds.py](src/research_rounds.py) | 411 | Stages 03-06 as a repeatable round, bounded by `--max-rounds` |
+| [src/trials.py](src/trials.py) | 384 | Paired A/B trials over archived runs, with an exact sign-flip p-value and its attainable floor |
+| [src/stage_comments.py](src/stage_comments.py) | 375 | Anchored review comments and the collateral-change diff |
+| [src/effort.py](src/effort.py) | 349 | Routine vs deliberative tiering, and the concentration of the strong model |
+| [src/scorecard.py](src/scorecard.py) | 319 | Reads all five self-measurement ledgers and says which features earned their cost |
+| [src/obligations.py](src/obligations.py) | 306 | What a later stage still owes; only a reviewer can discharge it |
+| [src/decisions.py](src/decisions.py) | 269 | "Was offered the edge and declined" — the control arm the archive's payoffs are computed against |
+| [src/cross_reviewer.py](src/cross_reviewer.py) | 239 | A second opinion from a different model family. Veto only, never an override |
+| [src/experimental_protocol.py](src/experimental_protocol.py) | 234 | Declared baselines, seeds and dispersion, fixed before the result exists |
+| [src/deliverables.py](src/deliverables.py) | 221 | Did the run answer what the task statement actually demanded? |
+| [src/pareto.py](src/pareto.py) | 212 | Non-dominated drafts kept beside the champion, and the pair worth merging |
+| [src/review_policy.py](src/review_policy.py) | 212 | Standing review rules learned from this run's own corrections |
+| [src/inference.py](src/inference.py) | 167 | Exact permutation tests and attainable-p floors; derives the archive's `min_observations` rather than asserting it |
+| [src/rigor.py](src/rigor.py) | 122 | The one dial: which optional machinery a level turns on |
+| [src/backend_health.py](src/backend_health.py) | 106 | Distinguishes "the backend is down" from "the research failed" |
+| [src/prompt_fragments.py](src/prompt_fragments.py) | 104 | Shared prompt blocks generated from the validators' own constants |
+
+Supporting modules: [operator_codex.py](src/operator_codex.py) and
+[operator_protocol.py](src/operator_protocol.py), [intake.py](src/intake.py),
+[manifest.py](src/manifest.py), [artifact_index.py](src/artifact_index.py),
+[experiment_manifest.py](src/experiment_manifest.py), [evidence_ledger.py](src/evidence_ledger.py),
+[hypothesis_manifest.py](src/hypothesis_manifest.py), [mcp_web_search.py](src/mcp_web_search.py),
+[diagram_gen.py](src/diagram_gen.py), [bootstrap.py](src/bootstrap.py) and
+[project_bootstrap.py](src/project_bootstrap.py), [platform/foundry.py](src/platform/foundry.py),
+[run_skills.py](src/run_skills.py), [terminal_ui.py](src/terminal_ui.py), [prompts/](src/prompts),
+[skills/](src/skills), and [backend/](src/backend) + [frontend/](src/frontend) for the Studio.
+Runnable tools: [tools/score_rcb_run.py](tools/score_rcb_run.py) (score a benchmark run with the
+reference judge) and [tools/archive_sample_complexity.py](tools/archive_sample_complexity.py) (how
+many runs the archive needs before an edge becomes believable).
+
+The full module map, the stage attempt loop and the extension points are in
+**[docs/architecture.md](docs/architecture.md)**. The design rationale — what is new here and why —
+is in **[docs/framework.md](docs/framework.md)**.
+
+## Benchmarks
+
+`python rcb_agent.py --workspace <WORKSPACE>` runs AutoR against a
+[ResearchClawBench](https://github.com/InternScience/ResearchClawBench) workspace with no human in
+the loop and exports the benchmark's deliverables (`report/report.md`, `report/images/`, `code/`,
+`outputs/`). Scoring is the benchmark's own rubric judge; `tools/score_rcb_run.py` defaults to the
+reference judge, **gpt-5.1**, which is what ResearchClawBench itself scores with.
+
+**Judge choice is worth roughly sixteen points.** On one identical artifact set, Opus scored 52.6
+where gpt-5.1 scored 46.0; on another, Gemini 2.5 Flash scored 37.0 where Opus scored 20.8. A number
+carrying the wrong judge is not a smaller number, it is an incomparable one. Quote the judge with
+every total.
+
+Measured on `Astronomy_000`, reference judge gpt-5.1, before and after the export and figure-budget
+fixes in #147 / #149 / #153:
+
+| Checklist item | Weight | Before | After |
+| --- | ---: | ---: | ---: |
+| Text: data characterisation | 0.2 | 48 | 38 |
+| Image: exclusion curve | 0.3 | 0 | 48 |
+| Text: coupling limits | 0.5 | 0 | 48 |
+| **Weighted total** | | **9.6** | **46.0** |
+
+**This is one task out of forty and must not be extrapolated.** ResearchClawBench's published
+leaderboard numbers are means over all 40 tasks; a single-task score is not comparable to one. For
+what the reported systems actually score and which of their numbers reproduce, see
+[docs/researchclawbench-landscape.md](docs/researchclawbench-landscape.md); for the adapter, its
+output contract and the export rules, see
+[docs/researchclawbench.md](docs/researchclawbench.md).
+
+## Documentation
+
+The [docs/](docs/) directory is the reference documentation. This README is the overview; everything
+below is the detail behind it.
+
+| | |
+| --- | --- |
+| [The Framework](docs/framework.md) | What AutoR is as a system: the implementation, every module and what it owns, what is new here, and what it contributes. Start here if you want the design, not the commands. |
+| [English Guide](docs/tutorial_en.md) · [中文教程](docs/tutorial_zh.md) | Install, run your first project end to end, review each stage, and write feedback that actually improves output. |
+| [CLI Reference](docs/cli-reference.md) | Every flag on `main.py`, `rcb_agent.py` and `studio.py`, defaults, what is preserved on resume, exit codes. |
+| [Configuration](docs/configuration.md) | `run_config.json`, the venue registry, diagram setup, environment variables, hard-coded limits. |
+| [Run Artifacts](docs/run-artifacts.md) | The run directory, file by file, and the schema of every machine-readable artifact. |
+| [Stage Contract](docs/stage-contract.md) | Exactly what a stage must produce to be accepted, as `validate_stage_artifacts` enforces it. |
+| [Recursive Self-Improvement](docs/self-improvement.md) | The stage graph, routing, the rigour rubric and the champion ratchet, the cross-run archive — and the constraints that stop a scored loop from optimising toward a nicer answer. |
+| [Rigor Levels](docs/rigor.md) | The one dial, what each level turns on, and how an explicit flag overrides it. |
+| [Effort Tiers](docs/effort-tiers.md) | Routine vs deliberative stages, tier promotion, and concentrating the strong model. |
+| [Review Panel](docs/review-panel.md) | The five seats, the independent round and the cross-examination that only runs on disagreement, blocking objections, `--panel-models`, `--persona`, and the solo baseline every panel run measures itself against. |
+| [Ideation Panel](docs/ideation-panel.md) | The five proposer lenses, Jaccard deduplication, scoring into a candidate pool, and the adoption measurement taken after the stage is approved. |
+| [Crux Deliberation](docs/deliberation.md) | When a stage may stop and escalate, the four voices, and the falsifier the resolution must name. |
+| [Anchored Comments](docs/stage-comments.md) | Quoting a passage instead of refusing a stage, and the collateral-change diff. |
+| [Run Scorecard](docs/scorecard.md) | The five self-measurement ledgers and the end-of-run verdict on which flags earned their cost. |
+| [Backend Health](docs/backend-health.md) | Telling "the model was unreachable" apart from "the research failed". |
+| [Studio Guide & API](docs/studio.md) | The browser workspace and its complete HTTP API. |
+| [ResearchClawBench](docs/researchclawbench.md) | Running with no human in the loop: unattended execution, the benchmark adapter and its output contract, and Gemini-backed web search. |
+| [ResearchClawBench Landscape](docs/researchclawbench-landscape.md) | How EvoScientist, ARIS Codex and MIRA actually score on the benchmark, which reported numbers reproduce, and the baseline any result must be quoted against. |
+| [Architecture](docs/architecture.md) | Layers, the module map, the stage walk, prompt assembly by typed channel, recovery, extension points. |
+| [Development](docs/development.md) | Dev setup, tests, CI, conventions, and recipes for adding a stage, venue, or backend. |
+| [Troubleshooting](docs/troubleshooting.md) | Symptom-to-fix for the errors AutoR actually raises. |
+| [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Code of Conduct](CODE_OF_CONDUCT.md) | How to land a change; the security model, the sandbox trade-offs and how to report a vulnerability; community expectations. |
 
 ## Showcase
 
-`runs/20260330_101222` is the full example run the docs work from. Run directories are gitignored,
-so what ships in the repository is the artifacts lifted out of it, under `assets/`.
+`runs/20260330_101222` is the full example run the docs work from. Run directories are gitignored, so
+what ships in the repository is the artifacts lifted out of it, under `assets/`.
 
 | What the run produced | What it demonstrates |
 | --- | --- |
@@ -287,8 +831,6 @@ so what ships in the repository is the artifacts lifted out of it, under `assets
 | Review and dissemination materials | The run continues past writing into release readiness |
 
 `AGSNv2` reached **36.21 ± 1.08** on Actor, and the run preserved the full human approval trail.
-The shot at the top of this page is the real terminal UI: colored stage panels, parsed backend
-event streams, display-width-aware wrapping, keyboard-selectable menus.
 
 <table>
   <tr>
@@ -317,559 +859,104 @@ Four artifact-backed runs, two pages each: the framing page and an evidence page
     <td align="center"><img src="assets/paper_gallery/other_run_3_results.png" alt="Output 4 analysis page" width="220" /><br /><strong>Analysis Page</strong></td></tr>
 </table>
 
-### What the human changed, and what they check now
-
-In that run the human intervened where direction mattered: Stage 04 pushed the system to download
-real datasets and run pre-checks, Stage 05 forced experimentation to continue until real benchmark
-results existed, Stage 06 redirected the story from leaderboard framing to mechanism analysis.
-
-What a human checks at Stage 02 has since changed. The headline feature there is now the opposite
-of narrowing — `--ideation-panel` exists to widen the pool. The prompt instead requires a
-`- Decision rule:` line on every empirical hypothesis, stating in advance what observation would
-count as support and what would count as refutation
-([`02_hypothesis_generation.md`](src/prompts/02_hypothesis_generation.md)); those are the
-hypotheses frozen at Stage 04 and adjudicated at Stage 06. "Narrow it to one claim" is advice about
-scope. "Make each one refutable" is advice about a gate that now exists.
-
-## Quick Start
-
-### Prerequisites
-
-- Python 3.10+
-- Claude CLI or Codex CLI available on `PATH` for real runs
-- Local TeX tools are only needed for `--output-format latex`; the default markdown output needs no TeX
-- `pip install google-genai` and a Gemini key in `GOOGLE_API_KEY` or `GEMINI_API_KEY` — needed by three paths, not only the diagram one: `--web-search gemini`, required where the backend's own `WebSearch` tool is disabled (`build_genai_client`, src/web_search.py:346, called at :482); the cross-model veto `--cross-review auto|gemini`, which builds the same client (src/cross_reviewer.py:108); and `--research-diagram`, which also reads `configs/diagram_config.yaml` (see `configs/diagram_config.template.yaml`)
-- The SDK is **not** a default dependency. Without it the diagram step prints `Diagram generation failed: No module named 'google'` and the run continues; cross-review records itself unavailable rather than agreeing
-
-### Common commands
-
-| Goal | Command |
-| --- | --- |
-| Start a run (the goal is prompted for if omitted) | `python main.py --goal "Your research goal here"` |
-| Start with preloaded resources | `python main.py --goal "Your research goal here" --resources paper.pdf refs.bib data.csv` |
-| Run a local smoke test without a real agent backend | `python main.py --fake-operator --goal "Smoke test"` |
-| Run with the automated reviewer gate | `python main.py --full-auto --goal "Your research goal here"` |
-| Choose how much optional machinery to run | `python main.py --rigor thorough --goal "..."` |
-| Give the panel a researcher persona to stand in for | `python main.py --review-panel --persona docs/persona-example.md --goal "..."` |
-| Seat the panel across different models | `python main.py --review-panel --panel-models pi=opus skeptic=codex:default --goal "..."` |
-<<<<<<< HEAD
-| Choose the execution backend and model | `python main.py --operator claude --model opus` or `python main.py --operator codex --model default` |
-=======
-| Keep the strong model for the steps that matter | `python main.py --effort-tiers --model opus --routine-model sonnet --goal "..."` |
-| Choose the execution backend | `python main.py --operator claude` or `python main.py --operator codex` |
->>>>>>> dd3d62c (Spend effort where the research needs it, not evenly)
-| Choose the reviewer backend separately | `python main.py --full-auto --review-operator claude --review-model opus` |
-| Allow Codex-backed SSH / remote GPU execution | `python main.py --operator codex --codex-sandbox danger-full-access --goal "Your research goal here"` |
-| Produce a LaTeX paper package instead of a markdown report | `python main.py --output-format latex --goal "..."` |
-| Stop once the report is written, skipping dissemination | `python main.py --final-stage 07_writing --goal "..."` |
-| Choose a writing venue profile | `python main.py --venue neurips_2025` or `python main.py --venue nature` or `python main.py --venue jmlr` |
-| Resume the latest run | `python main.py --resume-run latest` |
-| Redo a stage inside the same run | `python main.py --resume-run 20260329_210252 --redo-stage 03` |
-| Roll back to a stage inside the same run | `python main.py --resume-run 20260329_210252 --rollback-stage 03` |
-| Re-enter an existing project instead of starting over | `python main.py --project-root ~/code/my-project --goal "..."` |
-| Seed the run from your own prior papers | `python main.py --paper-corpus ~/papers --goal "..."` |
-| Store runs on another disk | `python main.py --runs-dir /mnt/big-disk/runs --goal "..."` |
-| Raise the per-attempt ceiling for long training runs | `python main.py --stage-timeout 43200 --goal "..."` |
-| Give a stubborn stage more retries | `python main.py --max-attempts 10 --goal "..."` |
-| Let Stages 03-06 run as a repeatable round, so a refuted hypothesis can start a second one (default 1) | `python main.py --max-rounds 2 --goal "..."` |
-| Skip the intake stage | `python main.py --skip-intake --goal "..."` |
-| Add a generated method diagram to the paper | `python main.py --research-diagram --goal "..."` |
-| Search the web where the agent's own `WebSearch` is disabled | `python main.py --web-search gemini --goal "..."` |
-| Benchmark AutoR on ResearchClawBench | `python rcb_agent.py --workspace <WORKSPACE> --prompt <PROMPT>` |
-
-Every flag, its default, and what is preserved on resume: **[docs/cli-reference.md](docs/cli-reference.md)**. Stage identifiers accept `03`, `3` or `03_study_design`; `--venue` defaults to `neurips_2025`.
-
-**Two flags in that table remove the human from the gate.** `resolve_unattended` returns `True` for both `--full-auto` and `--review-panel` (main.py:567-577), and `approval_mode = "agent" if (args.full_auto or args.review_panel)` (main.py:862). So both replace the approval menu with an agent reviewer, never block on terminal input, and auto-skip a stage that exhausts its retries, up to `--max-auto-skips` (default 3). Under a badge reading *Human approval required*, the flag that looks like more review is the flag that removes the reviewer. Three headline mechanisms — obligations, the standing review policy, the cross-model veto — also run only behind that agent gate. Manual approval is the default and remains the path for work you intend to publish.
-
-For Codex-backed runs, AutoR defaults to `--codex-sandbox workspace-write`. If a verified remote experiment needs SSH or external GPU access, use `--codex-sandbox danger-full-access` intentionally. This grants the Codex backend unrestricted local/remote execution ability, so it should not be the default for untrusted tasks.
-
-```bash
-# Self-improvement is on by default: navigate the graph, score every draft, keep the
-# best, and record the route in ~/.autor/archive.
-python main.py --goal "..."
-python main.py --archive-report                   # what the archive has learned so far
-python main.py --goal "..." --evolve-rounds 4     # spend more on improvement
-python main.py --goal "..." --evolve-rounds 0     # measure and ratchet, no extra passes
-python main.py --goal "..." --archive-steer       # let the archive pick the topology
-
-# Opt out entirely: the strict 01-through-08 sequence, last draft wins.
-python main.py --goal "..." --stage-graph linear --routing off --no-evolve --no-archive
-```
-
-### Studio (browser UI)
-
-A local web UI over the same Claude-backed runs: create a project, watch stages execute, approve or send feedback, read the compiled paper. It needs the Claude CLI on `PATH` to start a run.
-
-```bash
-python studio.py                                # http://127.0.0.1:8000/studio/
-python studio.py --host 0.0.0.0 --port 8765     # bind externally, see the warning below
-python studio.py --runs-dir /path/to/runs       # override runs directory
-```
-
-> The Studio API has **no authentication**. It binds to `127.0.0.1` by default; anything that can reach it can start runs, approve stages, and read every file under the runs directory. For remote access prefer an SSH tunnel over `--host 0.0.0.0`. See [SECURITY.md](SECURITY.md).
-
-One honest limit, then the walkthrough: the Studio's lazy-resume approve path picks the next stage arithmetically — the first stage with a higher number (src/backend/studio_runner.py:361-364) — and never consults the router, so graph routing and backward moves are a CLI capability today. Page-by-page walkthrough and the full HTTP API: **[docs/studio.md](docs/studio.md)**.
-
-## How it works: the stage graph
-
-Eight stages are the nodes; a `finish` node closes the walk. Stage 00 intake is not one of
-them — it runs before the walk starts, and `_graph_entry_stage` → `_select_stages_for_run`
-(src/manager.py:507-510, 693-715) only ever yields the eight. Solid edges advance, dotted
-edges go back; `--stage-graph linear` is the solid edges alone, and the guards come off with
-the backward ones (`_advance_edges(guarded=False)`, src/stage_graph.py:535) — one edge out of
-each node leaves nothing to choose, so a guard there could only halt a run that the stage's
-own validation is about to fail anyway.
-
-```mermaid
-flowchart LR
-    S1[01 Literature] --> S2[02 Hypotheses]
-    S2 -->|has_hypotheses| S3[03 Design]
-    S3 -->|design_artifacts| S4[04 Implementation]
-    S4 -->|runnable_code| S5[05 Experiments]
-    S5 -->|results_exist| S6[06 Analysis]
-    S6 -->|validity_chain| S7[07 Writing]
-    S7 -->|report_exists| S8[08 Dissemination]
-    S8 --> Z([finish])
-
-    S2 -.->|the gap it rests on is not a gap| S1
-    S3 -.->|a hypothesis cannot be brought to a decision| S2
-    S4 -.->|not executable as specified| S3
-    S5 -.->|implementation is at fault| S4
-    S5 -.->|comparison cannot distinguish| S3
-    S6 -.->|results insufficient to decide| S5
-    S6 -.->|confound the results cannot repair| S3
-    S6 -.->|evidence refutes, and points somewhere| S2
-    S6 -.->|the numbers are wrong, not disappointing| S4
-    S7 -.->|claim has no analysis behind it| S6
-    S7 -.->|needs a result never produced| S5
-    S7 -.->|the survey missed related work| S1
-    S8 -.->|deliverable is not what a reader needs| S7
-```
-
-Six of the eight forward edges carry a guard, one per target stage
-(`_ADVANCE_GUARDS`, src/stage_graph.py:266-273); 01→02 and 08→`finish` are
-unguarded. Thirteen dotted edges go back (`REVISIT_EDGES`). The longest is
-07→01: writing it up showed the finding relates to work the survey missed. The
-Stage 07 guard is the strictest — every preregistered empirical hypothesis needs a
-verdict **and** at least one figure under `workspace/figures`
-(`_guard_validity_chain`, :157-190).
-
-**Who decides the move.** AutoR decides which moves are *admissible*, by evaluating
-each edge's guard against the artifacts on disk. With `--routing auto` (the default,
-src/utils.py:367) the agent chooses among them and states a reason; `--routing off`
-always takes the graph's default. An off-menu choice — an unlisted target, or one
-with no stated reason — is refused, written to `evolution/routing_refusals.jsonl`
-(src/router.py:186), and replaced by the forward edge.
-
-Two design calls worth naming. Blocked moves are handed to the agent *with the
-reason they are blocked* (`StageGraph.moves`, :555) — the useful thing to say is not
-"you may go to 06" but "07 is closed because H2 has no verdict", and an agent that
-sees why writing is closed routes to the analysis that opens it. And a revisit whose
-justification repeats one already on the path is refused (`repeats_a_previous_reason`, :652): going again on the same grounds is a loop, not an iteration.
-
-**A backward move is only ever a deliberate choice.** The default is always the
-forward edge, and when a guard has closed it the default advances anyway and lets
-the stage's own validation — still refusing a Stage 07 that writes up unadjudicated
-hypotheses — be the gate it always was. A guard is a routing preference; the gate is
-the gate. So a refusal, a routing failure, or a run nobody is steering all come out
-as the linear pipeline rather than as a stall.
-
-A stage is a node with a visit budget, not a position in a sequence:
-`DEFAULT_MAX_VISITS = 3` (:76, `--graph-max-visits`); `--graph-max-steps` bounds the whole walk at 20.
-
-### The eight stages, and what you check at each
-
-| Stage | Role | What the human is checking |
-| --- | --- | --- |
-| `00_intake` (before the walk) | Align the goal, resources, constraints, target venue and success criteria. | Answer the clarification questions, add the missing constraints, and narrow the project until it is executable. |
-| `01_literature_survey` | Build the related-work base, organize the evidence, identify the real gap. | Reject shallow paper lists; require task framing, benchmarks, baselines, differences, and structured literature files. |
-| `02_hypothesis_generation` | Convert the direction into typed, testable hypotheses and provisional paper claims. | A `- Decision rule:` line on every empirical hypothesis, stating in advance what would count as support and what would count as refutation (src/prompts/02_hypothesis_generation.md:52-58). These are the hypotheses frozen at 04 and adjudicated at 06. |
-| `03_study_design` | Turn the hypotheses into an executable plan and a declared protocol. | Datasets, metrics, ablations, budgets, failure criteria, machine-readable data artifacts — and a baseline set where every entry says `why_competent` and names its `tuning_budget`. |
-| `04_implementation` | Build the runnable code, configs, data preparation and sanity checks. | This is the freeze point: approving the stage hashes the hypothesis set into `workspace/notes/preregistration.json`. Check the set you are freezing, and do not approve skeletons. |
-| `05_experimentation` | Run the planned experiments and write machine-readable results. | The declared baselines and the seeds: a supported or refuted verdict off a single seed is refused unless the run states why one run settles it (`MIN_SEEDS_FOR_A_VERDICT = 2`, src/experimental_protocol.py:37). |
-| `06_analysis` | Interpret the results, produce figures, adjudicate every frozen hypothesis. | A verdict for each one, backed by a result file the validator can find. The forward edge stays closed until then. |
-| `07_writing` | Produce the deliverable: a markdown report with embedded figures, or a venue-aware LaTeX package with a compiled PDF. | That every claim traces. A `confirmatory` claim whose hypothesis is not in the supported set is already refused, so what is left to check is whether the exploratory ones are honestly labelled. |
-| `08_dissemination` | Package the run for review, release, reproduction or presentation. | Readiness notes, review materials, manifests and outward-facing deliverables exist. |
-
-### Self-Improvement Rounds
-
-Every valid stage draft is measured against a rigour rubric read off disk — do the
-paths it names resolve, do the numbers it reports appear in a results file, did it
-produce artifacts during *this* execution, is the decision ledger four different
-things rather than one sentence four times.
-
-**Measuring is free and always on.** The rubric reads the run off disk and never
-calls a backend, so the property it buys costs nothing: the draft that gets
-promoted is the best one the run produced, not the last one. That is the half that
-was missing before — AutoR could iterate, but "later" was the only ordering it had,
-so a refinement that dropped a resolving reference was promoted on exactly the same
-terms as one that fixed something.
-
-**Improvement rounds are the half that costs**, and they are budgeted separately
-from `--max-attempts`, which bounds a stage that is *failing* rather than one being
-improved. Two per stage by default, and a stage whose rubric has no shortfall worth
-acting on spends none of them — a round aimed at a criterion already at full marks
-produces churn, so AutoR does not buy one. `--evolve-rounds 0` measures without
-polishing; `--no-evolve` restores the old behaviour entirely.
-
-One edge of that budget is worth knowing before you resume a run. `state()` rehydrates the
-champion and the Pareto frontier from disk and nothing else (src/evolution.py:204-243), so
-`--resume-run` restarts `rounds_spent` and the patience counter at zero: the best draft
-survives the resume, the *spend cap* does not, and a stage resumed twice can buy the two
-rounds twice.
-
-A round that scores worse is reverted, so a stage can only improve. A round that
-changes a hypothesis verdict is rejected outright, whatever it scored — the rubric
-is blind to what the run concluded, which removes the incentive, and the drift
-check removes the possibility.
-
-A revision a *human* asked for always stands, whatever it measures. The ratchet
-governs AutoR's own rounds, not the direction it is given.
-
-Full mechanism, and the reasoning behind each refusal, in
-[docs/self-improvement.md](docs/self-improvement.md).
-
-### Approval semantics
-
-- Stage 00 has a dedicated manual intake flow. On the first pass, AutoR asks the clarification questions one by one with selectable options, custom answers, and skip. On the revised pass, the user sees a compact intake brief and chooses refine, approve, or abort.
-- Stages 01-08 use the standard six-action review menu: `1 / 2 / 3` continue with an AI refinement suggestion, `4` continues with custom feedback, `5` approves, and `6` aborts.
-
-The division of labour is not "AutoR drives, the agent types": AutoR owns the menu of admissible moves, the agent owns the pick and has to justify it, and the human owns the approval without which there is no next move at all.
-
-### The archive: which moves paid, across runs
-
-Every finished run is recorded into `~/.autor/archive` — the route it took, the rubric
-fitness it reached, and the set of stages it actually measured (`Archive.record_run`,
-src/archive.py:426, from `record_into_archive`, main.py:657). `edge_payoffs` compares runs
-that *took* an edge against runs that reached the same node and did not, and
-`propose_variant` (:512) turns a payoff that is believable — enough observations, and a
-delta above `min_gain` — into a child variant that moves that one edge one step up or down
-the preference order.
-
-A variant is only a reordering. It never opens a guarded edge, never adds one that was not
-declared, and never removes one: the guards are the correctness argument for letting an
-agent route at all, and the component that learns from outcomes is precisely the one that
-must not be able to weaken them. Promotion is as conservative — a challenger has to beat the
-incumbent *within every comparability basis* rather than on a pooled mean, because "runs
-that stopped early" is the cheapest composition for a topology to win on (`promote`, :661).
-
-Two limits, stated here rather than left to be assumed:
-
-- **The archive records and proposes on every run; it steers only when you ask.** The
-  proposed variant is written down and reported, but the topology a run walks comes from
-  the archive only under `--archive-steer` (main.py:792, 874). Without it, `resolve_graph`
-  returns the declared topology unchanged.
-- **A payoff comparison cannot reach an edge nothing has taken.** No takers means no
-  evidence in either direction, so such an edge is never proposed and never preferred — and
-  the backward edges start unpreferred, so they are the ones this strands.
-  `propose_exploration` and `unexplored_edges` (src/archive.py:595, :576) are written for
-  exactly that blind spot and have no production caller; see [Limits](#-limits).
-
-### Obligations carried forward
-
-The reviewer's insight used to be captured only when it refused. But most stages are
-approved, and an approval discarded everything the reviewer noticed — which is where most
-of the review actually lives. A real reviewer approving a literature survey says "fine, but
-you owe me a power analysis at design time", and then checks.
-
-An approving reviewer can now attach **obligations** to a later stage. Each is injected into
-that stage's prompt *and* into its review, so the reviewer who inherits one is asked whether
-it was met:
-
-```
-approval ──obligation──▶ later stage prompt ──▶ that stage's review ──▶ discharged
-                                                          │
-                                                 not met ─┴──▶ refusal
-```
-
-Recorded in `runs/<run_id>/obligations.json`. Three rules keep it from becoming theatre:
-
-- **Only a reviewer may discharge one.** The stage that owes it cannot mark its own
-  homework — it can do the work and say so, and a reviewer decides.
-- **Deferral is counted, never silent.** A stage may push an obligation later, but it stays
-  open and its deferral count is shown to every subsequent reviewer, so "carried forward"
-  cannot quietly become "dropped".
-- **Bounded and deduplicated**, so a reviewer restating itself cannot manufacture rigour.
-
-Together with the two mechanisms below, refusals teach rules, approvals set debts, and a
-different model family can veto either.
-
-### Cross-model review
-
-The approval gate runs a coding agent with tools, so it can re-read a paper and re-execute
-an analysis before judging. But it is the same model family as the executor — usually the
-same model. Opus judging opus shares the blind spots that produced the work, which is
-exactly what a review is supposed to catch.
-
-So when the primary reviewer **approves**, a reviewer from a different model family reads
-the same evidence and decides whether that approval is defensible. It is a **veto, never an
-override**:
-
-- It only audits approvals. A refusal already sends the stage back.
-- It cannot approve anything the primary refused, so enabling it can only make the gate
-  stricter — which is why `--cross-review auto` turns it on whenever a Gemini backend is
-  configured.
-- An auditor that errors or returns unparseable output is recorded as *unavailable*, not as
-  agreement. Silence is never laundered into a passed audit.
-
-A cross-model veto is recorded as a standing rule, so a blind spot caught once is checked
-on every stage after it.
-
-### Self-improving review
-
-The approval gate does not just judge each stage — it **accumulates the corrections it
-demands and applies them to every stage after**. A reviewer that once insisted on a stated
-power analysis keeps insisting, so the same class of weakness cannot recur later in the run:
-
-```
-stage N review  ──demands a correction──▶  standing rule
-                                              │
-stage N+1 review  ◀──rule is now checked──────┘
-```
-
-Two properties keep this honest rather than decorative:
-
-- **It is auditable.** The policy is a plain artifact at `runs/<run_id>/review_policy.json`,
-  and every rule names the stage and attempt that produced it, so the claim can be checked
-  against the record instead of believed.
-- **It cannot inflate.** Rules are deduplicated on normalized text — casing, punctuation and
-  stage numbers collapse — and the set is bounded, so a reviewer restating one complaint
-  does not manufacture the appearance of learning.
-
-A rollback is recorded at higher weight than a routine refinement, because it is the
-strongest evidence a review can produce: an approval already given turned out to be wrong.
-Approvals teach nothing and are not recorded.
-
-### Unattended runs
-
-`--full-auto` — equivalently `--approval-mode agent`, and implied by `--review-panel` — removes the human entirely, which is what benchmark harnesses and overnight sweeps need:
-
-- The reviewer agent decides every approval, including the Stage 00 intake flow.
-- `--unattended` on its own is only half of that. It stops AutoR blocking on stdin, but it does not install a reviewer: `approval_mode` stays `manual` (main.py:862), so the first approval menu raises `UnattendedInputError` instead of being decided. For a run with nobody at the terminal, pass `--full-auto`.
-- The resource prompt is skipped even on a TTY. Pass resources with `--resources` instead.
-- A stage that exhausts its retry budget is auto-skipped rather than aborting the run, bounded by `--max-auto-skips` (default 3). The skip is promoted as an explicit skip summary so downstream stages know the work is missing.
-- Any interactive prompt still reachable raises `UnattendedInputError` instead of waiting on stdin — a prompt added later fails on its first unattended run rather than silently hanging an overnight job.
-
-`python rcb_agent.py` runs AutoR against a [ResearchClawBench](https://github.com/InternScience/ResearchClawBench) workspace on this basis and exports the benchmark's deliverables (`report/report.md`, `report/images/`, `code/`, `outputs/`). See [docs/researchclawbench.md](docs/researchclawbench.md).
-
-## ✅ The Stage Contract and What Gets Validated
-
-AutoR does not consider a run successful just because it generated a plausible markdown summary.
-
-**Required stage summary shape.** Seven headings, in this order — `REQUIRED_STAGE_HEADINGS` ([src/utils.py:144-152](src/utils.py)):
-
-```md
-# Stage X: <name>
-
-## Objective
-## What I Did
-## Key Results
-## Files Produced
-## Decision Ledger
-## Suggestions for Refinement
-## Your Options
-```
-
-There was an eighth heading, retired in this branch: a section in which each stage restated the approved summaries of the stages before it. It made every node contractually required to relay its inbound edge. Stage output grew 235 → 1,211 words across a run and 64% of it was relay of context the stage had just been handed; without the section, relay is 0% and output is flat at 228-277 words per stage.
-
-Also required, and checked: exactly 3 numbered refinement suggestions, exactly the fixed 6 user options, concrete file paths under `Files Produced`, and no `[In progress]`, `[Pending]`, `[TODO]` or `[TBD]` placeholders.
-
-**Artifact gates.** Most start by asking whether a file is there — and the rows below that say
-"valid", "resolving" or "matching" then parse it:
-
-| Stage | Required non-toy output |
-| --- | --- |
-| Stage 01 | A cross-referenced evidence ledger: `sources.json` and `claims.json`, where every cited `source_id` resolves |
-| Stage 03+ | Machine-readable data under `workspace/data/` |
-| Stage 05+ | Machine-readable results under `workspace/results/`, plus a valid `experiment_manifest.json` |
-| Stage 06+ | Real figure files under `workspace/figures/` |
-| Stage 07+ (markdown) | `report/report.md` with resolving figure references, at most 5 figures under `report/images/`, `citation_verification.json`, `self_review.json`, `report_review.json` |
-| Stage 07+ (latex) | `main.tex` matching the venue, `sections/*.tex`, a bibliography, a compiled PDF, `build_log.txt`, `citation_verification.json`, `self_review.json`, `layout_review.json` |
-| Stage 08+ | Review and readiness assets under `workspace/reviews/` |
-
-Requirements are cumulative, and the stage that *produces* a class of artifact must produce it **during that stage's execution** — a re-run is not credited with the previous attempt's files. The cutoff is `stage_execution_started_at` feeding `recent_in` ([src/utils.py:1249-1261](src/utils.py)), and the rubric enforces the same rule independently in `_fresh_artifact_kinds` ([src/rubric.py:417](src/rubric.py)), so a Stage 07 draft cannot score on Stage 06's figures.
-
-**Validity gates.** The same function — `validate_stage_artifacts` ([src/utils.py:1232](src/utils.py)) — also runs seven validators that ask whether a *claim* is warranted rather than whether output exists: `validate_preregistration`, `validate_experimental_protocol`, `validate_hypothesis_outcomes`, `validate_outcome_statistics`, `validate_claim_provenance`, `validate_validity_response`, `validate_round_decision`. (Three of them do refuse on an absent file — the artifact they need is the record of the claim itself, so its absence *is* the unwarranted claim.) The code labels the split itself: "The scientific-validity chain, distinct from the artifact gates around it" ([src/utils.py:1292-1297](src/utils.py)). A run can fail because a claim is unwarranted, not only because a file is absent.
-
-The complete gate, including every JSON schema that is parsed rather than merely counted, is in **[docs/stage-contract.md](docs/stage-contract.md)**.
-
-## 🧠 Execution Model
-
-Context is composed per consumer, not per availability. A stage's inbound block is built by `render_inbound(ChannelContext(...), CHANNELS)` ([src/manager.py:2033-2039](src/manager.py)) from the fifteen typed channels in [src/information_flow.py](src/information_flow.py). Each channel declares `produced_by`, a `consumed_by` set of real stage slugs, and a `rationale`; `test_every_narrowing_is_argued_for` ([tests/test_information_flow.py:67](tests/test_information_flow.py)) fails a channel that withholds itself from a stage without saying why. Withholding has to be argued for, not just done.
-
-Three narrowings, because the abstraction is not the point:
-
-- the **artifact index** skips Stages 00-02 — they produce no data, results or figures, so the index is empty noise there
-- the **writing manifest** reaches Stage 07 alone
-- the mutable **Stage 02 hypotheses** stop at `04_implementation` ([src/information_flow.py:333-350](src/information_flow.py)), because the freeze at Stage 04's approval supersedes them. Before that edge was typed, the same H1 went into every prompt from Stage 05 on twice — one copy labelled editable, sitting next to the frozen one at exactly the stages where the freeze is the point.
-
-`dependency_edges()` returns every `(producer, consumer, channel key)` triple, so the information topology can be printed and diffed rather than reconstructed from thirteen `if` statements. `_record_inbound_channels` ([src/manager.py:2900](src/manager.py)) writes the delivered channel keys per stage into the run log.
-
-Honest scope: thirteen blocks are typed. Five more — `obligations_context`, `intake_context_text`, `web_search_context`, `approved_memory` and `handoff_context` — are still passed to `build_prompt` as ordinary arguments rather than declared as channels ([src/manager.py:2041-2069](src/manager.py)), so each one's delivery rule lives in `build_prompt` instead of next to a `consumed_by` set. Around them, `compose_stage_template` ([src/prompt_fragments.py](src/prompt_fragments.py)) assembles the stage's own instructions, the accepted-extension lists generated from the validators' constants rather than hand-copied, and the run-safety rules.
-
-One duplication has already been cut: `build_prompt` withholds the handoff when approved memory is non-empty ([src/utils.py:807-811](src/utils.py)). The handoff was a strict subset of memory, so sending both put ~350 words of verbatim duplicate into every prompt from Stage 04 on. Assembled prompts across a run: 21,823 → 20,353 words.
-
-The assembled prompt is written to `runs/<run_id>/prompt_cache/`, per-stage session IDs to `runs/<run_id>/operator_state/`, and the selected CLI backend is invoked in live streaming mode. Alongside the prompt, AutoR installs an agent skill pack from [src/skills/](src/skills) into `runs/<run_id>/.claude/skills/` — the operator's working directory — so the agent can *pull* long-form craft guidance when it needs it. A skill costs nothing in the prompts that do not use it.
-
-<details>
-<summary><strong>Exact Claude CLI pattern</strong></summary>
-
-First attempt for a stage:
-
-```bash
-claude --model <model> \
-  --permission-mode bypassPermissions \
-  --dangerously-skip-permissions \
-  --session-id <stage_session_id> \
-  -p @runs/<run_id>/prompt_cache/<stage>_attempt_<nn>.prompt.md \
-  --output-format stream-json \
-  --verbose
-```
-
-Continuation attempt for the same stage:
-
-```bash
-claude --model <model> \
-  --permission-mode bypassPermissions \
-  --dangerously-skip-permissions \
-  --resume <stage_session_id> \
-  -p @runs/<run_id>/prompt_cache/<stage>_attempt_<nn>.prompt.md \
-  --output-format stream-json \
-  --verbose
-```
-
-</details>
-
-Important behavior:
-
-- refinement attempts reuse the same stage conversation whenever possible
-- streamed agent output is shown live in the terminal
-- raw stream-json output is captured in `logs_raw.jsonl`
-- if resume fails, AutoR can fall back to a fresh session
-- if stage markdown is incomplete, AutoR can repair or normalize it locally
-
-## 📂 Run Layout
-
-Every run lives entirely inside its own directory. The tree is `build_run_paths` ([src/utils.py:232-273](src/utils.py)).
-
-```text
-runs/<run_id>/
-├── user_input.txt      memory.md             run_config.json
-├── run_manifest.json   artifact_index.json   intake_context.json
-├── obligations.json    review_policy.json    # both per-run; nothing crosses runs
-├── logs.txt            logs_raw.jsonl
-├── prompt_cache/       operator_state/       handoff/        stages/
-├── .claude/skills/     # the skill pack, pulled on demand by the agent
-├── evolution/          # champion drafts, improvement_ledger.jsonl, summary.json,
-│                       # stage_graph.json, routing_refusals.jsonl
-└── workspace/
-    ├── literature/  code/  data/  figures/  report/  writing/
-    ├── bootstrap/   profile/
-    ├── notes/       preregistration.json, experimental_protocol.json,
-    │                research_rounds.json, round_decision.json, hypothesis_manifest.json
-    ├── results/     experiment_manifest.json, hypothesis_outcomes.json
-    ├── artifacts/   claim_provenance.json, review JSON, build metadata, compiled PDFs
-    └── reviews/     validity_review_<stage>.json, panel/
-```
-
-`evolution/` sits outside `workspace/` on purpose, and the dataclass records the reason: it is "a record of how the run reached its answer, not part of the answer, and a benchmark export that swept it up would ship the losing drafts alongside the report" ([src/utils.py:92-96](src/utils.py)).
-
-**Workspace semantics.** `literature/` reading notes, survey tables, benchmark notes · `code/` runnable code, scripts, configs, implementations · `data/` machine-readable datasets, manifests, processed splits · `results/` metrics, predictions, ablations, plus the standardized `experiment_manifest.json` · `report/` the markdown deliverable, `report.md` and the PNGs it embeds under `images/` · `writing/` LaTeX sources, sections, tables, bibliography (latex mode) · `figures/` plots and paper figures · `artifacts/` review JSON, build metadata, compiled PDFs, packaged deliverables · `notes/` the frozen files of the validity chain plus supporting notes · `reviews/` adversarial validity reviews, panel transcripts, readiness reviews.
-
-Outside `workspace/`: `memory.md` is the approved free-text cross-stage memory; `handoff/<slug>.md` is the second free-text carrier, each approved summary trimmed to Objective / Key Results / Files Produced (`write_stage_handoff`, [src/utils.py:1628](src/utils.py)) and sent only on a continuation attempt or when memory is still empty; every other cross-stage edge is a typed channel or a JSON artifact. `run_manifest.json` is the lifecycle state that resume, redo and rollback read; `artifact_index.json` indexes `data/`, `results/` and `figures/`; `prompt_cache/` holds the exact prompt of every attempt and repair.
-
-## 🏗️ Architecture
-
-```mermaid
-flowchart LR
-    C[information_flow.py<br/>13 typed channels] --> M
-    M[manager.py<br/>walks the stage graph] --> W[walk<br/>stage_graph · router]
-    M --> G[gates<br/>preregistration · experimental_protocol · validity_review]
-    M --> I[improvement<br/>rubric · evolution · pareto · archive]
-    M --> R[review<br/>review_panel · cross_reviewer · obligations · review_policy]
-```
-
-| Module | Lines | What it owns |
-| --- | ---: | --- |
-| [main.py](main.py) | 1188 | CLI entry: start, resume, `--redo-stage`, `--rollback-stage`, and the archive record at the end of a run |
-| [src/manager.py](src/manager.py) | 3753 | Walks the stage graph until it reaches finish or nothing is open — plus the router call, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto and the inbound-channel record |
-| [src/utils.py](src/utils.py) | 2360 | Stage metadata, run paths, prompt assembly, markdown validation, the artifact gates and the validity-chain wiring |
-| [src/review_panel.py](src/review_panel.py) | 1273 | The deliberating panel; a blocking objection is enforced in code against its own chair |
-| [src/rubric.py](src/rubric.py) | 936 | The rigour score over a draft and the artifacts it names. Never calls a backend |
-| [src/archive.py](src/archive.py) | 974 | Cross-run routes and edge payoffs, keyed on a comparability basis; variant proposal and promotion |
-| [src/stage_graph.py](src/stage_graph.py) | 1000 | Stages as nodes: six guarded forward edges, thirteen backward edges, a conditional terminal, a per-stage visit budget |
-| [src/ideation_panel.py](src/ideation_panel.py) | 733 | Divergent Stage 02 proposers across five lenses, deduplicated into a candidate pool |
-| [src/evolution.py](src/evolution.py) | 727 | The champion ratchet: budgeted polish rounds, reverted when they do not improve |
-| [src/preregistration.py](src/preregistration.py) | 579 | Freeze, amend, adjudicate, trace |
-| [src/validity_review.py](src/validity_review.py) | 512 | The adversarial pass after Stages 05 and 06 |
-| [src/information_flow.py](src/information_flow.py) | 522 | Fifteen typed information channels, each with declared readers |
-| [src/router.py](src/router.py) | 533 | The agent's choice among admissible moves; an off-menu choice is refused and logged |
-| [src/research_rounds.py](src/research_rounds.py) | 411 | Stages 03-06 as a repeatable round, bounded by `--max-rounds` |
-| [src/obligations.py](src/obligations.py) | 306 | What a later stage still owes; only a reviewer can discharge it |
-| [src/cross_reviewer.py](src/cross_reviewer.py) | 239 | A second opinion from a different model family. Veto only, never an override |
-| [src/experimental_protocol.py](src/experimental_protocol.py) | 234 | Declared baselines, seeds and dispersion, fixed before the result exists |
-| [src/pareto.py](src/pareto.py) | 212 | Non-dominated drafts kept beside the champion, and the pair worth merging |
-| [src/review_policy.py](src/review_policy.py) | 212 | Standing review rules learned from this run's own corrections |
-| [src/prompt_fragments.py](src/prompt_fragments.py) | 104 | Shared prompt blocks generated from the validators' own constants |
-
-Supporting modules: [operator.py](src/operator.py) and [operator_codex.py](src/operator_codex.py) (the Claude and Codex CLI adapters — stage session state, live streaming, resume fallback), [approval_agent.py](src/approval_agent.py), [intake.py](src/intake.py), [manifest.py](src/manifest.py), [artifact_index.py](src/artifact_index.py), [experiment_manifest.py](src/experiment_manifest.py), [evidence_ledger.py](src/evidence_ledger.py), [hypothesis_manifest.py](src/hypothesis_manifest.py), [writing_manifest.py](src/writing_manifest.py), [bootstrap.py](src/bootstrap.py) and [project_bootstrap.py](src/project_bootstrap.py), [platform/foundry.py](src/platform/foundry.py), [run_skills.py](src/run_skills.py), [prompts/](src/prompts), [skills/](src/skills), and [backend/](src/backend) + [frontend/](src/frontend) for the Studio.
-
-The full module map, the stage attempt loop and the extension points are in **[docs/architecture.md](docs/architecture.md)**.
-
-## 📚 Documentation
-
-The [docs/](docs/) directory is the reference documentation. This README is the overview; everything below is the detail behind it.
-
-| | |
-| --- | --- |
-| [English Guide](docs/tutorial_en.md) · [中文教程](docs/tutorial_zh.md) | Install, run your first project end to end, review each stage, and write feedback that actually improves output. |
-| [CLI Reference](docs/cli-reference.md) | Every flag on `main.py` and `studio.py`, defaults, what is preserved on resume, exit codes. |
-| [Configuration](docs/configuration.md) | `run_config.json`, the venue registry, diagram setup, environment variables, hard-coded limits. |
-| [Run Artifacts](docs/run-artifacts.md) | The run directory, file by file, and the schema of every machine-readable artifact. |
-| [Stage Contract](docs/stage-contract.md) | Exactly what a stage must produce to be accepted, as `validate_stage_artifacts` enforces it. |
-| [Recursive Self-Improvement](docs/self-improvement.md) | The stage graph, routing, the rigour rubric and the champion ratchet, the cross-run archive — and the constraints that stop a scored loop from optimising toward a nicer answer. |
-| [Review Panel](docs/review-panel.md) | The five seats, the independent round and the cross-examination that only runs on disagreement, blocking objections, `--panel-models`, `--persona`, and the solo baseline every panel run measures itself against. |
-| [Ideation Panel](docs/ideation-panel.md) | The five proposer lenses, Jaccard deduplication, scoring into a candidate pool, and the adoption measurement taken after the stage is approved. |
-| [Studio Guide & API](docs/studio.md) | The browser workspace and its complete HTTP API. |
-| [ResearchClawBench](docs/researchclawbench.md) | Running with no human in the loop: unattended execution, the benchmark adapter and its output contract, and Gemini-backed web search. |
-| [ResearchClawBench Landscape](docs/researchclawbench-landscape.md) | How EvoScientist, ARIS Codex and MIRA actually score on the benchmark, which reported numbers reproduce, and the baseline any result must be quoted against. |
-| [Architecture](docs/architecture.md) | Layers, the module map with line counts, the stage walk, prompt assembly by typed channel, recovery, extension points. |
-| [Development](docs/development.md) | Dev setup, tests, CI, conventions, and recipes for adding a stage, venue, or backend. |
-| [Troubleshooting](docs/troubleshooting.md) | Symptom-to-fix for the errors AutoR actually raises. |
-| [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Code of Conduct](CODE_OF_CONDUCT.md) | How to land a change; the security model, the sandbox trade-offs and how to report a vulnerability; community expectations. |
-
-## 🚧 Limits
-
-Six things the mechanisms above do not close. Each is also the next thing worth building, named at the code that would have to change.
-
-- **The archive's explore proposer does not run.** `propose_exploration` and `unexplored_edges` ([src/archive.py](src/archive.py):595, :576) have no production caller: `record_into_archive` calls `propose_variant` alone ([main.py](main.py):687), and every other reference is in `tests/test_archive_exploration.py`. `propose_variant` reads only believable payoffs, and an edge nobody has taken has no payoff in either direction — so a never-taken backward edge stays untaken.
-- **A crashed adversarial pass is indistinguishable from a clean result.** `_write_review(..., failed=True)` records `reviewer_failed: true` ([src/validity_review.py](src/validity_review.py):405) and no production code reads that flag. Zero findings and a reviewer that never returned are the same input to `validate_validity_response`: nothing owed, gate open.
-- **Attribution stops at the log.** `_record_inbound_channels` ([src/manager.py](src/manager.py):2900) writes which channels reached each stage, but `RunRecord` ([src/archive.py](src/archive.py):113-125) has no channel field, so "this edge helped" cannot yet become "this information helped".
-- **The self-measurement files have no reader in code.** `panel_effect.json` is read only by the function that appends to it, and the adoption marks `measure_adoption` writes back into `idea_pool.json` change no later decision. Both files exist to say when a feature did not earn its cost, and the party they say it to is you.
-- **Most of the recursion is opt-in or partial.** `--max-rounds` defaults to 1 ([main.py](main.py):128), so a round that asks to go back is recorded with `acted_on: false` and a budget note, and the run continues to writing anyway ([src/manager.py](src/manager.py):2741-2755); the archive steers the topology only under `--archive-steer`; and `REVIEWED_STAGE_NUMBERS = (5, 6)` ([src/validity_review.py](src/validity_review.py):42), so nothing attacks Stage 07 or 08.
-- **Studio does not route.** Its lazy-resume approve path picks the next stage by stage number ([src/backend/studio_runner.py](src/backend/studio_runner.py):361-364) and never consults the router, so graph routing is a CLI capability today.
-
-**Intentionally out of scope**: generic multi-agent orchestration, database-backed runtime state, concurrent stage execution, heavyweight platform abstractions, dashboard-first productization.
-
-## 🤝 Contributing
-
-Bug reports, feature requests, documentation fixes, and shared runs are all welcome. Setup is one clone and one command — AutoR's runtime imports nothing outside the standard library and there is no build step. Only the optional Gemini-backed paths (`--web-search gemini`, `--research-diagram`, the cross-model reviewer) need `google-genai`:
+<p align="center">
+  <img src="assets/terminal.png" alt="AutoR terminal UI" width="92%" />
+</p>
+
+The shot above is the real terminal UI: colored stage panels, parsed backend event streams,
+display-width-aware wrapping, keyboard-selectable menus, and a Stage 00 clarification flow that asks
+its questions one at a time.
+
+## News
+
+- **2026-08-11** — Documentation rebuilt against the code: [docs/framework.md](docs/framework.md)
+  added, and every count in this README re-derived from a named symbol.
+- **2026-08-08** — The report plan ([src/report_plan.py](src/report_plan.py)) and the task-deliverables
+  contract ([src/deliverables.py](src/deliverables.py)): a run now commits at Stage 03 to the figures
+  and headline numbers its report will carry, and Stage 07 is refused if the report does not answer
+  what the task statement demanded.
+- **2026-08-06** — **Recursive self-improvement is the default.** The eight stages became a directed
+  graph with a router that must justify its move and is refused off-menu; every valid draft is scored
+  and held to a champion ratchet; the cross-run archive keys every fitness comparison on the stages a
+  run actually measured. Opt out with `--stage-graph linear`, `--routing off`, `--no-evolve`,
+  `--no-archive`.
+- **2026-08-04** — `--rigor {fast,standard,thorough,max}`: one dial over effort tiers, crux
+  deliberation, the ideation panel and the review panel, ordered by what each costs and what evidence
+  there is for it.
+- **2026-06-02** — `--codex-sandbox danger-full-access` for runs that intentionally need remote GPU or
+  SSH execution. Codex still defaults to `workspace-write`.
+- **2026-04-20** — `--full-auto`: the manual approval gate can be replaced by a strict reviewer agent.
+- **2026-04-19** — AutoR Studio merged into main: a local browser workspace over the same run
+  directories.
+
+## Limits
+
+Things the mechanisms above do not close. Each is also the next thing worth building, named at the
+code that would have to change.
+
+- **A crashed adversarial pass is indistinguishable from a clean result.** `_write_review(...,
+  failed=True)` records `reviewer_failed: true` ([src/validity_review.py](src/validity_review.py)) and
+  no production code reads that flag. Zero findings and a reviewer that never returned are the same
+  input to `validate_validity_response`: nothing owed, gate open.
+- **Attribution stops at the log.** `_record_inbound_channels` writes which channels reached each
+  stage, but `RunRecord` ([src/archive.py](src/archive.py)) has no channel field, so "this edge
+  helped" cannot yet become "this information helped".
+- **The frozen preregistration is not checked against itself.** `validate_preregistration` compares
+  the manifest's digest to the recorded `source_digest` and never recomputes the digest of the frozen
+  file. Editing `preregistration.json` in place passes; deleting the manifest silences the check
+  entirely.
+- **Standing rules and obligations never reach a panel seat.** Both are injected only into the solo
+  reviewer's prompt. Under `--review-panel`, no seat is shown the accumulated rules and no seat is
+  asked whether an inherited obligation was met — and because neither the seat nor the chair prompt
+  asks for `carry_forward`, a panel run essentially never creates an obligation either.
+- **The cross-model veto is unreachable from `main.py`.** `--cross-review` is declared and parsed
+  there, but `resolve_cross_reviewer` is called only from `rcb_agent.py`. The feature is live on the
+  benchmark path only.
+- **The validity chain is bypassable in unattended mode.** A stage that burns its five attempts
+  against the gate is auto-skipped, up to `--max-auto-skips` (default 3), and the run proceeds past a
+  gate it never passed.
+- **No mechanism here has evidence that it improves a research output.** `src/trials.py` is the
+  apparatus built to produce that evidence; not one paired trial has been run. The scorecard says
+  when a feature did not change a decision *in this run*, which is a different and weaker claim.
+- **Most of the recursion is opt-in or partial.** `--max-rounds` defaults to 1, so a round that asks
+  to go back is recorded with `acted_on: false` and the run continues to writing anyway; the archive
+  steers only under `--archive-steer`; and `REVIEWED_STAGE_NUMBERS = (5, 6)`, so nothing attacks
+  Stage 07 or 08.
+- **Studio does not route.** Its lazy-resume approve path picks the next stage by stage number and
+  never consults the router, so graph routing is a CLI capability today.
+
+**Intentionally out of scope**: generic multi-agent orchestration, database-backed runtime state,
+concurrent stage execution, heavyweight platform abstractions, dashboard-first productization.
+
+## Contributing
+
+Bug reports, feature requests, documentation fixes, and shared runs are all welcome. Setup is one
+clone and one command — AutoR's runtime imports nothing outside the standard library and there is no
+build step. Only the optional Gemini-backed paths (`--web-search gemini`, `--research-diagram`, the
+cross-model reviewer) need `google-genai`:
 
 ```bash
 git clone https://github.com/tangxiangru/AutoR.git
 cd AutoR
-python -m unittest discover -s tests -p "test_*.py"
+python -m unittest discover -s tests -p "test_*.py"    # 1820 tests, ~70s, no dependencies
 ```
 
-Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request, and [docs/development.md](docs/development.md) before changing code. Security issues go through [SECURITY.md](SECURITY.md), not a public issue. Contributions are assigned to the copyright holder under Section 6 of the [LICENSE](LICENSE), and running AutoR requires written permission — see below.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request, and
+[docs/development.md](docs/development.md) before changing code. Security issues go through
+[SECURITY.md](SECURITY.md), not a public issue. Contributions are assigned to the copyright holder
+under Section 6 of the [LICENSE](LICENSE), and running AutoR requires written permission — see below.
 
-## 📜 License
+## License
 
 **AutoR is proprietary software. It is not open source.**
 
-Copyright © 2026 **Xiangru Tang**. All rights reserved. See [LICENSE](LICENSE) for the full terms and [NOTICE](NOTICE) for the summary.
+Copyright © 2026 **Xiangru Tang**. All rights reserved. Licensed under the AutoR Proprietary
+License 1.0 (`LicenseRef-AutoR-Proprietary-1.0`) — see [LICENSE](LICENSE) for the full terms and
+[NOTICE](NOTICE) for the summary.
 
-This repository is public so that AutoR's design and behaviour can be examined, cited, and discussed. **Publication is not a license.** No right to use, run, copy, modify, fork, or redistribute the Software is granted by its availability here.
+This repository is public so that AutoR's design and behaviour can be examined, cited, and discussed.
+**Publication is not a license.** No right to use, run, copy, modify, fork, or redistribute the
+Software is granted by its availability here.
 
 | | |
 | --- | --- |
@@ -878,4 +965,5 @@ This repository is public so that AutoR's design and behaviour can be examined, 
 | **Not granted** | Any patent license. Any trademark license to the AutoR name or marks. |
 | **Contributions** | Assigned to the copyright holder with a relicensable right (LICENSE §6). |
 
-To request permission, open an issue or contact the copyright holder directly. Permission applies only to the specific use, party, and period stated in writing.
+To request permission, open an issue or contact the copyright holder directly. Permission applies
+only to the specific use, party, and period stated in writing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ detail behind it.
 
 | If you want to… | Read |
 | --- | --- |
+| Understand what AutoR is as a system — design, modules, novelty, contribution | **[The Framework](framework.md)** |
 | Install AutoR and run your first project end to end | [English Guide](tutorial_en.md) · [中文教程](tutorial_zh.md) |
 | Look up a command-line flag | [CLI Reference](cli-reference.md) |
 | Run AutoR unattended, or benchmark it on ResearchClawBench | [ResearchClawBench](researchclawbench.md) |
@@ -24,9 +25,17 @@ detail behind it.
 | Use or script the browser UI | [Studio Guide & HTTP API](studio.md) |
 | Understand how the code is organized | [Architecture](architecture.md) |
 | Hack on AutoR, run the tests, add a stage or a venue | [Development](development.md) |
+| Know when the backend, not the research, is what failed | [Backend Health](backend-health.md) |
 | Fix an error you just hit | [Troubleshooting](troubleshooting.md) |
 
 ## The whole documentation set
+
+### Design
+
+- **[framework.md](framework.md)** — the design document. The problem AutoR is
+  built for, the six commitments that determine its architecture, the control
+  loop, every module and what it owns, what is new here, what it contributes,
+  and what has *not* been established.
 
 ### User guides
 
@@ -37,9 +46,9 @@ detail behind it.
 
 ### Reference
 
-- **[cli-reference.md](cli-reference.md)** — every flag on `main.py` and
-  `studio.py`, what each one defaults to, what is persisted on resume, and
-  which flags are mutually exclusive.
+- **[cli-reference.md](cli-reference.md)** — every flag on `main.py`,
+  `rcb_agent.py` and `studio.py`, what each one defaults to, what is persisted
+  on resume, and which flags are mutually exclusive.
 - **[configuration.md](configuration.md)** — `run_config.json`, the venue
   registry, the optional Gemini diagram config, environment variables, and
   which settings survive a resume.
@@ -62,6 +71,27 @@ detail behind it.
 
 ### Internals
 
+- **[self-improvement.md](self-improvement.md)** — the stage graph and its
+  guards, routing, the rigour rubric and the champion ratchet, the cross-run
+  archive and its comparability basis, paired trials — and the constraints that
+  stop a scored loop from optimising toward a nicer answer.
+- **[rigor.md](rigor.md)** — the one dial: which optional machinery each level
+  turns on, and how an explicit flag overrides it.
+- **[effort-tiers.md](effort-tiers.md)** — routine vs deliberative stages, tier
+  promotion, and concentrating the strong model where something is undecided.
+- **[review-panel.md](review-panel.md)** — the five seats, the blind round and
+  the cross-examination, blocking objections, and the solo baseline every panel
+  run measures itself against.
+- **[ideation-panel.md](ideation-panel.md)** — the five proposer lenses, Jaccard
+  deduplication, and the adoption measurement taken after approval.
+- **[deliberation.md](deliberation.md)** — when a stage may stop and escalate a
+  crux, the four voices, and the falsifier the resolution must name.
+- **[stage-comments.md](stage-comments.md)** — anchored review comments and the
+  collateral-change diff.
+- **[scorecard.md](scorecard.md)** — the five self-measurement ledgers and the
+  end-of-run verdict on which flags earned their cost.
+- **[backend-health.md](backend-health.md)** — telling "the model was
+  unreachable" apart from "the research failed".
 - **[architecture.md](architecture.md)** — layers, module map, the stage
   attempt loop, how prompts are assembled, how recovery works, and the
   extension points.
@@ -107,4 +137,6 @@ Outside this directory:
   `03`.
 - Anything described as *validated* is checked in code, and the source of that
   check is named so you can read it yourself.
-| Know when the backend, not the research, is what failed | [Backend Health](backend-health.md) |
+- Symbols are cited by name rather than by `file.py:NNN`. Line anchors drift
+  with every refactor, and an anchor pointing at the wrong line is worse than
+  no anchor; a symbol name can be grepped.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,23 +23,29 @@ survives a crash because it was never anywhere else.
 **No conversation crosses a stage boundary.** Stage 05 cannot see Stage 03's
 session. What crosses is `memory.md` — the approved stage summaries — plus
 `handoff/<slug>.md`, the same summaries cut down to Objective / Key Results /
-Files Produced (`write_stage_handoff`, `src/utils.py:1628`), plus thirteen typed
-channels in [`src/information_flow.py`](../src/information_flow.py), each of
-which declares which stages read it. Memory and the handoff are the free text;
+Files Produced (`write_stage_handoff`), plus **sixteen** typed channels in
+[`src/information_flow.py`](../src/information_flow.py), each of which declares
+which stages read it. Memory and the handoff are the free text;
 everything else that crosses a boundary is a typed channel or a JSON artifact.
 Approval stays load-bearing because it is what puts a summary into memory and
 what triggers the preregistration freeze; a refused stage propagates neither.
 
 **Two different kinds of check, deliberately separated.**
-`validate_stage_artifacts` ([`src/utils.py`](../src/utils.py):1232-1490) runs
-artifact gates — this file exists, is parseable, is fresh, cross-references
-correctly — and then runs seven validity-chain validators that ask whether a
-claim is warranted: `validate_preregistration`,
-`validate_experimental_protocol`, `validate_hypothesis_outcomes`,
-`validate_outcome_statistics`, `validate_claim_provenance`,
-`validate_validity_response`, `validate_round_decision`. The code labels the
-split itself at `src/utils.py:1292-1297`. A run can fail because a claim is
-unwarranted, not only because a file is absent.
+`validate_stage_artifacts` ([`src/utils.py`](../src/utils.py)) runs artifact
+gates — this file exists, is parseable, is fresh, cross-references correctly —
+and then runs the validators that ask whether a *claim* is warranted:
+`validate_preregistration`, `validate_experimental_protocol`,
+`validate_hypothesis_outcomes`, `validate_outcome_statistics`,
+`validate_claim_provenance`, `validate_validity_response`,
+`validate_round_decision`, plus the three report-plan validators
+(`validate_report_plan`, `validate_report_plan_sources`,
+`validate_report_plan_coverage`) and the task-deliverables gate
+(`validate_deliverables_coverage`). Seventeen `validate_*` functions are
+reachable from it in total; the full table is in the
+[README](../README.md#the-stage-contract-and-what-gets-validated). The code
+labels the split itself: *"the scientific-validity chain, distinct from the
+artifact gates around it"*. A run can fail because a claim is unwarranted, not
+only because a file is absent.
 
 **Nothing that measures may also approve.** The rubric scores, the evolution
 controller reverts, the adversarial reviewer objects, the archive reorders
@@ -56,7 +62,11 @@ the agent learned in it.
 
 ```
 ┌───────────────────────────────────────────────────────────────────┐
-│  Interfaces    main.py (terminal)            studio.py (browser)  │
+│  Interfaces    main.py (terminal)  studio.py (browser)            │
+│                rcb_agent.py (benchmark adapter)                   │
+├───────────────────────────────────────────────────────────────────┤
+│  Policy        rigor · effort                                     │
+│                which optional machinery this run uses at all      │
 ├───────────────────────────────────────────────────────────────────┤
 │  Walk          ResearchManager · stage_graph · router             │
 │                which moves are admissible · which one is taken    │
@@ -64,13 +74,18 @@ the agent learned in it.
 │  Gates         utils.validate_stage_markdown / _stage_artifacts   │
 │                artifact gates ┊ preregistration ·                 │
 │                               ┊ experimental_protocol ·           │
+│                               ┊ report_plan · deliverables ·      │
 │                               ┊ validity_review · research_rounds │
 ├───────────────────────────────────────────────────────────────────┤
-│  Improvement   rubric → evolution → pareto → archive              │
+│  Improvement   rubric → evolution → pareto                        │
 │                measures a draft; cannot approve one               │
 ├───────────────────────────────────────────────────────────────────┤
 │  Review        approval_agent · review_panel · cross_reviewer     │
+│                validity_review · deliberation · stage_comments    │
 │                review_policy · obligations                        │
+├───────────────────────────────────────────────────────────────────┤
+│  Self-measure  scorecard · archive · decisions · trials·inference │
+│                did any of the above earn its cost?                │
 ├───────────────────────────────────────────────────────────────────┤
 │  Contract      utils · manifest · information_flow ·              │
 │                prompt_fragments · artifact_index ·                │
@@ -78,6 +93,7 @@ the agent learned in it.
 │                hypothesis_manifest · writing_manifest             │
 ├───────────────────────────────────────────────────────────────────┤
 │  Execution     OperatorProtocol → ClaudeOperator · CodexOperator  │
+│                web_search · mcp_web_search · backend_health       │
 ├───────────────────────────────────────────────────────────────────┤
 │  Backend CLI   claude                        codex                │
 └───────────────────────────────────────────────────────────────────┘
@@ -93,9 +109,13 @@ layers writes a prompt; and the improvement layer never approves.
 
 ## Module map
 
-Line counts are the shape of the system: `manager.py` (2955) and `utils.py`
-(2214) are the two largest files in the repo, and after them the four largest
-counted below are the panel, the rubric, the archive and the graph.
+Line counts are the shape of the system: `manager.py` (3772) and `utils.py`
+(2386) are the two largest files in the repo, and after them come `operator.py`
+(1630), `review_panel.py` (1277), `main.py` (1194), `report_plan.py` (1103),
+`rcb.py` (1037) and `stage_graph.py` (1000). 150 modules, ~62 k lines, 1820
+tests. For the design argument behind this layering — why a gate reads the
+filesystem rather than the transcript, and why the improvement layer is
+forbidden from touching a verdict — see **[framework.md](framework.md)**.
 
 ### Entry points
 
@@ -103,57 +123,85 @@ counted below are the panel, the rubric, the archive and the graph.
 | --- | --- |
 | [`main.py`](../main.py) | CLI parsing, backend and reviewer construction, archive wiring, new-run vs resume dispatch. Contains no workflow logic. |
 | [`studio.py`](../studio.py) | Three-line shim over `src/backend/studio_http.main`. |
+| [`rcb_agent.py`](../rcb_agent.py) | The ResearchClawBench adapter entry point: 37 flags, its own unattended defaults, `BENCHMARK_MIN_REPORT_FIGURES = 3`, and the only production caller of `resolve_cross_reviewer`. |
+| [`tools/score_rcb_run.py`](../tools/score_rcb_run.py) | Scores a finished benchmark run. `--judge reference` (the default) is gpt-5.1, which is what ResearchClawBench itself scores with; `--judge vertex` is the Anthropic fallback. |
+| [`tools/archive_sample_complexity.py`](../tools/archive_sample_complexity.py) | Prints how many runs the archive needs before an edge becomes believable, then exits. |
+
+### Policy
+
+| Module | Lines | Responsibility |
+| --- | --- | --- |
+| [`src/rigor.py`](../src/rigor.py) | 122 | The one dial. `LEVELS = (fast, standard, thorough, max)`, `DEFAULT_LEVEL = standard`, and `_LEVEL_FEATURES` mapping each level to the optional features it enables — `effort_tiers`, `deliberation`, `ideation_panel`, `review_panel`. `resolve()` writes the decision onto the parsed args before anything reads them; an explicit `--flag`/`--no-flag` always wins, which is why those switches use `BooleanOptionalAction` with `default=None`. |
+| [`src/effort.py`](../src/effort.py) | 349 | `EffortPlan`, `TierDecision`, `Concentration`. Each stage runs as `routine` or `deliberative`; `DEFAULT_TIERS` marks 04, 05 and 08 routine. A routine stage gets a lean prompt, `manager.solo_reviewer` instead of the panel, and no polish rounds. Each stage declares the next one's tier; a routine stage that fails twice is promoted. Both directions of mis-spending are recorded in `workspace/reviews/effort.json`. |
 
 ### The walk
 
 | Module | Lines | Responsibility |
 | --- | --- | --- |
-| [`src/manager.py`](../src/manager.py) | 2955 | `ResearchManager` — "walk the stage graph until it reaches `finish` or nothing is open" (`:412`). Owns intake, the attempt loop, prompt assembly, validation dispatch, the approval menu, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto, the inbound-channel record, repair, resume, redo and rollback. |
-| [`src/stage_graph.py`](../src/stage_graph.py) | 724 | Eight stages plus `FINISH` as a directed graph. Six of the seven forward edges carry a guard (`_ADVANCE_GUARDS`, `:266-273`) evaluated against artifacts on disk; `REVISIT_EDGES` (`:301-359`) adds ten backward moves; `DEFAULT_MAX_VISITS = 3` (`:76`) is a per-node budget. `moves()` (`:555`) returns blocked edges *with* the reason they are blocked, and `repeats_a_previous_reason()` (`:652`) refuses a revisit already justified on the same grounds. |
-| [`src/router.py`](../src/router.py) | 385 | Picks among admissible moves and records why. `--routing auto` asks only where more than one move is live. A choice outside the menu is refused, appended to `evolution/routing_refusals.jsonl` (`:186`), and replaced by the forward edge. |
-| [`src/research_rounds.py`](../src/research_rounds.py) | 320 | Stages 03-06 as a repeatable round. Stage 06 records `converged`, `refine_design`, `new_hypothesis` or `abandon`; `converged` with nothing supported is refused unless the round declares `negative_result` (`:161`). Bounded by `--max-rounds`, which defaults to 1. |
+| [`src/manager.py`](../src/manager.py) | 3772 | `ResearchManager` — "walk the stage graph until it reaches `finish` or nothing is open" (`:412`). Owns intake, the attempt loop, prompt assembly, validation dispatch, the approval menu, the evolution controller, the freeze/amend seam, the validity review, the round close, the obligation ledger, the cross-review veto, the inbound-channel record, repair, resume, redo and rollback. |
+| [`src/stage_graph.py`](../src/stage_graph.py) | 1000 | Eight stages plus `FINISH` as a directed graph. Six of the eight forward edges carry a guard (`_ADVANCE_GUARDS`) evaluated against artifacts on disk; `REVISIT_EDGES` adds thirteen backward moves and `TERMINAL_EDGES` one conditional finish, for twenty-two edges in the default `adaptive` topology against nine in `linear`; `DEFAULT_MAX_VISITS = 3` is a per-node budget and `DEFAULT_MAX_STEPS = 20` bounds the walk. `moves()` returns blocked edges *with* the reason they are blocked, and `repeats_a_previous_reason()` refuses a revisit already justified on the same grounds. |
+| [`src/router.py`](../src/router.py) | 536 | Picks among admissible moves and records why. `--routing auto` asks only where more than one move is live. A choice outside the menu is refused, appended to `evolution/routing_refusals.jsonl` (`:186`), and replaced by the forward edge. |
+| [`src/research_rounds.py`](../src/research_rounds.py) | 411 | Stages 03-06 as a repeatable round. Stage 06 records `converged`, `refine_design`, `new_hypothesis` or `abandon`; `converged` with nothing supported is refused unless the round declares `negative_result` (`:161`). Bounded by `--max-rounds`, which defaults to 1. |
 | [`src/terminal_ui.py`](../src/terminal_ui.py) | | All terminal rendering: banners, stage panels, backend event streams, display-width-aware markdown wrapping, keyboard-selectable menus. The manager never writes to stdout directly. |
 
 ### Gates
 
 | Module | Lines | Responsibility |
 | --- | --- | --- |
-| [`src/utils.py`](../src/utils.py) | 2214 | The contract layer. `STAGES`, `RunPaths`/`build_run_paths`, `REQUIRED_STAGE_HEADINGS`, `FIXED_STAGE_OPTIONS`, prompt assembly, `validate_stage_markdown`, `validate_stage_artifacts`, memory rendering, handoff read/write, venue resolution, `run_config.json` I/O, and every default the CLI overrides. |
+| [`src/utils.py`](../src/utils.py) | 2386 | The contract layer. `STAGES`, `RunPaths`/`build_run_paths`, `REQUIRED_STAGE_HEADINGS`, `FIXED_STAGE_OPTIONS`, prompt assembly, `validate_stage_markdown`, `validate_stage_artifacts`, memory rendering, handoff read/write, venue resolution, `run_config.json` I/O, and every default the CLI overrides. |
 | [`src/preregistration.py`](../src/preregistration.py) | 579 | Freezes and hashes the hypothesis set before results exist, adjudicates every frozen hypothesis at Stage 06 against a named result artifact, and traces every manuscript claim back to a supported hypothesis at Stage 07. A post-freeze change is legal only as an `amend_preregistration` (`:234`) amendment carrying the previous digest. |
 | [`src/experimental_protocol.py`](../src/experimental_protocol.py) | 234 | Declares the primary metric, the seed count and each baseline's `why_competent` and `tuning_budget` before the experiments run. `MIN_SEEDS_FOR_A_VERDICT = 2` (`:37`) refuses a supported/refuted verdict resting on one run unless the run says why one run settles it. |
-| [`src/validity_review.py`](../src/validity_review.py) | 512 | The adversarial pass after Stages 05 and 06 (`REVIEWED_STAGE_NUMBERS`, `:42`). Asks why the result is wrong across ten named failure modes rather than whether the stage is complete, and requires the next stage to answer every finding. Has no authority to approve or reject. |
+| [`src/validity_review.py`](../src/validity_review.py) | 510 | The adversarial pass after Stages 05 and 06 (`REVIEWED_STAGE_NUMBERS`, `:42`). Asks why the result is wrong across ten named failure modes rather than whether the stage is complete, and requires the next stage to answer every finding. Has no authority to approve or reject. |
 | [`src/manifest.py`](../src/manifest.py) | | `run_manifest.json`: stage lifecycle, status transitions, rollback and stale marking, memory rebuild from approved entries. |
 | [`src/artifact_index.py`](../src/artifact_index.py) | | Scans `data/`, `results/`, `figures/`; infers or reads declared schemas; writes `artifact_index.json`. |
 | [`src/experiment_manifest.py`](../src/experiment_manifest.py) | | Builds and validates `results/experiment_manifest.json` as a view over the artifact index. |
 | [`src/evidence_ledger.py`](../src/evidence_ledger.py) | | Validates the Stage 01 `sources.json`/`claims.json` pair and the Stage 07 `citation_verification.json`. |
 | [`src/hypothesis_manifest.py`](../src/hypothesis_manifest.py) | | Parses Stage 02's typed `T*`/`H*`/`C*` identifiers into `hypothesis_manifest.json` — the input the `has_hypotheses` guard reads. |
 | [`src/writing_manifest.py`](../src/writing_manifest.py) | | Stage 07 support: writing manifest, figure/result scanning, layout review generation and validation. |
+| [`src/report_plan.py`](../src/report_plan.py) | 1103 | The report contract. `PlannedFigure`, `HeadlineNumber`, `TaskOutput`, `ReportPlan`. The run commits at Stage 03 to which figures the report will carry and which claim each supports; `stamp_report_plan` writes `declared_at` and a digest to `runs/<id>/report_plan_stamp.json` — outside `workspace/`, so the agent cannot backdate its own declaration. Three validators hang off it, at Stage 03 (shape), 06 (every `source_artifact` resolves and is non-empty) and 07 markdown (every non-dropped slot published *and* referenced). |
+| [`src/deliverables.py`](../src/deliverables.py) | 221 | The task-deliverables contract — the only gate that asks whether the run answered *what it was asked*. `demanding_sentences()` parses the user's own task statement for 34 demand verbs; `validate_deliverables_coverage` requires every `task_quote` to be a verbatim span of `user_input.txt`, every addressed entry to name a `where` that appears in `report.md`, and every demanding sentence to be covered at >= 34% content-word overlap. `format_deliverables_for_prompt` injects a `# What the Task Asks For` block into every stage prompt. |
 
 ### Improvement
 
 | Module | Lines | Responsibility |
 | --- | --- | --- |
-| [`src/rubric.py`](../src/rubric.py) | 926 | Eight weighted criteria read off disk with no backend call (`CRITERIA`, `:135-143`), including `reproducibility` (3.0), which walks the same validity chain the gate walks, and `commitment` (1.5), which counts hedge patterns. Verdicts are read only through `_verdict_blind_outcomes` (`:260`), so the score carries no gradient toward changing an answer. |
-| [`src/evolution.py`](../src/evolution.py) | 692 | The champion ratchet. `consider()` (`:248`) scores each valid draft; `_revert()` (`:383`) copies the champion back over a losing polish round before the reviewer sees it; a round whose `verdict_digest` moved is rejected whatever it scored (`:306-327`); a human-directed revision is exempt (`:288-304`). `measure=True`, `rounds=2` by default (`:97`, `:102`). |
+| [`src/rubric.py`](../src/rubric.py) | 936 | Eight weighted criteria read off disk with no backend call (`CRITERIA`, `:135-143`), including `reproducibility` (3.0), which walks the same validity chain the gate walks, and `commitment` (1.5), which counts hedge patterns. Verdicts are read only through `_verdict_blind_outcomes` (`:260`), so the score carries no gradient toward changing an answer. |
+| [`src/evolution.py`](../src/evolution.py) | 727 | The champion ratchet. `consider()` (`:248`) scores each valid draft; `_revert()` (`:383`) copies the champion back over a losing polish round before the reviewer sees it; a round whose `verdict_digest` moved is rejected whatever it scored (`:306-327`); a human-directed revision is exempt (`:288-304`). `measure=True`, `rounds=2` by default (`:97`, `:102`). |
 | [`src/pareto.py`](../src/pareto.py) | 212 | Keeps drafts that are non-dominated on the criterion vector even when they lose on the weighted total (`frontier`, `:74`). `complementary_pair` (`:153`) names the two whose merge has the most headroom — the only place two drafts are combined rather than ranked. |
-| [`src/archive.py`](../src/archive.py) | 784 | Cross-run record under `~/.autor/archive`. `record_run` (`:426`) stores route, edges and per-stage fitness; `edge_payoffs` compares runs that took an edge against runs that reached the same node and did not; `propose_variant` (`:512`) reorders priorities and can never open, add or remove a guard. Promotion requires a win within every `comparability_basis` (`:91`), so halting early cannot raise mean fitness. |
+| [`src/archive.py`](../src/archive.py) | 974 | Cross-run record under `~/.autor/archive`. `record_run` (`:426`) stores route, edges and per-stage fitness; `edge_payoffs` compares runs that took an edge against runs that reached the same node and did not; `propose_variant` (`:512`) reorders priorities and can never open, add or remove a guard. Promotion requires a win within every `comparability_basis` (`:91`), so halting early cannot raise mean fitness. |
+
+### Self-measurement
+
+Every optional mechanism in AutoR runs its own control arm and writes a ledger. This layer reads
+them. See [framework.md](framework.md#53-machinery-that-reports-on-itself-in-the-unflattering-direction)
+for why.
+
+| Module | Lines | Responsibility |
+| --- | --- | --- |
+| [`src/scorecard.py`](../src/scorecard.py) | 319 | `FEATURES` maps five ledgers — `panel_effect.json`, `idea_pool.json`, `comment_ledger.json`, `deliberations.json`, `effort.json` — to assessor functions. `write_scorecard` runs from `ResearchManager._report_optional_machinery` at the end of every run and writes `workspace/reviews/scorecard.md`, keeping "could not be measured" strictly apart from "changed nothing". |
+| [`src/decisions.py`](../src/decisions.py) | 269 | `Decision`, `decisions_from`, `offered_payoffs`, `believable_evidence`. Replaces the run-level control arm ("reached the node and did not take the edge") with the decision-level one ("was *offered* the edge and declined"), and feeds the archive's numbers into the routing prompt. |
+| [`src/trials.py`](../src/trials.py) | 384 | Paired A/B trials over archived runs tagged with `--trial`/`--capability`/`--arm`. `collect_pairs` excludes fake-provenance and stale-rubric arms; `sign_flip_p` is an exact two-sided paired permutation test; `min_attainable_p` prints the floor beside it; `MIN_PAIRS_FOR_SIGNIFICANCE = 6` labels anything smaller `underpowered`. Reachable only from `main.py --trial-report`; **no trial has been run**. |
+| [`src/inference.py`](../src/inference.py) | 167 | `unpaired_floor`, `paired_floor`, `minimum_arms_for`, `unpaired_permutation`. Derives `DEFAULT_MIN_OBSERVATIONS` in `archive.py` from the size of the edge family rather than asserting a threshold. |
+| [`tools/archive_sample_complexity.py`](../tools/archive_sample_complexity.py) | 259 | Simulates how many runs the archive needs before an edge becomes believable, per edge and under an exploration policy. Prints, exits. |
 
 ### Review
 
 | Module | Lines | Responsibility |
 | --- | --- | --- |
 | [`src/approval_agent.py`](../src/approval_agent.py) | | `AutomatedReviewer` — the strict reviewer agent that stands in for the human gate under `--full-auto`. Returns a `ReviewDecision`, and renders the standing rules and open obligations into its own prompt. |
-| [`src/review_panel.py`](../src/review_panel.py) | 1223 | Five seats. Round 1 is independent; a cross-examination round runs only if that round was not unanimous, up to `--panel-rounds` (default 2, `:513`); then the chair synthesizes one decision. The Adversarial Reviewer's exposure is `"none"` (`:256`); peers are anonymised in round 2 (`:893`); abstention is a first-class verdict (`:325`); an unreachable member breaks unanimity rather than counting as agreement (`_is_unanimous`, `:723`); `_enforce_blocking_objections` (`:783`) converts a chair's approval into a refusal in code. `record_panel_effect` (`:1143`) accumulates the chair's round-1 solo verdict as the panel's own control arm. |
+| [`src/review_panel.py`](../src/review_panel.py) | 1277 | Five seats. Round 1 is independent; a cross-examination round runs only if that round was not unanimous, up to `--panel-rounds` (default 2, `:513`); then the chair synthesizes one decision. The Adversarial Reviewer's exposure is `"none"` (`:256`); peers are anonymised in round 2 (`:893`); abstention is a first-class verdict (`:325`); an unreachable member breaks unanimity rather than counting as agreement (`_is_unanimous`, `:723`); `_enforce_blocking_objections` (`:783`) converts a chair's approval into a refusal in code. `record_panel_effect` (`:1143`) accumulates the chair's round-1 solo verdict as the panel's own control arm. |
 | [`src/cross_reviewer.py`](../src/cross_reviewer.py) | 239 | A second opinion from a different model family, applied only to approvals. A veto, never an override; an auditor that errors or returns unparseable output is recorded `unavailable` (`:60`, `:111-134`), never as agreement. |
 | [`src/review_policy.py`](../src/review_policy.py) | 212 | Corrections the reviewer demanded become standing rules in `runs/<id>/review_policy.json` (`policy_path`, `:103`) and are rendered into every later review prompt. Per-run: nothing carries a rule into the next run. |
 | [`src/obligations.py`](../src/obligations.py) | 306 | What an approving reviewer says a later stage still owes. Written to `runs/<id>/obligations.json` (`:160`), injected into that stage's prompt *and* its review, discharged only by a reviewer (`discharge_obligations`, `:226`), with deferrals counted rather than silent (`note_deferrals`, `:249`). |
-| [`src/ideation_panel.py`](../src/ideation_panel.py) | 712 | Stage 02 divergence: five proposer lenses, Jaccard deduplication, scoring into a candidate pool the stage chooses from. Decides nothing. `measure_adoption` (`:604`) marks afterwards which pooled candidates the approved stage actually built on. |
+| [`src/ideation_panel.py`](../src/ideation_panel.py) | 735 | Stage 02 divergence: five proposer lenses, Jaccard deduplication, scoring into a candidate pool the stage chooses from. Decides nothing. `measure_adoption` (`:604`) marks afterwards which pooled candidates the approved stage actually built on. |
+| [`src/deliberation.py`](../src/deliberation.py) | 751 | The crux panel — not a reviewer of a stage. The executing agent writes a question to `workspace/notes/deliberation_request.json`; four voices (theorist, empiricist, critic, pragmatist) each commit to an answer and then argue against themselves; a resolver produces an answer that must name its own falsifier. Budgeted by `--max-deliberations` (3); a crux similar (>= 0.6) to one already answered reuses the stored answer. |
+| [`src/stage_comments.py`](../src/stage_comments.py) | 375 | Anchored comments. A comment must quote >= 12 characters findable in the draft; an unfindable quote is recorded `unanchored` and dropped. The revision is told to change only those spans, and the next draft is diffed to count anchored against collateral line changes into `workspace/reviews/comment_ledger.json`. |
 
 ### Context and inputs
 
 | Module | Lines | Responsibility |
 | --- | --- | --- |
-| [`src/information_flow.py`](../src/information_flow.py) | 395 | Thirteen typed channels (`CHANNELS`, `:240-395`). Each declares `produced_by`, a `consumed_by` set of real stage slugs, and a rationale for every narrowing. `render_inbound()` composes a stage's context per consumer; `dependency_edges()` prints the producer→consumer topology. |
+| [`src/information_flow.py`](../src/information_flow.py) | 553 | Sixteen typed channels (`CHANNELS`). Each declares `produced_by`, a `consumed_by` set of real stage slugs, and a rationale for every narrowing. `render_inbound()` composes a stage's context per consumer; `dependency_edges()` prints the producer→consumer topology. |
 | [`src/prompt_fragments.py`](../src/prompt_fragments.py) | 104 | The rules every stage prompt shares, held once. `compose_stage_template` (`:97`) orders them: the stage's own instructions, then the output-format rules that constrain them, then `RUN_SAFETY`. |
 | [`src/intake.py`](../src/intake.py) | | Stage 00: clarification-question parsing, resource classification and ingestion, `intake_context.json`. Runs before the graph walk begins. |
 | [`src/bootstrap.py`](../src/bootstrap.py) | | `--paper-corpus`: scans your prior papers (PDF/LaTeX/BibTeX) into a researcher profile, citation neighborhood, and style profile. |
@@ -168,6 +216,9 @@ counted below are the panel, the rubric, the archive and the graph.
 | [`src/operator_protocol.py`](../src/operator_protocol.py) | `OperatorProtocol` — the interface the manager depends on. Implement this to add a backend. |
 | [`src/operator.py`](../src/operator.py) | `ClaudeOperator` — session management, prompt-file invocation, live `stream-json` parsing, resume-failure detection and fallback, the repair pass, per-attempt state records. Also the shared base for other CLI backends. |
 | [`src/operator_codex.py`](../src/operator_codex.py) | `CodexOperator` — subclass of `ClaudeOperator` overriding invocation. Runs `codex exec --json`, applies the sandbox mode, and works through a stable temp-directory symlink to the run root. |
+| [`src/web_search.py`](../src/web_search.py) | Gemini-backed search for deployments where the coding agent's own `WebSearch` tool is disabled. `SearchReadiness`/`assess_search_readiness()` report a hard blocker (no key, no SDK) *before* the run starts rather than at Stage 01, and `build_mcp_config()` writes the config the CLI is handed. |
+| [`src/mcp_web_search.py`](../src/mcp_web_search.py) | A stdlib JSON-RPC 2.0 MCP server over stdio exposing one tool, `mcp__autor-search__web_search`. No SDK. A notification (absent `id`) is answered with silence, as the spec requires. |
+| [`src/backend_health.py`](../src/backend_health.py) | `classify`, `describe`, `BackendUnavailable`. Raised out of the stage loop and turned into a `run.backend_unavailable` manifest state, so "the model was unreachable" never reads as "the research failed". |
 
 ### Output
 
@@ -175,8 +226,7 @@ counted below are the panel, the rubric, the archive and the graph.
 | --- | --- |
 | [`src/platform/foundry.py`](../src/platform/foundry.py) | Post-approval packaging: paper package and release package. |
 | [`src/diagram_gen.py`](../src/diagram_gen.py) | Optional Gemini method-diagram generation, injected into `report.md` or `method.tex` depending on the run's output format. |
-| [`src/web_search.py`](../src/web_search.py) | `build_genai_client` and the Gemini backend shared by `--web-search gemini`, `--research-diagram` and the cross-model reviewer. The only place `google-genai` is imported for reviews. |
-| [`src/mcp_web_search.py`](../src/mcp_web_search.py) | An MCP server exposing Gemini search as a real `web_search` tool, so the capability sits where the disabled built-in used to: in the tool list, and in the trace as a named call. Stdlib JSON-RPC over stdio. |
+| [`src/rcb.py`](../src/rcb.py) | The ResearchClawBench export contract: `ensure_workspace_layout`, `build_benchmark_goal`, `collect_reference_resources`, `ReportSynthesizer`, `build_fallback_report`, and `export_run`, which mirrors `code/` and `results/` into the benchmark workspace, picks the report from four ranked sources, and publishes at most `MAX_REPORT_FIGURES` figures into `report/images/`. |
 
 ### Studio
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -214,7 +214,7 @@ description in [Rigor](rigor.md).
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--routine-model MODEL` | - | Model for routine-tier stages, keeping the strong model for the few steps whose output the rest of the run inherits. Requires `--effort-tiers`. |
-| `--effort-tiers` | off | Run each stage as `routine` or `deliberative` instead of treating them alike. Routine gets a lean prompt, a single reviewer, and no escalation offer. Each stage declares what the next needs; a routine stage that fails twice is promoted automatically. |
+| `--effort-tiers` / `--no-effort-tiers` | **on** (from `--rigor standard`, the default) | Run each stage as `routine` or `deliberative` instead of treating them alike. Routine gets a lean prompt, a single reviewer, and no escalation offer. Each stage declares what the next needs; a routine stage that fails twice is promoted automatically. Turn it off with `--no-effort-tiers` or `--rigor fast`. |
 
 Under tiering, polish rounds — the run's most expensive setting — are withheld from routine stages entirely, so the same rounds land only where something is still undecided. Off means exactly the previous behaviour. Both directions of mis-spending are recorded in
 `workspace/reviews/effort.json`. Full description in [Effort Tiers](effort-tiers.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,7 +40,7 @@ pip install google-genai pyyaml
 ## Tests
 
 ```bash
-# Everything (~10s, 234 tests)
+# Everything (~70s, 1820 tests across 83 modules, no third-party dependency)
 python -m unittest discover -s tests -p "test_*.py"
 
 # Verbose

--- a/docs/effort-tiers.md
+++ b/docs/effort-tiers.md
@@ -137,5 +137,11 @@ as routine, which is the thing tiering exists to avoid.
   pass first time because it was done well.
 - **The declaring stage is guessing about work it has not done.** It knows whether *its own*
   decisions are settled, which is a good proxy and not the same thing.
-- **Tiering is off by default, and off means exactly the previous behaviour** — every stage
+- **Tiering is ON by default**, because `--rigor` defaults to `standard` and `standard` enables
+  `effort_tiers` (`_LEVEL_FEATURES`, `src/rigor.py`). `--rigor fast` or an explicit
+  `--no-effort-tiers` turns it off, and off means exactly the previous behaviour — every stage
   deliberative, nothing gated more cheaply by accident.
+- **A consequence worth knowing under `--rigor max`.** `DEFAULT_TIERS` marks `04_implementation`,
+  `05_experimentation` and `08_dissemination` routine, and a routine stage is reviewed by
+  `manager.solo_reviewer` rather than the seated panel. So `--rigor max` alone does not put the
+  panel at those three gates; `--rigor max --no-effort-tiers` does.

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1,0 +1,528 @@
+# The AutoR Framework
+
+*What this system is, how it is built, what is new in it, and what it contributes.*
+
+This is the design document. [The README](../README.md) is the overview and the operating manual;
+[architecture.md](architecture.md) is the module map; this page is the argument. Every claim here
+names the symbol that implements it, so it can be checked rather than believed.
+
+---
+
+## Contents
+
+1. [The problem](#1-the-problem)
+2. [The design commitments](#2-the-design-commitments)
+3. [Implementation: the control loop](#3-implementation-the-control-loop)
+4. [The modules, by layer](#4-the-modules-by-layer)
+5. [Novelty](#5-novelty)
+6. [Contribution](#6-contribution)
+7. [What has not been established](#7-what-has-not-been-established)
+
+---
+
+## 1. The problem
+
+A coding agent is already a competent research executor. Give one a GPU, a dataset and a clear
+instruction and it will write the training loop, run the sweep, make the plot and describe what it
+found. That capability is not the bottleneck.
+
+The bottleneck is that **nothing in the loop distinguishes a finding from a fluent description of
+one.** Three failure modes recur, and they are all invisible to the artifact the agent produces:
+
+1. **Post-hoc hypothesis.** The agent runs the experiment, sees the result, and writes the
+   hypothesis the result supports. Nothing in the transcript reveals the reordering, because the
+   final document is written last either way.
+2. **The self-graded loop.** Ask the agent to improve its own work and it will produce something
+   different and describe it as better. Iteration without an external measurement is drift with a
+   progress bar.
+3. **The unfalsifiable report.** Prose is a lossy encoding of evidence. "The method improves
+   performance" survives the loss of the number, the seed, the baseline and the file that would have
+   let a reader disagree.
+
+Existing research harnesses mostly attack the *capability* gap: better tools, more subagents, longer
+memory, accumulated skills. AutoR attacks the *warrant* gap. Its thesis is that the interesting
+engineering problem is not making an agent produce more research-shaped output, but building a
+structure in which a claim that is not warranted **cannot be advanced** — enforced in code, not in a
+prompt.
+
+The design constraint that follows: **every mechanism must be a file on disk and a function that
+refuses.** Not an instruction the model is asked to follow, not a persona, not a self-report. A
+prompt asking a model to be rigorous is a wish. A validator that reads `hypothesis_outcomes.json`,
+resolves each cited evidence path, and returns a non-empty problem list is a gate.
+
+---
+
+## 2. The design commitments
+
+Six commitments determine most of the architecture. Each one is a decision that could have gone the
+other way, and each one costs something.
+
+### 2.1 The human owns the approval gate
+
+`approval_mode` is `manual` unless a flag opts out. Of the eight recursive mechanisms, seven can only
+**score, refuse, revert or re-order** — none can approve a stage. The eighth, the review panel, *is*
+an approval gate, and only exists on runs where you hand it the gate.
+
+*Cost:* a default run is not autonomous, and cannot be benchmarked without `--full-auto`.
+*Why anyway:* the alternative is a system whose most consequential act — deciding that a stage is
+done — is performed by the same model family that produced the work.
+
+### 2.2 A gate reads the filesystem, not the transcript
+
+Every gate in AutoR takes `RunPaths` and returns a list of problems. It does not read the model's
+account of what it did; it reads what is on disk. `validate_hypothesis_outcomes` does not ask whether
+the agent says it adjudicated H1 — it opens `workspace/results/hypothesis_outcomes.json`, checks the
+verdict is one of four legal tokens, and resolves every cited evidence path to a file that exists.
+
+*Cost:* the agent has to write machine-readable artifacts it would not otherwise write, and the gate
+has to be told about every new artifact class.
+*Why anyway:* a check over a self-report measures the model's willingness to describe itself
+accurately, which is exactly the variable under test.
+
+### 2.3 Commitments are frozen before the evidence exists
+
+`freeze_preregistration()` copies the typed hypothesis manifest into `preregistration.json` with a
+`digest` and a `source_digest` when Stage 04 is approved, and never overwrites it. From Stage 05 on,
+every empirical hypothesis must carry a `decision_rule` stated **before** the experiment. At Stage
+06, exactly one verdict per frozen hypothesis, adjudicating nothing that was not preregistered. The
+same shape applies to the report: `report_plan.json` commits at Stage 03 to which figures the report
+will carry and which claim each supports, and it is stamped into
+`runs/<id>/report_plan_stamp.json` — deliberately **outside** `workspace/`, so the agent cannot
+backdate its own declaration.
+
+*Cost:* a run that discovers something better at Stage 06 has to file an amendment rather than just
+change the plan.
+*Why anyway:* this is the only structural defence against the post-hoc hypothesis, and an amendment
+with a `previous_digest` is a record of the change rather than an erasure of it.
+
+### 2.4 The improvement loop is scored by something it cannot influence
+
+`src/rubric.py` scores a draft on eight weighted criteria, **never calls a backend**, and is
+**verdict-blind**: a refuted hypothesis with clean evidence outscores a supported one resting on an
+assertion. `src/evolution.py` keeps the champion and reverts a round that scores worse. On top of
+that, `verdict_digest()` hashes the `(id, verdict)` set, and any AutoR-initiated polish round that
+moves it is rejected outright with a `verdict_drift` ledger row.
+
+*Cost:* the rubric can only measure what is mechanically checkable, so it is blind to whether the
+idea is any good.
+*Why anyway:* a self-improvement loop scored by a model develops a taste for whatever that model
+likes. Removing the incentive (verdict-blindness) and then removing the possibility (drift
+rejection) is belt and braces, on purpose: the failure it prevents — a loop that improves its
+*answer* rather than its *work* — is the one that would be hardest to detect after the fact.
+
+### 2.5 Every optional mechanism carries its own control arm
+
+A review panel run also records what its chair alone would have decided in round 1: one model, one
+call, no peer input. `panel_effect.json` accumulates panel-vs-solo across the run. The ideation panel
+measures adoption after the stage is approved. Anchored comments are diffed for collateral change.
+Crux deliberation is compared against what the agent already believed. Effort tiers record what they
+routed where. `src/scorecard.py` reads all five ledgers at the end of every run and writes a verdict
+phrased to be unflattering — *"it did not earn that cost; consider dropping the panel"* — when that
+is the truth, and keeps *"could not be measured"* strictly separate from *"changed nothing"*.
+
+*Cost:* every feature is roughly 20% more code than the feature alone would need.
+*Why anyway:* a research harness that cannot say whether its own machinery helps is asking for the
+same credulity it is built to remove.
+
+### 2.6 No runtime dependency outside the standard library
+
+AutoR's runtime imports nothing that is not in the Python standard library. 150 modules, ~62 k lines,
+1820 tests running in ~70 s with no install step. The MCP web-search server
+([`mcp_web_search.py`](../src/mcp_web_search.py)) is a stdlib JSON-RPC 2.0 implementation over stdio
+rather than an SDK. `google-genai` is needed only by three optional paths (`--web-search gemini`,
+`--cross-review`, `--research-diagram`), and each degrades to a recorded *unavailable* rather than a
+crash.
+
+*Cost:* some wheels get reinvented.
+*Why anyway:* a research harness that cannot be run five years from now cannot be used to reproduce
+anything, and a dependency tree is the most common reason a scientific artifact stops running.
+
+---
+
+## 3. Implementation: the control loop
+
+### 3.1 The unit of work
+
+One **run** is one directory: `runs/<run_id>/`. Everything the run knows, produced, was told, and
+decided is inside it. The only state written outside is the optional cross-run archive at
+`~/.autor/archive`. A run is isolated, resumable (`--resume-run`), replayable at a single stage
+(`--redo-stage`), and reversible (`--rollback-stage`).
+
+### 3.2 The walk
+
+Eight stages are nodes in a directed graph ([`stage_graph.py`](../src/stage_graph.py)); a `finish`
+node closes the walk. The default topology is `adaptive`: **22 edges** — eight advance edges of which
+six carry a guard, thirteen `REVISIT_EDGES` that go backward, and one conditional terminal that lets
+an abandoned round finish from Stage 06. `--stage-graph linear` is nine edges and no guards.
+
+```
+                        ┌──────────────── 13 backward edges ─────────────────┐
+                        ▼                                                    │
+  01 ──▶ 02 ──▶ 03 ──▶ 04 ──▶ 05 ──▶ 06 ──▶ 07 ──▶ 08 ──▶ finish             │
+   survey  hypo  design  impl   exp   analysis  write  release               │
+                  ▲       ▲      ▲      ▲        ▲        ▲                  │
+              has_hypo  design  runnable results validity report ────────────┘
+                        artifacts  code   exist   chain    exists
+```
+
+The control loop, per step:
+
+1. **Compose the prompt.** `render_inbound(ChannelContext(...), CHANNELS)` builds the stage's inbound
+   context from the sixteen typed channels in [`information_flow.py`](../src/information_flow.py).
+   Each channel declares `produced_by`, a `consumed_by` set of real stage slugs, and a written
+   `rationale`; a test fails any channel that withholds itself from a stage without saying why.
+2. **Execute.** The prompt is written verbatim to `prompt_cache/` and handed to the coding agent CLI
+   in streaming mode, with a per-stage session ID so a refinement attempt continues the same
+   conversation. A skill pack is installed into the operator's working directory so the agent can
+   *pull* long-form craft guidance instead of being pushed it.
+3. **Validate.** `validate_stage_markdown` checks the seven-heading contract; `validate_stage_artifacts`
+   runs the cumulative artifact gates and the seventeen `validate_*` functions. A failure triggers a
+   repair attempt, then local normalisation, then a full re-run, bounded by `--max-attempts` (5).
+4. **Measure and improve.** Every *valid* draft is scored by the rubric. Up to two polish rounds per
+   stage are budgeted, skipped entirely when no criterion has a shortfall worth acting on. Losing
+   rounds are reverted; the Pareto frontier keeps a draft that loses on the weighted total but is
+   non-dominated on the criterion vector.
+5. **Review.** The gate: a human by default, or a solo agent reviewer, or a five-seat panel. An
+   approval may attach obligations to a later stage; a refusal becomes a standing rule. After Stages
+   05 and 06 an adversarial reviewer attacks the approved result, and the *next* stage is refused
+   until it answers every finding in writing.
+6. **Route.** `StageGraph.moves()` evaluates every edge's guard against the artifacts on disk and
+   hands the agent the admissible moves **plus the reason each blocked one is blocked**. The agent
+   picks and justifies; an off-menu pick, or one with no stated reason, is refused, logged to
+   `routing_refusals.jsonl`, and replaced by the forward edge.
+7. **Record.** The route, the per-stage and per-criterion fitness, the comparability basis, and the
+   decisions that were *offered and declined* go into the archive.
+
+Two properties of step 6 are load-bearing. First, **AutoR owns the menu and the agent owns the
+pick**: the guards are the correctness argument for letting a model route at all, so the component
+that learns from outcomes (the archive) may reorder preferences but can never open a guarded edge,
+add an undeclared one, or remove one. Second, **the default is always forward**. A refusal, a routing
+failure, or a run nobody is steering all come out as the linear pipeline rather than as a stall — a
+backward move is only ever a deliberate, justified choice, and one whose justification repeats a
+reason already on the path is refused as a loop.
+
+### 3.3 The validity chain
+
+The chain that runs unconditionally at every rigor level, `fast` included:
+
+| Point | What happens | Enforced by |
+| --- | --- | --- |
+| Stage 02 | Markdown is parsed into typed `T*`/`H*`/`C*` entries with `decision_rule` | `write_hypothesis_manifest` |
+| Stage 04 approval | The hypothesis set is copied, hashed and frozen; never overwritten | `freeze_preregistration` |
+| Stage 02 re-run | The freeze is re-derived and an amendment row records `previous_digest` | `amend_preregistration` |
+| Stage 05+ | A prereg exists, has an empirical hypothesis, every one has a decision rule, the manifest has not silently changed | `validate_preregistration` |
+| Stage 05+ | A protocol declares a primary metric, planned seeds, and per-baseline `why_competent` + `tuning_budget` | `validate_experimental_protocol` |
+| Stage 06+ | Exactly one verdict per frozen hypothesis, nothing unpreregistered adjudicated, every `supported`/`refuted` verdict citing an evidence file that exists | `validate_hypothesis_outcomes` |
+| Stage 06+ | A verdict carries `n_seeds`, a `dispersion_type` from a fixed vocabulary, and a written justification if a single seed settled it | `validate_outcome_statistics` |
+| Stage 06 close | `converged` is refused when nothing came out supported, unless the round declares `negative_result: true` | `validate_round_decision` |
+| Stage 06→07 edge | The router keeps writing closed until every empirical id has a verdict and a figure exists | `_guard_validity_chain` |
+| Stage 07+ | Every manuscript claim is `confirmatory` on a `supported` hypothesis, or labelled `exploratory` — and cites a file that exists | `validate_claim_provenance` |
+| Stage 07 | The report answers every demanding sentence of the task statement, quoting the task verbatim | `validate_deliverables_coverage` |
+
+Every one of these can be traced from `validate_stage_artifacts` in [`utils.py`](../src/utils.py),
+whose own comment names the split: *"the scientific-validity chain, distinct from the artifact gates
+around it"*.
+
+### 3.4 Rounds, not just stages
+
+Stages 03–06 form a repeatable **round** ([`research_rounds.py`](../src/research_rounds.py)). A round
+closes at Stage 06 with one of four decisions — `converged`, `refine_design`, `new_hypothesis`,
+`abandon` — recorded with the hypothesis verdicts as they stood. This is what makes a refuted
+hypothesis a legitimate outcome that can start a second round rather than a failure to be written
+around. `--max-rounds` defaults to 1, which is the main place the recursion is currently throttled.
+
+### 3.5 The rigor dial
+
+Four levels collapse the optional machinery into one flag ([`rigor.py`](../src/rigor.py)), ordered by
+what each costs and what evidence there is for it:
+
+| `--rigor` | effort tiers | crux deliberation | ideation panel | review panel |
+| --- | :---: | :---: | :---: | :---: |
+| `fast` | – | – | – | – |
+| `standard` *(default)* | **on** | – | – | – |
+| `thorough` | **on** | **on** | **on** | – |
+| `max` | **on** | **on** | **on** | **on** |
+
+An explicit `--flag`/`--no-flag` always beats the level. The validity chain is not on this dial.
+
+---
+
+## 4. The modules, by layer
+
+150 Python modules, ~62 k lines. Grouped by what they own rather than by directory.
+
+### Policy — what machinery this run uses
+
+| Module | Owns |
+| --- | --- |
+| [`rigor.py`](../src/rigor.py) | The four levels and the feature set each turns on. One source of truth. |
+| [`effort.py`](../src/effort.py) | Routine vs deliberative stages; each stage sets the next one's tier; a routine stage that keeps failing is promoted. Concentrates the strong model where something is undecided. |
+
+### The walk — where the run goes next
+
+| Module | Owns |
+| --- | --- |
+| [`manager.py`](../src/manager.py) | The control loop: the attempt/repair/normalise cycle, the freeze seam, the round close, the crux settlement, the obligation ledger, the cross-review call, the inbound-channel record. The largest module, and deliberately so — it is the place the sequencing lives. |
+| [`stage_graph.py`](../src/stage_graph.py) | Nodes, edges, guards, visit budgets, and the two topologies. |
+| [`router.py`](../src/router.py) | The agent's pick among admissible moves, and the refusal of an off-menu or unjustified one. |
+| [`research_rounds.py`](../src/research_rounds.py) | Stages 03–06 as a repeatable round with a recorded closing decision. |
+| [`information_flow.py`](../src/information_flow.py) | Sixteen typed context channels with declared readers and written rationales. |
+
+### Gates — what a stage must produce to be accepted
+
+| Module | Owns |
+| --- | --- |
+| [`utils.py`](../src/utils.py) | `validate_stage_artifacts`: the single cumulative gate that hosts everything below, plus stage metadata, run paths and prompt assembly. |
+| [`preregistration.py`](../src/preregistration.py) | Freeze, amend, adjudicate, trace. |
+| [`hypothesis_manifest.py`](../src/hypothesis_manifest.py) | Stage 02 markdown → typed `T`/`H`/`C` entries. |
+| [`experimental_protocol.py`](../src/experimental_protocol.py) | Declared baselines, seeds and dispersion, fixed before the result. |
+| [`report_plan.py`](../src/report_plan.py) | Figures and headline numbers committed at Stage 03, stamped outside the workspace, enforced at 03, 06 and 07. |
+| [`deliverables.py`](../src/deliverables.py) | Did the run answer what the task statement actually demanded? |
+| [`evidence_ledger.py`](../src/evidence_ledger.py) | Stage 01's `sources.json`/`claims.json` cross-reference, and Stage 07's citation self-report. |
+| [`experiment_manifest.py`](../src/experiment_manifest.py) · [`artifact_index.py`](../src/artifact_index.py) · [`writing_manifest.py`](../src/writing_manifest.py) | The machine-readable inventories later stages read instead of guessing from filenames. |
+
+### Review — five kinds of critic, two of which are the gate
+
+| Module | Owns | Can approve? |
+| --- | --- | :---: |
+| [`approval_agent.py`](../src/approval_agent.py) | The solo gate: six choices, a re-ask-once parser, an unattended fallback that sends back rather than aborting. | yes |
+| [`review_panel.py`](../src/review_panel.py) | Five seats, blind round then anonymised cross-examination then a chair; a blocking objection is enforced *in code* against the chair. | yes |
+| [`cross_reviewer.py`](../src/cross_reviewer.py) | A different model family auditing an approval. Unavailable is never laundered into agreement. | veto only |
+| [`validity_review.py`](../src/validity_review.py) | The adversarial pass after 05 and 06 across ten named failure modes, and the response gate that follows it. | no |
+| [`deliberation.py`](../src/deliberation.py) | The crux panel: four voices, each committing then arguing against itself, resolved into an answer that must name its own falsifier. | no |
+| [`stage_comments.py`](../src/stage_comments.py) | Anchored comments: quote ≥12 characters, change only those spans, diff for collateral. | no |
+| [`obligations.py`](../src/obligations.py) | What a later stage owes; only a reviewer discharges it; deferral is counted. | no |
+| [`review_policy.py`](../src/review_policy.py) | Standing rules learned from this run's own refusals, deduplicated so restatement cannot fake learning. | no |
+
+### Improvement — which draft survives
+
+| Module | Owns |
+| --- | --- |
+| [`rubric.py`](../src/rubric.py) | Eight weighted criteria over a draft and the artifacts it names. Backend-free, verdict-blind, versioned. |
+| [`evolution.py`](../src/evolution.py) | The champion ratchet, the polish budget, the revert, and the `verdict_drift` rejection. |
+| [`pareto.py`](../src/pareto.py) | Non-dominated drafts kept beside the champion. |
+| [`ideation_panel.py`](../src/ideation_panel.py) | Five divergent Stage 02 proposers, Jaccard-deduplicated into a scored candidate pool. It decides nothing. |
+
+### Self-measurement — did any of this help?
+
+| Module | Owns |
+| --- | --- |
+| [`scorecard.py`](../src/scorecard.py) | Reads all five feature ledgers and writes the end-of-run verdict on which flags earned their cost. |
+| [`archive.py`](../src/archive.py) | Cross-run routes and edge payoffs keyed on a comparability basis; variant proposal, exploration and conservative promotion. |
+| [`decisions.py`](../src/decisions.py) | "Was offered this edge and declined" — the control arm the payoffs are computed against. |
+| [`trials.py`](../src/trials.py) | Paired A/B trials over archived runs. |
+| [`inference.py`](../src/inference.py) | Exact permutation tests and attainable-p floors; derives the archive's `min_observations` from the family size rather than asserting it. |
+
+### Execution — the agent, and everything around it
+
+| Module | Owns |
+| --- | --- |
+| [`operator.py`](../src/operator.py) · [`operator_codex.py`](../src/operator_codex.py) · [`operator_protocol.py`](../src/operator_protocol.py) | The Claude and Codex CLI adapters behind one protocol: session state, live streaming, resume fallback, MCP config, skill install. |
+| [`web_search.py`](../src/web_search.py) · [`mcp_web_search.py`](../src/mcp_web_search.py) | Gemini-backed search, readiness assessment, and a stdlib JSON-RPC MCP stdio server exposing it as a tool. |
+| [`backend_health.py`](../src/backend_health.py) | Telling "the model was unreachable" apart from "the research failed". |
+| [`prompt_fragments.py`](../src/prompt_fragments.py) | Shared prompt blocks generated from the validators' own constants, so a limit cannot drift between the gate and the instruction. |
+| [`run_skills.py`](../src/run_skills.py) · [`skills/`](../src/skills) | Six pull-on-demand craft skills installed into the run's working directory. |
+
+### Output and adapters
+
+| Module | Owns |
+| --- | --- |
+| [`platform/foundry.py`](../src/platform/foundry.py) | The LaTeX paper package and the Stage 08 release bundle. |
+| [`rcb.py`](../src/rcb.py) · [`rcb_agent.py`](../rcb_agent.py) | The ResearchClawBench adapter: workspace layout, goal construction, report selection, figure publication, export. |
+| [`studio_service.py`](../src/studio_service.py) · [`backend/`](../src/backend) · [`frontend/`](../src/frontend) | The local browser workspace over the same run directories. |
+| [`terminal_ui.py`](../src/terminal_ui.py) | The terminal-first interaction layer. |
+
+---
+
+## 5. Novelty
+
+Four things in AutoR are, as far as we are aware, not present in the research-agent systems it is
+comparable to. Each is stated as a mechanism, not as an aspiration, and each names the file.
+
+### 5.1 A preregistration that is a gate, not a document
+
+Many systems ask a model to state hypotheses before experimenting. AutoR makes the statement
+**structurally binding**: the typed hypothesis set is hashed at Stage 04 approval, the digest is
+echoed into the outcomes file at Stage 06, and `validate_hypothesis_outcomes` refuses a run that
+adjudicates something not in the frozen set, omits something that is, or cites an evidence path that
+does not resolve. Changing the set later is legal, but only as an `amendment` row carrying
+`previous_digest`. A dropped hypothesis leaves a trace; it cannot be silently deleted.
+
+The distinctive part is not the freeze — it is the **chain**: freeze at 04, adjudicate at 06 against
+a file that exists, trace every manuscript claim at 07 to a `supported` hypothesis or an explicit
+`exploratory` label, and close the router edge into writing until all of that holds. Each link is a
+function that returns problems, and a run cannot advance while any of them does.
+
+We are not aware of another agentic research harness in which the post-hoc hypothesis is refused by a
+validator rather than discouraged by a prompt.
+
+### 5.2 A self-improvement loop that is explicitly prevented from improving the answer
+
+The obvious way to build a scored improvement loop is to score the output. That produces a system
+that optimises toward whatever the scorer likes — and if the scorer is a model, toward whatever that
+model finds persuasive.
+
+AutoR's rubric is deliberately weaker than that and deliberately blind. It **never calls a backend**:
+it resolves paths, matches reported numbers against results files, checks artifact freshness against
+the stage-execution marker, and inspects the decision ledger for four distinct entries. It is
+**verdict-blind**: a refuted hypothesis with clean evidence scores above a supported one resting on
+an assertion, so there is no gradient toward a nicer conclusion. And it is backed by a second,
+independent guard: `verdict_digest()` hashes the `(id, verdict)` set, and an AutoR-initiated polish
+round that moves it is rejected outright with a `verdict_drift` row — whatever it scored.
+
+The pairing is the point. Verdict-blindness removes the *incentive* to improve the answer; drift
+rejection removes the *possibility*. A revision a **human** asked for is exempt by design: the
+ratchet governs AutoR's own rounds, not the direction it is given.
+
+### 5.3 Machinery that reports on itself, in the unflattering direction
+
+Every optional feature in AutoR runs its own control arm and writes a ledger:
+
+- **Review panel** — the chair's round-1 verdict is the solo baseline; `panel_effect.json` records
+  gates reviewed, gates where the panel *changed* the decision, chair overrides, call count and cost
+  multiple.
+- **Ideation panel** — adoption is measured *after* the stage is approved, so "the panel proposed
+  five ideas" is separated from "the stage used one".
+- **Anchored comments** — `comment_ledger.json` counts lines changed on target against lines changed
+  as collateral, so "preserve the correct parts" is measured.
+- **Crux deliberation** — the resolution is compared against what the agent already believed, so an
+  escalation that confirmed a prior belief is not counted as an escalation that changed one.
+- **Effort tiers** — `effort.json` records what was routed where and what it saved.
+
+[`scorecard.py`](../src/scorecard.py) reads all five at the end of every run, keeps *"could not be
+measured"* strictly apart from *"changed nothing"*, and writes sentences like *"it did not earn that
+cost; consider dropping the panel."* A harness that ships a mechanism to tell you to turn its own
+features off is an unusual design choice, and it is the one we would most like to see copied.
+
+The cross-run half is [`decisions.py`](../src/decisions.py): the control arm for "did taking this
+edge pay?" is not "runs that did not take it" but **"runs that were offered it and declined"** —
+which is the comparison that isolates the decision from the circumstances that produced it. Payoffs
+are keyed on a comparability basis so a run cannot win by stopping early, and
+[`inference.py`](../src/inference.py) derives the observation count needed for believability from the
+family size rather than asserting a threshold.
+
+### 5.4 A workflow graph whose guards are computed from the filesystem
+
+Agentic workflow graphs are common. Two things here are not:
+
+**The guards are evaluated against artifacts on disk, not against agent state.** `results_exist` is
+a directory listing; `validity_chain` is a parse of `preregistration.json` and
+`hypothesis_outcomes.json`. Which move is legal is therefore a property of what the run has actually
+produced, and it survives a resume, a crash, a manual edit and a different model.
+
+**A blocked move is handed to the agent with its blocking reason.** The useful thing to say is not
+"you may go to 06" but "07 is closed because H2 has no verdict" — an agent that sees *why* writing is
+closed routes to the analysis that opens it. This turns the guard set from a fence into an
+explanation, and it is why the thirteen backward edges are usable at all.
+
+Two smaller mechanisms fall out of the same idea. A revisit whose justification **repeats a reason
+already on the path** is refused (`repeats_a_previous_reason`): going again on the same grounds is a
+loop, not an iteration. And the archive, which learns from outcomes, is permitted to reorder edge
+preferences but **never** to open a guarded edge, add an undeclared one, or remove one — the
+component that learns is precisely the one that must not be able to weaken the correctness argument.
+
+### 5.5 How this sits against the systems it is comparable to
+
+Grounded in [the landscape study](researchclawbench-landscape.md), which recomputed the published
+numbers rather than quoting them:
+
+| | EvoScientist | ARIS Codex | MIRA | **AutoR** |
+| --- | --- | --- | --- | --- |
+| Bets the bottleneck is | accumulated capability | self-deception | premature convergence | **unwarranted claims** |
+| Mechanism | skills + memory that compound | cross-model adversarial review | competing hypotheses, physical lab | **preregistration → adjudication → provenance, as validators** |
+| Improvement loop | skill evolution | — | — | **backend-free, verdict-blind, drift-rejecting ratchet** |
+| Self-measurement | — | integrity forensics | — | **per-feature control arm + run scorecard** |
+| Human role | on-the-loop | `human checkpoint: false` | unspecified | **in-the-loop by default; seven of eight mechanisms cannot approve** |
+| Dependencies | LangChain / LangGraph / DeepAgents | host coding agent | proprietary cloud | **stdlib only** |
+
+ARIS's bet — that the executor grading its own work is the problem — is the closest to AutoR's, and
+AutoR includes that mechanism ([`cross_reviewer.py`](../src/cross_reviewer.py)) as one of five
+critics rather than as the thesis. The landscape study also records ARIS as the cautionary case: a
+large, thoughtful scaffold that lands *below* the bare-harness baseline. Structure is not
+self-justifying, which is the reason §2.5 exists.
+
+---
+
+## 6. Contribution
+
+What a reader can take from this system, in descending order of how transferable it is.
+
+1. **A working demonstration that scientific-method constraints can be enforced mechanically over an
+   LLM agent.** Preregistration, decision rules, seed and dispersion requirements, hypothesis
+   adjudication against files that exist, and claim provenance are all implemented as functions
+   returning problem lists over a directory tree. None of them requires the model's cooperation, and
+   none is a prompt. This is the part most directly reusable in another harness.
+
+2. **A concrete answer to "how do you score a self-improvement loop without corrupting it?"** —
+   score with something that cannot call a model, make the score blind to the conclusion, and then
+   separately reject any round that moves the conclusion. The result is a loop that can improve the
+   *work* and is structurally prevented from improving the *answer*.
+
+3. **A pattern for shipping an optional mechanism together with its own control arm**, and a reader
+   ([`scorecard.py`](../src/scorecard.py)) that reports the result in the direction that costs the
+   author something. Five features do this today. The pattern generalises to any agentic feature
+   whose value is asserted rather than measured.
+
+4. **A stage graph whose admissibility is a function of the filesystem**, with blocked moves
+   explained rather than hidden, revisit-reason deduplication, and a learning component that is
+   structurally forbidden from weakening the guards it learns around.
+
+5. **A typed information-flow layer for agent prompts.** Sixteen channels, each naming its producer,
+   its consumers by stage slug, and a written rationale for every narrowing — with a test that fails
+   a channel that withholds itself without an argument. It makes "what did this stage actually see?"
+   a diffable topology instead of a reconstruction from `if` statements.
+
+6. **A statistically literate archive.** Paired trials with an exact sign-flip p-value, the
+   attainable-p floor printed beside it, an explicit `underpowered` label below six pairs, and a
+   sample-complexity tool that says how many runs an edge needs before it is believable. This is
+   apparatus, not evidence — see §7.
+
+7. **A full-fidelity research run as an inspectable artifact.** Every prompt of every attempt, every
+   reviewer verdict, every panel seat's dissent that lost, every routing refusal, every losing draft,
+   and the ledger of why each was rejected. `evolution/` sits outside `workspace/` precisely so an
+   export ships the answer and not the search.
+
+8. **A documented negative result about benchmark scoring.** Judge choice is worth roughly sixteen
+   points on ResearchClawBench: on one identical artifact set Opus scored 52.6 where the reference
+   judge gpt-5.1 scored 46.0. A score carrying the wrong judge is not a smaller number, it is an
+   incomparable one — and a scorer that records a judge parse failure as `0` will quietly turn a
+   working run into a broken-looking one. See [researchclawbench.md](researchclawbench.md).
+
+---
+
+## 7. What has not been established
+
+Stated as plainly as the rest, because a system built to refuse unwarranted claims should not make
+any.
+
+- **No mechanism in AutoR has evidence that it improves a research output.** Not the panel, not the
+  ideation lenses, not the crux deliberation, not the graph, not the ratchet.
+  [`trials.py`](../src/trials.py) is the apparatus built to produce that evidence and **no paired
+  trial has been run**. The run scorecard says when a feature did not change a decision *within one
+  run*, which is a genuinely weaker claim than "it does not help".
+- **The archive has not learned anything yet.** It records every run, and it proposes variants, but
+  the shipped archive holds no paired trials and the sample-complexity tool exists precisely because
+  the observation counts are not there yet.
+- **The benchmark number is one task of forty.** 46.0 on `Astronomy_000` under the reference judge
+  is a real measurement of a real run, and it is not comparable to a 40-task leaderboard mean. The
+  landscape study's first conclusion also stands: model choice dominates harness choice, and any
+  result must be quoted against the same-model bare-harness baseline.
+- **The frozen preregistration is not checked against itself.** `validate_preregistration` compares
+  the *manifest's* digest to the recorded `source_digest`; it never recomputes the digest of the
+  frozen file. Editing `preregistration.json` in place passes. The honest claim is that a manifest
+  rewrite is detected.
+- **Standing rules and obligations never reach a panel seat.** Both are injected only into the solo
+  reviewer's prompt, so `--review-panel` silently loses two of the accumulation mechanisms.
+- **The cross-model veto is unreachable from `main.py`.** It is wired on the `rcb_agent.py` path
+  only.
+- **A crashed adversarial reviewer is indistinguishable from a clean result.** `reviewer_failed:
+  true` is written and nothing reads it.
+- **The chain is bypassable in unattended mode.** A stage that burns its five attempts against the
+  gate is auto-skipped, up to three per run.
+
+Each of these is also a specific next thing to build, named at the code that would have to change.
+The list is maintained in the README's [Limits](../README.md#limits) section and is meant to shrink.
+
+---
+
+*AutoR is proprietary software; see [LICENSE](../LICENSE). Copyright © 2026 Xiangru Tang.*

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -58,8 +58,8 @@ Nodes are stages. Edges are the moves allowed between them.
 
 | Topology | Edges | Behaviour |
 | --- | --- | --- |
-| `linear` (default) | one advance edge out of each node | identical to the sequence AutoR has always run |
-| `adaptive` | the advance edges, the abandonment terminal, and thirteen backward moves | the run can return to an earlier stage when a later one shows it has to |
+| `linear` | the eight advance edges, unguarded, plus the abandonment terminal — nine in all | identical to the sequence AutoR has always run |
+| `adaptive` **(default)** | the eight advance edges with six guards, the abandonment terminal, and thirteen backward moves — twenty-two in all | the run can return to an earlier stage when a later one shows it has to |
 
 The backward edges exist for named research conditions, not as an error path:
 


### PR DESCRIPTION
## Why

The shipped `README.md` had **four unresolved merge-conflict markers** (`<<<<<<< HEAD` at lines 26/27/157 and 355/357/360) and two stacked overview sections — an emoji-headed `## 📖 Overview` block and a non-emoji `## What AutoR is` block — saying the same things with different numbers.

Behind that, most counts were one revision behind the source. A reader who re-derives them from the named symbols, exactly as the README invites, gets different answers:

| Claim | Doc said | Code says |
|---|---:|---:|
| Stages | nine | **8** (`STAGES`) |
| Backward edges | ten | **13** (`REVISIT_EDGES`) |
| Typed channels | thirteen | **16** (`CHANNELS`) |
| Validity validators | seven / nine | **17** reachable from `validate_stage_artifacts` |
| Guarded forward edges | "six of the seven" | **6 of 8** |
| `manager.py` | 2955 L | **3772 L** |
| Test suite | 234 tests, ~10 s | **1820 tests, ~70 s** |

And two of the six `## Limits` bullets had **inverted** — a section whose whole value is credibility-by-self-criticism was carrying stale claims:

- "the archive's explore proposer does not run" — it does: `main.py` calls `archive.propose_exploration()` in the `if proposal is None` branch, and `tests/test_archive_exploration_wiring.py` pins that caller.
- "the self-measurement files have no reader in code" — `src/scorecard.py` reads all five ledgers and runs from `ResearchManager._report_optional_machinery` on every completed run.

## What changed

**`README.md` rewritten against the tree.** Conflicts resolved (the emoji block's unique content — the rigor dial, effort tiers, deliberation, ideation panel, scorecard — is preserved in the surviving spine). Every count re-derived from a named symbol and verified by import. New material for subsystems the README never documented: the rigor table generated from `_LEVEL_FEATURES`, the full seventeen-validator table, the five kinds of critic and which two are the gate, `report_plan.py`, `deliverables.py`, paired trials, the MCP web-search path, and sixteen modules the old module table omitted.

Two corrections that change what a user does:

- **Four flags remove the human from the gate, not two.** `resolve_unattended` returns `True` for `--unattended`, `--full-auto`, `--review-panel` *and* `--approval-mode agent` — and `--rigor` is resolved **before** it, so a plain `--rigor max` silently converts an interactive run into an unattended agent-gated one.
- **Effort tiers are on by default**, so `--rigor max` alone does not seat the panel at Stages 04, 05 and 08.

**`docs/framework.md` added** — the design document the repo did not have. The problem (the warrant gap, not the capability gap), the six commitments and what each one costs, the control loop step by step, every module by layer, four novelty claims each stated as a mechanism with the file that implements it, eight contributions, and a closing section on what has **not** been established: no mechanism in AutoR has evidence that it improves a research output, `trials.py` is the apparatus built to produce that evidence, and no paired trial has been run.

**Cross-doc contradictions fixed** where the rewrite exposed them: `effort-tiers.md` and `cli-reference.md` said tiering was off by default; `self-improvement.md` labelled `linear` the default topology when `DEFAULT_STAGE_GRAPH = "adaptive"`; `development.md` promised a 234-test suite; `docs/README.md` had a stray table row rendering as literal pipes and was missing nine pages including its largest internals document. `architecture.md` gains a Policy layer, a Self-measurement layer, and rows for the thirteen modules added since it was written.

## Verification

- `python -m unittest discover -s tests -p "test_*.py"` — **1820 tests, OK** (1 skip)
- All relative markdown links in the four touched docs resolve; all in-page anchors match a real heading
- Counts re-derived by importing the modules, not by reading prose

One test caught a real thing: `test_no_tracked_file_holds_a_key_shaped_literal` flagged the phrase `re-ask-once-then-fall-back`, which matches `sk-[A-Za-z0-9_-]{16,}`. Rephrased.

## Not in scope

`tutorial_en.md` / `tutorial_zh.md` are pre-graph documents and still describe a fixed nine-stage sequence. They are ~45 KB each and rewriting them is its own change; the README header now points at `docs/framework.md` first.