### PR TITLE
Give the graph a terminal edge, and hold the report to the task

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -163,6 +163,7 @@ from .utils import (
     INTAKE_STAGE,
     MAX_STAGE_ATTEMPTS,
     STAGES,
+    WRITING_STAGE,
     RunPaths,
     StageSpec,
     append_approved_stage_summary,
@@ -544,18 +545,22 @@ class ResearchManager:
             self._round_intent = None
             approved = self._run_stage(paths, stage)
 
-            # Three things reach this seam: `/back <stage>`, a rollback after retry
-            # exhaustion, and a research round that decided to refine its design or
-            # change its hypothesis. All of them outrank the router — the move is
-            # already made by the time the walk sees it — and all of them are
-            # recorded on the route as the revisits they are.
+            # Four things reach this seam: `/back <stage>`, a rollback after retry
+            # exhaustion, a research round that decided to refine its design or change
+            # its hypothesis, and the terminal route to the deliverable. All of them
+            # outrank the router — the move is already made by the time the walk sees it.
+            #
+            # The first three go backwards and the fourth does not, so the kind is read
+            # off the direction rather than assumed. Recording a forward route as a
+            # revisit would tell the archive that `04 -> 07` is a backward edge, and
+            # `REVISIT_EDGES` has no such edge to attribute it to.
             if self._jump_target_stage is not None:
                 target = self._jump_target_stage
                 graph_leave(
                     paths,
                     state,
                     chose=target.slug,
-                    kind="revisit",
+                    kind="revisit" if target.number <= stage.number else "advance",
                     reason=self._jump_reason or "The run was redirected to an earlier stage.",
                     default_choice="",
                     agent_directed=False,
@@ -2549,6 +2554,20 @@ class ResearchManager:
                 return True
 
             if choice == "6":
+                # Abort is a person's decision. Unattended there is no person, and this
+                # branch was reached by an automated reviewer that could not be read —
+                # eleven of the twelve dead benchmark runs, each ending a run that had
+                # already done the work. Route to the deliverable instead, which is the
+                # same move an exhausted stage makes, for the same reason: the run has
+                # something and exiting publishes nothing.
+                if self.unattended and self._route_to_deliverable(
+                    paths=paths,
+                    stage=stage,
+                    attempt_no=attempt_no,
+                    because=f"{stage.stage_title} was aborted at the approval gate with no human to ask",
+                    errors_note="- (the stage was aborted rather than failing validation)",
+                ):
+                    return True
                 update_manifest_run_status(
                     paths,
                     run_status="cancelled",
@@ -3155,11 +3174,23 @@ class ResearchManager:
         )
 
         if len(self.auto_skipped_stages) >= self.max_auto_skips:
+            if self._route_to_deliverable(
+                paths=paths,
+                stage=stage,
+                attempt_no=attempt_no,
+                because=(
+                    f"{stage.stage_title} exhausted its retries and the auto-skip budget "
+                    f"({self.max_auto_skips}) is spent"
+                ),
+                errors_note=errors_note,
+            ):
+                return True
             append_log_entry(
                 paths.logs,
                 f"{stage.slug} unattended_abort",
                 (
-                    "Unattended run aborted: the auto-skip budget is exhausted.\n"
+                    "Unattended run aborted: the auto-skip budget is exhausted and the run is "
+                    "already at the stage that writes the deliverable.\n"
                     f"auto_skip_budget: {self.max_auto_skips}\n"
                     f"already_skipped: {', '.join(self.auto_skipped_stages)}\n"
                     f"last validation errors:\n{errors_note}"
@@ -3241,6 +3272,93 @@ class ResearchManager:
             if normalized in {candidate.slug.lower(), str(candidate.number), f"{candidate.number:02d}"}:
                 return candidate
         return None
+
+    def _route_to_deliverable(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        attempt_no: int,
+        because: str,
+        errors_note: str,
+    ) -> bool:
+        """Spend what is left of the run writing up, instead of exiting.
+
+        The graph has thirteen backward edges and no terminal one. Every way a stage can
+        fail terminally — an exhausted auto-skip budget here, an abort at the approval
+        gate — was ``return False``, which is not an edge but the absence of one, and the
+        runtime expresses the absence of an edge as process exit. On eight of forty
+        benchmark runs the only reachable terminal state was that exit, and a run holding
+        18 KB of survey and five rendered figures published 197 bytes.
+
+        The move is available under one predicate and it is not a quality judgement: the
+        budget for *doing more research* is spent and the node that produces the
+        deliverable has not been visited. Then the admissible set collapses to one move —
+        go and write up what the run has. Nothing about the writing node is relaxed; it
+        still runs its own gates, and if it too exhausts, this returns False and the run
+        aborts as before.
+
+        The guards on the ordinary edge into writing are bypassed on purpose, and this is
+        the only place in AutoR where that is true. A guard is a repair instruction, and
+        the validity chain's repair is "go back and adjudicate the hypotheses" — a
+        rollback that costs more budget than the run has. A refusal whose only repair is
+        unaffordable stops being a gate and becomes an exit. What the run owes instead is
+        disclosure: every bypassed stage is named in the run's not-completed list, which
+        reaches the report as its own banner, and the writing stage sees the skip summary
+        of the stage that failed.
+        """
+        # The node that produces the deliverable is the writing stage, not the last one:
+        # Stage 08 makes posters and release notes, which is not what a run short of
+        # budget should be spending it on. A run told to stop earlier than that is routed
+        # to where *it* was told to stop.
+        target = WRITING_STAGE
+        if self._final_stage is not None and self._final_stage.number < target.number:
+            target = self._final_stage
+        if stage.number >= target.number:
+            return False
+
+        bypassed = [
+            other.slug
+            for other in STAGES
+            if stage.number < other.number < target.number
+            and other.slug not in self.auto_skipped_stages
+        ]
+        # `auto_skipped_stages` is the run's "did not complete" record and the report
+        # prints it verbatim under **Stages not completed**, which is exactly what a
+        # bypassed stage is. The budget it also feeds has already fired by the time this
+        # runs, and the check above stops a second route, so nothing double-counts.
+        self.auto_skipped_stages.extend(bypassed)
+
+        reason = (
+            f"{because}, so the run routed to {target.stage_title} to produce its "
+            "deliverable rather than exiting with nothing."
+        )
+        append_log_entry(
+            paths.logs,
+            f"{stage.slug} routed_to_deliverable",
+            (
+                f"{reason}\n"
+                f"target: {target.slug}\n"
+                f"bypassed: {', '.join(bypassed) or '(none)'}\n"
+                f"already_skipped: {', '.join(self.auto_skipped_stages)}\n"
+                f"last validation errors:\n{errors_note}"
+            ),
+        )
+        self.ui.show_status(reason, level="warn")
+
+        # The stage that failed still gets its skip summary, so the writing stage reads
+        # what was missing rather than inferring it from an absence.
+        self.auto_skipped_stages.append(stage.slug)
+        self._skip_stage(
+            paths=paths,
+            stage=stage,
+            attempt_no=attempt_no,
+            reason=reason,
+            kind="auto",
+        )
+        self._jump_reason = reason
+        self._jump_target_stage = target
+        return True
 
     def _rollback_and_jump(
         self,

--- a/src/operator.py
+++ b/src/operator.py
@@ -23,6 +23,7 @@ from .utils import (
     approved_stage_summaries,
     extract_stream_text_fragments,
     read_text,
+    task_statement,
     relative_to_run,
     write_text,
 )
@@ -1005,7 +1006,7 @@ Original stderr:
             # because that is exactly the rule a real run is held to.
             from .deliverables import COVERAGE_FILENAME, demanding_sentences
 
-            _statement = read_text(paths.user_input)
+            _statement = task_statement(read_text(paths.user_input))
             _fake_reason = (
                 "fake-operator mode does not do research; nothing was actually derived."
             )

--- a/src/rcb.py
+++ b/src/rcb.py
@@ -898,6 +898,14 @@ def export_run(
         synthesized = synthesize(paths=paths, workspace=workspace, figures=figures)
         if synthesized and len(synthesized.strip()) >= MIN_REPORT_CHARS:
             _publish_report(workspace, report_path, synthesized.strip(), "synthesized")
+            # Recompute against the report that shipped. The pass above ran before this
+            # report existed — `report_text` was empty, so `collect_figures` could not
+            # rank by what the report argues with and fell back to filesystem order,
+            # and its prune enforced the budget against a selection the report had no
+            # say in. On 39 of 40 benchmark runs that was the only pass there was, so
+            # `ExportResult.figures` described a set the deliverable did not reference
+            # and a figure the synthesizer did cite could already have been pruned.
+            figures = collect_figures(paths, workspace, report_text=synthesized)
             return result("synthesized")
         # A synthesis attempt that came back thin is worse than the deterministic assembly,
         # so fall through rather than shipping it.
@@ -917,6 +925,7 @@ def export_run(
     # is genuinely worse than what we are about to write.
     on_disk = read_text(report_path).strip() if report_path.exists() else ""
     if len(on_disk) >= MIN_REPORT_CHARS and len(on_disk) > len(fallback.strip()):
+        figures = collect_figures(paths, workspace, report_text=on_disk)
         return result("synthesized")
 
     _publish_report(workspace, report_path, fallback, "fallback")

--- a/src/utils.py
+++ b/src/utils.py
@@ -839,7 +839,7 @@ def build_prompt(
     # about the wrong question, and nothing else in the prompt notices.
     from .deliverables import format_deliverables_for_prompt
 
-    deliverables_block = format_deliverables_for_prompt(user_request)
+    deliverables_block = format_deliverables_for_prompt(task_statement(user_request))
     if deliverables_block:
         sections.extend(["# What the Task Asks For", deliverables_block])
     if obligations_context:
@@ -929,7 +929,7 @@ def build_continuation_prompt(
     # A contract that only appears on the first attempt is one every retry can forget.
     from .deliverables import format_deliverables_for_prompt
 
-    _deliverables = format_deliverables_for_prompt(read_text(paths.user_input))
+    _deliverables = format_deliverables_for_prompt(task_statement(read_text(paths.user_input)))
     if _deliverables:
         sections.extend(["# What the Task Asks For", _deliverables])
     if intake_context_text:
@@ -1004,6 +1004,20 @@ def extract_fenced_task(goal: str) -> str | None:
     if end < 0:
         return None
     return goal[start:end].strip() or None
+
+
+def task_statement(goal: str) -> str:
+    """What the *task* asked for, with anything wrapped around it removed.
+
+    A goal is not always only the question. The benchmark adapter builds one that carries
+    a workspace contract, a grading rubric and a figure budget alongside the task, and
+    :mod:`src.deliverables` reads a goal for the sentences that ask for something. Read
+    off the whole thing, ``demanding_sentences`` returned 23 demands for Astronomy_000
+    where the task has 10 — thirteen phantoms, the first of which is "Benchmark Run:
+    ResearchClawBench". The stage was then told those were its requirements and the
+    coverage gate held the report to them.
+    """
+    return extract_fenced_task(goal) or goal
 
 
 def goal_excerpt(goal: str, max_chars: int) -> str:
@@ -1496,7 +1510,7 @@ def validate_stage_artifacts(
 
         problems.extend(
             f"{stage.stage_title}: {problem}"
-            for problem in validate_deliverables_coverage(paths, read_text(paths.user_input))
+            for problem in validate_deliverables_coverage(paths, task_statement(read_text(paths.user_input)))
         )
 
         if not (paths.artifacts_dir / "citation_verification.json").exists():

--- a/src/utils.py
+++ b/src/utils.py
@@ -146,6 +146,11 @@ STAGES: list[StageSpec] = [
     StageSpec(8, "08_dissemination", "Dissemination"),
 ]
 
+#: The node that produces the deliverable. Stage 08 comes after it and makes posters and
+#: release notes, so it is where a run *ends*, not where its output is written — the
+#: distinction matters to anything deciding where to route a run that is out of budget.
+WRITING_STAGE = STAGES[6]
+
 REQUIRED_STAGE_HEADINGS = [
     "Objective",
     "What I Did",

--- a/tests/test_manager_smoke.py
+++ b/tests/test_manager_smoke.py
@@ -1026,6 +1026,49 @@ class ManagerSmokeTests(unittest.TestCase):
             self.assertEqual(manifest.current_stage_slug, INTAKE_STAGE.slug)
             self.assertIsNone(manifest.completed_at)
 
+    def test_an_unattended_abort_routes_to_the_deliverable_instead_of_cancelling(self) -> None:
+        """Abort is a person's decision, and unattended there is no person.
+
+        Eleven of the twelve dead ResearchClawBench runs reached this branch from an
+        automated reviewer whose verdict could not be parsed, and each one cancelled a
+        run that had already done the work. Interactive runs are unchanged --
+        `test_manager_abort_marks_run_cancelled` above is the same scenario with a human
+        at the gate, and it still cancels.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            runs_dir = Path(tmp_dir) / "runs"
+            manager = ResearchManager(
+                project_root=REPO_ROOT,
+                runs_dir=runs_dir,
+                operator=ScriptedSmokeOperator(),
+                output_stream=io.StringIO(),
+                evolution=EvolutionConfig(rounds=0),
+                unattended=True,
+            )
+
+            # Abort once, at Stage 01; approve whatever the run reaches next.
+            choices = iter(["6"])
+
+            def choice(*_args: object, **_kwargs: object) -> str:
+                return next(choices, "5")
+
+            with self._auto_approve_intake(manager), patch.object(manager, "_ask_choice", side_effect=choice):
+                manager.run("Smoke-test the unattended abort route.", venue="neurips_2025")
+
+            paths = build_run_paths(self._run_roots(runs_dir)[0])
+            self.assertIn("routed_to_deliverable", read_text(paths.logs))
+            # It aborted at Stage 01 and still *ran* the node that writes the report,
+            # rather than leaving the process at Stage 01. Whether that node then passes
+            # its own gates is its business — this fixture's Stage 07 does not, with
+            # every upstream artifact missing, and that is the correct outcome.
+            self.assertTrue(paths.stage_tmp_file(STAGES[6]).exists())
+            self.assertFalse(paths.stage_tmp_file(STAGES[3]).exists())
+            # The stage that failed, plus every stage the route stepped over.
+            self.assertEqual(
+                sorted(manager.auto_skipped_stages),
+                sorted(stage.slug for stage in STAGES[:6]),
+            )
+
     def test_project_bootstrap_carries_forward_prior_stages(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             runs_dir, operator, manager = self._build_manager(tmp_dir)

--- a/tests/test_rcb_scoring.py
+++ b/tests/test_rcb_scoring.py
@@ -515,6 +515,47 @@ class CollectFiguresUnitTests(unittest.TestCase):
         self.assertEqual(published, ["b.png", "g.png"])
 
 
+class SynthesizedFiguresMatchTheReportThatShippedTest(unittest.TestCase):
+    """The published set has to describe the report, not the one that did not exist yet.
+
+    `export_run` selects figures before calling the synthesizer, because the synthesizer
+    is handed the list. On the synthesized path that first pass sees `report_text=""`, so
+    it cannot rank by what the report argues with and falls back to filesystem order —
+    and 39 of 40 benchmark runs took that path, so it was the only pass there was.
+    """
+
+    def test_the_published_list_is_recomputed_against_the_synthesized_report(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        root = Path(tmp_dir.name)
+        workspace = root / "workspace"
+        workspace.mkdir()
+        paths = build_run_paths(root / ".autor" / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Benchmark task")
+        write_text(paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(paths, model="sonnet", venue="neurips_2025", output_format="markdown")
+        for name in ("a.png", "b.png", "c.png", "d.png", "e.png", "f.png", "g.png"):
+            (paths.figures_dir / name).write_bytes(b"\x89PNG " + name.encode())
+
+        body = "# Report\n\n## Results\n\n" + (_PARAGRAPH * 40) + "\n\n![g](images/g.png)\n"
+
+        def synthesize(*, paths, workspace, figures):  # noqa: ANN001, ARG001
+            write_text(workspace / "report" / "report.md", body)
+            return body
+
+        result = export_run(
+            paths=paths, workspace=workspace, pipeline_completed=False, synthesize=synthesize
+        )
+
+        self.assertEqual(result.report_source, "synthesized")
+        # Exactly what the report argues with — not five picked in filesystem order.
+        self.assertEqual(result.figures, ["g.png"])
+        self.assertEqual(
+            sorted(p.name for p in (workspace / "report" / "images").glob("*.png")), ["g.png"]
+        )
+
+
 class OutputsPruneIsNotADataLossTest(unittest.TestCase):
     """The prune deletes; so it has to offer a slot before it deletes.
 

--- a/tests/test_task_deliverables_contract.py
+++ b/tests/test_task_deliverables_contract.py
@@ -59,6 +59,44 @@ class DemandExtractionTest(unittest.TestCase):
         self.assertFalse(found[0].startswith("-"))
 
 
+class DemandsComeFromTheTaskNotTheWrapperTest(unittest.TestCase):
+    """AutoR's own prose is not a requirement the report owes an answer to.
+
+    A goal is not always only the question: the benchmark adapter builds one carrying a
+    workspace contract, a grading rubric and a figure budget around the task. Read off
+    the whole thing, `demanding_sentences` returned 23 demands for Astronomy_000 against
+    the task's 10 — 857 against 337 across all 40 shipped tasks, so 61% of what every
+    stage was told it owed was AutoR talking to itself. The first phantom demand was
+    literally "Benchmark Run: ResearchClawBench".
+    """
+
+    def _wrapped(self) -> str:
+        from src.rcb import build_benchmark_goal
+
+        with tempfile.TemporaryDirectory() as tmp:
+            return build_benchmark_goal(Path(tmp).resolve(), TASK)
+
+    def test_the_wrapper_contributes_no_demands(self) -> None:
+        from src.utils import task_statement
+
+        goal = self._wrapped()
+        self.assertGreater(len(demanding_sentences(goal)), len(demanding_sentences(TASK)))
+        self.assertEqual(demanding_sentences(task_statement(goal)), demanding_sentences(TASK))
+
+    def test_the_prompt_block_does_not_ask_for_the_benchmark_contract(self) -> None:
+        from src.utils import task_statement
+
+        block = format_deliverables_for_prompt(task_statement(self._wrapped()))
+        self.assertIn("coupling strengths", block)
+        self.assertNotIn("ResearchClawBench", block)
+        self.assertNotIn("Workspace Contract", block)
+
+    def test_a_goal_nobody_wrapped_is_read_whole(self) -> None:
+        from src.utils import task_statement
+
+        self.assertEqual(task_statement(TASK), TASK)
+
+
 class CoverageGateTest(unittest.TestCase):
     def setUp(self) -> None:
         tmp = tempfile.TemporaryDirectory()

--- a/tests/test_unattended.py
+++ b/tests/test_unattended.py
@@ -9,7 +9,14 @@ import main as autor_main
 from src.manager import ResearchManager
 from src.manifest import load_run_manifest, mark_stage_skipped_manifest
 from src.terminal_ui import TerminalUI, UnattendedInputError
-from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
+from src.utils import (
+    STAGES,
+    WRITING_STAGE,
+    build_run_paths,
+    ensure_run_layout,
+    read_text,
+    write_text,
+)
 
 
 class AlwaysTTY(io.StringIO):
@@ -122,7 +129,15 @@ class UnattendedExhaustionTest(unittest.TestCase):
         self.assertTrue(self.paths.stage_file(stage).exists())
         self.assertIn("unattended_auto_skip", read_text(self.paths.logs))
 
-    def test_auto_skip_budget_is_enforced(self) -> None:
+    def test_the_spent_budget_routes_to_the_writing_stage_instead_of_exiting(self) -> None:
+        """Out of budget is a move, not an exit.
+
+        This used to `return False`, which the walk turns into process exit. Eight of
+        forty benchmark runs took that path and published a 197-byte report over the work
+        they were holding. The budget bounds how many stages may be *skipped and the
+        research continued*; once it is spent the only move left is to go and write up
+        what the run has.
+        """
         manager = self._manager(unattended=True, max_auto_skips=2)
 
         for stage in STAGES[:2]:
@@ -132,12 +147,48 @@ class UnattendedExhaustionTest(unittest.TestCase):
                 )
             )
 
-        self.assertFalse(
+        self.assertTrue(
             manager._handle_stage_exhaustion(
                 paths=self.paths, stage=STAGES[2], attempt_no=5, last_validation_errors=[]
             )
         )
-        self.assertEqual(len(manager.auto_skipped_stages), 2)
+        self.assertEqual(manager._jump_target_stage, WRITING_STAGE)
+        self.assertIn("routed_to_deliverable", read_text(self.paths.logs))
+        self.assertNotIn("unattended_abort", read_text(self.paths.logs))
+
+    def test_every_stage_the_route_stepped_over_is_named_as_not_completed(self) -> None:
+        """A bypassed stage is one the report has to disclose, not one it may omit."""
+        manager = self._manager(unattended=True, max_auto_skips=1)
+        manager._handle_stage_exhaustion(
+            paths=self.paths, stage=STAGES[0], attempt_no=5, last_validation_errors=[]
+        )
+        manager._handle_stage_exhaustion(
+            paths=self.paths, stage=STAGES[1], attempt_no=5, last_validation_errors=[]
+        )
+
+        # 03, 04, 05 and 06 were never entered; 02 failed. All five are missing from the
+        # report, and the report says so.
+        self.assertEqual(
+            manager.auto_skipped_stages,
+            [
+                "01_literature_survey",
+                "03_study_design",
+                "04_implementation",
+                "05_experimentation",
+                "06_analysis",
+                "02_hypothesis_generation",
+            ],
+        )
+
+    def test_the_writing_stage_itself_running_out_still_aborts(self) -> None:
+        """There is nowhere left to route to, so the old behaviour is the right one."""
+        manager = self._manager(unattended=True, max_auto_skips=0)
+
+        self.assertFalse(
+            manager._handle_stage_exhaustion(
+                paths=self.paths, stage=WRITING_STAGE, attempt_no=5, last_validation_errors=[]
+            )
+        )
         self.assertIn("unattended_abort", read_text(self.paths.logs))
 
     def test_the_skip_summary_says_it_was_skipped(self) -> None:


### PR DESCRIPTION
Follows #180, which fixed the two defects that cost the most. This is the structural
one behind them.

## The graph has thirteen backward edges and no terminal edge

`src/stage_graph.py` opens by arguing that a linear stage list cannot express "Stage 06
shows the design was wrong", so the stages are a graph. It is right about backward moves.
But every way a stage can fail *terminally* was `return False`:

- `_handle_unattended_stage_exhaustion`, when the auto-skip budget is spent
- the approval gate's `choice == "6"` — which unattended is reached by an automated
  reviewer, not a person

`return False` is not an edge. It is the absence of one, and the runtime expresses the
absence of an edge as process exit. On eight of forty ResearchClawBench runs that exit was
the only reachable terminal state, and a run holding 18 KB of survey and five rendered
figures published 197 bytes. What AutoR reifies as a graph was, on 20% of the benchmark, a
linear pipeline with a retry loop and two trapdoors.

`_route_to_deliverable` makes the writing node reachable from any node under one
predicate, and the predicate is not a quality judgement: **the budget for doing more
research is spent, and the node that produces the deliverable has not been visited.** Then
the admissible set collapses to one move.

Nothing about the writing node is relaxed — it runs its own gates, and when it too
exhausts there is nowhere left to route to and the run aborts exactly as before.

### The one guard bypass in AutoR

The ordinary edge into writing is guarded by the validity chain. A guard is a repair
instruction, and that one's repair is *go back and adjudicate the hypotheses* — a rollback
costing more budget than the run has. A refusal whose only repair is unaffordable is not a
gate; it is an exit under another name.

What the run owes instead is disclosure: the stage that failed keeps its skip summary, and
every stage the route stepped over is added to the not-completed list the report prints
verbatim.

Interactive runs are unchanged. The abort route is gated on `self.unattended`, and
`test_manager_abort_marks_run_cancelled` — the same scenario with a human at the gate —
still cancels.

## The coverage gate was reading AutoR's own prose as requirements

`src/deliverables.py` reads a goal for the sentences that ask for something. Those become
the "What the Task Asks For" prompt block *and* the gate Stage 07 must satisfy. All four
readers passed it `user_input.txt` whole — which on a benchmark run wraps the task in a
workspace contract, a grading rubric and a figure budget:

| | demands found |
|:---|---:|
| off the goal, Astronomy_000 | 23 |
| off the task, Astronomy_000 | 10 |
| off the goal, all 40 tasks | 857 |
| off the task, all 40 tasks | **337** |

520 phantom demands — 61% of every task's stated requirements. The first one enumerated to
the stage was `Benchmark Run: ResearchClawBench`; the next three were workspace paths. A
run reading that list had thirteen reasons to write about something other than the
research, and the gate then held it to them.

`task_statement()` unwraps the goal at all four sites. A goal nobody wrapped is returned
whole, so no non-benchmark run changes.

Absence accounts for 22.49 of the 35.84 points AutoR gives up against paper parity. A
coverage signal computed over 61% noise is not a signal, so this is the precondition for
pointing anything else at it.

## Figures are reconciled against the report that shipped

`export_run` picks figures before the synthesizer runs, because the synthesizer is handed
the list. That pass sees `report_text=""` and falls back to filesystem order — and 39 of 40
runs took that path, so it was the only pass. `ExportResult.figures` described a set the
report did not reference, and `collect_figures` prunes, so a figure the synthesizer went on
to cite could already be deleted.

**Deliberately not done:** ranking slots by criterion weight, and the
spec/render/validate/audit figure protocol. The evidence does not support them —
correlation between judge-visible figure count and image score is 0.061 over the 30
non-stub tasks with image weight, and re-scoring two runs with their curated five instead
of their `outputs/` set moved them *down*, by 0.78 and 7.08.

## Two records that were wrong

- The route target is `WRITING_STAGE`, not `STAGES[-1]`: Stage 08 makes posters, and a run
  short of budget should not spend it there.
- The walk recorded every `_jump_target_stage` as `kind="revisit"`. Three of the four
  things reaching that seam go backwards and this one does not, so the kind is read off the
  direction. Recording `04 -> 07` as a revisit would tell the archive it is a backward
  edge, and `REVISIT_EDGES` has none to attribute it to.

1842 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)