### PR TITLE
Measure #175 instead of asserting it

### DIFF
--- a/configs/rcb_trial_175.json
+++ b/configs/rcb_trial_175.json
@@ -1,0 +1,24 @@
+{
+  "capability": "pr175_scale_and_settled_reasoning",
+  "bench": "/home/robtang_google_com/RCB",
+  "tasks": ["Energy_001", "Astronomy_000", "Energy_002"],
+  "control": {
+    "label": "621566b",
+    "worktree": "/home/robtang_google_com/AutoR-control",
+    "sha": "621566b"
+  },
+  "treatment": {
+    "label": "47f3fbf",
+    "worktree": "/home/robtang_google_com/AutoR-treatment",
+    "sha": "47f3fbf"
+  },
+  "judge_kind": "reference",
+  "judge_model": "gpt-5.1",
+  "agent_model": "opus",
+  "review_model": "opus",
+  "state_dir": "/rmeng_data/robtang/rcb-trial-175",
+  "arm_order_mode": "control_first",
+  "deadline": 0.0,
+  "replicates": 3,
+  "operator": "autor"
+}

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -507,6 +507,27 @@ The classification is a model's reading of a rubric, not ground truth — a crit
 near the boundary could go either way, and the judge re-decides on every run. Treat the
 split as an order of magnitude: **roughly two-thirds capped, roughly one-third open.**
 
+**That 32.7% is a ceiling, and it has been read as an estimate.** Two corrections, both
+of which cut it:
+
+* **It counts every boundary criterion as Mode B.** A criterion that wants a number
+  *and* an inference drawn from it — Physics_001, Neuroscience_000/001, Chemistry_003 —
+  can be scored either way. The firm Mode B floor is **10.1%**; 30.4% is firm plus
+  every boundary case resolved generously. The honest statement is a range, not a
+  point.
+* **Most of it is behind image criteria, which never see the argument.** 20.4pp of the
+  32.7% is in the image row of the table above, and an image criterion is shown only
+  `report_text[:10000]` (`evaluation/score.py`), while the Discussion is at the end of
+  the report by construction — the goal contract puts it there. So Mode B weight that
+  *prose in the Discussion can actually reach* is **8.2%–14.8%**, not a third.
+
+This matters because `src/settled_reasoning.py` quotes the 32.7% in its docstring as
+the justification for the channel existing. The channel is still worth having at
+8–15%; it is not worth having on the strength of a number that is two to four times
+its addressable surface. Nineteen of the forty tasks carry zero Mode-B *text* weight,
+and nine of those have no text criteria at all — on those nine the Discussion cannot be
+read by any criterion, whatever it says.
+
 Three consequences that invert the usual instinct, and which AutoR now passes to the
 run in its goal contract:
 
@@ -632,3 +653,141 @@ python3 /abs/path/to/AutoR/rcb_agent.py --fake-operator --no-synthesis --max-aut
 
 This exercises the whole path — unattended pipeline, auto-skip recovery, export — without
 spending tokens. Expect exit code 0 and a `report/report.md` assembled by the fallback.
+
+---
+
+## Measuring a change against the benchmark score
+
+AutoR's own rubric cannot answer "did this PR make the research better" — it is AutoR
+grading its own drafts, and a change that makes it like its own work more is not the
+claim. `src/trials.py` already does the paired statistics honestly; what it lacked was
+an outcome measure that came from outside. `src/rcb_trial.py` supplies one, as a
+*producer* of the two dicts `trials.Pair` reads, so every refusal in that module keeps
+working untouched:
+
+* `stage_fitness` — exactly one key, `"<task_id>|<env_digest>"`, holding the 0–100
+  total. One key because `Pair._mean_over` is unweighted while the benchmark total is
+  weighted, and a mean over one element is that element. The environment digest is in
+  the key so that a pair whose arms differed in judge, `model`, `review_model`,
+  checklist bytes, resolved web-search level, `INSTRUCTIONS.md`, benchmark revision or
+  *the number of judge draws its total averages* is excluded by the composition refusal
+  that already exists, with no new gate to get wrong. `rcb_trial.py report` additionally
+  names *which* field differed; that is diagnostics, and a test holds it in step with
+  the digest field by field — and a second test holds that the fields are actually read
+  off the run, because seven blank strings are a constant digest and a gate that
+  excludes nothing.
+
+  The draw count is in there because `final_pass` gives each replicate two tries and
+  then moves on writing nothing: an arm silently scored once against an arm scored three
+  times is the ordinary failure, and it is the direction that inflates, since the single
+  draw carries the judge's whole sampling range into the delta while the other arm has
+  averaged its own away. The pair block prints both arms' counts against the planned
+  number, and says **unmeasured** rather than ±0.00 when one arm has a single draw —
+  fewer draws must not produce a smaller stated uncertainty.
+* `criterion_fitness` — one key per checklist item, holding `weight * score`. Every
+  shipped checklist's weights sum to 1.0, so **within one run** the decomposition sums
+  to the scalar and `concentration` becomes literally the share of the movement in one
+  checklist item. The identity is per-run; adding raw per-pair contributions across
+  *n* pairs gives *n* times the total, and the trial table reports means on both sides
+  rather than sums.
+
+No record is ever written to disk. `RunRecord.usable` requires AutoR's rubric version,
+which a benchmark row cannot honestly carry; the containment is that no `Archive` is
+constructible from either file, and a test says so.
+
+### The plan file
+
+One `--plan PATH` in place of ten flags (`configs/rcb_trial_175.json` is the shipped
+one). Fields: `capability`, `bench`, `tasks`, `control`/`treatment` (each
+`{label, worktree, sha}`), `judge_kind`, `judge_model`, `agent_model`, `review_model`,
+`state_dir`, `arm_order_mode`, `deadline`, `stall_seconds`, `replicates`, `operator`,
+`fake_quality`. It is sha256-frozen before the first launch and stamped into every
+state file: an apparatus that can be re-planned while it runs is an apparatus that can
+be stopped when the sign looks good, and the report says `INTERIM — k of N planned
+pairs` whenever it was.
+
+`control_arm` and `treatment_arm` are always explicit, so `_infer_arms` never runs.
+Its lexicographic fallback happens to give the right direction for `621566b` against
+`47f3fbf` only because ASCII digits sort below letters; two SHAs both starting with a
+letter would invert the sign silently.
+
+### The ten admission clauses
+
+A run becomes a measurement only after all ten pass, and a failure refuses the **pair**
+— refusing one arm turns it into "no treatment arm" and hides the cause. Each is here
+because of something observed on a real workspace:
+
+| Clause | The observation |
+| --- | --- |
+| `status_completed` | The scorer never reads `_meta.status`; a workspace mid-run scored its 12 KB working draft. |
+| `pipeline_completed` | A second witness: one workspace has `status: completed` and `pipeline_completed: false`. |
+| `report_from_agent` | A quota death still exports a fallback report worth about 7.5 points and records `completed`. |
+| `single_run_root` | Nothing stops a second invocation in one workspace; the exporter picks the lexicographically last root, which is the failed retry. |
+| `no_images_under_outputs` | Thirteen PNGs under `outputs/` took all five judge image slots: one image item 48 → 0, total 46.0 → 9.6. |
+| `single_report_md` | With `report.md` missing the scorer reads whatever an unsorted glob yields first, and records nothing about which file it read. |
+| `backend_reached` | `run.backend_unavailable` is the only machine-readable trace of a quota death; `last_error` stays null. |
+| `no_quota_in_logs` | `classify_backend` runs only when neither attempt wrote a stage file, so a mid-stage 429 reports itself complete. |
+| `revision_matches_arm` | `RunRecord` has no revision field and `run_config.json` records no SHA; the arm label is the only carrier. |
+| `every_item_judged` | A judge failure is scored 0: one run's honest total was 37.0 and the number on screen was 19.5. |
+
+The report prints a refused-run count **per clause, including zeros**, above the total.
+A clause that has stopped firing because an internal artifact was renamed looks exactly
+like a clause never violated, and the gate does not fail loudly when that happens — it
+stops refusing.
+
+### What no clause can bound: which five images
+
+`no_images_under_outputs` bounds where the judge's images come from. It cannot bound how
+many there were: the scorer shows the first five of one `rglob` list against *every*
+image criterion, and image criteria are 60.6% of the benchmark's weight. Four figures all
+shown and twelve figures of which an arbitrary five were shown are different evidence,
+and the score file was already recording which images went in — the trial simply threw
+it away, so two arms shown different figures produced an identical `env_digest` and the
+whole delta was attributed to the code change. It is not a gate, because how many figures
+a run produced is an *effect* of the change under test rather than a confound to hold
+fixed. Both counts are printed per arm, and a pair whose arms were shown different
+evidence is told so where its image stratum is read.
+
+### The refusals the gate never sees
+
+Most deaths never reach a clause. `final_pass` scores only runs classified `ok`, and an
+arm with no score file produces no evidence at all, so a run killed by quota, by the
+stall watchdog, by a backend outage, by a fallback report, by an incomplete pipeline or
+by the scorer's own refusal was rendered as "no `<arm>` arm" — the same sentence as an
+arm that was never launched — while the paragraph underneath told the reader to judge
+the difference on the per-arm death counts. Those deaths now enter the same ledger as
+`driver:quota`, `driver:stalled`, `driver:fallback`, `driver:unscored` and so on, they
+are named in the exclusion line for the pair, and the per-arm counts are printed even
+when both are zero, because that is the reading where the reader most needs them.
+
+This also fixes what a zero in the clause table means. Four of the ten clauses
+(`status_completed`, `report_from_agent`, `backend_reached`, `no_quota_in_logs`) are
+implied by `classification == "ok"`, which is the only classification `final_pass` will
+score, so they cannot fire on the driver's path at all: a quota death arrives as a
+`driver:` row and never as `no_quota_in_logs`. The caveat under the table says so.
+
+Two things the ledger deliberately does not do: it does not count a run in flight as a
+death, and it counts each `(task, arm)` once however many ways it died — a doubled
+per-arm count is a lie in the direction that looks like a finding.
+
+### What it cannot show
+
+Both changes in PR #175 are in one commit, so the trial cannot attribute an effect to
+one of them; the task choice makes an argument (Astronomy_000 is (a)-only at 0.00 Mode-B
+weight, Energy_002 is (b)-dominant with its image criteria floored, Energy_001 carries
+both) and an argument is not an attribution. At three pairs the exact p cannot go below
+0.25 at any effect size. Each (task, arm) runs once, so replicate scoring measures the
+judge's sampling range and there are **zero** observations of AutoR's own run-to-run
+variance. And a refusal removes a pair, not an arm — refusals are not random with
+respect to arm, so a lopsided refusal ledger is itself the result.
+
+### Dry run
+
+```bash
+python3 -m unittest tests.test_rcb_trial_driver
+```
+
+`operator: "fake"` and `judge_kind: "fake"` in the plan fabricate workspaces and scores
+while keeping the real lock, real `start_new_session` children, real atomic state, the
+real stall watchdog, the real gate and the real report. It runs a whole trial in about
+twenty seconds instead of four days.

--- a/src/rcb_trial.py
+++ b/src/rcb_trial.py
@@ -1,0 +1,1373 @@
+"""Measure a capability against ResearchClawBench's score, not against AutoR's own rubric.
+
+:mod:`src.trials` already does the statistics honestly — within-pair differences, a
+refusal to compare across a composition difference, the exact sign-flip p printed
+beside the floor it cannot go below. Its one limitation is the outcome measure: it
+reads ``stage_fitness`` and ``criterion_fitness``, which are AutoR grading its own
+drafts. A capability that makes AutoR like its own work more is not the claim anyone
+wants; the claim is that the external benchmark score moves.
+
+This module is a **producer**, not a second statistics module. :class:`src.trials.Pair`
+is the only reader of those two dicts anywhere in the tree, and nothing above it names
+a stage slug or a rubric key. So swapping the outcome measure is swapping what fills
+them, and every one of the refusals in :mod:`src.trials` keeps working on the new
+numbers without being touched.
+
+**The mapping, and why each half is shaped the way it is.**
+
+``stage_fitness`` gets exactly one key, ``"<task_id>|<env_digest>"``. One key because
+``Pair._mean_over`` is an *unweighted* mean and ResearchClawBench's total is a
+*weighted* one: a mean over a single element is that element, so ``Pair.difference``
+comes out as the benchmark total difference exactly, with the weighting already done
+where it belongs. The environment digest is in the key because a pair whose two arms
+used different judges, different ``--model``, a different checklist or a different
+web-search level is a *composition difference*, which is the thing
+``collect_pairs`` already refuses to compare across. Folding the environment into the
+key makes that refusal fire on a confounded pair with no new gate to write — and,
+more to the point, no new gate to get wrong.
+
+``criterion_fitness`` gets one key per checklist item, holding ``weight * score`` —
+the item's contribution to the total. Every one of the forty shipped checklists has
+weights summing to exactly 1.0, so **within one run** the decomposition sums to the
+scalar, which AutoR's own decomposition does not do, and ``concentration`` becomes
+literally "share of the movement sitting in one checklist item". The identity is a
+per-run one and does not survive aggregation: ``TrialResult`` reports the *mean*
+difference per key over *n* pairs against a total that is also a mean, so the column
+sums to the scalar there too, but a reader who adds the raw per-pair contributions
+across pairs gets ``n`` times it. Stated once here rather than implied twice. Not per-item keys' obvious
+alternative, a two-key image/text split: two keys put ``concentration`` in [0.5, 1.0]
+unconditionally and reduce the 0.6 Goodhart threshold to "the bigger half is 1.5× the
+smaller", which fires on nearly everything. The image/text axis is real and causal —
+image criteria see only ``report_text[:10000]`` and the Discussion is at the end of
+the report, so a settled-reasoning channel can only reach text criteria — so it is
+printed as its own table below, where it does not have to double as the decomposition.
+
+**No record written here is ever persisted.** ``RunRecord.usable`` is
+``rubric_version == RUBRIC_VERSION and provenance == "live"``, and a benchmark row
+carrying AutoR's rubric version is a claim it cannot support. The containment is not a
+comment: these records exist in memory for the length of one report and there is no
+code path in this module or its tool that opens an :class:`src.archive.Archive`. If
+one of these rows ever reached ``Archive.variant_fitness``, 0–100 benchmark totals
+would pool with [0, 1] rubric means and drive topology promotion off a unit error.
+
+**What a run has to be before it is a measurement.** Ten clauses, every one of them
+written from something that actually happened on this box: a workspace with
+``status == "running"`` and a 12 KB working draft in ``report/report.md`` scores
+perfectly well; a run killed by quota still exports a fallback report and records
+``status: "completed"``; thirteen PNGs under ``outputs/`` took all five judge image
+slots and dropped one image criterion from 48 to 0, moving the total from 46.0 to 9.6.
+None of those is a bad run. Each is a *non-run* that produces a plausible number, and
+averaging one into a paired difference is how a four-day measurement becomes fiction.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field, replace
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from .archive import RunRecord
+from .information_flow import CHANNELS
+from .rubric import RUBRIC_VERSION
+from .trials import (
+    TrialResult,
+    collect_pairs,
+    format_trial_report,
+    min_attainable_concentration,
+)
+
+
+#: Judge calls per workspace in the final scoring pass. The reference judge's
+#: ``responses.create`` passes no ``temperature``, so it has real sampling noise, and
+#: replicates are the only thing that turns "a text item moved 30 points, call it
+#: noise" from folklore into a measured band. Three is cheap — scoring is minutes
+#: against a run's hours — and it is a poor variance estimator, so what it produces is
+#: reported as a range the judge could not resolve, never as a significance test.
+SCORE_REPLICATES = 3
+
+#: No heartbeat on ``logs_raw.jsonl`` for this long and the run is hung. The only
+#: second-granularity signal a run emits: ``run_manifest.json`` updates on stage
+#: transitions only, and ``_meta.json`` is written once at the end.
+STALL_SECONDS = 2700
+
+#: Deliberately absent: a per-run wall clock. A measured run on this box took 57011
+#: seconds (15.8 h) and finished with ``report_source == "agent"``. Any cap short
+#: enough to be useful against a hang is short enough to kill that run, so the trial
+#: gets a deadline after which no *new* run starts and a running one is left alone.
+BACKOFF_SCHEDULE_SECONDS = (1800, 3600, 7200)
+
+#: Attempts per (task, arm) before the pair is refused, counting abandoned drivers and
+#: transient backend deaths. Applied identically to both arms — an asymmetric retry
+#: budget is a thumb on the scale.
+MAX_ATTEMPTS = 2
+
+#: Quota backoffs per (task, arm), on top of :data:`MAX_ATTEMPTS`. Vertex quota is
+#: per-base-model and recovers; refusing the pair on the first 429 most likely ends a
+#: four-day trial with zero pairs.
+MAX_BACKOFFS = 2
+
+#: The channel's own heading, read off the channel rather than written out again.
+#:
+#: Its absence from the treatment arm's Stage 07 prompt means the channel under test
+#: delivered nothing — ``information_flow._render`` emits the heading whenever the block
+#: is non-empty and emits nothing at all when it is — so that pair is not a test of it.
+#:
+#: The obvious marker, ``build_block``'s ``## Methodological questions this run settled``,
+#: sees only half the channel: that sub-heading is emitted inside ``if cruxes:``, and a
+#: block built from rejected idea-pool candidates alone — one of the two things PR #175
+#: routes here — contains only ``## Hypotheses generated and not pursued``. Reading it
+#: would publish "this pair did not administer the channel" over a dose that was
+#: delivered. Derived from ``CHANNELS`` rather than copied so that renaming the heading
+#: cannot leave the detector looking for a string nothing emits.
+SETTLED_REASONING_HEADING = {
+    channel.key: channel.heading for channel in CHANNELS
+}["settled_reasoning"]
+
+
+def _digest(payload: object) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# The environment a run was measured in
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RunEnvironment:
+    """Everything that changes the number without changing the code under test.
+
+    Each field is here because it was observed to move, not because it could. The
+    web-search level is the sharpest: the same command line produced ``level: info``
+    on two days and ``level: warn`` on a third, because ``google.genai`` was not
+    importable by the interpreter that day — meaning Stage 01 had no way to search at
+    all. That is a larger effect than anything a prompt change can buy, and nothing in
+    the run's own artifacts flags it as an anomaly.
+    """
+
+    #: sha256 of the checklist bytes. Item identity is a property of the benchmark
+    #: checkout and the scorer's output records only ``task_id``.
+    checklist_digest: str = ""
+    #: Worth about sixteen points on identical artifacts (Gemini 2.5 Flash 37.0,
+    #: Claude Opus 20.8). Same judge both arms or there is no comparison.
+    judge_model: str = ""
+    #: The operator model.
+    agent_model: str = ""
+    #: Independent of the operator model, and the one that silently dies on an
+    #: exhausted pool when only ``--model opus`` is passed.
+    review_model: str = ""
+    #: Resolved, not requested. ``run_config.json`` records ``"auto"``.
+    web_search_level: str = ""
+    #: The judge reads ``INSTRUCTIONS.md`` as background. Both arms byte-identical.
+    instructions_digest: str = ""
+    #: ``git rev-parse HEAD`` in the benchmark checkout.
+    bench_revision: str = ""
+    #: How many judge draws this arm's published total is the mean of. Not a property of
+    #: the run but of the measurement of it, and it belongs in the digest for the same
+    #: reason the judge model does: one draw against the mean of three is not a
+    #: comparison. ``final_pass`` gives a replicate two tries and then moves on writing
+    #: nothing, so an arm silently scored once against an arm scored three times is the
+    #: ordinary failure, not the exotic one — and it is the direction that inflates,
+    #: because a single draw carries the judge's full sampling range into the delta while
+    #: the other arm has averaged its own away.
+    judge_replicates: int = 0
+
+    @property
+    def digest(self) -> str:
+        return _digest(dataclasses.asdict(self))
+
+    def describe_difference(self, other: "RunEnvironment") -> list[str]:
+        """Name every field that differs, in the report's voice.
+
+        The digest is the gate; this is the diagnostics. Their separation is
+        deliberate — a bug here cannot let a confounded pair through, because the pair
+        dies on the key mismatch whatever this returns. What a bug here *can* do is
+        leave a reader with "the two arms measured no stage in common", which is true
+        and useless, so :func:`collect_rcb_pairs` asserts the two stay in step.
+        """
+        reasons: list[str] = []
+        for spec in dataclasses.fields(self):
+            mine = getattr(self, spec.name)
+            theirs = getattr(other, spec.name)
+            if mine != theirs:
+                reasons.append(
+                    f"the arms differ in `{spec.name}` "
+                    f"(control {mine or '<unset>'}, treatment {theirs or '<unset>'})"
+                )
+        return reasons
+
+
+# ---------------------------------------------------------------------------
+# What one scored arm of a pair is
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoredItem:
+    """One checklist item, scored ``SCORE_REPLICATES`` times by one judge."""
+
+    index: int
+    kind: str
+    weight: float
+    content_key: str
+    scores: tuple[int, ...]
+
+    @property
+    def score(self) -> float:
+        return sum(self.scores) / len(self.scores) if self.scores else 0.0
+
+    @property
+    def spread(self) -> float:
+        """Max minus min across replicates: what this judge could not resolve.
+
+        A range over three draws underestimates the distribution, so this is a floor
+        on the judge's noise and is reported as one.
+        """
+        return (max(self.scores) - min(self.scores)) if self.scores else 0.0
+
+    @property
+    def contribution(self) -> float:
+        return self.weight * self.score
+
+    @property
+    def key(self) -> str:
+        return f"#{self.index:02d} {self.kind} w={self.weight:g}"
+
+
+@dataclass(frozen=True)
+class ArmEvidence:
+    """One arm of one pair: what was scored, and everything the gate needs to see."""
+
+    task_id: str
+    arm: str
+    run_id: str
+    workspace: str
+    env: RunEnvironment
+    items: tuple[ScoredItem, ...]
+    #: ``score.py``'s own ``total_score``: ``round(sum(w*s)/sum(w), 2)`` from a single
+    #: pass. Carried so the recomputed number can be reconciled against it rather than
+    #: quietly replacing it.
+    published_total: float
+    #: What the plan asked for. Carried so "scored three times" and "scored once because
+    #: the judge failed twice on two of the three draws" are different sentences in the
+    #: report rather than the same one.
+    replicates_requested: int = 0
+    #: How many images the scorer actually put in front of every image criterion, and how
+    #: many it had to choose from. Image criteria are 60.6% of the benchmark's weight and
+    #: all of them see the *same* first five of one ``rglob`` list, so an arm that emitted
+    #: twelve figures was judged on an arbitrary five of them. It is not in the digest:
+    #: how many figures a run produced is an effect of the code under test, not a
+    #: confound to exclude. It is printed, because attributing an image-stratum delta to
+    #: figure quality when the two arms were shown different figures is the error.
+    images_shown: int = 0
+    images_available: int = 0
+    judge_failures: tuple[str, ...] = ()
+    checklist_items_expected: int = 0
+    #: Admission facts, read off the workspace by the tool. A mapping rather than
+    #: fields so the gate and the reader agree about what was looked at.
+    facts: Mapping[str, Any] = field(default_factory=dict)
+    #: Stage slugs AutoR's own evolution loop scored. Not the outcome measure; a
+    #: composition difference the benchmark seam is structurally blind to.
+    autor_stages_scored: tuple[str, ...] = ()
+    #: Whether Stage 07's prompt actually carried the settled-reasoning block.
+    settled_reasoning_dose: bool = False
+
+    @property
+    def replicates(self) -> int:
+        """How many judge draws the published total averages.
+
+        Read off the environment rather than stored beside it. Two encodings of one
+        count is how an arm scored once came to be printed as "3 replicate scorings per
+        arm": the report read one copy and the composition gate read neither.
+        """
+        return self.env.judge_replicates
+
+    @property
+    def replicates_lost(self) -> int:
+        return max(0, self.replicates_requested - self.replicates)
+
+    @property
+    def total_weight(self) -> float:
+        return sum(item.weight for item in self.items)
+
+    @property
+    def total_weighted(self) -> float:
+        """The published scalar: ``sum(weight * mean score)`` over every item.
+
+        Not ``score.py``'s ``total_score``, which is one pass rounded to two places.
+        With ``total_weight`` asserted to be 1.0 the two are the same number up to that
+        rounding, and :func:`to_run_record` refuses when they are not.
+        """
+        return sum(item.contribution for item in self.items)
+
+
+# ---------------------------------------------------------------------------
+# Admission: is this run a measurement at all?
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AdmissionClause:
+    name: str
+    why: str
+    test: Callable[[ArmEvidence], bool]
+
+
+def _fact(evidence: ArmEvidence, name: str, default: Any = None) -> Any:
+    return evidence.facts.get(name, default)
+
+
+#: Every clause refuses a *pair*, not an arm, because refusing one arm turns the pair
+#: into "no treatment arm" and hides the cause. Each is a fixture in the tests, and the
+#: report prints how many runs each one refused — a clause that has silently stopped
+#: firing because an internal artifact was renamed shows up as a zero rather than as
+#: nothing at all.
+ADMISSION_CLAUSES: tuple[AdmissionClause, ...] = (
+    AdmissionClause(
+        "status_completed",
+        "`_meta.status` must be `completed`. The scorer never looks at it, and a "
+        "workspace mid-run scores its working draft as if it were the deliverable.",
+        lambda ev: _fact(ev, "meta_status") == "completed",
+    ),
+    AdmissionClause(
+        "pipeline_completed",
+        "`_meta.pipeline_completed` must be true. A second, independent witness to the "
+        "clause above: one measured workspace here has status `completed` and "
+        "pipeline_completed false.",
+        lambda ev: _fact(ev, "meta_pipeline_completed") is True,
+    ),
+    AdmissionClause(
+        "report_from_agent",
+        "`_meta.report_source` must be `agent`. A run killed by quota still exports a "
+        "fallback report and is scored as an attempt — worth about 7.5 points of "
+        "nothing.",
+        lambda ev: _fact(ev, "meta_report_source") == "agent",
+    ),
+    AdmissionClause(
+        "single_run_root",
+        "Exactly one `.autor/<run_id>`. Nothing stops a second invocation writing into "
+        "the same workspace, and the exporter picks the lexicographically last run "
+        "root, which is the failed retry.",
+        lambda ev: _fact(ev, "autor_run_count") == 1,
+    ),
+    AdmissionClause(
+        "no_images_under_outputs",
+        "Zero images under `outputs/`. The judge is shown the first five of one list "
+        "that sweeps `outputs/` before `report/`, against every image criterion: "
+        "thirteen PNGs there took an image item from 48 to 0 and the total from 46.0 "
+        "to 9.6.",
+        lambda ev: _fact(ev, "images_under_outputs") == 0,
+    ),
+    AdmissionClause(
+        "single_report_md",
+        "`report/report.md` exists and is the only `report/*.md`. Counting is not "
+        "naming: with `report.md` missing the scorer returns the first `.md` an "
+        "unsorted glob yields, so a lone leftover `draft.md` satisfies a count of one "
+        "and is then scored as the deliverable, with nothing recording which file was "
+        "read.",
+        lambda ev: _fact(ev, "report_md_count") == 1
+        and _fact(ev, "report_md_present") is True,
+    ),
+    AdmissionClause(
+        "backend_reached",
+        "`run_manifest.last_event` must not be `run.backend_unavailable`. The only "
+        "machine-readable trace a quota death leaves: `last_error` stays null and "
+        "`current_stage_slug` is nulled out.",
+        lambda ev: _fact(ev, "last_event") != "run.backend_unavailable",
+    ),
+    AdmissionClause(
+        "no_quota_in_logs",
+        "No `RESOURCE_EXHAUSTED` in the run's own `logs.txt`. `classify_backend` only "
+        "runs when neither the primary nor the repair attempt wrote a stage file, so a "
+        "429 that lands mid-stage is baked into the summary as prose and the run reports "
+        "itself complete.",
+        lambda ev: _fact(ev, "resource_exhausted_hits", 0) == 0,
+    ),
+    AdmissionClause(
+        "revision_matches_arm",
+        "The worktree's HEAD at launch and at finish must be the same commit, must be "
+        "clean, and must be the commit the arm label names. `RunRecord` has no revision "
+        "field and `run_config.json` records no SHA; the arm label is the only carrier "
+        "and nothing else checks it.",
+        lambda ev: _revision_matches_arm(ev),
+    ),
+    AdmissionClause(
+        "every_item_judged",
+        "Every checklist item judged, none of them by a failed call. A judge failure is "
+        "recorded as score 0 and is indistinguishable from a criterion the report "
+        "missed: one run's honest total was 37.0 and the number on screen was 19.5.",
+        lambda ev: (
+            not ev.judge_failures
+            and len(ev.items) > 0
+            and len(ev.items) == ev.checklist_items_expected
+        ),
+    ),
+)
+
+
+def _revision_matches_arm(evidence: ArmEvidence) -> bool:
+    launch = str(_fact(evidence, "revision_at_launch", ""))
+    finish = str(_fact(evidence, "revision_at_finish", ""))
+    if not launch or launch != finish:
+        return False
+    if _fact(evidence, "worktree_dirty", True):
+        return False
+    label = evidence.arm.strip()
+    # Prefix either way: an arm labelled with a short SHA against a full HEAD, or the
+    # reverse. Not a substring test — `47f3fbf` appearing anywhere in a SHA is chance.
+    return bool(label) and (launch.startswith(label) or label.startswith(launch))
+
+
+def admit_arm(evidence: ArmEvidence) -> tuple[bool, list[str]]:
+    """``(admitted, failed clause names)``. Order is the clause order, for the ledger."""
+    failed = [clause.name for clause in ADMISSION_CLAUSES if not clause.test(evidence)]
+    return (not failed), failed
+
+
+def clause_by_name(name: str) -> AdmissionClause:
+    for clause in ADMISSION_CLAUSES:
+        if clause.name == name:
+            return clause
+    raise KeyError(name)
+
+
+# ---------------------------------------------------------------------------
+# The seam
+# ---------------------------------------------------------------------------
+
+
+def to_run_record(evidence: ArmEvidence, *, capability: str) -> RunRecord:
+    """One admitted arm as a :class:`RunRecord`, so :mod:`src.trials` can do the rest.
+
+    **This record is never written to disk, and there is no code here that could write
+    it.** ``rubric_version`` has to be ``RUBRIC_VERSION`` for ``RunRecord.usable`` to be
+    true, and on a benchmark row that is a claim the row cannot support: the number in
+    ``stage_fitness`` is a judge's 0–100 reading of a report, not AutoR's rubric. The
+    containment is structural rather than documentary — no ``Archive`` is constructed
+    anywhere in this module or in ``tools/rcb_trial.py``, and a test asserts it stays
+    that way — because if one of these rows reached ``Archive.variant_fitness`` it
+    would pool a 0–100 total with [0, 1] rubric means and steer topology promotion.
+
+    Three refusals, because each invariant is silent when it breaks:
+
+    * the checklist's weights must sum to 1.0, or the decomposition does not sum to the
+      scalar and ``concentration`` stops meaning what the report says it means;
+    * the arm must have been admitted, so a fallback report cannot arrive here by
+      another route;
+    * with a single replicate the recomputed weighted sum must reconcile with
+      ``score.py``'s own ``total_score``, because that is one number written twice and
+      the two encodings will otherwise drift without anybody noticing.
+    """
+    admitted, failed = admit_arm(evidence)
+    if not admitted:
+        raise ValueError(
+            f"{evidence.task_id}/{evidence.arm} is not a measurement: "
+            + ", ".join(failed)
+            + ". A refused run belongs in the ledger, not in an average."
+        )
+    if abs(evidence.total_weight - 1.0) > 1e-9:
+        raise ValueError(
+            f"{evidence.task_id} checklist weights sum to {evidence.total_weight!r}, not 1.0. "
+            "The per-item decomposition is only the total's decomposition when they do."
+        )
+    contributions = {item.key: item.contribution for item in evidence.items}
+    if len(contributions) != len(evidence.items):
+        raise ValueError(
+            f"{evidence.task_id} produced duplicate item keys; the decomposition would "
+            "silently drop an item and still sum to something plausible."
+        )
+    total = sum(contributions.values())
+    if abs(total - evidence.total_weighted) > 1e-9:
+        raise ValueError("the contributions do not sum to the published weighted total")
+    if evidence.replicates <= 1:
+        # score.py rounds to two places; anything past that is two encodings drifting.
+        # ``<= 1`` and not ``== 1``: an evidence whose replicate count was never recorded
+        # is a single pass until something says otherwise, and skipping the only place
+        # the two encodings meet is not the safe direction to guess in.
+        if abs(total - evidence.published_total) > 0.005 + 1e-9:
+            raise ValueError(
+                f"{evidence.task_id}/{evidence.arm}: recomputed total {total:.4f} does not "
+                f"reconcile with score.py's {evidence.published_total:.4f}. One number, two "
+                "encodings, and this is the only place they meet."
+            )
+
+    stage_key = f"{evidence.task_id}|{evidence.env.digest[:12]}"
+    return RunRecord(
+        run_id=evidence.run_id,
+        variant_id=f"rcb/{evidence.env.judge_model}",
+        rubric_version=RUBRIC_VERSION,
+        edges={},
+        stage_fitness={stage_key: total},
+        topology="rcb",
+        provenance="live",
+        route=evidence.workspace,
+        steps=len(evidence.items),
+        revisits=0,
+        agent_directed=0,
+        bypassed=0,
+        recorded_at="",
+        criterion_fitness={f"{evidence.task_id}{key}": value for key, value in contributions.items()},
+        trial_id=evidence.task_id,
+        capability=capability,
+        arm=evidence.arm,
+    )
+
+
+def compare_arms(control: ArmEvidence, treatment: ArmEvidence) -> list[str]:
+    """Named reasons two admitted arms are not comparable.
+
+    The environment digest inside the stage key already excludes them; this says which
+    field did it. "The two arms measured no stage in common" is a true sentence about a
+    one-byte difference in ``INSTRUCTIONS.md`` and it helps nobody.
+    """
+    reasons: list[str] = []
+    if control.task_id != treatment.task_id:
+        reasons.append(
+            f"the arms scored different tasks (`{control.task_id}` and `{treatment.task_id}`)"
+        )
+    reasons += control.env.describe_difference(treatment.env)
+    control_keys = [item.content_key for item in control.items]
+    treatment_keys = [item.content_key for item in treatment.items]
+    if control_keys != treatment_keys:
+        reasons.append(
+            "the arms were scored against different checklist items, so the per-item "
+            "decomposition would pair by position across two different lists"
+        )
+    return reasons
+
+
+# ---------------------------------------------------------------------------
+# Pairing
+# ---------------------------------------------------------------------------
+
+
+#: Clause names for the refusals the driver makes before the gate can see the run at all.
+#: They share the ledger with the ten admission clauses because they lose the reader the
+#: same thing — a pair — and because the ledger's whole job is the per-arm death count.
+DRIVER_CLAUSE_PREFIX = "driver:"
+
+
+def driver_clause(classification: str) -> str:
+    return DRIVER_CLAUSE_PREFIX + (classification or "unknown")
+
+
+@dataclass(frozen=True)
+class Refusal:
+    task_id: str
+    arm: str
+    clauses: tuple[str, ...]
+
+    @property
+    def summary(self) -> str:
+        return f"`{self.task_id}` / `{self.arm}`: " + ", ".join(self.clauses)
+
+
+@dataclass(frozen=True)
+class RcbTrial:
+    """A finished (or interrupted) paired trial and everything a reader needs to argue."""
+
+    result: TrialResult
+    #: Admitted evidence, keyed ``(task_id, arm)``.
+    evidence: Mapping[tuple[str, str], ArmEvidence]
+    refusals: tuple[Refusal, ...]
+    planned_pairs: int
+
+    @property
+    def interim(self) -> bool:
+        return self.result.n != self.planned_pairs
+
+    def refusals_by_clause(self) -> dict[str, int]:
+        """Every admission clause at its count, then every driver refusal that happened.
+
+        The admission clauses are listed even at zero, because a clause that stopped
+        firing looks exactly like a clause never violated. The driver rows are listed
+        only when they fired, because they are not a fixed set — and because a zero
+        against ``driver:quota`` would be the wrong claim: four of the ten clauses below
+        can only be reached by a run the driver already let through, so a quota death
+        arrives in this table under its driver name and never under the clause's.
+        """
+        counts = {clause.name: 0 for clause in ADMISSION_CLAUSES}
+        driver: dict[str, int] = {}
+        for refusal in self.refusals:
+            for name in refusal.clauses:
+                if name in counts:
+                    counts[name] += 1
+                else:
+                    driver[name] = driver.get(name, 0) + 1
+        counts.update(sorted(driver.items()))
+        return counts
+
+    def refusals_by_arm(self) -> dict[str, int]:
+        counts: dict[str, int] = {
+            self.result.control_arm: 0,
+            self.result.treatment_arm: 0,
+        }
+        for refusal in self.refusals:
+            counts[refusal.arm] = counts.get(refusal.arm, 0) + 1
+        return counts
+
+
+def collect_rcb_pairs(
+    evidences: Iterable[ArmEvidence],
+    *,
+    capability: str,
+    control_arm: str,
+    treatment_arm: str,
+    planned_pairs: int,
+    driver_refusals: Sequence[Refusal] = (),
+) -> RcbTrial:
+    """Admit, pair, and replace every generic exclusion reason with a named one.
+
+    The gate and the explanation are separate on purpose. ``collect_pairs`` does the
+    excluding, off the environment digest baked into the stage key; this only renames
+    what it excluded. The assertion at the end is what keeps the two honest: if a field
+    is dropped from :class:`RunEnvironment` while its diff line survives, a confounded
+    pair reaches ``pairs`` with a named reason for excluding it, and that raises here
+    rather than being published.
+
+    ``driver_refusals`` is the other half of the ledger, and the half that used to be
+    missing: a run killed by quota, by the stall watchdog, by a backend outage, by a
+    fallback report or by the scorer never becomes an :class:`ArmEvidence` at all, so the
+    gate cannot refuse it and it was printed as "no treatment arm" — indistinguishable
+    from an arm that was never launched. Three treatment deaths against zero control
+    deaths is this trial's result whenever it happens, and it cannot be the one thing the
+    ledger structurally cannot see.
+    """
+    admitted: dict[tuple[str, str], ArmEvidence] = {}
+    refusals: list[Refusal] = []
+    for evidence in evidences:
+        ok, failed = admit_arm(evidence)
+        if ok:
+            admitted[(evidence.task_id, evidence.arm)] = evidence
+        else:
+            refusals.append(Refusal(evidence.task_id, evidence.arm, tuple(failed)))
+
+    # One (task, arm) is one lost pair and is counted once. A driver refusal for an arm
+    # that a later attempt got admitted for cost an attempt, not a pair; a driver refusal
+    # for an arm the gate already refused would double the per-arm count that the reader
+    # is told to judge the whole trial on.
+    seen = set(admitted) | {(item.task_id, item.arm) for item in refusals}
+    for refusal in driver_refusals:
+        if (refusal.task_id, refusal.arm) in seen:
+            continue
+        seen.add((refusal.task_id, refusal.arm))
+        refusals.append(refusal)
+
+    records = [to_run_record(item, capability=capability) for item in admitted.values()]
+    result = collect_pairs(
+        records,
+        capability=capability,
+        control_arm=control_arm,
+        treatment_arm=treatment_arm,
+    )
+
+    named: dict[str, list[str]] = {}
+    for refusal in refusals:
+        side = "control" if refusal.arm == control_arm else "treatment"
+        named.setdefault(refusal.task_id, []).append(
+            f"the {side} arm `{refusal.arm}` was refused ({', '.join(refusal.clauses)})"
+        )
+    tasks = {task for task, _ in admitted} | {refusal.task_id for refusal in refusals}
+    for task in tasks:
+        control = admitted.get((task, control_arm))
+        treatment = admitted.get((task, treatment_arm))
+        if control is not None and treatment is not None:
+            named.setdefault(task, []).extend(compare_arms(control, treatment))
+
+    kept = {pair.trial_id for pair in result.pairs}
+    leaked = sorted(task for task, reasons in named.items() if reasons and task in kept)
+    if leaked:
+        raise AssertionError(
+            "a pair with a named reason to be excluded survived pairing: "
+            + ", ".join(leaked)
+            + ". The environment digest and the cross-arm diff have gone out of step, "
+            "which means a confound can now reach the published difference."
+        )
+
+    excluded = dict(result.excluded)
+    for task, reasons in named.items():
+        if reasons:
+            excluded[task] = "; ".join(reasons)
+    for task in tasks:
+        if task not in kept and task not in excluded:
+            excluded[task] = "no run of either arm was admitted"
+
+    return RcbTrial(
+        result=replace(result, excluded=tuple(sorted(excluded.items()))),
+        evidence=admitted,
+        refusals=tuple(refusals),
+        planned_pairs=planned_pairs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reading the two arms side by side
+# ---------------------------------------------------------------------------
+
+
+def pair_resolution(control: ArmEvidence, treatment: ArmEvidence) -> float:
+    """How much of a pair's difference this judge could not resolve, in total points.
+
+    ``sum_i w_i * max(spread_i^control, spread_i^treatment)``. Replaces the folklore
+    rule that a text item moving under thirty raw points is noise — that rule is in the
+    wrong units (an item at ``w = 0.2`` converts thirty raw points into six total
+    points) and it was never measured. This is measured, on these two workspaces, by
+    this judge. It is a floor: a range over three draws underestimates a distribution,
+    and it says nothing at all about run-to-run variance, of which there are zero
+    observations.
+    """
+    total = 0.0
+    for left, right in zip(control.items, treatment.items):
+        total += left.weight * max(left.spread, right.spread)
+    return total
+
+
+def resolution_is_measured(control: ArmEvidence, treatment: ArmEvidence) -> bool:
+    """Whether :func:`pair_resolution` is a measurement rather than an artefact of one draw.
+
+    A spread needs two draws to exist. With one, every ``ScoredItem.spread`` is 0 and
+    :func:`pair_resolution` returns 0.00 — *fewer* draws producing a *smaller* stated
+    uncertainty, which is exactly backwards, and which reads off the page as "this judge
+    resolved every item exactly" on the one arm where nothing about the judge's noise was
+    observed at all. Losing replicates is the ordinary case: ``final_pass`` gives each
+    draw two tries and then moves on.
+    """
+    return min(control.replicates, treatment.replicates) >= 2
+
+
+def stratum_rollup(control: ArmEvidence, treatment: ArmEvidence) -> dict[str, Any]:
+    """The image/text split, with the identity that makes it checkable.
+
+    Causal, not cosmetic: image criteria are shown only ``report_text[:10000]`` and the
+    Discussion sits at the end of the report by construction, so a channel that routes
+    settled reasoning into Discussion can reach the text stratum and structurally
+    cannot reach the image one. Within a pair
+    ``delta_total == share_image * delta_image + share_text * delta_text`` holds
+    exactly, and the residual is asserted rather than assumed — it is a free check that
+    the two arms' item lists really did line up.
+    """
+    strata: dict[str, dict[str, float]] = {}
+    for kind in ("image", "text"):
+        weight = sum(item.weight for item in control.items if item.kind == kind)
+        control_mean = (
+            sum(item.contribution for item in control.items if item.kind == kind) / weight
+            if weight
+            else 0.0
+        )
+        treatment_mean = (
+            sum(item.contribution for item in treatment.items if item.kind == kind) / weight
+            if weight
+            else 0.0
+        )
+        strata[kind] = {
+            "share": weight,
+            "control": control_mean,
+            "treatment": treatment_mean,
+            "delta": treatment_mean - control_mean,
+        }
+    delta_total = treatment.total_weighted - control.total_weighted
+    rebuilt = sum(value["share"] * value["delta"] for value in strata.values())
+    return {
+        "strata": strata,
+        "delta_total": delta_total,
+        "residual": delta_total - rebuilt,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The report
+# ---------------------------------------------------------------------------
+
+
+#: The single largest hole, and it goes directly under the total rather than in a
+#: caveats section nobody reaches. Every (task, arm) ran once, so the apparatus has no
+#: observation at all of AutoR's own run-to-run variance, which is almost certainly
+#: larger than the judge's.
+_ONE_OBSERVATION = (
+    "Each (task, arm) ran **once**. The resolution above is the judge's sampling range "
+    "over replicate scorings of the same two workspaces; there are zero observations of "
+    "AutoR's own run-to-run variance, which is very likely larger. Read a difference "
+    "that exceeds the resolution as *the judge cannot explain it*, never as *the "
+    "treatment explains it*."
+)
+
+#: Printed wherever an n below the planned n carries a p. Every refusal removes a pair,
+#: and refusals are not random with respect to arm.
+_REFUSAL_BIAS = (
+    "Every refusal above removes a **pair**, and quota and wall-clock deaths are not "
+    "random with respect to arm: the channel under test adds prompt content to Stage "
+    "07, which can make treatment runs longer and likelier to be cut off. A surviving "
+    "sample weighted toward the treatment runs that finished fastest is a sample of the "
+    "treatment runs that did less, and it manufactures a null. If the per-arm refusal "
+    "counts above are lopsided, the difference below is not this trial's result."
+)
+
+
+def format_rcb_trial_report(
+    trial: RcbTrial,
+    *,
+    contrast_log: str = "",
+    plan_digest: str = "",
+    judge_model: str = "",
+    planned_judge_model: str = "",
+    unit: str = "RCB points (0-100 total scale)",
+) -> str:
+    """The whole rendering: provenance, ledger, statistics, decomposition, dose.
+
+    Order is an argument. The refusal ledger sits *above* the total because a trial
+    that refused three treatment runs and zero control runs has produced a result, and
+    it is not the number underneath. The p-value sits at the bottom under the floor it
+    cannot beat, because at three pairs the floor is 0.25 and the conclusion has to be
+    carried by the decomposition and by which channel each task can see.
+    """
+    result = trial.result
+    lines: list[str] = [
+        "# ResearchClawBench paired trial",
+        "",
+        f"- capability: `{result.capability}`",
+        f"- control revision: `{result.control_arm}`   treatment revision: `{result.treatment_arm}`",
+        f"- judge: `{judge_model or '<unrecorded>'}`   (judge choice is worth about "
+        "sixteen points on identical artifacts, so it is part of the number)",
+    ]
+    if planned_judge_model and judge_model and planned_judge_model != judge_model:
+        # The judge above is read off the score files; this one is what the plan asked
+        # for. `score_rcb_run.py` builds its judge with `args.model or its own default`,
+        # so a dropped `--model` scores the whole trial with a model nobody chose while
+        # the header states the declaration and reads correct.
+        lines.append(
+            f"- **the judge that ran is not the judge the plan declared** "
+            f"(`{planned_judge_model}`). Sixteen points on identical artifacts is larger "
+            "than anything this trial is looking for."
+        )
+    if plan_digest:
+        lines.append(f"- plan digest: `{plan_digest[:16]}` (frozen before the first launch)")
+    if contrast_log:
+        lines += [
+            "",
+            "The contrast, verbatim from `git log --oneline <control>..<treatment>`:",
+            "",
+            "```",
+            contrast_log.strip(),
+            "```",
+        ]
+
+    if trial.interim:
+        lines += [
+            "",
+            f"> **INTERIM — {result.n} of {trial.planned_pairs} planned pairs.** The p-value "
+            "below is not this trial's result. A resumable apparatus whose report runs at "
+            "any moment is a machine for stopping when the sign looks good; the planned n "
+            "was frozen before the first launch so that stopping early is visible here "
+            "rather than invisible everywhere.",
+        ]
+
+    lines += ["", "## Runs refused, before any number", ""]
+    by_arm = trial.refusals_by_arm()
+    # Printed even when both counts are zero. The paragraph below tells the reader to
+    # judge the difference on this line, and a line that appears only once something has
+    # already gone wrong is not there on the reading where they need it.
+    lines.append(
+        "- per arm: "
+        + f"control `{result.control_arm}` {by_arm.get(result.control_arm, 0)}, "
+        + f"treatment `{result.treatment_arm}` {by_arm.get(result.treatment_arm, 0)}"
+    )
+    if trial.refusals:
+        for refusal in trial.refusals:
+            lines.append(f"  - {refusal.summary}")
+    else:
+        lines.append("- no run was refused.")
+    lines += ["", "| Clause | Runs refused |", "| --- | --- |"]
+    for name, count in trial.refusals_by_clause().items():
+        lines.append(f"| `{name}` | {count} |")
+    lines += [
+        "",
+        "A clause showing zero has never been violated, or has stopped firing because the "
+        "artifact it reads was renamed, or cannot fire at all on this path — a run killed "
+        f"by quota or by the watchdog is refused by the driver and arrives above as a "
+        f"`{DRIVER_CLAUSE_PREFIX}` row, never as `no_quota_in_logs`. All three look the "
+        "same from here, which is why the count is printed rather than the failures alone.",
+    ]
+    if trial.refusals or trial.interim:
+        lines += ["", _REFUSAL_BIAS]
+
+    lines += ["", "## The difference", "", format_trial_report(result, unit=unit)]
+
+    for pair in result.pairs:
+        control = trial.evidence.get((pair.trial_id, result.control_arm))
+        treatment = trial.evidence.get((pair.trial_id, result.treatment_arm))
+        if control is None or treatment is None:  # pragma: no cover - pairing guarantees both
+            continue
+        lines += _format_pair(pair.trial_id, control, treatment)
+
+    lines += [
+        "",
+        "## What this is a measurement of",
+        "",
+        "The number above is one judge's reading of one report against a checklist the "
+        "run never saw, on tasks chosen because the two channels under test could show "
+        "there at all. It is an upper bound on the benchmark-wide effect, not an "
+        "estimate of it: nineteen of the forty tasks carry zero Mode-B text weight and "
+        "nine have no text criteria whatsoever, so on those the Discussion cannot be "
+        "read by any criterion.",
+    ]
+    return "\n".join(lines)
+
+
+def _images_shown_lines(control: ArmEvidence, treatment: ArmEvidence) -> list[str]:
+    """What the judge was actually shown, which the score file records and nothing read.
+
+    Image criteria carry 60.6% of the benchmark's weight and every one of them is shown
+    the same first five entries of one list that sweeps ``outputs/`` and then ``report/``.
+    So "the treatment arm's figures scored better" and "the treatment arm emitted twelve
+    figures and an arbitrary five of them were shown" produce the same number, and one
+    real workspace on this box is already over the cap at six. This is not in the
+    environment digest — how many figures a run produced is an effect of the change under
+    test, not a confound to hold fixed — so the pair is admitted and the reader is told.
+    """
+    lines = [
+        f"- images shown to the judge: control **{control.images_shown}** of "
+        f"{control.images_available}, treatment **{treatment.images_shown}** of "
+        f"{treatment.images_available}"
+    ]
+    capped = [
+        name
+        for name, arm in (("control", control), ("treatment", treatment))
+        if arm.images_available > arm.images_shown
+    ]
+    if capped or control.images_shown != treatment.images_shown:
+        lines.append(
+            "- **The two arms were not shown the same evidence.** "
+            + (
+                f"The {' and '.join(capped)} arm's figures were over the scorer's cap, so "
+                "an arbitrary five of them stood for all of them. "
+                if capped
+                else ""
+            )
+            + "Any movement in the image stratum below is figure count and figure "
+            "selection as much as figure quality, and the image stratum is 60.6% of the "
+            "benchmark's weight."
+        )
+    return lines
+
+
+def _format_pair(task_id: str, control: ArmEvidence, treatment: ArmEvidence) -> list[str]:
+    resolution = pair_resolution(control, treatment)
+    delta = treatment.total_weighted - control.total_weighted
+    lines = [
+        "",
+        f"### `{task_id}`",
+        "",
+        f"- total: control **{control.total_weighted:.2f}**, treatment "
+        f"**{treatment.total_weighted:.2f}**, delta **{delta:+.2f}**",
+        # Both counts, always, and never one of them labelled "per arm": an arm whose
+        # replicates were lost to judge failures was printed as the other arm's count,
+        # which is the one reading under which the number needs no caveat.
+        f"- judge draws: control **{control.replicates}**, treatment "
+        f"**{treatment.replicates}**, of "
+        f"{control.replicates_requested or treatment.replicates_requested or '?'} planned",
+    ]
+    if resolution_is_measured(control, treatment):
+        lines.append(
+            f"- judge resolution on this pair: **±{resolution:.2f}** total points"
+        )
+    else:
+        lines.append(
+            "- judge resolution on this pair: **unmeasured**. A spread needs two draws, "
+            "and one arm here has one, so nothing was observed about what this judge "
+            "could not resolve on these two workspaces. Read the delta below against "
+            "the folklore band it replaces — a text item has moved 30 raw points "
+            "between judges on identical text — and not against zero."
+        )
+    if control.replicates_lost or treatment.replicates_lost:
+        lines.append(
+            f"- **Under-replicated.** {control.replicates_lost} control and "
+            f"{treatment.replicates_lost} treatment replicate scorings were planned and "
+            "never produced: `final_pass` gives each draw two tries and then moves on. "
+            "The totals above are means over fewer draws than the plan asked for."
+        )
+    lines += _images_shown_lines(control, treatment)
+    lines += ["", _ONE_OBSERVATION]
+
+    if set(control.autor_stages_scored) != set(treatment.autor_stages_scored):
+        lines += [
+            "",
+            f"- **the arms' own runs did not score the same stages** "
+            f"(control {len(control.autor_stages_scored)}, treatment "
+            f"{len(treatment.autor_stages_scored)}). The benchmark seam cannot see this: "
+            "both arms are scored against the same checklist whatever their internal "
+            "composition, so `shape_changes` is structurally zero here. That a revision "
+            "changes how far a run gets is a separate result and is not in the delta.",
+        ]
+
+    lines += [
+        "",
+        "| # | type | w | control | treatment | delta | resolution |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for left, right in zip(control.items, treatment.items):
+        lines.append(
+            f"| {left.index} | {left.kind} | {left.weight:g} | {left.score:.1f} | "
+            f"{right.score:.1f} | {right.score - left.score:+.1f} | "
+            f"±{max(left.spread, right.spread):.1f} |"
+        )
+
+    rollup = stratum_rollup(control, treatment)
+    lines += [
+        "",
+        "| stratum | share of weight | control | treatment | delta |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for kind, value in rollup["strata"].items():
+        lines.append(
+            f"| {kind} | {value['share']:.2f} | {value['control']:.1f} | "
+            f"{value['treatment']:.1f} | {value['delta']:+.1f} |"
+        )
+    lines.append("")
+    lines.append(
+        f"Within this pair `delta_total = share_image*delta_image + share_text*delta_text` "
+        f"to a residual of {rollup['residual']:+.4f}. Across pairs it does not hold — the "
+        "three tasks have different image shares — so no cross-pair stratum total is "
+        "printed. Only the text stratum is reachable by anything routed into Discussion: "
+        "image criteria are shown the first 10,000 characters of the report and the "
+        "Discussion is at the end."
+    )
+
+    deltas = [
+        abs(right.weight * right.score - left.weight * left.score)
+        for left, right in zip(control.items, treatment.items)
+    ]
+    movement = sum(deltas)
+    if movement > 0:
+        share = max(deltas) / movement
+        floor = min_attainable_concentration(len(deltas))
+        lines.append("")
+        lines.append(
+            f"Concentration on this pair: **{share:.0%}** of the movement is in one "
+            f"checklist item (floor at {len(deltas)} items: {floor:.0%}). The pooled "
+            "figure in the table above mixes items from different tasks into one "
+            "denominator, which is why the per-pair number is printed too."
+        )
+
+    if not treatment.settled_reasoning_dose:
+        lines += [
+            "",
+            "- **Zero settled-reasoning dose.** Stage 07's prompt in the treatment arm did "
+            f"not carry `{SETTLED_REASONING_HEADING}`, which the channel emits whenever it "
+            "has anything at all to send — a settled crux, a rejected hypothesis, or both. "
+            "This pair did not administer the channel, so it is **not a test of it**, "
+            "whichever way the delta went.",
+        ]
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# The plan, and the planner
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArmSpec:
+    label: str
+    worktree: str
+    sha: str
+
+
+@dataclass(frozen=True)
+class TrialPlan:
+    """Frozen before the first launch, and hashed into every state file.
+
+    One ``--plan PATH`` in place of ten arm/task/model/judge flags, because the repo
+    owner has objected to flag proliferation and because a trial that runs for days
+    needs its parameters in a file somebody can read afterwards, not in a shell history.
+    """
+
+    capability: str
+    bench: str
+    tasks: tuple[str, ...]
+    control: ArmSpec
+    treatment: ArmSpec
+    judge_kind: str = "reference"
+    judge_model: str = "gpt-5.1"
+    agent_model: str = "opus"
+    review_model: str = "opus"
+    state_dir: str = "/rmeng_data/robtang/rcb-trial"
+    #: ``control_first`` or ``counterbalanced``. See :func:`arm_order`.
+    arm_order_mode: str = "control_first"
+    #: Unix time after which no *new* run starts. A running one is left alone.
+    deadline: float = 0.0
+    stall_seconds: int = STALL_SECONDS
+    replicates: int = SCORE_REPLICATES
+    operator: str = "autor"
+    #: Dry-run only: how much better the fake operator makes the treatment arm's
+    #: report. Zero would give two identical columns, which a broken seam would pass.
+    fake_quality: float = 0.0
+
+    @property
+    def planned_pairs(self) -> int:
+        return len(self.tasks)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = dataclasses.asdict(self)
+        payload["tasks"] = list(self.tasks)
+        return payload
+
+    @property
+    def digest(self) -> str:
+        return _digest(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "TrialPlan":
+        known = {spec.name for spec in dataclasses.fields(cls)}
+        unknown = sorted(set(payload) - known - {"digest"})
+        if unknown:
+            raise ValueError(
+                f"unknown plan fields: {', '.join(unknown)}. A misspelled field that is "
+                "silently ignored is a parameter set wrong for four days."
+            )
+        values = {key: payload[key] for key in known if key in payload}
+        values["tasks"] = tuple(values.get("tasks", ()))
+        for side in ("control", "treatment"):
+            if side in values:
+                values[side] = ArmSpec(**values[side])
+        plan = cls(**values)
+        if plan.control.label == plan.treatment.label:
+            raise ValueError("the two arms carry the same label; the difference would be zero")
+        if not plan.tasks:
+            raise ValueError("a plan with no tasks cannot become a measurement")
+        return plan
+
+
+def arm_order(plan: TrialPlan) -> tuple[tuple[str, str], ...]:
+    """The launch order: pair-major, both arms of a task adjacent.
+
+    Adjacency is the point — the two arms of one pair should straddle as little drift
+    in Vertex load and judge behaviour as possible.
+
+    ``control_first`` is the default and is what the shipped plan uses. The obvious
+    alternative, alternating the within-pair order, de-confounds a first-versus-second
+    position effect across pairs — but only if the pairs finish. This trial will very
+    likely complete one or two of them, and with one pair completed an alternating
+    order turns a position effect into something that cannot even be named afterwards.
+    A fixed order leaves it confounded and *legible*: every treatment run ran second,
+    and a reader can say so. ``counterbalanced`` is kept because with six pairs
+    completed it is the better choice.
+    """
+    order: list[tuple[str, str]] = []
+    for index, task in enumerate(plan.tasks):
+        first, second = plan.control.label, plan.treatment.label
+        if plan.arm_order_mode == "counterbalanced" and index % 2 == 1:
+            first, second = second, first
+        order.append((task, first))
+        order.append((task, second))
+    return tuple(order)
+
+
+#: Quota, unlike a bad idea, recovers. Everything else about a dead run is terminal.
+#:
+#: Strings only a model backend emits. A bare ``429`` was in this tuple and it classified
+#: every healthy run on this box as a quota death: all four real ``logs.txt`` here carry
+#: ``429`` incidentally — a chi2 value, ``sources.json:429`` from a grep, a table cell,
+#: and arXiv answering ``HTTP Error 429`` to a literature fetch that then succeeded —
+#: while none of them contains ``RESOURCE_EXHAUSTED`` at all. Classifying a healthy run
+#: as quota is not a conservative error: :func:`next_action` spends two backoffs and two
+#: relaunches on it and then refuses the pair, so the whole trial ends with zero pairs
+#: after nine hours of sleeping.
+#:
+#: :mod:`src.backend_health` reaches the same conclusion about the same substring and
+#: defends against it by requiring an error-shaped line. That defence is not enough here:
+#: arXiv's rate limit *is* an error-shaped line, and it is not the model backend refusing
+#: to serve the run. :func:`count_quota_hits` reads this same tuple, because a classifier
+#: and an admission clause that disagree about what a quota death is are two encodings of
+#: one rule, and they had already drifted.
+_QUOTA_MARKERS = ("RESOURCE_EXHAUSTED", "Quota exceeded", "rate_limit_error")
+
+
+def classify_run(state: Mapping[str, Any]) -> str:
+    """``ok`` / ``quota`` / ``backend`` / ``fallback`` / ``incomplete`` / ``stalled``.
+
+    Quota is checked against the run's own ``logs.txt`` and not only against
+    ``last_event``, because ``classify_backend`` runs only when neither the primary nor
+    the repair attempt wrote a stage file. A 429 that lands mid-stage leaves
+    ``last_event == "run.completed"`` and the error text baked into a stage summary, and
+    a driver that reads only the manifest retries nothing and refuses nothing.
+
+    It is never checked against the driver's stdout. The operator catches the API error
+    and writes it to the run's log; a retry loop that greps the driver's stdout has
+    never once fired.
+    """
+    if state.get("stalled"):
+        return "stalled"
+    log_text = str(state.get("run_log_text", ""))
+    if any(marker in log_text for marker in _QUOTA_MARKERS):
+        return "quota"
+    if state.get("last_event") == "run.backend_unavailable":
+        return "quota" if state.get("backend_cause") == "quota" else "backend"
+    if state.get("meta_status") != "completed":
+        return "incomplete"
+    if state.get("meta_report_source") != "agent":
+        return "fallback"
+    return "ok"
+
+
+@dataclass(frozen=True)
+class Action:
+    """What the shell should do next. A value, so the planner can be tested at all."""
+
+    kind: str
+    task_id: str = ""
+    arm: str = ""
+    attempt: int = 0
+    seconds: int = 0
+    reason: str = ""
+
+
+def next_action(
+    plan: TrialPlan,
+    states: Sequence[Mapping[str, Any]],
+    *,
+    now: float,
+    live_pids: frozenset[int] = frozenset(),
+    final_pass_done: bool = False,
+) -> Action:
+    """The whole recovery policy, as a pure function of the state directory.
+
+    Written as a value-returning function rather than as control flow inside the driver
+    because the alternative is testing multi-day kill-and-restart behaviour by spending
+    multi-day kill-and-restart wall clock.
+    """
+    for state in states:
+        if state.get("phase") == "launched" and int(state.get("child_pid") or 0) in live_pids:
+            return Action(
+                "abort",
+                task_id=str(state.get("task_id", "")),
+                arm=str(state.get("arm", "")),
+                reason=(
+                    f"a child from a previous driver is still running (pid "
+                    f"{state.get('child_pid')}). Adopting it cannot recover its exit code "
+                    "honestly, and starting alongside it is the concurrency that exhausts "
+                    "the quota."
+                ),
+            )
+
+    by_key: dict[tuple[str, str], list[Mapping[str, Any]]] = {}
+    for state in states:
+        key = (str(state.get("task_id", "")), str(state.get("arm", "")))
+        by_key.setdefault(key, []).append(state)
+
+    for key in arm_order(plan):
+        entries = by_key.get(key, [])
+        task_id, arm = key
+        if any(item.get("phase") == "refused" for item in entries):
+            # Terminal. Re-emitting the refusal would loop, and re-launching after one
+            # would spend the budget the refusal exists to stop spending.
+            continue
+        attempts = sorted(entries, key=lambda item: int(item.get("attempt") or 0))
+        if not attempts:
+            if now >= plan.deadline > 0:
+                continue
+            return Action("launch", task_id=task_id, arm=arm, attempt=1)
+
+        latest = attempts[-1]
+        attempt = int(latest.get("attempt") or 1)
+        phase = str(latest.get("phase", ""))
+        launches = len(attempts)
+        backoffs = sum(1 for item in attempts if item.get("classification") == "quota")
+
+        if phase == "launched":
+            return Action(
+                "abandon",
+                task_id=task_id,
+                arm=arm,
+                attempt=attempt,
+                reason=(
+                    "the driver died with this run in flight and the child is gone. "
+                    "`rcb_agent.py` has no resume — only `--export-only` — so the attempt "
+                    "is abandoned and re-planned into a fresh workspace, and the old one "
+                    "is left on disk because `.autor/` lives inside it."
+                ),
+            )
+
+        classification = str(latest.get("classification") or classify_run(latest))
+        if phase == "abandoned" or classification in ("backend", "stalled"):
+            if launches - backoffs >= MAX_ATTEMPTS or now >= plan.deadline > 0:
+                return Action("refuse", task_id=task_id, arm=arm, reason=classification or "abandoned")
+            return Action("launch", task_id=task_id, arm=arm, attempt=attempt + 1)
+
+        if classification == "quota":
+            if backoffs > MAX_BACKOFFS or now >= plan.deadline > 0:
+                return Action("refuse", task_id=task_id, arm=arm, reason="quota")
+            wait = BACKOFF_SCHEDULE_SECONDS[min(backoffs - 1, len(BACKOFF_SCHEDULE_SECONDS) - 1)]
+            return Action(
+                "backoff", task_id=task_id, arm=arm, attempt=attempt + 1, seconds=wait,
+                reason="quota is per-base-model and recovers; a first 429 is not a verdict",
+            )
+
+        if classification in ("fallback", "incomplete"):
+            # The run ran and produced a non-run. Retrying is a fresh draw on the same
+            # dice, and it is not the failure retrying is for.
+            return Action("refuse", task_id=task_id, arm=arm, reason=classification)
+
+        if not latest.get("scored"):
+            return Action("score", task_id=task_id, arm=arm, attempt=attempt)
+
+    if not final_pass_done:
+        return Action("final_pass")
+    return Action("done")
+
+
+# ---------------------------------------------------------------------------
+# Reading a workspace (parsing only; the tool does the I/O)
+# ---------------------------------------------------------------------------
+
+
+def count_quota_hits(log_text: str) -> int:
+    """How many quota refusals the run's own log records.
+
+    The same markers :func:`classify_run` reads, deliberately: the clause
+    ``no_quota_in_logs`` and the classifier are one rule about what a quota death looks
+    like, and when they were two tuples they disagreed.
+    """
+    return sum(len(re.findall(re.escape(marker), log_text)) for marker in _QUOTA_MARKERS)
+
+
+def items_from_score_payloads(payloads: Sequence[Mapping[str, Any]]) -> tuple[ScoredItem, ...]:
+    """Zip N replicate scorings of one workspace into one item vector.
+
+    Positional pairing is sound and checked: ``score.py`` enumerates the checklist in
+    file order, the serial executor preserves order by construction, and ``content[:200]``
+    is unique inside every one of the forty shipped checklists — so the content key is
+    asserted equal across replicates rather than trusted.
+    """
+    if not payloads:
+        return ()
+    base = list(payloads[0].get("items") or [])
+    for other in payloads[1:]:
+        rows = list(other.get("items") or [])
+        if len(rows) != len(base):
+            raise ValueError("replicate scorings returned different item counts")
+        for left, right in zip(base, rows):
+            if str(left.get("content", "")) != str(right.get("content", "")):
+                raise ValueError(
+                    "replicate scorings disagree about item identity; the checklist "
+                    "changed underneath the trial"
+                )
+    items: list[ScoredItem] = []
+    for position, row in enumerate(base):
+        scores = tuple(
+            int((list(payload.get("items") or [])[position]).get("score", 0))
+            for payload in payloads
+        )
+        items.append(
+            ScoredItem(
+                index=int(row.get("index", position)),
+                kind=str(row.get("type", "text")),
+                weight=float(row.get("weight", 0.0)),
+                content_key=str(row.get("content", "")),
+                scores=scores,
+            )
+        )
+    return tuple(items)

--- a/src/trials.py
+++ b/src/trials.py
@@ -44,6 +44,16 @@ the reading that the capability was tested and found wanting. The floor is print
 next to the p-value so the difference between *did not show an effect* and *could
 not have shown one* stays visible.
 
+**A known crack, recorded here because it is invisible where it lives.** Above
+``MAX_EXACT_PAIRS`` the enumeration truncates ``usable[:18]`` while
+:attr:`TrialResult.floor` still divides by the untruncated *n*. At n = 19 the printed
+p is computed from eighteen pairs and the floor printed beside it is ``2 / 2**19`` —
+lower than that p can reach, which breaks the third refusal above at exactly the
+point it matters. Unreachable at the sample sizes anyone has run (a paired
+ResearchClawBench trial is three to six pairs), and deliberately left alone; the next
+reader extending a trial to forty tasks walks straight into it and should fix the
+floor, or sample the sign assignments, in a change of its own.
+
 What this measures is the rubric score, and the rubric is a proxy for rigour rather
 than a measure of insight. A capability can raise it without making the research
 better, and can make the research better without raising it. The decomposition and
@@ -80,6 +90,22 @@ def min_attainable_p(pairs: int) -> float:
     if pairs <= 0:
         return 1.0
     return min(1.0, 2.0 / (2**pairs))
+
+
+def min_attainable_concentration(criteria: int) -> float:
+    """The smallest concentration a decomposition over ``criteria`` keys can show.
+
+    The same discipline as :func:`min_attainable_p`, for the same reason. The
+    Goodhart threshold below is 0.6, and 0.6 was calibrated against AutoR's eight
+    rubric criteria, where a perfectly even spread reads 0.125. Hand the same
+    property a two-key decomposition and an even spread already reads 0.50, so
+    "60% of the movement is in one criterion" stops meaning anything — it fires on
+    a 1.5:1 split. Printing the floor beside the observed value is what keeps a
+    reader from believing a warning whose denominator changed underneath it.
+    """
+    if criteria <= 0:
+        return 0.0
+    return 1.0 / criteria
 
 
 def sign_flip_p(differences: Sequence[float]) -> float:
@@ -237,6 +263,24 @@ class TrialResult:
             for key, values in sorted(totals.items(), key=lambda item: -abs(sum(item[1])))
         }
 
+    def criterion_support(self) -> dict[str, int]:
+        """How many pairs each criterion's mean was taken over.
+
+        The denominator in :meth:`criterion_differences` is per key and has never
+        been printed. With AutoR's own rubric every key is present in every pair, so
+        the denominator is always *n* and nobody missed it. Hand the same table an
+        outcome measure whose keys are per-goal — a ResearchClawBench checklist is
+        written per task — and every key has a denominator of 1, while the column
+        header still says "mean difference". A single observation and a mean over
+        three pairs then render identically, which is the whole of the difference
+        between an anecdote and a measurement.
+        """
+        counts: dict[str, int] = {}
+        for pair in self.pairs:
+            for key in pair.criterion_differences():
+                counts[key] = counts.get(key, 0) + 1
+        return counts
+
     @property
     def concentration(self) -> float:
         """Share of the total movement sitting in the single largest criterion.
@@ -302,13 +346,23 @@ def declared_trials(records: Iterable[RunRecord]) -> dict[str, set[str]]:
     return found
 
 
-def format_trial_report(result: TrialResult) -> str:
+def format_trial_report(result: TrialResult, *, unit: str = "rubric points") -> str:
+    """Render a trial. ``unit`` names what the mean difference is measured in.
+
+    A rendering concern, so it lives here and not on :class:`TrialResult`, which is a
+    record about the statistics. The default keeps every existing caller byte-identical.
+    It exists because the arithmetic in this module is scale-free — ``sign_flip_p`` is
+    invariant to it, ``concentration`` is a ratio — and the only thing that was not was
+    the literal string on the mean-difference line. Handed a ResearchClawBench total in
+    0–100 points, that line printed "+24.6000 rubric points", which is a lie about the
+    instrument in the one place a reader takes the number from.
+    """
     lines = [
         f"## `{result.capability}`  —  `{result.treatment_arm}` against `{result.control_arm}`",
         "",
         f"- pairs: **{result.n}**"
         + (f" ({len(result.excluded)} excluded)" if result.excluded else ""),
-        f"- mean difference: **{result.mean_difference:+.4f}** rubric points",
+        f"- mean difference: **{result.mean_difference:+.4f}** {unit}",
         f"- won {result.wins}, lost {result.losses}, tied {result.ties}",
     ]
     if result.n:
@@ -330,13 +384,19 @@ def format_trial_report(result: TrialResult) -> str:
 
     deltas = result.criterion_differences()
     if deltas:
+        support = result.criterion_support()
+        floor = min_attainable_concentration(len(deltas))
         lines += [
             "",
-            "| Criterion | Mean difference |",
-            "| --- | --- |",
-            *[f"| `{key}` | {value:+.4f} |" for key, value in deltas.items()],
+            "| Criterion | Mean difference | pairs |",
+            "| --- | --- | --- |",
+            *[
+                f"| `{key}` | {value:+.4f} | {support.get(key, 0)} |"
+                for key, value in deltas.items()
+            ],
             "",
-            f"Concentration: **{result.concentration:.0%}** of the movement is in one criterion.",
+            f"Concentration: **{result.concentration:.0%}** of the movement is in one criterion "
+            f"(floor at {len(deltas)} criteria: {floor:.0%}).",
         ]
         if result.concentration >= 0.6 and result.n:
             lines.append(

--- a/tests/test_rcb_trial.py
+++ b/tests/test_rcb_trial.py
@@ -1,0 +1,1051 @@
+"""The benchmark seam, and the ten ways a run fails to be a measurement.
+
+The whole apparatus is one producer feeding :mod:`src.trials`, so almost every rule
+worth holding is a rule about what gets into ``stage_fitness`` and
+``criterion_fitness`` — and about what is refused before it gets there. Each test below
+is written to die when its rule is mutated, because a gate over internal artifacts does
+not fail loudly when one of them drifts: it stops refusing.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from src.rcb_trial import (
+    ADMISSION_CLAUSES,
+    SETTLED_REASONING_HEADING,
+    ArmEvidence,
+    ArmSpec,
+    Refusal,
+    RunEnvironment,
+    ScoredItem,
+    TrialPlan,
+    admit_arm,
+    arm_order,
+    classify_run,
+    collect_rcb_pairs,
+    compare_arms,
+    count_quota_hits,
+    format_rcb_trial_report,
+    items_from_score_payloads,
+    next_action,
+    pair_resolution,
+    resolution_is_measured,
+    stratum_rollup,
+    to_run_record,
+)
+
+# Private on purpose — it is one rule shared by the classifier and the admission clause,
+# and the test below is here to keep it one rule.
+from src.rcb_trial import _QUOTA_MARKERS
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+GOOD_FACTS = {
+    "meta_status": "completed",
+    "meta_pipeline_completed": True,
+    "meta_report_source": "agent",
+    "autor_run_count": 1,
+    "images_under_outputs": 0,
+    "report_md_count": 1,
+    "report_md_present": True,
+    "last_event": "run.completed",
+    "resource_exhausted_hits": 0,
+    "revision_at_launch": "621566bdeadbeef",
+    "revision_at_finish": "621566bdeadbeef",
+    "worktree_dirty": False,
+}
+
+
+def env(**overrides) -> RunEnvironment:
+    base = dict(
+        checklist_digest="cl",
+        judge_model="gpt-5.1",
+        agent_model="opus",
+        review_model="opus",
+        web_search_level="info",
+        instructions_digest="ins",
+        bench_revision="bench",
+        judge_replicates=1,
+    )
+    base.update(overrides)
+    return RunEnvironment(**base)
+
+
+def items(*scores: float, weights=(0.5, 0.3, 0.2), kinds=("image", "text", "text")) -> tuple:
+    return tuple(
+        ScoredItem(
+            index=index,
+            kind=kinds[index],
+            weight=weights[index],
+            content_key=f"item-{index}",
+            scores=(int(score),) if not isinstance(score, tuple) else score,
+        )
+        for index, score in enumerate(scores)
+    )
+
+
+def arm(
+    task: str = "Energy_001",
+    label: str = "621566b",
+    *,
+    scores=(40, 30, 20),
+    facts: dict | None = None,
+    environment: RunEnvironment | None = None,
+    replicates: int = 1,
+    requested: int = 0,
+    images: tuple[int, int] = (1, 1),
+    dose: bool = False,
+    stages: tuple[str, ...] = ("01_s", "02_s"),
+    judge_failures: tuple[str, ...] = (),
+    weights=(0.5, 0.3, 0.2),
+) -> ArmEvidence:
+    scored = items(*scores, weights=weights)
+    total = sum(item.weight * item.score for item in scored)
+    merged = dict(GOOD_FACTS)
+    merged["revision_at_launch"] = merged["revision_at_finish"] = label + "0" * 33
+    merged.update(facts or {})
+    return ArmEvidence(
+        task_id=task,
+        arm=label,
+        run_id=f"{task}_{label}",
+        workspace=f"/ws/{task}_{label}",
+        # The replicate count lives in the environment, because two arms averaged over
+        # different numbers of judge draws are a composition difference.
+        env=environment or env(judge_replicates=replicates),
+        items=scored,
+        published_total=round(total, 2),
+        replicates_requested=requested or replicates,
+        images_shown=images[0],
+        images_available=images[1],
+        judge_failures=judge_failures,
+        checklist_items_expected=len(scored),
+        facts=merged,
+        autor_stages_scored=stages,
+        settled_reasoning_dose=dose,
+    )
+
+
+def trial(*evidences, planned: int = 1, driver_refusals=()):
+    return collect_rcb_pairs(
+        evidences,
+        capability="pr175",
+        control_arm="621566b",
+        treatment_arm="47f3fbf",
+        planned_pairs=planned,
+        driver_refusals=driver_refusals,
+    )
+
+
+class SeamTests(unittest.TestCase):
+    def test_the_pair_difference_is_the_benchmark_total_difference_exactly(self) -> None:
+        """A mean over one element is that element.
+
+        ``Pair._mean_over`` is unweighted and ResearchClawBench's total is weighted, so
+        anything other than a single stage key publishes a number that is not the
+        benchmark's total. With one key the two arithmetics cannot disagree.
+        """
+        control = arm(scores=(40, 30, 20))
+        treatment = arm(label="47f3fbf", scores=(60, 30, 20))
+        result = trial(control, treatment).result
+
+        self.assertEqual(result.n, 1)
+        expected = treatment.total_weighted - control.total_weighted
+        self.assertAlmostEqual(result.pairs[0].difference, expected, places=9)
+        self.assertAlmostEqual(expected, 0.5 * 20, places=9)
+
+    def test_one_stage_key_per_record(self) -> None:
+        record = to_run_record(arm(), capability="pr175")
+        self.assertEqual(len(record.stage_fitness), 1)
+        self.assertTrue(next(iter(record.stage_fitness)).startswith("Energy_001|"))
+
+    def test_the_decomposition_sums_to_the_scalar(self) -> None:
+        """The property AutoR's own decomposition does not have.
+
+        Every shipped checklist's weights sum to 1.0, so per-item contributions sum to
+        the total and ``concentration`` becomes literally the share of the movement in
+        one checklist item.
+        """
+        record = to_run_record(arm(), capability="pr175")
+        total = next(iter(record.stage_fitness.values()))
+        self.assertAlmostEqual(sum(record.criterion_fitness.values()), total, places=9)
+
+    def test_weights_that_do_not_sum_to_one_are_refused(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            to_run_record(arm(weights=(0.5, 0.3, 0.1)), capability="pr175")
+        self.assertIn("1.0", str(caught.exception))
+
+    def test_a_single_replicate_must_reconcile_with_the_scorers_own_total(self) -> None:
+        """One number, two encodings, and this is the only place they meet.
+
+        ``score.py`` truncates every item score with ``int()`` and rounds the total to
+        two places. Recomputing from the items is right, and it is right only as long as
+        it still lands on the number the scorer published.
+        """
+        good = arm()
+        to_run_record(good, capability="pr175")  # does not raise
+
+        drifted = ArmEvidence(**{**good.__dict__, "published_total": good.published_total + 1.0})
+        with self.assertRaises(ValueError) as caught:
+            to_run_record(drifted, capability="pr175")
+        self.assertIn("reconcile", str(caught.exception))
+
+    def test_the_reconciliation_tolerates_only_the_scorers_rounding(self) -> None:
+        good = arm()
+        rounded = ArmEvidence(**{**good.__dict__, "published_total": good.published_total + 0.004})
+        to_run_record(rounded, capability="pr175")
+
+    def test_replicated_scoring_is_not_reconciled_against_one_pass(self) -> None:
+        """Three replicate means are not the number a single pass published."""
+        good = arm(replicates=3)
+        drifted = ArmEvidence(**{**good.__dict__, "published_total": 0.0})
+        to_run_record(drifted, capability="pr175")
+
+    def test_duplicate_item_keys_are_refused(self) -> None:
+        collided = ArmEvidence(
+            **{
+                **arm().__dict__,
+                "items": tuple(
+                    ScoredItem(0, "text", 0.5, f"c{n}", (40,)) for n in range(2)
+                ),
+                "checklist_items_expected": 2,
+                "published_total": 40.0,
+            }
+        )
+        with self.assertRaises(ValueError) as caught:
+            to_run_record(collided, capability="pr175")
+        self.assertIn("duplicate", str(caught.exception))
+
+    def test_no_record_is_ever_written_to_an_archive(self) -> None:
+        """The containment for `rubric_version = RUBRIC_VERSION` on a benchmark row.
+
+        A benchmark row is not an AutoR rubric row, and the version it must carry to be
+        ``usable`` is a claim it cannot support. Prose in a docstring is not a guard: the
+        guard is that no archive is constructible from either file. Pooled into
+        ``Archive.variant_fitness`` these 0-100 totals would sit beside [0, 1] rubric
+        means and steer topology promotion off a unit error.
+        """
+        for name in ("src/rcb_trial.py", "tools/rcb_trial.py"):
+            body = (REPO_ROOT / name).read_text(encoding="utf-8")
+            for forbidden in ("Archive(", "record_run", "runs.jsonl"):
+                self.assertNotIn(forbidden, body, f"{name} can reach the archive via {forbidden}")
+
+
+class EnvironmentTests(unittest.TestCase):
+    def test_every_field_in_the_digest_shows_up_in_the_cross_arm_diff(self) -> None:
+        """The digest is the gate; the diff is the only explanation of it.
+
+        A field silently dropped from the diff leaves a pair excluded with "the two arms
+        measured no stage in common", which is true and useless. A field dropped from
+        the digest instead lets a confounded pair through. This holds the two in step
+        field by field, so adding a field to :class:`RunEnvironment` without teaching the
+        diff about it fails here.
+        """
+        import dataclasses
+
+        base = env()
+        for spec in dataclasses.fields(RunEnvironment):
+            with self.subTest(field=spec.name):
+                other = dataclasses.replace(base, **{spec.name: "CHANGED"})
+                self.assertNotEqual(base.digest, other.digest, "field is not in the digest")
+                reasons = base.describe_difference(other)
+                self.assertTrue(
+                    any(f"`{spec.name}`" in reason for reason in reasons),
+                    f"{spec.name} changes the digest but is never named in the diff",
+                )
+
+    def test_an_environment_difference_excludes_the_pair_and_names_the_field(self) -> None:
+        control = arm()
+        treatment = arm(label="47f3fbf", environment=env(web_search_level="warn"))
+        result = trial(control, treatment).result
+
+        self.assertEqual(result.n, 0)
+        self.assertEqual(len(result.excluded), 1)
+        self.assertIn("web_search_level", result.excluded[0][1])
+
+    def test_a_different_judge_in_the_two_arms_is_not_a_comparison(self) -> None:
+        """Judge choice is worth about sixteen points on identical artifacts."""
+        control = arm()
+        treatment = arm(label="47f3fbf", environment=env(judge_model="claude-opus-4-5"))
+        self.assertEqual(trial(control, treatment).result.n, 0)
+
+    def test_the_digest_and_the_diff_cannot_go_out_of_step_silently(self) -> None:
+        """If a named reason exists and the pair survived, the gate has a hole.
+
+        The assertion is what makes the split between gate and diagnostics safe. Drop a
+        field from the digest and its diff line still fires — and then the pair reaches
+        ``pairs`` with a written reason for excluding it, which raises here rather than
+        being published.
+        """
+        control = arm()
+        # Same environment digest, different checklist content keys: `compare_arms`
+        # names it, and nothing in the stage key can see it.
+        treatment = ArmEvidence(
+            **{
+                **arm(label="47f3fbf").__dict__,
+                "items": tuple(
+                    ScoredItem(index=item.index, kind=item.kind, weight=item.weight,
+                               content_key=f"other-{item.index}", scores=item.scores)
+                    for item in arm().items
+                ),
+            }
+        )
+        self.assertTrue(compare_arms(control, treatment))
+        with self.assertRaises(AssertionError) as caught:
+            trial(control, treatment)
+        self.assertIn("out of step", str(caught.exception))
+
+
+class AdmissionTests(unittest.TestCase):
+    """One fixture per clause. A clause that has stopped firing is a silent hole."""
+
+    BREAKERS = {
+        "status_completed": {"meta_status": "running"},
+        "pipeline_completed": {"meta_pipeline_completed": False},
+        "report_from_agent": {"meta_report_source": "fallback"},
+        "single_run_root": {"autor_run_count": 2},
+        "no_images_under_outputs": {"images_under_outputs": 1},
+        "single_report_md": {"report_md_count": 2},
+        "backend_reached": {"last_event": "run.backend_unavailable"},
+        "no_quota_in_logs": {"resource_exhausted_hits": 1},
+        "revision_matches_arm": {"revision_at_finish": "deadbeef" * 5},
+    }
+
+    def test_a_clean_run_is_admitted(self) -> None:
+        ok, failed = admit_arm(arm())
+        self.assertTrue(ok, failed)
+
+    def test_every_clause_refuses_on_its_own(self) -> None:
+        for clause in ADMISSION_CLAUSES:
+            if clause.name == "every_item_judged":
+                continue
+            with self.subTest(clause=clause.name):
+                ok, failed = admit_arm(arm(facts=self.BREAKERS[clause.name]))
+                self.assertFalse(ok)
+                self.assertEqual(failed, [clause.name])
+
+    def test_a_dirty_worktree_refuses_even_when_the_shas_agree(self) -> None:
+        ok, failed = admit_arm(arm(facts={"worktree_dirty": True}))
+        self.assertEqual(failed, ["revision_matches_arm"])
+
+    def test_a_head_that_could_not_be_read_refuses_rather_than_matching_everything(self) -> None:
+        """``git_head`` returns ``""`` whenever ``rev-parse`` exits non-zero.
+
+        A worktree moved or deleted during a four-day trial, a directory that is not a
+        repository, git not on the path: launch and finish are then both ``""``, they
+        agree, and the prefix test degenerates because ``label.startswith("")`` is true of
+        every label. The arm label is the only carrier of the revision, so a run admitted
+        that way is a run nobody checked was the commit under test.
+        """
+        blank = arm(facts={"revision_at_launch": "", "revision_at_finish": ""})
+        self.assertEqual(admit_arm(blank), (False, ["revision_matches_arm"]))
+
+    def test_an_arm_label_that_is_not_the_sha_that_ran_refuses(self) -> None:
+        """The arm label is the only carrier of the revision and nothing else checks it."""
+        mislabelled = ArmEvidence(**{**arm().__dict__, "arm": "notasha"})
+        self.assertIn("revision_matches_arm", admit_arm(mislabelled)[1])
+
+    def test_a_judge_failure_refuses_and_kills_the_whole_pair(self) -> None:
+        """Refusing one arm turns the pair into "no treatment arm" and hides the cause."""
+        control = arm()
+        treatment = arm(label="47f3fbf", judge_failures=("timeout",))
+        outcome = trial(control, treatment)
+
+        self.assertEqual(outcome.result.n, 0)
+        self.assertEqual(len(outcome.refusals), 1)
+        reason = dict(outcome.result.excluded)["Energy_001"]
+        self.assertIn("every_item_judged", reason)
+        self.assertNotIn("no `47f3fbf` arm", reason)
+
+    def test_a_short_item_vector_refuses(self) -> None:
+        short = ArmEvidence(**{**arm().__dict__, "checklist_items_expected": 5})
+        self.assertIn("every_item_judged", admit_arm(short)[1])
+
+    def test_an_empty_item_vector_refuses(self) -> None:
+        empty = ArmEvidence(
+            **{**arm().__dict__, "items": (), "checklist_items_expected": 0, "published_total": 0.0}
+        )
+        self.assertIn("every_item_judged", admit_arm(empty)[1])
+
+    def test_a_refused_arm_never_becomes_a_record(self) -> None:
+        with self.assertRaises(ValueError):
+            to_run_record(arm(facts={"meta_report_source": "synthesized"}), capability="pr175")
+
+    def test_every_clause_says_what_observation_motivated_it(self) -> None:
+        for clause in ADMISSION_CLAUSES:
+            self.assertGreater(len(clause.why), 60, f"{clause.name} does not argue for itself")
+
+
+class ResolutionTests(unittest.TestCase):
+    def test_the_resolution_is_the_weighted_worst_replicate_spread(self) -> None:
+        """In total points, not raw item points.
+
+        The rule it replaces — "a text item moving under thirty points is noise" — is in
+        the wrong units: at ``w = 0.2`` thirty raw points is six total points, and the
+        two readings differ by a factor of five.
+        """
+        control = arm(scores=((40, 40, 40), (30, 40, 50), (20, 20, 20)))
+        treatment = arm(label="47f3fbf", scores=((40, 46, 40), (30, 30, 30), (20, 20, 20)))
+        # image w=0.5 spread 6; text w=0.3 spread 20; text w=0.2 spread 0
+        self.assertAlmostEqual(pair_resolution(control, treatment), 0.5 * 6 + 0.3 * 20, places=9)
+
+    def test_the_stratum_identity_closes(self) -> None:
+        control = arm(scores=(40, 30, 20))
+        treatment = arm(label="47f3fbf", scores=(50, 45, 25))
+        rollup = stratum_rollup(control, treatment)
+        self.assertAlmostEqual(rollup["residual"], 0.0, places=9)
+        self.assertAlmostEqual(rollup["strata"]["image"]["share"], 0.5, places=9)
+        self.assertAlmostEqual(rollup["strata"]["text"]["share"], 0.5, places=9)
+
+
+class ReplicateParityTests(unittest.TestCase):
+    """What happens when the judge's draws go missing, which is the ordinary failure.
+
+    ``final_pass`` gives each replicate two tries and then moves on writing nothing, so
+    an arm scored once against an arm scored three times needs no exotic sequence of
+    events. Every consequence of that used to point the same way: the delta moved, the
+    stated uncertainty *shrank*, and the report printed the count of whichever arm it
+    happened to read.
+    """
+
+    def test_two_arms_scored_a_different_number_of_times_are_not_a_comparison(self) -> None:
+        """One un-averaged draw against a three-draw mean is not the pair's difference.
+
+        It is also the direction that inflates: the single draw carries the judge's whole
+        sampling range into the delta while the other arm has averaged its own away.
+        """
+        outcome = trial(
+            arm(replicates=3, requested=3),
+            arm(label="47f3fbf", replicates=1, requested=3),
+        )
+        self.assertEqual(outcome.result.n, 0)
+        self.assertIn("judge_replicates", dict(outcome.result.excluded)["Energy_001"])
+
+    def test_a_pair_scored_the_same_number_of_times_is_compared(self) -> None:
+        self.assertEqual(trial(arm(replicates=3), arm(label="47f3fbf", replicates=3)).result.n, 1)
+
+    def test_one_draw_cannot_state_a_resolution_of_zero(self) -> None:
+        """Fewer draws produced a *smaller* stated uncertainty, which is backwards.
+
+        With one draw every ``spread`` is 0, so the pair printed "judge resolution:
+        ±0.00 total points" — the strongest claim on the page — about the one arm where
+        nothing at all was observed of the judge's noise.
+        """
+        control = arm(replicates=1, requested=3)
+        treatment = arm(label="47f3fbf", replicates=1, requested=3)
+        self.assertFalse(resolution_is_measured(control, treatment))
+        text = format_rcb_trial_report(trial(control, treatment))
+        self.assertIn("**unmeasured**", text)
+        self.assertNotIn("±0.00", text)
+
+    def test_both_arms_draw_counts_are_printed_and_neither_stands_for_the_other(self) -> None:
+        control = arm(replicates=3, requested=3, scores=((40, 40, 40), (30, 30, 30), (20, 20, 20)))
+        treatment = arm(
+            label="47f3fbf", replicates=3, requested=3,
+            scores=((60, 60, 60), (30, 30, 30), (20, 20, 20)),
+        )
+        text = format_rcb_trial_report(trial(control, treatment))
+        self.assertIn("judge draws: control **3**, treatment **3**, of 3 planned", text)
+        self.assertNotIn("per arm)", text)
+
+    def test_a_pair_scored_fewer_times_than_planned_says_so(self) -> None:
+        text = format_rcb_trial_report(
+            trial(arm(replicates=2, requested=3), arm(label="47f3fbf", replicates=2, requested=3))
+        )
+        self.assertIn("Under-replicated", text)
+        self.assertIn("1 control and 1 treatment replicate scorings were planned", text)
+
+    def test_a_fully_replicated_pair_is_not_disclaimed(self) -> None:
+        text = format_rcb_trial_report(
+            trial(arm(replicates=3, requested=3), arm(label="47f3fbf", replicates=3, requested=3))
+        )
+        self.assertNotIn("Under-replicated", text)
+
+    def test_an_unrecorded_draw_count_still_meets_the_scorers_own_total(self) -> None:
+        """``<= 1``, not ``== 1``. An evidence whose replicate count nobody recorded is a
+        single pass until something says otherwise, and skipping the one place the two
+        encodings of the total meet is not the safe way to guess."""
+        good = arm(replicates=1)
+        drifted = ArmEvidence(
+            **{
+                **good.__dict__,
+                "env": env(judge_replicates=0),
+                "published_total": good.published_total + 1.0,
+            }
+        )
+        with self.assertRaises(ValueError) as caught:
+            to_run_record(drifted, capability="pr175")
+        self.assertIn("reconcile", str(caught.exception))
+
+
+class ImagesShownTests(unittest.TestCase):
+    """60.6% of the weight, chosen by an unsorted sweep, and previously never printed."""
+
+    def test_the_images_the_judge_saw_are_printed_for_both_arms(self) -> None:
+        text = format_rcb_trial_report(
+            trial(arm(images=(4, 4)), arm(label="47f3fbf", images=(4, 4)))
+        )
+        self.assertIn("images shown to the judge: control **4** of 4, treatment **4** of 4", text)
+
+    def test_an_arm_over_the_five_image_cap_says_the_evidence_differed(self) -> None:
+        """A real workspace here already has six images under ``report/``.
+
+        Four figures all shown against twelve figures of which an arbitrary five were
+        shown is a difference in the evidence, not in the research, and it moves the
+        stratum that carries most of the benchmark's weight.
+        """
+        text = format_rcb_trial_report(
+            trial(arm(images=(4, 4)), arm(label="47f3fbf", images=(5, 12)))
+        )
+        self.assertIn("not shown the same evidence", text)
+        self.assertIn("treatment arm's figures were over the scorer's cap", text)
+
+    def test_two_arms_shown_the_same_figures_are_not_disclaimed(self) -> None:
+        text = format_rcb_trial_report(
+            trial(arm(images=(3, 3)), arm(label="47f3fbf", images=(3, 3)))
+        )
+        self.assertNotIn("not shown the same evidence", text)
+
+
+class DriverRefusalLedgerTests(unittest.TestCase):
+    """The deaths that never reach the gate, which are most of the deaths.
+
+    A run killed by quota, by the watchdog, by a backend outage or by the scorer produces
+    no evidence at all, so the gate cannot refuse it. Left out, the ledger printed "none"
+    and the loss appeared only as "no `<arm>` arm" — the same sentence as an arm that was
+    never launched — under a paragraph telling the reader to judge the whole trial on the
+    per-arm death counts.
+    """
+
+    def quota_death(self, task: str = "Energy_001", arm_label: str = "47f3fbf") -> Refusal:
+        return Refusal(task, arm_label, ("driver:quota",))
+
+    def test_a_death_the_driver_refused_is_in_the_ledger(self) -> None:
+        outcome = trial(arm(), driver_refusals=[self.quota_death()])
+        self.assertEqual(len(outcome.refusals), 1)
+        self.assertEqual(outcome.refusals_by_clause()["driver:quota"], 1)
+        text = format_rcb_trial_report(outcome)
+        self.assertIn("driver:quota", text)
+        self.assertNotIn("- no run was refused.", text)
+
+    def test_the_per_arm_count_sees_it(self) -> None:
+        outcome = trial(arm(), driver_refusals=[self.quota_death()])
+        self.assertEqual(outcome.refusals_by_arm(), {"621566b": 0, "47f3fbf": 1})
+        self.assertIn(
+            "control `621566b` 0, treatment `47f3fbf` 1", format_rcb_trial_report(outcome)
+        )
+
+    def test_the_pair_is_excluded_by_name_and_not_as_never_launched(self) -> None:
+        outcome = trial(arm(), driver_refusals=[self.quota_death()])
+        reason = dict(outcome.result.excluded)["Energy_001"]
+        self.assertIn("was refused (driver:quota)", reason)
+        self.assertNotIn("no `47f3fbf` arm", reason)
+
+    def test_three_treatment_deaths_against_zero_control_deaths_are_visible(self) -> None:
+        """The asymmetry is a result even though it has no number attached."""
+        outcome = collect_rcb_pairs(
+            [arm(task=task) for task in ("Energy_001", "Energy_002", "Astronomy_000")],
+            capability="pr175",
+            control_arm="621566b",
+            treatment_arm="47f3fbf",
+            planned_pairs=3,
+            driver_refusals=[
+                self.quota_death(task) for task in ("Energy_001", "Energy_002", "Astronomy_000")
+            ],
+        )
+        self.assertEqual(outcome.refusals_by_arm(), {"621566b": 0, "47f3fbf": 3})
+        text = format_rcb_trial_report(outcome)
+        self.assertIn("control `621566b` 0, treatment `47f3fbf` 3", text)
+        self.assertIn("manufactures a null", text)
+
+    def test_the_per_arm_line_is_printed_even_when_nothing_died(self) -> None:
+        """The paragraph tells the reader to judge the difference on this line, so a line
+        that only appears once something has gone wrong is missing where it is needed."""
+        text = format_rcb_trial_report(trial(arm(), arm(label="47f3fbf")))
+        self.assertIn("control `621566b` 0, treatment `47f3fbf` 0", text)
+
+    def test_an_arm_a_later_attempt_rescued_did_not_cost_a_pair(self) -> None:
+        outcome = trial(
+            arm(), arm(label="47f3fbf"), driver_refusals=[self.quota_death()]
+        )
+        self.assertEqual(outcome.refusals, ())
+        self.assertEqual(outcome.result.n, 1)
+
+    def test_one_arm_is_counted_once_however_many_ways_it_died(self) -> None:
+        """The gate and the driver both have a claim on a fallback report; the reader is
+        told to read the per-arm counts, and double counting them is a lie in the
+        direction that looks like a finding."""
+        outcome = trial(
+            arm(),
+            arm(label="47f3fbf", facts={"meta_report_source": "fallback"}),
+            driver_refusals=[Refusal("Energy_001", "47f3fbf", ("driver:fallback",))],
+        )
+        self.assertEqual(outcome.refusals_by_arm()["47f3fbf"], 1)
+        self.assertEqual(outcome.refusals[0].clauses, ("report_from_agent",))
+
+    def test_the_zero_count_caveat_offers_the_reading_where_a_clause_cannot_fire(self) -> None:
+        """Four clauses are pre-empted by the driver's own classification, so their zero
+        does not mean "never violated"; it means the death arrived under a driver row."""
+        text = format_rcb_trial_report(trial(arm(), arm(label="47f3fbf")))
+        self.assertIn("cannot fire at all on this path", text)
+
+
+class ReportTests(unittest.TestCase):
+    def report(self, *evidences, planned=1, **kwargs) -> str:
+        return format_rcb_trial_report(trial(*evidences, planned=planned), **kwargs)
+
+    def test_the_refusal_ledger_is_above_the_total_and_counts_per_arm(self) -> None:
+        """Three treatment deaths against zero control deaths is a result.
+
+        It has no number attached, which is exactly why it cannot be a footnote under
+        one.
+        """
+        text = self.report(
+            arm(), arm(label="47f3fbf", facts={"meta_report_source": "fallback"}), planned=1
+        )
+        self.assertLess(text.index("Runs refused"), text.index("## The difference"))
+        self.assertIn("`47f3fbf` 1", text)
+        self.assertIn("`621566b` 0", text)
+
+    def test_every_clause_gets_a_printed_count_even_at_zero(self) -> None:
+        """A clause that stopped firing looks exactly like a clause never violated."""
+        text = self.report(arm(), arm(label="47f3fbf"))
+        for clause in ADMISSION_CLAUSES:
+            self.assertIn(f"| `{clause.name}` |", text)
+
+    def test_an_incomplete_trial_is_labelled_interim(self) -> None:
+        text = self.report(arm(), arm(label="47f3fbf"), planned=3)
+        self.assertIn("INTERIM — 1 of 3 planned pairs", text)
+        self.assertIn("not this trial's result", text)
+
+    def test_a_complete_trial_is_not_labelled_interim(self) -> None:
+        self.assertNotIn("INTERIM", self.report(arm(), arm(label="47f3fbf"), planned=1))
+
+    def test_the_refusal_bias_paragraph_appears_wherever_pairs_were_lost(self) -> None:
+        text = self.report(arm(), arm(label="47f3fbf"), planned=3)
+        self.assertIn("manufactures a null", text)
+
+    def test_a_zero_dose_pair_is_refused_as_a_test_of_the_channel(self) -> None:
+        """``build_block`` returns nothing when the run argued nothing.
+
+        A treatment run that emitted an empty channel is indistinguishable from one that
+        used it and gained nothing — unless the prompt is checked, which is the one
+        thing that turns an uninformative null into a diagnosis.
+        """
+        text = self.report(arm(), arm(label="47f3fbf", dose=False))
+        self.assertIn("Zero settled-reasoning dose", text)
+        self.assertIn("not a test of it", text)
+
+    def test_the_dose_marker_is_the_channel_that_carries_the_dose(self) -> None:
+        """Not ``build_block``'s crux sub-heading, which is half the channel.
+
+        ``build_block`` emits ``## Methodological questions this run settled`` inside
+        ``if cruxes:``. A block built from rejected idea-pool candidates alone — one of
+        the two things PR #175's channel routes — carries only ``## Hypotheses generated
+        and not pursued``, and looking for the crux sub-heading published "this pair did
+        not administer the channel" over a dose that was delivered.
+        """
+        from src.information_flow import CHANNELS
+
+        channel = next(item for item in CHANNELS if item.key == "settled_reasoning")
+        self.assertEqual(SETTLED_REASONING_HEADING, channel.heading)
+        self.assertNotIn("Methodological questions", SETTLED_REASONING_HEADING)
+
+    def test_a_dosed_pair_is_not_disclaimed(self) -> None:
+        self.assertNotIn(
+            "Zero settled-reasoning dose", self.report(arm(), arm(label="47f3fbf", dose=True))
+        )
+
+    def test_the_unit_is_benchmark_points_and_not_rubric_points(self) -> None:
+        text = self.report(arm(), arm(label="47f3fbf"))
+        self.assertIn("RCB points", text)
+        self.assertNotIn("rubric points", text)
+
+    def test_the_judge_is_printed_with_the_number(self) -> None:
+        self.assertIn("gpt-5.1", self.report(arm(), arm(label="47f3fbf"), judge_model="gpt-5.1"))
+
+    def test_a_judge_that_is_not_the_planned_one_is_said_so_beside_the_number(self) -> None:
+        """The header stated the plan's field whatever had actually scored the runs.
+
+        ``score_rcb_run.py`` builds its judge with ``args.model or`` its own fallback, so
+        a dropped ``--model`` scores a whole trial with a model nobody chose — and judge
+        choice is worth about sixteen points on identical artifacts, which is larger than
+        anything this trial is looking for.
+        """
+        text = self.report(
+            arm(), arm(label="47f3fbf"),
+            judge_model="claude-opus-4-5", planned_judge_model="gpt-5.1",
+        )
+        self.assertIn("not the judge the plan declared", text)
+        self.assertNotIn(
+            "not the judge the plan declared",
+            self.report(
+                arm(), arm(label="47f3fbf"),
+                judge_model="gpt-5.1", planned_judge_model="gpt-5.1",
+            ),
+        )
+
+    def test_the_one_observation_caveat_sits_under_the_total(self) -> None:
+        text = self.report(arm(), arm(label="47f3fbf"))
+        self.assertIn("ran **once**", text)
+        self.assertIn("zero observations", text)
+
+    def test_a_stage_composition_difference_is_reported_outside_the_score(self) -> None:
+        """``shape_changes`` is structurally zero here, so it is re-armed by hand.
+
+        Both arms are scored against the same checklist whatever their internal
+        composition, so the strongest refusal in :mod:`src.trials` is true and empty on
+        this outcome measure.
+        """
+        control = arm(stages=("01_s", "02_s"))
+        treatment = arm(label="47f3fbf", stages=tuple(f"0{n}_s" for n in range(1, 9)))
+        text = self.report(control, treatment)
+        self.assertIn("did not score the same stages", text)
+        self.assertEqual(trial(control, treatment).result.shape_changes, 0)
+
+    def test_the_contrast_is_printed_verbatim(self) -> None:
+        text = self.report(arm(), arm(label="47f3fbf"), contrast_log="47f3fbf one commit (#175)")
+        self.assertIn("47f3fbf one commit (#175)", text)
+
+    def test_the_per_pair_concentration_is_printed_beside_its_floor(self) -> None:
+        text = self.report(arm(scores=(40, 30, 20)), arm(label="47f3fbf", scores=(60, 30, 20)))
+        self.assertIn("Concentration on this pair: **100%**", text)
+        self.assertIn("floor at 3 items: 33%", text)
+        self.assertIn("different tasks into one denominator", text)
+
+
+class PlanTests(unittest.TestCase):
+    def plan(self, **kwargs) -> TrialPlan:
+        base = dict(
+            capability="pr175",
+            bench="/bench",
+            tasks=("Energy_001", "Astronomy_000", "Energy_002"),
+            control=ArmSpec("621566b", "/wt/c", "621566b"),
+            treatment=ArmSpec("47f3fbf", "/wt/t", "47f3fbf"),
+        )
+        base.update(kwargs)
+        return TrialPlan(**base)
+
+    def test_the_shipped_plan_names_pr_175_and_its_parent(self) -> None:
+        """`be76a34` is #174, not #175. It changes `manager.py`, `archive.py` and
+        `inference.py` and un-silences three stages, so running it as the treatment
+        measures two PRs and reports one."""
+        import json
+
+        payload = json.loads(
+            (REPO_ROOT / "configs" / "rcb_trial_175.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(payload["control"]["sha"], "621566b")
+        self.assertEqual(payload["treatment"]["sha"], "47f3fbf")
+        self.assertNotIn("be76a34", json.dumps(payload))
+
+    def test_the_shipped_plan_loads(self) -> None:
+        import json
+
+        payload = json.loads(
+            (REPO_ROOT / "configs" / "rcb_trial_175.json").read_text(encoding="utf-8")
+        )
+        plan = TrialPlan.from_dict(payload)
+        self.assertEqual(plan.planned_pairs, 3)
+        self.assertFalse(plan.state_dir.startswith("/home/"), "state belongs off the shared NFS")
+
+    def test_a_misspelled_plan_field_is_refused_rather_than_ignored(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            TrialPlan.from_dict(
+                {
+                    "capability": "c", "bench": "/b", "tasks": ["T"],
+                    "control": {"label": "a", "worktree": "/x", "sha": "a"},
+                    "treatment": {"label": "b", "worktree": "/y", "sha": "b"},
+                    "reviewmodel": "opus",
+                }
+            )
+        self.assertIn("reviewmodel", str(caught.exception))
+
+    def test_two_arms_with_one_label_are_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            TrialPlan.from_dict(
+                {
+                    "capability": "c", "bench": "/b", "tasks": ["T"],
+                    "control": {"label": "a", "worktree": "/x", "sha": "a"},
+                    "treatment": {"label": "a", "worktree": "/y", "sha": "a"},
+                }
+            )
+
+    def test_editing_the_plan_changes_its_digest(self) -> None:
+        self.assertNotEqual(self.plan().digest, self.plan(judge_model="other").digest)
+
+    def test_the_order_is_pair_major_and_control_first_by_default(self) -> None:
+        """Both arms of a pair adjacent, so they straddle as little drift as possible."""
+        self.assertEqual(
+            arm_order(self.plan()),
+            (
+                ("Energy_001", "621566b"), ("Energy_001", "47f3fbf"),
+                ("Astronomy_000", "621566b"), ("Astronomy_000", "47f3fbf"),
+                ("Energy_002", "621566b"), ("Energy_002", "47f3fbf"),
+            ),
+        )
+
+    def test_counterbalancing_is_available_and_alternates(self) -> None:
+        order = arm_order(self.plan(arm_order_mode="counterbalanced"))
+        self.assertEqual(order[0][1], "621566b")
+        self.assertEqual(order[2][1], "47f3fbf")
+
+    def test_the_first_task_is_the_one_that_carries_both_channels(self) -> None:
+        """Twenty-four hours buys one pair. Which pair is a decision, not a shuffle."""
+        import json
+
+        payload = json.loads(
+            (REPO_ROOT / "configs" / "rcb_trial_175.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(payload["tasks"][0], "Energy_001")
+
+
+class ClassifyTests(unittest.TestCase):
+    def test_quota_is_found_in_the_runs_own_log_even_when_it_reported_completion(self) -> None:
+        """``classify_backend`` only runs when neither attempt wrote a stage file.
+
+        A 429 landing mid-stage is baked into the summary as prose, and the manifest
+        says the run completed. Reading only the manifest retries nothing.
+        """
+        self.assertEqual(
+            classify_run(
+                {
+                    "last_event": "run.completed",
+                    "meta_status": "completed",
+                    "meta_report_source": "agent",
+                    "run_log_text": "google.api_core RESOURCE_EXHAUSTED: 429",
+                }
+            ),
+            "quota",
+        )
+
+    def test_a_clean_run_classifies_ok(self) -> None:
+        self.assertEqual(
+            classify_run(
+                {
+                    "last_event": "run.completed", "meta_status": "completed",
+                    "meta_report_source": "agent", "run_log_text": "fine",
+                }
+            ),
+            "ok",
+        )
+
+    def test_a_fallback_report_is_not_a_completed_run(self) -> None:
+        """A quota death exports a fallback report and records status completed."""
+        self.assertEqual(
+            classify_run(
+                {
+                    "last_event": "run.completed", "meta_status": "completed",
+                    "meta_report_source": "fallback", "run_log_text": "",
+                }
+            ),
+            "fallback",
+        )
+
+    def test_a_stalled_run_is_not_an_incomplete_one(self) -> None:
+        self.assertEqual(classify_run({"stalled": True}), "stalled")
+
+    def test_a_429_in_ordinary_research_output_is_not_a_quota_death(self) -> None:
+        """All four real ``logs.txt`` on this box contain ``429``; none contains a marker.
+
+        A chi2 value, a grep hit reading ``sources.json:429``, a table cell, and arXiv
+        answering ``HTTP Error 429`` to a literature fetch that then succeeded. Reading a
+        bare ``429`` classified every healthy run as a quota death, and that is not the
+        safe direction to be wrong in: :func:`next_action` answers ``quota`` with two
+        backoffs — 1800 s then 3600 s — and two relaunches per arm before refusing the
+        pair, so a healthy three-task trial spends eighteen runs and nine hours of
+        sleeping to publish zero pairs.
+        """
+        log = (
+            "chi2 = 3.429 for the joint fit\n"
+            'literature/sources.json:429:        "output": "..."\n'
+            "2018 ERR HTTP Error 429: Unknown Error\n"
+        )
+        self.assertEqual(
+            classify_run(
+                {
+                    "last_event": "run.completed", "meta_status": "completed",
+                    "meta_report_source": "agent", "run_log_text": log,
+                }
+            ),
+            "ok",
+        )
+        self.assertEqual(count_quota_hits(log), 0)
+
+    def test_the_classifier_and_the_admission_clause_read_the_same_markers(self) -> None:
+        """One rule about what a quota death is, not two tuples that drifted.
+
+        ``count_quota_hits`` deliberately read a *prefix* of the classifier's markers, so
+        a run the classifier sent to a backoff was a run the clause called clean.
+        """
+        for marker in _QUOTA_MARKERS:
+            with self.subTest(marker=marker):
+                log = f"API Error: {marker} for claude-sonnet-4-5\n"
+                self.assertEqual(
+                    classify_run(
+                        {
+                            "last_event": "run.completed", "meta_status": "completed",
+                            "meta_report_source": "agent", "run_log_text": log,
+                        }
+                    ),
+                    "quota",
+                )
+                self.assertEqual(count_quota_hits(log), 1)
+
+
+class PlannerTests(unittest.TestCase):
+    def plan(self, **kwargs) -> TrialPlan:
+        base = dict(
+            capability="pr175",
+            bench="/bench",
+            tasks=("T1",),
+            control=ArmSpec("c", "/wt/c", "c"),
+            treatment=ArmSpec("t", "/wt/t", "t"),
+        )
+        base.update(kwargs)
+        return TrialPlan(**base)
+
+    def test_an_empty_state_launches_the_control_arm_first(self) -> None:
+        action = next_action(self.plan(), [], now=0.0)
+        self.assertEqual((action.kind, action.task_id, action.arm, action.attempt),
+                         ("launch", "T1", "c", 1))
+
+    def test_a_surviving_child_aborts_rather_than_racing_it(self) -> None:
+        """A ``setsid`` child outlives its driver, and two drivers is the concurrency
+        that exhausts the quota that kills both."""
+        states = [{"task_id": "T1", "arm": "c", "attempt": 1, "phase": "launched", "child_pid": 4242}]
+        action = next_action(self.plan(), states, now=0.0, live_pids=frozenset({4242}))
+        self.assertEqual(action.kind, "abort")
+        self.assertIn("4242", action.reason)
+
+    def test_a_dead_child_is_abandoned_and_never_resumed(self) -> None:
+        """``rcb_agent.py`` has only ``--export-only``; ``main.py --resume-run`` on a
+        benchmark workspace hits three false refusals because it passes neither
+        ``artifact_roots`` nor ``min_report_figures``."""
+        states = [{"task_id": "T1", "arm": "c", "attempt": 1, "phase": "launched", "child_pid": 4242}]
+        action = next_action(self.plan(), states, now=0.0, live_pids=frozenset())
+        self.assertEqual(action.kind, "abandon")
+        self.assertIn("no resume", action.reason)
+
+    def test_an_abandoned_attempt_is_re_planned_as_a_new_attempt(self) -> None:
+        states = [{"task_id": "T1", "arm": "c", "attempt": 1, "phase": "abandoned"}]
+        action = next_action(self.plan(), states, now=0.0)
+        self.assertEqual((action.kind, action.attempt), ("launch", 2))
+
+    def test_the_attempt_budget_is_finite(self) -> None:
+        states = [
+            {"task_id": "T1", "arm": "c", "attempt": n, "phase": "abandoned"} for n in (1, 2)
+        ]
+        self.assertEqual(next_action(self.plan(), states, now=0.0).kind, "refuse")
+
+    def test_quota_backs_off_rather_than_refusing_the_pair(self) -> None:
+        """Refusing on the first 429 most likely ends a four-day trial with zero pairs."""
+        states = [
+            {"task_id": "T1", "arm": "c", "attempt": 1, "phase": "finished",
+             "classification": "quota"}
+        ]
+        action = next_action(self.plan(), states, now=0.0)
+        self.assertEqual(action.kind, "backoff")
+        self.assertGreaterEqual(action.seconds, 1800)
+
+    def test_the_backoff_budget_is_finite(self) -> None:
+        states = [
+            {"task_id": "T1", "arm": "c", "attempt": n, "phase": "finished",
+             "classification": "quota"}
+            for n in (1, 2, 3)
+        ]
+        self.assertEqual(next_action(self.plan(), states, now=0.0).kind, "refuse")
+
+    def test_a_fallback_run_is_refused_rather_than_retried(self) -> None:
+        states = [
+            {"task_id": "T1", "arm": "c", "attempt": 1, "phase": "finished",
+             "classification": "fallback"}
+        ]
+        self.assertEqual(next_action(self.plan(), states, now=0.0).kind, "refuse")
+
+    def test_a_refusal_is_terminal_and_does_not_loop(self) -> None:
+        states = [{"task_id": "T1", "arm": "c", "attempt": 0, "phase": "refused"}]
+        self.assertEqual(next_action(self.plan(), states, now=0.0).arm, "t")
+
+    def test_a_finished_run_is_scored_before_the_next_one_launches(self) -> None:
+        """A gate that refuses everything must be visible after run one, not day five."""
+        states = [
+            {"task_id": "T1", "arm": "c", "attempt": 1, "phase": "finished",
+             "classification": "ok"}
+        ]
+        self.assertEqual(next_action(self.plan(), states, now=0.0).kind, "score")
+
+    def test_the_deadline_stops_new_launches_and_nothing_else(self) -> None:
+        """No per-run wall clock: a measured 15.8-hour run finished properly."""
+        plan = self.plan(deadline=100.0)
+        self.assertEqual(next_action(plan, [], now=200.0).kind, "final_pass")
+        self.assertEqual(next_action(plan, [], now=50.0).kind, "launch")
+
+    def test_the_final_pass_runs_once_and_then_the_trial_is_done(self) -> None:
+        states = [
+            {"task_id": "T1", "arm": a, "attempt": 1, "phase": "finished",
+             "classification": "ok", "scored": True}
+            for a in ("c", "t")
+        ]
+        self.assertEqual(next_action(self.plan(), states, now=0.0).kind, "final_pass")
+        self.assertEqual(
+            next_action(self.plan(), states, now=0.0, final_pass_done=True).kind, "done"
+        )
+
+
+class ReplicateTests(unittest.TestCase):
+    def test_replicates_zip_by_position_and_identity_is_checked(self) -> None:
+        payloads = [
+            {"items": [{"index": 0, "type": "text", "weight": 1.0, "content": "a", "score": 40}]},
+            {"items": [{"index": 0, "type": "text", "weight": 1.0, "content": "a", "score": 50}]},
+        ]
+        scored = items_from_score_payloads(payloads)
+        self.assertEqual(scored[0].scores, (40, 50))
+        self.assertEqual(scored[0].score, 45.0)
+        self.assertEqual(scored[0].spread, 10)
+
+    def test_a_checklist_that_changed_between_replicates_is_refused(self) -> None:
+        payloads = [
+            {"items": [{"index": 0, "type": "text", "weight": 1.0, "content": "a", "score": 40}]},
+            {"items": [{"index": 0, "type": "text", "weight": 1.0, "content": "b", "score": 50}]},
+        ]
+        with self.assertRaises(ValueError) as caught:
+            items_from_score_payloads(payloads)
+        self.assertIn("item identity", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class LeftoverDraftTest(unittest.TestCase):
+    """Counting is not naming.
+
+    ``score.py`` falls back to the first ``*.md`` an unsorted glob yields when
+    ``report/report.md`` is absent. A workspace holding only ``draft.md`` therefore
+    satisfies "exactly one markdown file" *and* gets its draft scored as the
+    deliverable, with nothing on the record saying which file was read. The clause has
+    to test both halves or it admits exactly the run it was written to catch.
+    """
+
+    def test_a_lone_leftover_draft_is_refused(self) -> None:
+        ok, failed = admit_arm(arm(facts={"report_md_count": 1, "report_md_present": False}))
+        self.assertFalse(ok)
+        self.assertEqual(failed, ["single_report_md"])
+
+    def test_report_md_beside_a_second_markdown_file_is_still_refused(self) -> None:
+        ok, failed = admit_arm(arm(facts={"report_md_count": 2, "report_md_present": True}))
+        self.assertFalse(ok)
+        self.assertEqual(failed, ["single_report_md"])
+
+    def test_a_missing_presence_fact_refuses_rather_than_passing(self) -> None:
+        # An older state file predates the field. Absent must not read as present: the
+        # cheapest way to satisfy a check over declared keys is to not declare the key.
+        ok, failed = admit_arm(arm(facts={"report_md_present": None}))
+        self.assertFalse(ok)
+        self.assertEqual(failed, ["single_report_md"])
+
+    def test_the_healthy_case_still_passes(self) -> None:
+        ok, failed = admit_arm(arm())
+        self.assertTrue(ok, failed)

--- a/tests/test_rcb_trial_driver.py
+++ b/tests/test_rcb_trial_driver.py
@@ -1,0 +1,1116 @@
+"""The driver: the lock, the state, and one whole trial end to end without spending it.
+
+A four-hour task per run and six runs per trial means the recovery logic gets exercised
+for real perhaps twice, days apart, under conditions nobody can reproduce. So the
+policy is a pure function tested in :mod:`tests.test_rcb_trial`, and what is left here
+is the machinery that touches processes and files — which is tested by running it, on a
+fabricated operator and a fabricated judge, against a fabricated benchmark checkout.
+
+The dry run is not a mock of the driver. It is the driver: the real lock, real
+``Popen(start_new_session=True)`` children, real atomic state writes, the real stall
+watchdog, the real admission gate and the real report. Only the four hours and the
+judge's bill are fake.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOL = REPO_ROOT / "tools" / "rcb_trial.py"
+
+
+def load_tool():
+    spec = importlib.util.spec_from_file_location("rcb_trial_tool", TOOL)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+CHECKLIST = [
+    {"content": "a curve of X against Y", "type": "image", "weight": 0.5, "path": "f1.png"},
+    {"content": "the coupling limit in GeV^-1", "type": "text", "weight": 0.3},
+    {"content": "the significance of the result", "type": "text", "weight": 0.2},
+]
+
+
+def make_bench(root: Path, task: str = "Energy_001") -> Path:
+    bench = root / "bench"
+    study = bench / "tasks" / task / "target_study"
+    study.mkdir(parents=True)
+    (study / "checklist.json").write_text(json.dumps(CHECKLIST), encoding="utf-8")
+    (bench / "tasks" / task / "data").mkdir()
+    (bench / "tasks" / task / "data" / "x.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    (bench / "tasks" / task / "task_info.json").write_text(
+        json.dumps({"task_description": "do the thing"}), encoding="utf-8"
+    )
+    return bench
+
+
+def make_worktree(root: Path, name: str, agent_body: str = "# placeholder\n") -> tuple[Path, str]:
+    """A real git checkout, because the revision clause reads a real ``rev-parse``.
+
+    ``agent_body`` is the worktree's ``rcb_agent.py``. The real (non-fake) operator branch
+    launches exactly that file, so a test that wants to see the argv the driver would
+    really build has to have something there that runs.
+    """
+    path = root / name
+    path.mkdir()
+    (path / "rcb_agent.py").write_text(agent_body, encoding="utf-8")
+    run = lambda *args: subprocess.run(  # noqa: E731
+        ["git", "-C", str(path), *args], capture_output=True, text=True, check=True
+    )
+    run("init", "-q")
+    run("config", "user.email", "t@example.com")
+    run("config", "user.name", "t")
+    run("add", "-A")
+    run("commit", "-q", "-m", name)
+    sha = run("rev-parse", "HEAD").stdout.strip()
+    return path, sha
+
+
+class LockTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = load_tool()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.state = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_the_lock_is_taken_with_link_and_not_with_exclusive_create(self) -> None:
+        """``O_CREAT|O_EXCL`` is not reliably atomic on NFS; ``os.link`` is, and the
+        state directory sits on shared NFS by design."""
+        body = TOOL.read_text(encoding="utf-8")
+        self.assertIn("os.link(", body)
+        self.assertNotIn("os.open(", body)
+
+    def test_a_second_driver_is_refused_while_the_first_is_alive(self) -> None:
+        # A real live process whose command line looks like a driver. A synthetic pid
+        # would be indistinguishable from the stale case the next test covers.
+        holder = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)", "tools/rcb_trial.py"]
+        )
+        self.addCleanup(holder.kill)
+        self.state.mkdir(parents=True, exist_ok=True)
+        (self.state / "driver.lock").write_text(
+            json.dumps({"pid": holder.pid, "boot_id": self.tool.boot_id()}), encoding="utf-8"
+        )
+        with self.assertRaises(SystemExit) as caught:
+            self.tool.acquire_lock(self.state)
+        self.assertIn(str(holder.pid), str(caught.exception))
+
+    def test_a_stale_lock_is_taken_over(self) -> None:
+        (self.state).mkdir(parents=True, exist_ok=True)
+        (self.state / "driver.lock").write_text(
+            json.dumps({"pid": 999999, "boot_id": self.tool.boot_id()}), encoding="utf-8"
+        )
+        self.tool.acquire_lock(self.state)
+        self.assertEqual(
+            json.loads((self.state / "driver.lock").read_text(encoding="utf-8"))["pid"],
+            os.getpid(),
+        )
+
+    def test_two_drivers_cannot_both_take_over_one_stale_lock(self) -> None:
+        """The takeover has to be as atomic as the creation, and it was not.
+
+        On ``FileExistsError`` the driver read the lock, tested liveness and then
+        ``os.replace``d it: two drivers that both read the same stale lock both replaced
+        it and both proceeded. A stale lock is not the exotic case — it is what ``kill
+        -9`` on a ``setsid`` driver leaves behind, i.e. the "I killed it and relaunched"
+        case the whole design is bent around, and it was reproduced at two races in five.
+        """
+        self.state.mkdir(parents=True, exist_ok=True)
+        lock = self.state / "driver.lock"
+        stale = {"pid": 999999, "boot_id": self.tool.boot_id(), "started_at": 1.0}
+        lock.write_text(json.dumps(stale), encoding="utf-8")
+
+        first, second = self.state / "tmp.a", self.state / "tmp.b"
+        first.write_text('{"pid": 1}', encoding="utf-8")
+        second.write_text('{"pid": 2}', encoding="utf-8")
+
+        self.assertTrue(self.tool.claim_stale_lock(self.state, stale, first, lock))
+        self.assertFalse(
+            self.tool.claim_stale_lock(self.state, stale, second, lock),
+            "both drivers took over one stale lock, and both will now hit Vertex",
+        )
+        self.assertEqual(json.loads(lock.read_text(encoding="utf-8"))["pid"], 1)
+
+    def test_the_driver_that_loses_the_takeover_stands_down(self) -> None:
+        """Losing the race has to end the process, not fall through into the trial."""
+        self.state.mkdir(parents=True, exist_ok=True)
+        stale = {"pid": 999999, "boot_id": self.tool.boot_id(), "started_at": 1.0}
+        (self.state / "driver.lock").write_text(json.dumps(stale), encoding="utf-8")
+        # The token a rival driver leaves behind when it wins the takeover.
+        (self.state / "driver.lock.taken.999999.1.0").write_text("{}", encoding="utf-8")
+        with self.assertRaises(SystemExit) as caught:
+            self.tool.acquire_lock(self.state)
+        self.assertIn("standing down", str(caught.exception))
+        self.assertEqual(
+            json.loads((self.state / "driver.lock").read_text(encoding="utf-8"))["pid"], 999999
+        )
+
+    def test_liveness_needs_the_pid_the_cmdline_and_the_boot_id(self) -> None:
+        """Each on its own gives a wrong answer.
+
+        A pid is reused. A cmdline cannot be read for a pid that is gone. And after a
+        reboot a live pid with a matching cmdline can be somebody else entirely, which
+        is the case the boot id exists for.
+        """
+        live = {"pid": os.getpid(), "boot_id": self.tool.boot_id()}
+        self.assertTrue(self.tool.lock_is_live(live, marker="python"))
+        self.assertFalse(self.tool.lock_is_live({**live, "pid": 999999}, marker="python"))
+        self.assertFalse(self.tool.lock_is_live(live, marker="definitely-not-in-cmdline"))
+        self.assertFalse(
+            self.tool.lock_is_live({**live, "boot_id": "0000-stale"}, marker="python")
+        )
+
+    def test_the_lock_is_only_released_by_its_owner(self) -> None:
+        lock = self.tool.acquire_lock(self.state)
+        payload = json.loads(lock.read_text(encoding="utf-8"))
+        payload["pid"] = 999999
+        lock.write_text(json.dumps(payload), encoding="utf-8")
+        self.tool.release_lock(lock)
+        self.assertTrue(lock.exists(), "released another driver's lock")
+
+
+class StateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = load_tool()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_state_is_replaced_and_never_truncated(self) -> None:
+        """A half-written state file after a kill is a run that cannot be classified."""
+        path = self.root / "runs" / "a.json"
+        self.tool.write_json(path, {"a": 1})
+        self.tool.write_json(path, {"a": 2})
+        self.assertEqual(self.tool.read_json(path), {"a": 2})
+        self.assertEqual(list((self.root / "runs").glob("*.tmp*")), [])
+
+    def test_the_web_search_level_is_read_from_the_progress_event(self) -> None:
+        """Not from ``run_config.json``, which records the request (``"auto"``).
+
+        The same command line produced ``info`` twice and ``warn`` once here, the warn
+        being a run whose Stage 01 could not search at all.
+        """
+        log = self.root / "out.log"
+        log.write_text(
+            '{"type":"system","subtype":"init"}\n'
+            '{"type":"progress","stage":"web_search","level":"warn"}\n',
+            encoding="utf-8",
+        )
+        self.assertEqual(self.tool.search_level(log), "warn")
+
+    def test_a_log_with_no_progress_event_yields_no_level_rather_than_a_guess(self) -> None:
+        log = self.root / "out.log"
+        log.write_text("nothing here\n", encoding="utf-8")
+        self.assertEqual(self.tool.search_level(log), "")
+
+    def test_harvest_counts_the_things_the_gate_asks_about(self) -> None:
+        workspace = self.root / "ws"
+        (workspace / "outputs" / "figures").mkdir(parents=True)
+        (workspace / "outputs" / "figures" / "a.png").write_bytes(b"x")
+        (workspace / "report").mkdir()
+        (workspace / "report" / "report.md").write_text("r", encoding="utf-8")
+        (workspace / "report" / "draft.md").write_text("d", encoding="utf-8")
+        (workspace / ".autor" / "r1").mkdir(parents=True)
+        (workspace / ".autor" / "r2").mkdir(parents=True)
+        (workspace / "_meta.json").write_text(json.dumps({"status": "running"}), encoding="utf-8")
+
+        facts = self.tool.harvest(workspace)
+        self.assertEqual(facts["images_under_outputs"], 1)
+        self.assertEqual(facts["report_md_count"], 2)
+        self.assertTrue(facts["report_md_present"])
+        self.assertEqual(facts["autor_run_count"], 2)
+        self.assertEqual(facts["meta_status"], "running")
+
+    def test_harvest_names_report_md_rather_than_counting_markdown(self) -> None:
+        """A lone ``draft.md`` counts one and is not the deliverable.
+
+        ``score.py`` globs ``report/*.md`` unsorted when ``report.md`` is absent, so a
+        count of one is satisfied by the very workspace the clause exists to catch. The
+        clause reads two facts; a test that only exercises the clause leaves the
+        producer of the second one free to return a constant.
+        """
+        workspace = self.root / "leftover"
+        (workspace / "report").mkdir(parents=True)
+        (workspace / "report" / "draft.md").write_text("d", encoding="utf-8")
+
+        facts = self.tool.harvest(workspace)
+        self.assertEqual(facts["report_md_count"], 1)
+        self.assertFalse(facts["report_md_present"])
+
+    def test_harvest_reports_no_report_md_when_the_report_dir_is_empty(self) -> None:
+        workspace = self.root / "empty"
+        (workspace / "report").mkdir(parents=True)
+
+        facts = self.tool.harvest(workspace)
+        self.assertEqual(facts["report_md_count"], 0)
+        self.assertFalse(facts["report_md_present"])
+
+    def test_harvest_reads_the_four_facts_a_quota_death_is_visible_in(self) -> None:
+        """The other half of the gate's inputs, and the half only a dead run exercises.
+
+        A run killed by quota reports ``status: completed`` and exports a fallback
+        report, so the four clauses that can tell it from a real run all read fields the
+        happy path never varies: ``report_source``, ``pipeline_completed``,
+        ``last_event`` and the count of quota markers in the run's own log. Each of them
+        could be replaced by its healthy constant with the whole suite green, and the
+        end-to-end dry run cannot see it — the fake operator writes ``report_source:
+        "agent"``, so that assertion agrees by construction with a hardcoded ``"agent"``.
+        """
+        workspace = self.root / "dead"
+        (workspace / "report").mkdir(parents=True)
+        (workspace / "_meta.json").write_text(
+            json.dumps(
+                {
+                    "status": "completed", "report_source": "fallback",
+                    "pipeline_completed": False, "task_id": "Energy_001",
+                }
+            ),
+            encoding="utf-8",
+        )
+        root = workspace / ".autor" / "r1"
+        root.mkdir(parents=True)
+        (root / "run_manifest.json").write_text(
+            json.dumps({"run_status": "failed", "last_event": "run.backend_unavailable"}),
+            encoding="utf-8",
+        )
+        (root / "logs.txt").write_text(
+            "API Error: 429 RESOURCE_EXHAUSTED for claude-sonnet-4-5\n", encoding="utf-8"
+        )
+
+        facts = self.tool.harvest(workspace)
+        self.assertEqual(facts["meta_report_source"], "fallback")
+        self.assertIs(facts["meta_pipeline_completed"], False)
+        self.assertEqual(facts["last_event"], "run.backend_unavailable")
+        self.assertEqual(facts["resource_exhausted_hits"], 1)
+
+    def test_harvest_keeps_the_task_id_of_a_run_that_never_wrote_its_meta(self) -> None:
+        """``rcb_agent.py`` writes ``_meta.json`` once, at the very end.
+
+        So every run the stall watchdog killed — the case the watchdog exists for — has
+        none, and reading the id out of a file that is not there returns ``None``.
+        ``next_action`` keys on ``(task_id, arm)``, so that does not lose one field: it
+        makes the whole attempt invisible to the planner.
+        """
+        workspace = self.root / "killed"
+        workspace.mkdir()
+        self.assertEqual(
+            self.tool.harvest(workspace, task_id="Energy_001")["task_id"], "Energy_001"
+        )
+
+    def test_the_instructions_digest_holds_the_file_and_not_just_its_presence(self) -> None:
+        """Normalise the workspace path out, hold everything else byte for byte.
+
+        The path is in the file by construction and the two arms are in different
+        directories by design, so digesting it raw reported every pair as an environment
+        difference. But the point of the digest is that the two arms were handed the same
+        background: the benchmark is a live checkout, ``INSTRUCTIONS.md`` is re-rendered
+        at each launch, and a ``task_description`` edited between two runs days apart has
+        to fire.
+        """
+        first, second, third = (self.root / name for name in ("a", "b", "c"))
+        for path in (first, second, third):
+            path.mkdir()
+        for path, task in ((first, "do it"), (second, "do it"), (third, "do it well")):
+            (path / "INSTRUCTIONS.md").write_text(
+                f"# Task\n\n{task}\n\nWorkspace: {path}\n", encoding="utf-8"
+            )
+
+        self.assertEqual(
+            self.tool.instructions_digest(first), self.tool.instructions_digest(second)
+        )
+        self.assertNotEqual(
+            self.tool.instructions_digest(first),
+            self.tool.instructions_digest(third),
+            "a changed task description is not an environment difference",
+        )
+        self.assertEqual(self.tool.instructions_digest(self.root / "gone"), "")
+
+    def test_the_heartbeat_is_the_raw_log_and_nothing_else(self) -> None:
+        """``run_manifest.json`` updates on stage transitions — one healthy run was
+        eight minutes stale — and ``_meta.json`` is written once, at the end."""
+        workspace = self.root / "ws"
+        (workspace / ".autor" / "r1").mkdir(parents=True)
+        self.assertEqual(self.tool.heartbeat(workspace), 0.0)
+        (workspace / ".autor" / "r1" / "logs_raw.jsonl").write_text("{}\n", encoding="utf-8")
+        self.assertGreater(self.tool.heartbeat(workspace), 0.0)
+
+    def test_a_block_of_rejected_ideas_alone_is_a_dose_of_the_channel(self) -> None:
+        """Built by the real ``build_block``, rendered by the real channel.
+
+        The dose detector is the only thing that tells "the channel was administered and
+        did nothing" from "the channel was never administered", which is the trial's whole
+        interpretive claim about change (b). It looked for ``build_block``'s crux
+        sub-heading, which is emitted inside ``if cruxes:`` — so a block made of rejected
+        idea-pool candidates alone, one of the two things the channel routes, is a real
+        delivered dose that reads as zero and gets the pair thrown away as "not a test of
+        it".
+        """
+        from src.information_flow import CHANNELS, _render
+        from src.settled_reasoning import build_block
+        from src.utils import build_run_paths
+
+        paths = build_run_paths(self.root / "run")
+        paths.reviews_dir.mkdir(parents=True, exist_ok=True)
+        (paths.reviews_dir / "idea_pool.json").write_text(
+            json.dumps(
+                {
+                    "candidates": [
+                        {
+                            "idea_id": "i1",
+                            "title": "Spectral clustering baseline",
+                            "statement": "Cluster the residuals before fitting.",
+                            "proposer_title": "statistics",
+                            "adopted": False,
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        block = build_block(paths)
+        self.assertIsNotNone(block, "a rejected candidate is material the channel sends")
+        self.assertNotIn("Methodological questions this run settled", block)
+
+        channel = next(item for item in CHANNELS if item.key == "settled_reasoning")
+        workspace = self.root / "ws-dose"
+        cache = workspace / ".autor" / "r1" / "prompt_cache"
+        cache.mkdir(parents=True)
+        (cache / "07_report_attempt_01.prompt.md").write_text(
+            _render(block, channel), encoding="utf-8"
+        )
+        self.assertTrue(
+            self.tool.harvest(workspace, task_id="Energy_001")["settled_reasoning_dose"]
+        )
+
+    def test_the_launch_state_is_on_disk_before_the_child_exists(self) -> None:
+        """A ``kill -9`` must cost the run in flight and nothing else, which means the
+        state cannot be written after the process it describes."""
+        from src.rcb_trial import ArmSpec, TrialPlan
+
+        bench = make_bench(self.root)
+        worktree, sha = make_worktree(self.root, "wt")
+        plan = TrialPlan(
+            capability="c", bench=str(bench), tasks=("Energy_001",),
+            control=ArmSpec(sha[:7], str(worktree), sha[:7]),
+            treatment=ArmSpec("other", str(worktree), "other"),
+            state_dir=str(self.root / "state"), operator="fake", judge_kind="fake",
+        )
+        seen: list[bool] = []
+        real = subprocess.Popen
+
+        def spy(*args, **kwargs):
+            # `git rev-parse` also goes through Popen; only the operator launch counts.
+            if any("fake-run" in str(part) for part in (args[0] if args else [])):
+                seen.append(self.tool.state_path(plan, "Energy_001", sha[:7], 1).exists())
+            return real(*args, **kwargs)
+
+        self.tool.subprocess.Popen = spy
+        try:
+            self.tool.launch(plan, "Energy_001", sha[:7], 1)
+        finally:
+            self.tool.subprocess.Popen = real
+        self.assertEqual(seen, [True])
+
+
+#: An operator that records the command line it was given and stops. The real launch
+#: branch is otherwise unreachable from a test — every dry run sets ``operator: "fake"``,
+#: which builds a completely different argv — and what it carries is fact one: the
+#: reviewer model resolves independently of the operator's, so ``--model opus`` alone
+#: leaves the panels on the exhausted sonnet pool, where they die mid-stage without ever
+#: being classified as a quota failure.
+AGENT_THAT_RECORDS_ITS_ARGV = """
+import json, sys
+from pathlib import Path
+workspace = Path(sys.argv[sys.argv.index("--workspace") + 1])
+workspace.mkdir(parents=True, exist_ok=True)
+(workspace / "argv.json").write_text(json.dumps(sys.argv), encoding="utf-8")
+"""
+
+#: An operator that dies before writing ``_meta.json`` — which ``rcb_agent.py`` writes
+#: once, at the very end, so this is every stalled, killed or crashed run.
+AGENT_THAT_DIES = "import sys\nsys.exit(3)\n"
+
+
+class RealOperatorTests(unittest.TestCase):
+    """The launch branch the dry run never takes.
+
+    ``operator: "fake"`` builds its own argv and its own workspace, so everything the
+    real branch does — the models it passes, and what the state file records when the run
+    it launched leaves nothing behind — is invisible to every other test here.
+    """
+
+    def setUp(self) -> None:
+        self.tool = load_tool()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        self.bench = make_bench(self.root)
+
+    def _plan(self, agent_body: str):
+        from src.rcb_trial import ArmSpec, TrialPlan
+
+        worktree, sha = make_worktree(self.root, "wt", agent_body)
+        return TrialPlan(
+            capability="pr175",
+            bench=str(self.bench),
+            tasks=("Energy_001",),
+            control=ArmSpec(sha[:7], str(worktree), sha[:7]),
+            treatment=ArmSpec("other", str(worktree), "other"),
+            state_dir=str(self.root / "state"),
+            operator="autor",
+            judge_kind="fake",
+            agent_model="claude-opus-4-5",
+            review_model="claude-opus-4-5-reviewer",
+        ), sha[:7]
+
+    def test_the_real_operator_is_launched_with_the_reviewer_model_too(self) -> None:
+        """Fact one, and the flag nothing held.
+
+        Vertex quota is per-base-model: sonnet is routinely exhausted while opus has
+        headroom, and AutoR resolves the reviewer/panel model independently of the
+        operator's. Without this flag every run in the plan launches ``--model opus``
+        with the panels left on the exhausted pool; they die mid-stage, ``classify_backend``
+        never fires because it only runs when neither attempt wrote a stage file, and both
+        arms score a degraded report the gate admits.
+        """
+        plan, arm = self._plan(AGENT_THAT_RECORDS_ITS_ARGV)
+        state = self.tool.launch(plan, "Energy_001", arm, 1)
+        argv = json.loads(
+            (Path(state["workspace"]) / "argv.json").read_text(encoding="utf-8")
+        )
+        self.assertIn("--model", argv)
+        self.assertEqual(argv[argv.index("--model") + 1], "claude-opus-4-5")
+        self.assertIn("--review-model", argv)
+        self.assertEqual(
+            argv[argv.index("--review-model") + 1], "claude-opus-4-5-reviewer",
+            "the panels were left to resolve their own model",
+        )
+        self.assertTrue(argv[0].endswith("rcb_agent.py"), argv)
+
+    def test_a_run_that_died_before_writing_its_meta_keeps_its_identity(self) -> None:
+        """Otherwise the attempt is invisible and the driver relaunches it forever.
+
+        ``harvest`` read ``task_id`` out of ``_meta.json`` with no fallback and ``launch``
+        let that overwrite the id it launched with, so a run that died early recorded
+        ``task_id: null``. ``next_action`` keys on ``(task_id, arm)``: it then sees no
+        attempts for this arm, returns ``launch attempt 1``, overwrites its own state file
+        and does it again — reproduced at twelve relaunches in thirteen seconds, and in
+        production each cycle costs a stall timeout plus a whole opus run. ``MAX_ATTEMPTS``
+        is never consulted, so the pair is never refused.
+        """
+        from src.rcb_trial import next_action
+
+        plan, arm = self._plan(AGENT_THAT_DIES)
+        state = self.tool.launch(plan, "Energy_001", arm, 1)
+        self.assertEqual(state["task_id"], "Energy_001")
+        self.assertEqual(state["classification"], "incomplete")
+
+        states = self.tool.all_states(plan)
+        self.assertEqual(next_action(plan, states, now=0.0).kind, "refuse")
+        # Isolated to the one field: the same state with the id lost relaunches instead.
+        blinded = [{**item, "task_id": None} for item in states]
+        self.assertEqual(
+            (next_action(plan, blinded, now=0.0).kind, next_action(plan, blinded, now=0.0).attempt),
+            ("launch", 1),
+        )
+
+
+class RealScorerArgvTests(unittest.TestCase):
+    """The scoring branch the dry run never takes, for the same reason.
+
+    Every test sets ``judge_kind: "fake"``, which returns on the line above the two rules
+    that decide what the number means: which judge produced it, and which five images
+    every image criterion was shown.
+    """
+
+    def setUp(self) -> None:
+        self.tool = load_tool()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def _capture(self, plan, out: Path) -> dict:
+        seen: dict = {}
+        real = self.tool.subprocess.run
+
+        def spy(argv, env=None, **kwargs):
+            seen["argv"] = list(argv)
+            seen["env"] = dict(env or {})
+            Path(argv[argv.index("--out") + 1]).parent.mkdir(parents=True, exist_ok=True)
+            Path(argv[argv.index("--out") + 1]).write_text("{}", encoding="utf-8")
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+        self.tool.subprocess.run = spy
+        try:
+            seen["ok"] = self.tool.score_once(
+                plan, {"workspace": str(self.root / "ws")}, out
+            )
+        finally:
+            self.tool.subprocess.run = real
+        return seen
+
+    def plan(self):
+        from src.rcb_trial import ArmSpec, TrialPlan
+
+        return TrialPlan(
+            capability="pr175", bench=str(self.root / "bench"), tasks=("Energy_001",),
+            control=ArmSpec("c", "/wt/c", "c"), treatment=ArmSpec("t", "/wt/t", "t"),
+            judge_kind="reference", judge_model="gpt-5.1",
+            state_dir=str(self.root / "state"),
+        )
+
+    def test_the_scorer_is_told_which_judge_to_use(self) -> None:
+        """Without it ``score_rcb_run.py`` falls back to its own default model, and the
+        report header prints the plan's declaration either way. Judge choice is worth
+        about sixteen points on identical artifacts, so that header would be stating a
+        number's provenance that nothing observed."""
+        plan = self.plan()
+        seen = self._capture(plan, self.root / "state" / "scores" / "s.json")
+        self.assertTrue(seen["ok"])
+        argv = seen["argv"]
+        self.assertIn("score_rcb_run.py", " ".join(argv))
+        self.assertEqual(argv[argv.index("--model") + 1], "gpt-5.1")
+        self.assertEqual(argv[argv.index("--judge") + 1], "reference")
+
+    def test_the_scorer_runs_with_a_pinned_hash_seed(self) -> None:
+        """The benchmark's ``IMAGE_EXTENSIONS`` is a ``set``, and which five images each
+        image criterion is shown is read off a list built by iterating it. This narrows
+        that variance across 60.6% of the benchmark's weight; it does not remove it,
+        because ``rglob``'s order is not pinned by anything."""
+        seen = self._capture(self.plan(), self.root / "state" / "scores" / "s.json")
+        self.assertEqual(seen["env"].get("PYTHONHASHSEED"), "0")
+
+    def test_a_scorer_that_writes_nothing_is_not_a_score(self) -> None:
+        """``score_rcb_run.py`` exits 1 and writes no ``--out`` when a judge call failed
+        or the item count is short. That refusal is inherited, not reimplemented."""
+        plan = self.plan()
+        real = self.tool.subprocess.run
+        self.tool.subprocess.run = lambda argv, env=None, **kw: subprocess.CompletedProcess(
+            argv, 1, "", "refused"
+        )
+        try:
+            self.assertFalse(
+                self.tool.score_once(plan, {"workspace": str(self.root / "ws")},
+                                     self.root / "state" / "scores" / "s.json")
+            )
+        finally:
+            self.tool.subprocess.run = real
+
+
+class EvidenceTests(unittest.TestCase):
+    """That the environment is *read off the run*, which nothing tested.
+
+    Every test of :class:`RunEnvironment` builds one by hand, and the dry run gives both
+    arms an identical environment, so neither can see the producer. Each of the seven
+    fields could be replaced by ``""`` with the whole suite green — and with all seven
+    blank the digest is a constant, the stage key is the same twelve characters in both
+    arms, and the composition refusal the whole design rests on excludes nothing.
+    """
+
+    def setUp(self) -> None:
+        self.tool = load_tool()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        self.bench = make_bench(self.root)
+
+    def plan(self, **overrides):
+        from src.rcb_trial import ArmSpec, TrialPlan
+
+        base = dict(
+            capability="pr175", bench=str(self.bench), tasks=("Energy_001",),
+            control=ArmSpec("621566b", "/wt/c", "621566b"),
+            treatment=ArmSpec("47f3fbf", "/wt/t", "47f3fbf"),
+            state_dir=str(self.root / "state"), replicates=2, judge_kind="fake",
+        )
+        base.update(overrides)
+        return TrialPlan(**base)
+
+    def state(self, arm: str, **overrides) -> dict:
+        payload = {
+            "task_id": "Energy_001", "arm": arm, "attempt": 1, "phase": "finished",
+            "workspace": f"/ws/{arm}", "run_id": f"run-{arm}",
+            "agent_model": "claude-opus-4-5", "review_model": "claude-sonnet-4-5",
+            "web_search_level": "warn", "instructions_digest": "ins-digest",
+            "meta_status": "completed", "meta_pipeline_completed": True,
+            "meta_report_source": "agent", "autor_run_count": 1,
+            "images_under_outputs": 0, "report_md_count": 1,
+            "report_md_present": True,
+            "last_event": "run.completed", "resource_exhausted_hits": 0,
+            "revision_at_launch": arm + "0" * 33, "revision_at_finish": arm + "0" * 33,
+            "worktree_dirty_at_launch": False, "worktree_dirty_at_finish": False,
+            "classification": "ok",
+        }
+        payload.update(overrides)
+        return payload
+
+    def write_scores(self, plan, arm: str, score: int, **overrides) -> None:
+        for rep in range(plan.replicates):
+            payload = {
+                "task_id": "Energy_001",
+                "items": [
+                    {"index": index, "type": entry["type"], "weight": entry["weight"],
+                     "content": entry["content"], "score": score}
+                    for index, entry in enumerate(CHECKLIST)
+                ],
+                "total_score": score,
+                "judge_model": "gpt-5.1",
+                "judge_failures": [],
+                "checklist_items_expected": len(CHECKLIST),
+                "images_shown": ["a.png"],
+                "images_available": 1,
+                "bench_revision": "bench-sha",
+            }
+            payload.update(overrides)
+            self.tool.write_json(
+                self.tool.score_path(plan, "Energy_001", arm, 1, "final", rep), payload
+            )
+
+    def test_a_replicate_the_judge_never_produced_is_written_down(self) -> None:
+        """Giving up quietly is how an arm scored once was published as one scored three.
+
+        The count reaches the report through the environment digest, which excludes the
+        pair; this is the operator's copy, on the stdout they are watching and in the
+        state directory, so the loss is attributable to a replicate rather than inferred
+        from a missing file days later.
+        """
+        plan = self.plan()
+        self.tool.write_json(
+            self.tool.state_path(plan, "Energy_001", "621566b", 1), self.state("621566b")
+        )
+        real = self.tool.score_once
+        self.tool.score_once = lambda *args, **kwargs: False
+        try:
+            self.tool.final_pass(plan)
+        finally:
+            self.tool.score_once = real
+        recorded = self.tool.read_json(Path(plan.state_dir) / "final_pass.json")
+        self.assertEqual(
+            recorded["unscored_replicates"],
+            ["Energy_001.621566b.a1.final.r0.json", "Energy_001.621566b.a1.final.r1.json"],
+        )
+
+    def test_every_field_of_the_environment_comes_off_the_run(self) -> None:
+        plan = self.plan()
+        self.write_scores(plan, "621566b", 20)
+        evidence = self.tool.evidence_for(plan, self.state("621566b"))
+        checklist = self.bench / "tasks" / "Energy_001" / "target_study" / "checklist.json"
+
+        self.assertEqual(evidence.env.agent_model, "claude-opus-4-5")
+        self.assertEqual(evidence.env.review_model, "claude-sonnet-4-5")
+        self.assertEqual(evidence.env.web_search_level, "warn")
+        self.assertEqual(evidence.env.instructions_digest, "ins-digest")
+        self.assertEqual(evidence.env.judge_model, "gpt-5.1")
+        self.assertEqual(evidence.env.bench_revision, "bench-sha")
+        self.assertEqual(evidence.env.checklist_digest, self.tool.digest_bytes(checklist))
+        self.assertEqual(evidence.env.judge_replicates, 2)
+        self.assertEqual(evidence.replicates_requested, 2)
+        self.assertEqual((evidence.images_shown, evidence.images_available), (1, 1))
+
+    def test_two_arms_run_on_different_models_are_not_a_pair(self) -> None:
+        """Fact one's exact confound, through the real producer.
+
+        A control run on the exhausted sonnet pool and a treatment run on opus is a
+        40-point model swap that the report would publish as PR #175's effect. The gate
+        that stops it is the environment digest, and the digest is only a gate if
+        something actually fills it in.
+        """
+        from src.rcb_trial import collect_rcb_pairs
+
+        plan = self.plan()
+        self.write_scores(plan, "621566b", 20)
+        self.write_scores(plan, "47f3fbf", 60)
+        evidences = [
+            self.tool.evidence_for(plan, self.state("621566b", agent_model="claude-sonnet-4-5")),
+            self.tool.evidence_for(plan, self.state("47f3fbf", agent_model="claude-opus-4-5")),
+        ]
+        outcome = collect_rcb_pairs(
+            evidences, capability="pr175", control_arm="621566b",
+            treatment_arm="47f3fbf", planned_pairs=1,
+        )
+        self.assertEqual(outcome.result.n, 0)
+        self.assertIn("agent_model", dict(outcome.result.excluded)["Energy_001"])
+
+    def test_an_arm_scored_fewer_times_than_the_other_is_not_a_pair(self) -> None:
+        """What ``final_pass`` leaves behind when a replicate fails both its tries."""
+        from src.rcb_trial import collect_rcb_pairs
+
+        plan = self.plan()
+        self.write_scores(plan, "621566b", 20)
+        self.write_scores(plan, "47f3fbf", 60)
+        self.tool.score_path(plan, "Energy_001", "47f3fbf", 1, "final", 1).unlink()
+
+        evidences = [
+            self.tool.evidence_for(plan, self.state(arm)) for arm in ("621566b", "47f3fbf")
+        ]
+        self.assertEqual([item.replicates for item in evidences], [2, 1])
+        outcome = collect_rcb_pairs(
+            evidences, capability="pr175", control_arm="621566b",
+            treatment_arm="47f3fbf", planned_pairs=1,
+        )
+        self.assertEqual(outcome.result.n, 0)
+        self.assertIn("judge_replicates", dict(outcome.result.excluded)["Energy_001"])
+
+
+class EndToEndDryRunTests(unittest.TestCase):
+    """One whole trial, with the four hours and the judge's bill taken out.
+
+    Everything else is the real thing. If the seam, the gate, the state machine or the
+    report were wrong, this is where it shows — and it costs seconds rather than days.
+    """
+
+    def setUp(self) -> None:
+        self.tool = load_tool()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        # The preflight refusal is a property of the box, not of the trial: this
+        # machine has been observed running three AutoR processes at once, and the test
+        # is not about them.
+        self.tool.foreign_runs = lambda: []
+
+    def _plan(self, **overrides) -> Path:
+        bench = make_bench(self.root)
+        control, control_sha = make_worktree(self.root, "control")
+        treatment, treatment_sha = make_worktree(self.root, "treatment")
+        payload = {
+            "capability": "pr175",
+            "bench": str(bench),
+            "tasks": ["Energy_001"],
+            "control": {
+                "label": control_sha[:7], "worktree": str(control), "sha": control_sha[:7]
+            },
+            "treatment": {
+                "label": treatment_sha[:7], "worktree": str(treatment), "sha": treatment_sha[:7]
+            },
+            "judge_kind": "fake",
+            "judge_model": "fake-judge",
+            "state_dir": str(self.root / "state"),
+            "operator": "fake",
+            "replicates": 2,
+            "fake_quality": 20.0,
+        }
+        payload.update(overrides)
+        path = self.root / "plan.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        self.control_arm = payload["control"]["label"]
+        self.treatment_arm = payload["treatment"]["label"]
+        return path
+
+    def test_a_whole_trial_runs_freezes_scores_and_reports(self) -> None:
+        plan_path = self._plan()
+        self.assertEqual(self.tool.main(["plan", "--plan", str(plan_path)]), 0)
+        self.assertEqual(self.tool.main(["run", "--plan", str(plan_path)]), 0)
+
+        state = self.root / "state"
+        runs = sorted(p.name for p in (state / "runs").glob("*.json"))
+        self.assertEqual(len(runs), 2, runs)
+        for name in runs:
+            payload = json.loads((state / "runs" / name).read_text(encoding="utf-8"))
+            self.assertEqual(payload["phase"], "finished")
+            self.assertEqual(payload["classification"], "ok")
+            self.assertEqual(payload["meta_report_source"], "agent")
+            self.assertEqual(payload["web_search_level"], "info")
+            self.assertEqual(payload["autor_run_count"], 1)
+
+        # Two arms, two replicates each, in the final pass; plus one early score apiece.
+        self.assertEqual(len(list((state / "scores").glob("*.final.*.json"))), 4)
+        self.assertEqual(len(list((state / "scores").glob("*.early.*.json"))), 2)
+
+        report = (state / "report.md").read_text(encoding="utf-8")
+        self.assertIn("pairs: **1**", report)
+        self.assertIn("RCB points", report)
+        self.assertIn("fake-judge", report)
+        # The fake operator hands the treatment arm a better report, so the apparatus
+        # must show a signed, non-zero, correctly-directed difference. Two identical
+        # columns would let a broken seam pass.
+        self.assertIn("won 1, lost 0", report)
+
+    def test_the_recovered_difference_is_the_benchmark_total_difference(self) -> None:
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+
+        from src.rcb_trial import collect_rcb_pairs
+
+        plan = self.tool.load_plan(plan_path)
+        evidences = [
+            self.tool.evidence_for(plan, state)
+            for state in self.tool.all_states(plan)
+            if state.get("phase") == "finished"
+        ]
+        trial = collect_rcb_pairs(
+            evidences, capability=plan.capability,
+            control_arm=plan.control.label, treatment_arm=plan.treatment.label,
+            planned_pairs=1,
+        )
+        control = trial.evidence[("Energy_001", plan.control.label)]
+        treatment = trial.evidence[("Energy_001", plan.treatment.label)]
+        self.assertAlmostEqual(
+            trial.result.mean_difference,
+            treatment.total_weighted - control.total_weighted,
+            places=9,
+        )
+        self.assertGreater(trial.result.mean_difference, 15.0)
+
+    def test_the_treatment_arm_is_the_one_that_carries_the_channel(self) -> None:
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        plan = self.tool.load_plan(plan_path)
+        dosed = {
+            state["arm"]: state["settled_reasoning_dose"] for state in self.tool.all_states(plan)
+        }
+        self.assertTrue(dosed[self.treatment_arm])
+        self.assertFalse(dosed[self.control_arm])
+        self.assertNotIn(
+            "Zero settled-reasoning dose",
+            (self.root / "state" / "report.md").read_text(encoding="utf-8"),
+        )
+
+    def _kill_the_treatment_arm(self, state: Path, refused: dict | None) -> None:
+        """Leave the state directory exactly as the driver leaves it after a death."""
+        for path in (state / "runs").glob(f"Energy_001.{self.treatment_arm}.*.json"):
+            path.unlink()
+        for path in (state / "scores").glob(f"Energy_001.{self.treatment_arm}.*.json"):
+            path.unlink()
+        if refused is not None:
+            (state / "runs" / f"Energy_001.{self.treatment_arm}.a0.json").write_text(
+                json.dumps(refused), encoding="utf-8"
+            )
+
+    def test_a_run_the_driver_refused_is_in_the_ledger_not_missing_from_it(self) -> None:
+        """Three treatment deaths against zero control deaths is this trial's result.
+
+        The ledger could not see any of them: ``build_report`` builds evidence only from
+        ``phase == "finished"`` states with score files, and ``final_pass`` scores only
+        ``classification == "ok"``, so every quota death, backend death, stall, fallback
+        and incomplete run was reported as "no `<arm>` arm" — the same sentence as an arm
+        that was never launched — above a clause table of ten zeros and a paragraph
+        telling the reader to judge the difference on the per-arm counts.
+        """
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        state = self.root / "state"
+        self._kill_the_treatment_arm(
+            state,
+            {
+                "task_id": "Energy_001", "arm": self.treatment_arm, "attempt": 0,
+                "phase": "refused", "classification": "quota",
+            },
+        )
+        self.tool.main(["report", "--plan", str(plan_path)])
+        report = (state / "report.md").read_text(encoding="utf-8")
+
+        self.assertIn("| `driver:quota` | 1 |", report)
+        self.assertIn(f"treatment `{self.treatment_arm}` 1", report)
+        self.assertIn(f"control `{self.control_arm}` 0", report)
+        self.assertNotIn("- no run was refused.", report)
+        self.assertIn("was refused (driver:quota)", report)
+        self.assertNotIn(f"no `{self.treatment_arm}` arm", report)
+
+    def test_a_run_nothing_could_score_is_a_refusal_and_not_a_silence(self) -> None:
+        """The whole-trial failure mode: every score fails, and the report says nothing.
+
+        With `<state_dir>/scores/` missing the real scorer judged every item and died
+        writing the result, which the driver reads as "scoring failed". Two completed
+        runs then published `pairs: 0`, `mean difference: +0.0000`, an empty ledger and
+        no exclusion line — three to four days of opus runs and the judge's whole bill
+        for a report with no diagnosis anywhere in it.
+        """
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        state = self.root / "state"
+        for path in (state / "scores").glob("*.final.*.json"):
+            path.unlink()
+
+        self.tool.main(["report", "--plan", str(plan_path)])
+        report = (state / "report.md").read_text(encoding="utf-8")
+        self.assertIn("| `driver:unscored` | 2 |", report)
+        self.assertIn(f"control `{self.control_arm}` 1", report)
+        self.assertIn(f"treatment `{self.treatment_arm}` 1", report)
+
+    def test_a_run_the_final_pass_has_not_reached_yet_is_not_a_refusal(self) -> None:
+        """The report runs at any moment by design, so "not scored yet" is a state.
+
+        Calling it a death would fill an interim ledger with attrition that has not
+        happened, which is the same failure as the ledger's silence, pointed the other
+        way.
+        """
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        state = self.root / "state"
+        for path in (state / "scores").glob("*.final.*.json"):
+            path.unlink()
+        (state / "final_pass.json").unlink()
+
+        self.tool.main(["report", "--plan", str(plan_path)])
+        report = (state / "report.md").read_text(encoding="utf-8")
+        self.assertNotIn("driver:unscored", report)
+        self.assertIn("INTERIM — 0 of 1 planned pairs", report)
+
+    def test_a_run_still_in_flight_is_not_reported_as_a_death(self) -> None:
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        state = self.root / "state"
+        self._kill_the_treatment_arm(
+            state,
+            {
+                "task_id": "Energy_001", "arm": self.treatment_arm, "attempt": 1,
+                "phase": "launched", "child_pid": 4242,
+            },
+        )
+        self.tool.main(["report", "--plan", str(plan_path)])
+        report = (state / "report.md").read_text(encoding="utf-8")
+        self.assertIn("- no run was refused.", report)
+
+    def test_the_judge_in_the_header_is_the_one_that_ran(self) -> None:
+        """Not the one the plan asked for, which is what it used to print.
+
+        Judge choice is worth about sixteen points on identical artifacts, so the header
+        is the line a reader uses to decide whether the number is comparable to anything
+        — and `score_rcb_run.py` will happily fall back to its own default model.
+        """
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        state = self.root / "state"
+        for path in (state / "scores").glob("*.final.*.json"):
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            payload["judge_model"] = "claude-opus-4-5"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+
+        self.tool.main(["report", "--plan", str(plan_path)])
+        report = (state / "report.md").read_text(encoding="utf-8")
+        self.assertIn("- judge: `claude-opus-4-5`", report)
+        self.assertIn("not the judge the plan declared", report)
+
+    def test_the_report_is_a_pure_function_of_the_state_directory(self) -> None:
+        """Re-running after fixing a bug in the producer must not leave half an answer."""
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        first = (self.root / "state" / "report.md").read_text(encoding="utf-8")
+        (self.root / "state" / "report.md").unlink()
+        self.tool.main(["report", "--plan", str(plan_path)])
+        self.assertEqual((self.root / "state" / "report.md").read_text(encoding="utf-8"), first)
+
+    def test_a_second_run_of_a_finished_trial_launches_nothing(self) -> None:
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        before = sorted(p.name for p in (self.root / "state" / "workspaces").iterdir())
+        self.tool.main(["run", "--plan", str(plan_path)])
+        after = sorted(p.name for p in (self.root / "state" / "workspaces").iterdir())
+        self.assertEqual(before, after)
+
+    def test_editing_a_frozen_plan_is_refused(self) -> None:
+        """An apparatus that can be re-planned while it runs can be stopped when the
+        sign looks good."""
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        payload = json.loads(plan_path.read_text(encoding="utf-8"))
+        payload["tasks"] = ["Energy_001", "Astronomy_000"]
+        plan_path.write_text(json.dumps(payload), encoding="utf-8")
+        with self.assertRaises(SystemExit) as caught:
+            self.tool.main(["run", "--plan", str(plan_path)])
+        self.assertIn("frozen", str(caught.exception))
+
+    def test_running_without_freezing_first_is_refused(self) -> None:
+        plan_path = self._plan()
+        with self.assertRaises(SystemExit) as caught:
+            self.tool.main(["run", "--plan", str(plan_path)])
+        self.assertIn("freeze the plan first", str(caught.exception))
+
+    def test_a_foreign_autor_process_stops_the_driver_starting(self) -> None:
+        """Fact three: a ``setsid`` driver survives ``pkill`` on its children, so "I
+        killed it and relaunched" yields two drivers racing — which is the concurrency
+        that exhausts the quota."""
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.foreign_runs = lambda: ["4242 python rcb_agent.py --workspace /x"]
+        self.assertEqual(self.tool.main(["run", "--plan", str(plan_path)]), 2)
+
+    def test_a_workspace_is_never_reused_between_arms(self) -> None:
+        """Two arms pre-created in the same second land in one directory and overwrite
+        each other's report, making the paired difference identically zero."""
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        workspaces = list((self.root / "state" / "workspaces").iterdir())
+        self.assertEqual(len(workspaces), 2)
+        self.assertEqual(len({p.name for p in workspaces}), 2)
+
+    def test_the_benchmark_background_is_copied_identically_into_both_arms(self) -> None:
+        """The judge reads ``INSTRUCTIONS.md``; ``rcb_agent.py`` never writes it."""
+        plan_path = self._plan()
+        self.tool.main(["plan", "--plan", str(plan_path)])
+        self.tool.main(["run", "--plan", str(plan_path)])
+        digests = {
+            self.tool.instructions_digest(ws)
+            for ws in (self.root / "state" / "workspaces").iterdir()
+        }
+        self.assertEqual(len(digests), 1)
+        self.assertNotIn("", digests)
+        for ws in (self.root / "state" / "workspaces").iterdir():
+            self.assertTrue((ws / "data" / "x.csv").exists(), "data/ was not copied")
+
+
+class StallTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tool = load_tool()
+
+    def test_there_is_no_per_run_wall_clock(self) -> None:
+        """A measured run here took 57011 seconds and finished with
+        ``report_source == "agent"``. Any cap short enough to catch a hang would have
+        killed it."""
+        body = TOOL.read_text(encoding="utf-8")
+        self.assertNotIn("max_seconds", body)
+        self.assertIn("stall_seconds", body)
+
+    def test_a_silent_child_is_killed_by_its_process_group(self) -> None:
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"], start_new_session=True
+        )
+        started = time.time()
+        with tempfile.TemporaryDirectory() as tmp:
+            stalled = self.tool.watch(child, Path(tmp), stall_seconds=1)
+        self.assertTrue(stalled)
+        self.assertLess(time.time() - started, 30)
+        self.assertIsNotNone(child.poll())
+
+    def test_a_beating_child_is_left_alone(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            (workspace / ".autor" / "r1").mkdir(parents=True)
+            beat = workspace / ".autor" / "r1" / "logs_raw.jsonl"
+            child = subprocess.Popen(
+                [
+                    sys.executable, "-c",
+                    f"import time\nfor _ in range(4):\n"
+                    f"    open({str(beat)!r},'a').write('{{}}\\n')\n    time.sleep(0.5)\n",
+                ],
+                start_new_session=True,
+            )
+            self.assertFalse(self.tool.watch(child, workspace, stall_seconds=2))
+        self.assertEqual(child.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_score_rcb_run.py
+++ b/tests/test_score_rcb_run.py
@@ -14,6 +14,9 @@ than swallowed, and a total is refused while any call failed.
 from __future__ import annotations
 
 import importlib.util
+import json
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -125,6 +128,227 @@ class JudgeIsPartOfTheResultTest(unittest.TestCase):
         text = TOOL.read_text(encoding="utf-8")
         self.assertIn("37.0", text)
         self.assertIn("20.8", text)
+
+
+class RefusalRuleTest(unittest.TestCase):
+    """A zero has to be distinguishable from a failure to score, at every count.
+
+    The guard that existed covered a judge that failed. It did not cover a judge that
+    was never asked: an empty or short checklist gives ``total_score: 0``,
+    ``judge_failures: []`` and exit 0 — the same 19.5-against-37.0 shape, one clause
+    short of the guard already here.
+    """
+
+    def setUp(self) -> None:
+        self.tool = _load()
+
+    def full(self, **overrides) -> dict:
+        base = {
+            "items": [{"score": 40}, {"score": 50}],
+            "checklist_items_expected": 2,
+            "judge_failures": [],
+            "total_score": 44.0,
+        }
+        base.update(overrides)
+        return base
+
+    def test_a_fully_judged_run_is_not_refused(self) -> None:
+        self.assertEqual(self.tool.refusal_reasons(self.full()), [])
+
+    def test_an_empty_checklist_is_refused(self) -> None:
+        reasons = self.tool.refusal_reasons(
+            self.full(items=[], checklist_items_expected=0, total_score=0)
+        )
+        self.assertEqual(len(reasons), 1)
+        self.assertIn("zero over nothing", reasons[0])
+
+    def test_a_short_item_vector_is_refused(self) -> None:
+        """Nothing anywhere cross-checked `items` against the checklist on disk."""
+        reasons = self.tool.refusal_reasons(self.full(checklist_items_expected=5))
+        self.assertEqual(len(reasons), 1)
+        self.assertIn("checklist of 5", reasons[0])
+
+    def test_a_judge_failure_is_still_refused(self) -> None:
+        reasons = self.tool.refusal_reasons(self.full(judge_failures=["timeout"]))
+        self.assertIn("timeout", reasons[0])
+
+    def test_the_refusal_is_raised_by_score_and_not_only_printed_by_main(self) -> None:
+        """A guarantee that lives in `main` is a printing policy, not a property.
+
+        Anything doing `from score_rcb_run import score` used to get back a dict whose
+        `total_score` already had the failed calls folded in as zeros, with no exception
+        and no flag.
+        """
+        body = TOOL.read_text(encoding="utf-8")
+        self.assertIn("raise ScoringRefused", body)
+        self.assertIn("refusal_reasons(result)", body)
+
+
+class SelfDescriptionTest(unittest.TestCase):
+    """Three keys without which an `--out` file cannot be read a week later."""
+
+    def test_the_output_records_which_images_the_judge_was_shown(self) -> None:
+        """60.6% of the benchmark's weight is image criteria and every one of them sees
+        the same first five of one list — and `IMAGE_EXTENSIONS` is a `set`, so which
+        five changes between interpreters. Nothing recorded them."""
+        body = TOOL.read_text(encoding="utf-8")
+        self.assertIn('result["images_shown"]', body)
+        self.assertIn("_find_generated_images", body)
+
+    def test_the_output_records_how_many_images_there_were_to_choose_from(self) -> None:
+        """Five of five and five of twelve are not the same evidence.
+
+        The judge sees the first five of one list against every image criterion, so an
+        arm that emitted twelve figures was scored on an arbitrary five of them. Without
+        the denominator the score file cannot say which of those two things happened, and
+        the paired trial attributes the whole image stratum to figure quality.
+        """
+        body = TOOL.read_text(encoding="utf-8")
+        self.assertIn('result["images_available"]', body)
+
+    def test_the_output_records_the_benchmark_revision(self) -> None:
+        """Item identity is a property of the checkout; the output records only task_id."""
+        self.assertIn('result["bench_revision"]', TOOL.read_text(encoding="utf-8"))
+
+    def test_the_output_records_what_the_item_count_should_have_been(self) -> None:
+        self.assertIn('result["checklist_items_expected"]', TOOL.read_text(encoding="utf-8"))
+
+
+class AgainstTheRealScorerTest(unittest.TestCase):
+    """The wiring, driven through ResearchClawBench's own `score_workspace`.
+
+    Skipped without a benchmark checkout, which is why every rule above is also held by
+    a test that needs neither. What this adds is that the rule is actually *reached*:
+    the refusal, the self-description and the exit code all sit on the far side of an
+    import that the unit tests do not perform.
+    """
+
+    def setUp(self) -> None:
+        import shutil
+
+        bench_source = Path("/home/robtang_google_com/RCB")
+        if not (bench_source / "evaluation" / "score.py").exists():
+            self.skipTest("no ResearchClawBench checkout")
+        try:
+            import structai  # noqa: F401
+        except ImportError:
+            self.skipTest("structai is not installed")
+
+        self.tool = _load()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        # A copy, because `PROJECT_ROOT` is derived from the package's own location, so
+        # copying `evaluation/` gives the real scorer over a task tree we control.
+        self.bench = self.root / "bench"
+        self.bench.mkdir()
+        shutil.copytree(bench_source / "evaluation", self.bench / "evaluation")
+        for stale in ("evaluation", "evaluation.score", "evaluation.config", "evaluation.utils"):
+            sys.modules.pop(stale, None)
+        self.addCleanup(
+            lambda: [sys.modules.pop(name, None) for name in list(sys.modules)
+                     if name.startswith("evaluation")]
+        )
+        self.addCleanup(lambda: sys.path.remove(str(self.bench))
+                        if str(self.bench) in sys.path else None)
+
+    def _workspace(self, task: str, checklist: list) -> Path:
+        study = self.bench / "tasks" / task / "target_study"
+        study.mkdir(parents=True)
+        (study / "checklist.json").write_text(json.dumps(checklist), encoding="utf-8")
+        workspace = self.root / f"{task}_20260101_000000"
+        (workspace / "report").mkdir(parents=True)
+        (workspace / "report" / "report.md").write_text("# report\n\nbody\n", encoding="utf-8")
+        (workspace / "_meta.json").write_text(
+            json.dumps({"run_id": workspace.name, "task_id": task}), encoding="utf-8"
+        )
+        return workspace
+
+    class _Judge:
+        model = "stub-judge"
+
+        def __init__(self) -> None:
+            self.calls = 0
+            self.failures: list[str] = []
+
+        def __call__(self, prompt, image_paths=None, return_example=None, max_try=2, **_):
+            self.calls += 1
+            return {"score": 40, "reasoning": "stub"}
+
+    def test_an_empty_checklist_exits_one_and_writes_no_result_file(self) -> None:
+        """Before this it exited 0, printed `TOTAL: 0.0`, and wrote the file."""
+        workspace = self._workspace("Empty_000", [])
+        out = self.root / "out.json"
+        argv = [
+            "score_rcb_run.py", "--workspace", str(workspace), "--bench", str(self.bench),
+            "--judge", "vertex", "--project-id", "x", "--out", str(out),
+        ]
+        self.tool.VertexJudge = lambda **_: self._Judge()
+        old = sys.argv
+        sys.argv = argv
+        try:
+            code = self.tool.main()
+        finally:
+            sys.argv = old
+        self.assertEqual(code, 1)
+        self.assertFalse(out.exists(), "a refused total was still written to disk")
+
+    def test_a_fully_judged_run_scores_and_describes_itself(self) -> None:
+        workspace = self._workspace(
+            "Full_000",
+            [
+                {"content": "a", "type": "text", "weight": 0.6},
+                {"content": "b", "type": "text", "weight": 0.4},
+            ],
+        )
+        result = self.tool.score(workspace, self.bench, judge=self._Judge())
+        self.assertEqual(result["total_score"], 40)
+        self.assertEqual(result["checklist_items_expected"], 2)
+        self.assertIn("images_shown", result)
+        self.assertIn("bench_revision", result)
+
+    def test_the_result_is_written_into_a_directory_that_does_not_exist_yet(self) -> None:
+        """`--out` is handed in by the paired-trial driver, and nothing creates its parent.
+
+        `tools/rcb_trial.py::score_path` builds `<state_dir>/scores/<...>.json` and passes
+        it straight through; the directory only ever appeared by accident of the dry
+        run's fake judge, which writes through a helper that creates it. So every test
+        was green while the real judge path could not write a single result: the scorer
+        judged every item, printed the total, and died on `FileNotFoundError` — which the
+        driver reads as "scoring failed", retries `replicates` x 2 times per run, and
+        finally publishes `pairs: 0` with no diagnosis after four days of opus runs.
+        """
+        workspace = self._workspace("Full_001", [{"content": "a", "type": "text", "weight": 1.0}])
+        out = self.root / "state" / "scores" / "Full_001.abc1234.a1.final.r0.json"
+        self.assertFalse(out.parent.exists())
+        self.tool.VertexJudge = lambda **_: self._Judge()
+        old = sys.argv
+        sys.argv = [
+            "score_rcb_run.py", "--workspace", str(workspace), "--bench", str(self.bench),
+            "--judge", "vertex", "--project-id", "x", "--out", str(out),
+        ]
+        try:
+            code = self.tool.main()
+        finally:
+            sys.argv = old
+        self.assertEqual(code, 0)
+        self.assertTrue(out.exists(), "the judge's whole bill, and nowhere to put it")
+        self.assertEqual(json.loads(out.read_text(encoding="utf-8"))["total_score"], 40)
+        # Replaced, never truncated: a kill during the write leaves a file that
+        # `final_pass` skips forever because it exists and that the report cannot parse.
+        self.assertEqual(list(out.parent.glob("*.tmp*")), [])
+
+    def test_score_raises_rather_than_returning_a_poisoned_total(self) -> None:
+        """The programmatic hole. `main` refused; `score` handed back the zero."""
+        workspace = self._workspace("Short_000", [{"content": "a", "type": "text", "weight": 1.0}])
+        judge = self._Judge()
+        judge.failures.append("deliberate")
+
+        with self.assertRaises(self.tool.ScoringRefused) as caught:
+            self.tool.score(workspace, self.bench, judge=judge)
+        # The result is carried on the exception, so a caller can still show the table.
+        self.assertIn("total_score", caught.exception.result)
+        self.assertIn("deliberate", caught.exception.reasons[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_trials.py
+++ b/tests/test_trials.py
@@ -18,6 +18,7 @@ from src.trials import (
     collect_pairs,
     format_all_trials,
     format_trial_report,
+    min_attainable_concentration,
     min_attainable_p,
     sign_flip_p,
 )
@@ -282,6 +283,76 @@ class ReportTests(unittest.TestCase):
         printed even when they were inferred."""
         records = [run("g1", "off", stages=flat(0.5)), run("g1", "on", stages=flat(0.7))]
         self.assertIn("`on` against `off`", format_all_trials(records))
+
+
+class RenderingContractTests(unittest.TestCase):
+    """The parts of the report a second outcome measure leans on.
+
+    Every one of these was unpinned before an external benchmark was fed through this
+    module, and every one renders something false when it is wrong rather than raising.
+    """
+
+    def collect(self, records, **kwargs):
+        return collect_pairs(
+            records, capability="effort_tiers", control_arm="off", treatment_arm="on", **kwargs
+        )
+
+    def test_the_default_unit_is_rubric_points(self) -> None:
+        """The default has to keep every existing report byte-identical."""
+        result = self.collect(paired(3, 0.5, 0.6))
+        self.assertIn("+0.1000** rubric points", format_trial_report(result))
+
+    def test_the_unit_is_whatever_the_caller_declared(self) -> None:
+        """An external benchmark's 0-100 total printed as "rubric points" is a lie
+        about the instrument in the one place a reader takes the number from."""
+        result = self.collect(paired(3, 0.5, 0.6))
+        rendered = format_trial_report(result, unit="RCB points (0-100 total scale)")
+        self.assertIn("+0.1000** RCB points (0-100 total scale)", rendered)
+        self.assertNotIn("rubric points", rendered)
+
+    def test_the_decomposition_table_says_how_many_pairs_each_row_is_over(self) -> None:
+        """A criterion seen in one pair of three renders exactly like a mean over three.
+
+        With AutoR's own rubric every key is in every pair and nobody missed the
+        denominator. Hand the same table a per-goal key set — a benchmark checklist is
+        written per task — and every row is a single observation under a header that
+        says "mean difference".
+        """
+        records = paired(3, 0.5, 0.6)
+        # One criterion only the first pair measured.
+        records[0] = run("g0", "off", stages=flat(0.5), criteria={"shared": 0.5, "rare": 0.1})
+        records[1] = run("g0", "on", stages=flat(0.6), criteria={"shared": 0.6, "rare": 0.9})
+        for index in (2, 4):
+            records[index] = run(f"g{index // 2}", "off", stages=flat(0.5), criteria={"shared": 0.5})
+            records[index + 1] = run(f"g{index // 2}", "on", stages=flat(0.6), criteria={"shared": 0.6})
+
+        result = self.collect(records)
+        self.assertEqual(result.criterion_support(), {"shared": 3, "rare": 1})
+
+        rendered = format_trial_report(result)
+        self.assertIn("| Criterion | Mean difference | pairs |", rendered)
+        self.assertIn("| `rare` | +0.8000 | 1 |", rendered)
+        self.assertIn("| `shared` | +0.1000 | 3 |", rendered)
+
+    def test_the_concentration_floor_is_printed_beside_the_concentration(self) -> None:
+        """Same discipline as the p and its floor, for the same reason.
+
+        0.6 was calibrated against eight rubric criteria, where an even spread reads
+        0.125. Over two keys an even spread already reads 0.50 and the warning fires on
+        a 1.5:1 split, so the denominator has to be visible.
+        """
+        self.assertAlmostEqual(min_attainable_concentration(8), 0.125)
+        self.assertAlmostEqual(min_attainable_concentration(2), 0.5)
+        self.assertEqual(min_attainable_concentration(0), 0.0)
+
+        result = self.collect(
+            paired(
+                3, 0.5, 0.6,
+                control_extra={"criteria": {"a": 0.5, "b": 0.5}},
+                treatment_extra={"criteria": {"a": 0.9, "b": 0.5}},
+            )
+        )
+        self.assertIn("floor at 2 criteria: 50%", format_trial_report(result))
 
 
 class TagTests(unittest.TestCase):

--- a/tools/rcb_trial.py
+++ b/tools/rcb_trial.py
@@ -1,0 +1,1191 @@
+"""Run a paired ResearchClawBench trial, one arm at a time, and survive being killed.
+
+The shell around :mod:`src.rcb_trial`. Everything here touches a process, a clock or a
+filesystem; everything that decides anything lives in the module and is a pure function
+of already-parsed data, because the alternative is validating multi-day
+kill-and-restart behaviour by spending multi-day kill-and-restart wall clock.
+
+**Why a driver at all.** AutoR has no serial multi-run driver. ``studio_runner`` starts
+a thread per project with no queue and no restart recovery; ``main.py`` runs one run;
+``rcb_agent.py`` never touches the archive, so a run through the benchmark entry point
+produces no tagged ``RunRecord`` at all. And the runs have to be strictly serialised:
+this box has been observed running three AutoR processes against one Vertex project at
+once, which is precisely the concurrency that exhausts the quota that then kills them.
+
+**Four operational facts the design is bent around**, each measured here rather than
+assumed:
+
+1. A 429 lands in the run's own ``logs.txt``, never on the driver's stdout — the
+   operator catches the API error. A retry loop that greps stdout has never fired.
+2. A ``setsid`` driver survives ``pkill`` on its children, so "I killed it and
+   relaunched" silently yields two drivers racing. The lock is ``os.link`` (atomic on
+   NFS, unlike ``O_CREAT|O_EXCL``) plus a liveness test that checks the pid, its
+   ``cmdline`` and the boot id, so a pid reused after a reboot reads as stale.
+3. Measured run durations here are 3426 / 57011 / 50536 / 11360 seconds. There is no
+   per-run wall clock: any cap short enough to catch a hang would have killed the
+   15.8-hour run that finished properly. A stall watchdog on ``logs_raw.jsonl``'s mtime
+   — the only second-granularity heartbeat a run emits — plus a trial deadline after
+   which no *new* run starts.
+4. State is written twice per run, before launch and after finish, tmp plus
+   ``os.replace``. A ``kill -9`` costs the run in flight and nothing else, and scoring
+   happens inside the loop so a systematically-refusing gate is visible after run one
+   rather than after day five.
+
+The dry-run path (``operator: "fake"``, ``judge_kind: "fake"`` in the plan) fabricates
+workspaces and scores instead of spending four hours per task. It exercises the real
+lock, the real subprocess and process-group handling, the real state machine, the real
+admission gate and the real report — everything except the two things that cost money.
+
+Usage::
+
+    python3 tools/rcb_trial.py plan --plan plan.json      # freeze it
+    python3 tools/rcb_trial.py run  --plan plan.json      # serial, resumable
+    python3 tools/rcb_trial.py report --plan plan.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.rcb_trial import (  # noqa: E402
+    SETTLED_REASONING_HEADING,
+    ArmEvidence,
+    Refusal,
+    RunEnvironment,
+    TrialPlan,
+    classify_run,
+    collect_rcb_pairs,
+    count_quota_hits,
+    driver_clause,
+    format_rcb_trial_report,
+    items_from_score_payloads,
+    next_action,
+)
+
+#: Extensions the benchmark's image sweep recognises. Duplicated here on purpose: the
+#: admission clause has to count what the scorer would show the judge, and importing
+#: the bench's config at gate time would make the gate depend on a checkout being
+#: present when the gate is exactly what runs when things have gone wrong.
+IMAGE_SUFFIXES = (".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg")
+
+
+# ---------------------------------------------------------------------------
+# Atomic state
+# ---------------------------------------------------------------------------
+
+
+def write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    """Replace, never truncate-and-write. ``/home`` here is shared NFS."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def digest_bytes(path: Path) -> str:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return ""
+
+
+def instructions_digest(workspace: Path) -> str:
+    """The judge's background text, with the one thing that differs by construction out.
+
+    ``INSTRUCTIONS.md`` is rendered with the workspace path in it, and the two arms of a
+    pair are in different directories by design — reusing a directory is how two runs
+    overwrite each other's report. Digesting the file raw therefore reports *every*
+    pair as an environment difference, which the first dry run duly did: a gate that
+    fires on everything refuses nothing, because the reader stops believing it. What
+    the digest is asking is whether the two arms were handed the same background, so
+    the path is normalised out and everything else is held byte for byte.
+    """
+    path = workspace / "INSTRUCTIONS.md"
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    return hashlib.sha256(
+        text.replace(str(workspace), "<WORKSPACE>").encode("utf-8")
+    ).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# The lock
+# ---------------------------------------------------------------------------
+
+
+def boot_id() -> str:
+    try:
+        return Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+    except OSError:  # pragma: no cover - not Linux
+        return ""
+
+
+def process_cmdline(pid: int) -> str:
+    try:
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return ""
+    return raw.replace(b"\0", b" ").decode("utf-8", "replace")
+
+
+def lock_is_live(payload: Mapping[str, Any], *, marker: str = "rcb_trial.py") -> bool:
+    """Three conditions, all required. Any one alone gives a false answer.
+
+    The pid alone is reused; the cmdline alone cannot be read for a pid that is gone;
+    and after a reboot a pid *and* a matching cmdline can both be somebody else's
+    process entirely, which is why the boot id is in the lock file.
+    """
+    pid = int(payload.get("pid") or 0)
+    if pid <= 0 or not Path(f"/proc/{pid}").exists():
+        return False
+    if marker not in process_cmdline(pid):
+        return False
+    recorded = str(payload.get("boot_id") or "")
+    return not recorded or recorded == boot_id()
+
+
+def claim_stale_lock(
+    state_dir: Path, existing: Mapping[str, Any], tmp: Path, lock: Path
+) -> bool:
+    """Take a dead driver's lock over — atomically, or not at all.
+
+    The bare ``os.replace`` this replaces threw away everything the ``os.link`` on the
+    create path was for: two drivers that both read the same stale lock both replaced it
+    and both proceeded, which is precisely the two-drivers-on-one-state-directory case
+    the lock exists to prevent. And a stale lock is not the exotic entry point to it — it
+    is what ``kill -9`` on a driver leaves behind, i.e. the documented "I killed it and
+    relaunched" case. Reproduced at two of five races on a ~1 ms window.
+
+    So the takeover is decided by the same primitive as the creation: a token named after
+    the *particular* stale lock being taken over, created with ``os.link``, which exactly
+    one process can win. The token is deliberately never deleted — deleting it after the
+    replace reopens a window of the same shape, because a driver that read the stale lock
+    before the replace would find the token gone, create it, and take the lock in turn.
+    """
+    token = state_dir / (
+        f"driver.lock.taken.{existing.get('pid', 'unknown')}."
+        f"{existing.get('started_at', 'unknown')}"
+    )
+    try:
+        os.link(tmp, token)
+    except FileExistsError:
+        return False
+    os.replace(tmp, lock)
+    return True
+
+
+def acquire_lock(state_dir: Path) -> Path:
+    """``os.link``, because ``O_CREAT|O_EXCL`` is not reliably atomic on NFS."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    lock = state_dir / "driver.lock"
+    payload = {
+        "pid": os.getpid(),
+        "pgid": os.getpgid(0),
+        "boot_id": boot_id(),
+        "argv": sys.argv,
+        "started_at": time.time(),
+    }
+    tmp = state_dir / f"driver.lock.{os.getpid()}"
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    try:
+        os.link(tmp, lock)
+    except FileExistsError:
+        existing = read_json(lock)
+        if lock_is_live(existing):
+            tmp.unlink(missing_ok=True)
+            raise SystemExit(
+                f"another driver holds {lock} (pid {existing.get('pid')}). Two drivers "
+                "racing is the concurrency that exhausts the quota. Wait for it, or kill "
+                f"that pid and re-run."
+            )
+        if not claim_stale_lock(state_dir, existing, tmp, lock):
+            tmp.unlink(missing_ok=True)
+            raise SystemExit(
+                f"another driver is taking over the stale lock at {lock} (it was pid "
+                f"{existing.get('pid')}). Two near-simultaneous relaunches after a "
+                "`kill -9` is exactly how this box came to be running three AutoR "
+                "processes against one Vertex project; this one is standing down."
+            )
+        return lock
+    tmp.unlink(missing_ok=True)
+    return lock
+
+
+def release_lock(lock: Path) -> None:
+    if read_json(lock).get("pid") == os.getpid():
+        lock.unlink(missing_ok=True)
+
+
+def autor_pids() -> frozenset[int]:
+    """Live pids whose command line is an agent run — ours or anybody's."""
+    found: set[int] = set()
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        line = process_cmdline(int(entry.name))
+        if "rcb_agent.py" in line or "rcb_trial.py fake-run" in line:
+            found.add(int(entry.name))
+    return frozenset(found)
+
+
+def foreign_runs() -> list[str]:
+    """Any AutoR process that is not ours. Refuse to start alongside one."""
+    found: list[str] = []
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        pid = int(entry.name)
+        if pid == os.getpid():
+            continue
+        line = process_cmdline(pid)
+        if "rcb_agent.py" in line or ("main.py" in line and "--goal" in line):
+            found.append(f"{pid} {line.strip()[:110]}")
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Reading a finished workspace
+# ---------------------------------------------------------------------------
+
+
+def latest_run_root(workspace: Path) -> Path | None:
+    roots = sorted(p for p in (workspace / ".autor").glob("*") if p.is_dir())
+    return roots[-1] if roots else None
+
+
+def search_level(stdout_path: Path) -> str:
+    """The resolved web-search level, from the one place it is ever stated.
+
+    Not from ``run_config.json``, which records the *request* (``"auto"``). The same
+    command line produced ``level: info`` twice and ``level: warn`` once here, the warn
+    being a run whose Stage 01 could not search at all because ``google.genai`` was not
+    importable by that day's interpreter. That is the largest uncontrolled variable
+    found in the real data and it is only ever announced as a progress event.
+    """
+    try:
+        text = stdout_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    level = ""
+    for line in text.splitlines():
+        if '"web_search"' not in line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if payload.get("stage") == "web_search":
+            level = str(payload.get("level") or "")
+    return level
+
+
+def bench_image_sweep(workspace: Path) -> list[Path]:
+    """The list ``evaluation/score._find_generated_images`` builds, in its order.
+
+    ``outputs/`` and then ``report/``, and the judge is shown the first five of it
+    against *every* image criterion. Duplicated here for the same reason
+    :data:`IMAGE_SUFFIXES` is: what the gate and the report need to know is what the
+    scorer would show, and importing the bench at report time makes the report depend on
+    a checkout being present exactly when things have gone wrong.
+    """
+    found: list[Path] = []
+    for directory in (workspace / "outputs", workspace / "report"):
+        if not directory.exists():
+            continue
+        found.extend(
+            sorted(
+                path
+                for path in directory.rglob("*")
+                if path.is_file() and path.suffix.lower() in IMAGE_SUFFIXES
+            )
+        )
+    return found
+
+
+def harvest(
+    workspace: Path, stdout_path: Path | None = None, *, task_id: str = ""
+) -> dict[str, Any]:
+    """Everything the admission gate and the environment digest read off a workspace.
+
+    ``task_id`` is the identity of the run being harvested and has to be passed in.
+    ``rcb_agent.py`` writes ``_meta.json`` once, at the very end, so every run the stall
+    watchdog killed — the case the watchdog exists for — has none, and reading the id out
+    of a file that is not there yields ``None``. ``next_action`` keys on
+    ``(task_id, arm)``, so a ``None`` there does not lose one field: it makes the whole
+    attempt invisible to the planner, which sees no attempts, relaunches attempt 1, and
+    does it again forever — the automated version of the kill-and-relaunch disaster this
+    driver was written to prevent.
+    """
+    meta = read_json(workspace / "_meta.json")
+    roots = sorted(p for p in (workspace / ".autor").glob("*") if p.is_dir())
+    root = roots[-1] if roots else None
+    manifest = read_json(root / "run_manifest.json") if root else {}
+    config = read_json(root / "run_config.json") if root else {}
+    log_text = ""
+    if root and (root / "logs.txt").exists():
+        log_text = (root / "logs.txt").read_text(encoding="utf-8", errors="replace")
+
+    images_under_outputs = sum(
+        1
+        for path in (workspace / "outputs").rglob("*")
+        if path.is_file() and path.suffix.lower() in IMAGE_SUFFIXES
+    )
+    report_md_count = len(list((workspace / "report").glob("*.md")))
+    # Counting is not naming. score.py falls back to the first *.md an unsorted glob
+    # yields when report.md is absent, so "exactly one markdown file" is satisfied by a
+    # workspace holding only `draft.md` -- and the draft is then scored as the
+    # deliverable with nothing recording which file was read.
+    report_md_present = (workspace / "report" / "report.md").is_file()
+
+    stages: list[str] = []
+    if root:
+        summary = read_json(root / "evolution" / "summary.json")
+        stages = sorted(str(key) for key in (summary.get("stages") or {}))
+
+    dose = False
+    if root:
+        for prompt in (root / "prompt_cache").glob("07_*.prompt.md"):
+            body = prompt.read_text(encoding="utf-8", errors="replace")
+            # The channel's own heading, not `build_block`'s crux sub-heading: a block
+            # made of rejected idea-pool candidates alone carries no crux sub-heading and
+            # is still a delivered dose of the channel under test.
+            if SETTLED_REASONING_HEADING in body:
+                dose = True
+                break
+
+    return {
+        "meta_status": meta.get("status"),
+        "meta_report_source": meta.get("report_source"),
+        "meta_pipeline_completed": meta.get("pipeline_completed"),
+        "meta_duration_seconds": meta.get("duration_seconds"),
+        "run_id": meta.get("run_id") or workspace.name,
+        "task_id": meta.get("task_id") or task_id,
+        "autor_run_count": len(roots),
+        "run_root": str(root) if root else "",
+        "run_status": manifest.get("run_status"),
+        "last_event": manifest.get("last_event"),
+        "run_log_text": log_text,
+        "resource_exhausted_hits": count_quota_hits(log_text),
+        "images_under_outputs": images_under_outputs,
+        "report_md_count": report_md_count,
+        "report_md_present": report_md_present,
+        "agent_model": config.get("model", ""),
+        "review_model": config.get("review_model", ""),
+        "web_search_level": search_level(stdout_path) if stdout_path else "",
+        "instructions_digest": instructions_digest(workspace),
+        "autor_stages_scored": stages,
+        "settled_reasoning_dose": dose,
+    }
+
+
+def git_head(worktree: Path) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=False,
+    )
+    return out.stdout.strip() if out.returncode == 0 else ""
+
+
+def git_dirty(worktree: Path) -> bool:
+    out = subprocess.run(
+        ["git", "-C", str(worktree), "status", "--porcelain"],
+        capture_output=True, text=True, check=False,
+    )
+    return out.returncode != 0 or bool(out.stdout.strip())
+
+
+def contrast_log(worktree: Path, control: str, treatment: str) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(worktree), "log", "--oneline", f"{control}..{treatment}"],
+        capture_output=True, text=True, check=False,
+    )
+    return out.stdout if out.returncode == 0 else "(git log unavailable)"
+
+
+# ---------------------------------------------------------------------------
+# Launching one run
+# ---------------------------------------------------------------------------
+
+
+def state_path(plan: TrialPlan, task: str, arm: str, attempt: int) -> Path:
+    return Path(plan.state_dir) / "runs" / f"{task}.{arm}.a{attempt}.json"
+
+
+def all_states(plan: TrialPlan) -> list[dict[str, Any]]:
+    directory = Path(plan.state_dir) / "runs"
+    return [read_json(path) for path in sorted(directory.glob("*.json"))]
+
+
+def make_workspace(plan: TrialPlan, task: str) -> Path:
+    """Never reuse a directory, never pre-create the whole set.
+
+    Two arms of one task pre-created in the same second land in the same directory —
+    the benchmark names workspaces ``<TaskId>_<%Y%m%d_%H%M%S>`` and creates them with
+    ``exist_ok=True`` — and then overwrite each other's report, making the paired
+    difference identically zero.
+    """
+    base = Path(plan.state_dir) / "workspaces"
+    base.mkdir(parents=True, exist_ok=True)
+    while True:
+        candidate = base / f"{task}_{time.strftime('%Y%m%d_%H%M%S')}"
+        if not candidate.exists():
+            candidate.mkdir(parents=True)
+            return candidate
+        time.sleep(1.1)
+
+
+def setup_workspace(plan: TrialPlan, task: str, workspace: Path) -> None:
+    """``rcb_agent.py`` creates four directories and nothing else.
+
+    It does not copy ``data/`` or ``related_work/`` and does not write
+    ``INSTRUCTIONS.md``, which the judge reads as background — so the driver has to do
+    what ``TaskRunner.setup_workspace`` does, or the two arms are scored against
+    different background text.
+    """
+    for name in ("code", "outputs", "report", "report/images"):
+        (workspace / name).mkdir(parents=True, exist_ok=True)
+    bench = Path(plan.bench)
+    task_dir = bench / "tasks" / task
+    import shutil
+
+    for name in ("data", "related_work"):
+        source = task_dir / name
+        if source.is_dir():
+            shutil.copytree(source, workspace / name, dirs_exist_ok=True)
+    info = read_json(task_dir / "task_info.json")
+    (workspace / "INSTRUCTIONS.md").write_text(
+        f"# Task\n\n{info.get('task_description', '')}\n\nWorkspace: {workspace}\n",
+        encoding="utf-8",
+    )
+
+
+def launch(plan: TrialPlan, task: str, arm: str, attempt: int) -> dict[str, Any]:
+    spec = plan.control if arm == plan.control.label else plan.treatment
+    worktree = Path(spec.worktree)
+    workspace = make_workspace(plan, task)
+    setup_workspace(plan, task, workspace)
+
+    if plan.operator == "fake":
+        argv = [
+            sys.executable, str(Path(__file__).resolve()), "fake-run",
+            "--workspace", str(workspace), "--task", task, "--arm", arm,
+            "--sha", spec.sha, "--model", plan.agent_model,
+            "--review-model", plan.review_model,
+            "--treatment-label", plan.treatment.label,
+            "--quality", str(plan.fake_quality if arm == plan.treatment.label else 0.0),
+        ]
+    else:
+        argv = [
+            sys.executable, str(worktree / "rcb_agent.py"),
+            "--workspace", str(workspace),
+            # Both, always. The reviewer model is resolved independently of the
+            # operator's, so `--model opus` alone leaves the panels on the exhausted
+            # sonnet pool, where they die without ever being classified as a quota
+            # failure.
+            "--model", plan.agent_model, "--review-model", plan.review_model,
+        ]
+
+    logs = Path(plan.state_dir) / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    stdout_path = logs / f"{task}.{arm}.a{attempt}.log"
+
+    state = {
+        "plan_digest": plan.digest,
+        "task_id": task,
+        "arm": arm,
+        "attempt": attempt,
+        "phase": "launched",
+        "worktree": str(worktree),
+        "revision_at_launch": git_head(worktree),
+        "worktree_dirty_at_launch": git_dirty(worktree),
+        "workspace": str(workspace),
+        "argv": argv,
+        "launched_at": time.time(),
+        "stdout_path": str(stdout_path),
+        "env": {
+            "ANTHROPIC_VERTEX_PROJECT_ID": os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", ""),
+            "CLOUD_ML_REGION": os.environ.get("CLOUD_ML_REGION", ""),
+            "python": sys.executable,
+        },
+        "foreign_pids_at_launch": foreign_runs(),
+    }
+    path = state_path(plan, task, arm, attempt)
+    write_json(path, state)
+
+    # A file, not a pipe. `emit_event` flushes on every event, and a driver killed
+    # while holding the read end leaves the agent taking a BrokenPipe on its next write.
+    with open(stdout_path, "ab", buffering=0) as sink:
+        child = subprocess.Popen(
+            argv, stdout=sink, stderr=subprocess.STDOUT, start_new_session=True, cwd=str(worktree)
+        )
+    state["child_pid"] = child.pid
+    state["child_pgid"] = os.getpgid(child.pid)
+    write_json(path, state)
+
+    stalled = watch(child, workspace, plan.stall_seconds)
+
+    finish = dict(state)
+    finish.update(harvest(workspace, stdout_path, task_id=task))
+    finish.update(
+        {
+            "phase": "finished",
+            "finished_at": time.time(),
+            "exit_code": child.returncode,
+            "revision_at_finish": git_head(worktree),
+            "worktree_dirty_at_finish": git_dirty(worktree),
+            "stalled": stalled,
+        }
+    )
+    finish["classification"] = classify_run(finish)
+    # The log text can be tens of megabytes; it was read to classify and is not state.
+    finish.pop("run_log_text", None)
+    write_json(path, finish)
+    return finish
+
+
+def watch(child: subprocess.Popen, workspace: Path, stall_seconds: int) -> bool:
+    """Wait, killing only on a stalled heartbeat. No per-run wall clock."""
+    last_seen = time.time()
+    while child.poll() is None:
+        # A second. The run takes hours, so the polling cost is nothing, and the
+        # alternative — a long poll — is a driver that notices a stall late and a dry
+        # run that spends its whole wall clock inside `sleep`.
+        time.sleep(1)
+        beat = heartbeat(workspace)
+        if beat > last_seen:
+            last_seen = beat
+        if time.time() - last_seen > stall_seconds:
+            kill_group(child)
+            return True
+    return False
+
+
+def heartbeat(workspace: Path) -> float:
+    """``logs_raw.jsonl``'s mtime, and nothing else.
+
+    ``run_manifest.json`` updates on stage transitions — one measured run was eight
+    minutes stale while healthy — and ``_meta.json`` is written once, at the end.
+    """
+    latest = 0.0
+    for path in (workspace / ".autor").glob("*/logs_raw.jsonl"):
+        try:
+            latest = max(latest, path.stat().st_mtime)
+        except OSError:  # pragma: no cover
+            continue
+    return latest
+
+
+def kill_group(child: subprocess.Popen) -> None:
+    """Kill the child's group, then give up loudly rather than use ``pkill -f``.
+
+    Grandchildren survive: the operator's Bash tool puts each command in its own
+    process group, so ``killpg`` on the driver's group does not reach them. A workspace
+    whose long-running python may still be writing is marked void rather than trusted.
+    """
+    try:
+        os.killpg(os.getpgid(child.pid), signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):  # pragma: no cover
+        return
+    try:
+        child.wait(timeout=60)
+    except subprocess.TimeoutExpired:  # pragma: no cover
+        try:
+            os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def score_path(plan: TrialPlan, task: str, arm: str, attempt: int, label: str, rep: int) -> Path:
+    return (
+        Path(plan.state_dir) / "scores" / f"{task}.{arm}.a{attempt}.{label}.r{rep}.json"
+    )
+
+
+def score_once(plan: TrialPlan, state: Mapping[str, Any], out: Path) -> bool:
+    workspace = Path(str(state["workspace"]))
+    if plan.judge_kind == "fake":
+        return fake_score(plan, workspace, out)
+    argv = [
+        sys.executable, str(REPO_ROOT / "tools" / "score_rcb_run.py"),
+        "--workspace", str(workspace), "--bench", plan.bench,
+        "--judge", plan.judge_kind, "--model", plan.judge_model, "--out", str(out),
+    ]
+    env = dict(os.environ)
+    # Only pins the iteration order of the bench's `IMAGE_EXTENSIONS` set, which decides
+    # *which five* images every image criterion is shown. It does not pin `rglob`'s
+    # order, so this narrows the variance rather than removing it.
+    env["PYTHONHASHSEED"] = "0"
+    done = subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
+    if done.returncode != 0:
+        sys.stderr.write(done.stdout[-4000:] + done.stderr[-4000:])
+    # The tool exits 1 and writes nothing when any judge call failed. That refusal is
+    # the pair-killing gate, inherited rather than reimplemented.
+    return done.returncode == 0 and out.exists()
+
+
+def fake_score(plan: TrialPlan, workspace: Path, out: Path) -> bool:
+    """A deterministic stand-in judge, for exercising the harness without spending it.
+
+    It reads the real checklist, so weights, item count, types and ordering are the
+    benchmark's; only the scores are fabricated. The fake report carries a
+    ``FAKE_QUALITY`` line, which is the one thing the fake judge reads out of it, so a
+    dry run produces a real, signed, non-zero difference instead of two identical
+    columns that would let a broken seam pass.
+    """
+    meta = read_json(workspace / "_meta.json")
+    task = str(meta.get("task_id") or "")
+    checklist = json.loads(
+        (Path(plan.bench) / "tasks" / task / "target_study" / "checklist.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    report = workspace / "report" / "report.md"
+    text = report.read_text(encoding="utf-8") if report.exists() else ""
+    quality = 0.0
+    for line in text.splitlines():
+        if line.startswith("FAKE_QUALITY:"):
+            quality = float(line.split(":", 1)[1])
+    items = []
+    total_weighted = 0.0
+    total_weight = 0.0
+    for index, entry in enumerate(checklist):
+        weight = float(entry.get("weight", 0.0))
+        seed = hashlib.sha256(
+            f"{task}|{index}|{workspace.name}|{out.name}".encode("utf-8")
+        ).digest()
+        jitter = seed[0] % 5
+        score = max(0, min(100, int(20 + quality + jitter)))
+        items.append(
+            {
+                "index": index,
+                "type": entry.get("type", "text"),
+                "content": str(entry.get("content", ""))[:200],
+                "weight": weight,
+                "score": score,
+                "reasoning": "fake judge",
+            }
+        )
+        total_weighted += weight * score
+        total_weight += weight
+    payload = {
+        "run_id": meta.get("run_id"),
+        "task_id": task,
+        "items": items,
+        "total_weight": total_weight,
+        "total_score": round(total_weighted / total_weight, 2) if total_weight else 0,
+        "judge_model": plan.judge_model,
+        "judge_calls": len(items),
+        "judge_failures": [],
+        "checklist_items_expected": len(checklist),
+        # The real sweep, not an empty list: which images the judge is shown is 60.6% of
+        # the benchmark's weight, and a dry run that reports none of them exercises none
+        # of the reporting that exists to say so.
+        "images_shown": [str(path) for path in bench_image_sweep(workspace)[:5]],
+        "images_available": len(bench_image_sweep(workspace)),
+        "bench_revision": "fake-bench",
+    }
+    write_json(out, payload)
+    return True
+
+
+def final_pass(plan: TrialPlan) -> None:
+    """Re-score every admitted workspace, back to back, at the end.
+
+    Scoring inside the loop is early warning and never enters a number: it is minutes
+    old for the first workspace and days old for the last, so a judge that drifted
+    across the trial would ride into the published difference unmeasured. The published
+    scores all come from one continuous pass with the same judge, and the replicates
+    inside it are what turn the noise band from folklore into a measurement.
+    """
+    lost: list[str] = []
+    for state in all_states(plan):
+        if state.get("phase") != "finished" or state.get("classification") != "ok":
+            continue
+        for rep in range(plan.replicates):
+            out = score_path(
+                plan, str(state["task_id"]), str(state["arm"]), int(state["attempt"]), "final", rep
+            )
+            if out.exists():
+                continue
+            for _try in range(2):
+                # A judge failure inside one replicate is a reason to redraw that
+                # replicate, not to kill the pair. Escalating on the first flake would
+                # hand a four-day trial to the judge's worst minute.
+                if score_once(plan, state, out):
+                    break
+            else:
+                # Giving up quietly is how an arm scored once was published as an arm
+                # scored three times. The count reaches the report through
+                # `RunEnvironment.judge_replicates`; this is the operator's copy, on the
+                # stdout they are watching while it happens.
+                lost.append(out.name)
+                print(f"  LOST REPLICATE: {out.name} could not be scored in two tries")
+    write_json(
+        Path(plan.state_dir) / "final_pass.json",
+        {"done": True, "at": time.time(), "unscored_replicates": sorted(lost)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Building evidence and reporting
+# ---------------------------------------------------------------------------
+
+
+def evidence_for(plan: TrialPlan, state: Mapping[str, Any]) -> ArmEvidence | None:
+    task = str(state.get("task_id") or "")
+    arm = str(state.get("arm") or "")
+    attempt = int(state.get("attempt") or 1)
+    payloads = []
+    for rep in range(plan.replicates):
+        path = score_path(plan, task, arm, attempt, "final", rep)
+        if path.exists():
+            payloads.append(read_json(path))
+    if not payloads:
+        return None
+
+    first = payloads[0]
+    checklist = Path(plan.bench) / "tasks" / task / "target_study" / "checklist.json"
+    env = RunEnvironment(
+        checklist_digest=digest_bytes(checklist),
+        judge_model=str(first.get("judge_model") or ""),
+        agent_model=str(state.get("agent_model") or ""),
+        review_model=str(state.get("review_model") or ""),
+        web_search_level=str(state.get("web_search_level") or ""),
+        instructions_digest=str(state.get("instructions_digest") or ""),
+        bench_revision=str(first.get("bench_revision") or ""),
+        # Whatever landed on disk, never what the plan asked for. Two arms averaged over
+        # different numbers of judge draws are not comparable, and putting the count in
+        # the digest is what makes the composition refusal that already exists say so.
+        judge_replicates=len(payloads),
+    )
+    facts = {
+        "meta_status": state.get("meta_status"),
+        "meta_pipeline_completed": state.get("meta_pipeline_completed"),
+        "meta_report_source": state.get("meta_report_source"),
+        "autor_run_count": state.get("autor_run_count"),
+        "images_under_outputs": state.get("images_under_outputs"),
+        "report_md_count": state.get("report_md_count"),
+        "report_md_present": state.get("report_md_present"),
+        "last_event": state.get("last_event"),
+        "resource_exhausted_hits": state.get("resource_exhausted_hits", 0),
+        "revision_at_launch": state.get("revision_at_launch"),
+        "revision_at_finish": state.get("revision_at_finish"),
+        "worktree_dirty": bool(state.get("worktree_dirty_at_launch"))
+        or bool(state.get("worktree_dirty_at_finish")),
+    }
+    failures: list[str] = []
+    for payload in payloads:
+        failures.extend(str(item) for item in (payload.get("judge_failures") or []))
+    return ArmEvidence(
+        task_id=task,
+        arm=arm,
+        run_id=str(state.get("run_id") or Path(str(state.get("workspace", ""))).name),
+        workspace=str(state.get("workspace") or ""),
+        env=env,
+        items=items_from_score_payloads(payloads),
+        published_total=float(first.get("total_score") or 0.0),
+        replicates_requested=int(plan.replicates),
+        images_shown=len(first.get("images_shown") or []),
+        images_available=int(
+            first.get("images_available") or len(first.get("images_shown") or [])
+        ),
+        judge_failures=tuple(failures),
+        checklist_items_expected=int(
+            first.get("checklist_items_expected") or len(first.get("items") or [])
+        ),
+        facts=facts,
+        autor_stages_scored=tuple(state.get("autor_stages_scored") or ()),
+        settled_reasoning_dose=bool(state.get("settled_reasoning_dose")),
+    )
+
+
+def driver_refusals(
+    states: Sequence[Mapping[str, Any]],
+    scored: set[tuple[str, str]],
+    *,
+    final_pass_done: bool,
+) -> list[Refusal]:
+    """Every run that died before the admission gate could ever look at it.
+
+    ``final_pass`` scores only ``classification == "ok"`` and ``evidence_for`` returns
+    ``None`` without score files, so a run killed by quota, by the watchdog, by a backend
+    outage, by a fallback report, by an incomplete pipeline or by the scorer's own
+    refusal produces no evidence, reaches no clause, and used to be rendered as "no
+    `<arm>` arm" — the same sentence as an arm that was never launched. The report tells
+    the reader to judge the difference on the per-arm death counts; those counts were
+    structurally zero for exactly the deaths the paragraph warns about.
+
+    ``phase == "launched"`` is not here: a run in flight has not died, and calling it a
+    refusal would report every interim run as an attrition. Neither is a healthy run with
+    no score file until the final pass has been over it — before that it is a run waiting
+    to be scored, and the report runs at any moment by design.
+    """
+    worst: dict[tuple[str, str], str] = {}
+    for state in states:
+        key = (str(state.get("task_id") or ""), str(state.get("arm") or ""))
+        if not key[0] or not key[1]:
+            continue
+        phase = str(state.get("phase") or "")
+        classification = str(state.get("classification") or "")
+        if phase == "refused":
+            # The driver's last word on this (task, arm), so it wins over whatever the
+            # individual attempts were classified as.
+            worst[key] = classification or "refused"
+        elif phase == "abandoned":
+            worst.setdefault(key, "abandoned")
+        elif phase == "finished":
+            if classification and classification != "ok":
+                worst.setdefault(key, classification)
+            elif key not in scored and final_pass_done:
+                # Ran, was admissible, the final pass has been over it and no score file
+                # exists: the judge failed every draw, or the scorer could not write. A
+                # whole trial of these published `pairs: 0` with an empty ledger, no
+                # exclusion line and no diagnosis anywhere.
+                worst.setdefault(key, "unscored")
+    return [
+        Refusal(task, arm, (driver_clause(cause),))
+        for (task, arm), cause in sorted(worst.items())
+    ]
+
+
+def build_report(plan: TrialPlan) -> str:
+    """A pure function of the state directory: nothing derived survives between runs.
+
+    Every artifact under the state directory is rebuilt from ``runs/`` and ``scores/``
+    on each invocation, so re-running after fixing a bug in the producer cannot leave
+    half of an old answer behind.
+    """
+    states = all_states(plan)
+    evidences = []
+    scored: set[tuple[str, str]] = set()
+    for state in states:
+        if state.get("phase") != "finished":
+            continue
+        item = evidence_for(plan, state)
+        if item is not None:
+            evidences.append(item)
+            scored.add((item.task_id, item.arm))
+
+    trial = collect_rcb_pairs(
+        evidences,
+        capability=plan.capability,
+        control_arm=plan.control.label,
+        treatment_arm=plan.treatment.label,
+        planned_pairs=plan.planned_pairs,
+        driver_refusals=driver_refusals(
+            states, scored,
+            final_pass_done=(Path(plan.state_dir) / "final_pass.json").exists(),
+        ),
+    )
+    # Observed, then declared. The header used to print the plan's field whatever had
+    # actually scored the runs, which is the one line a reader would use to decide the
+    # number is comparable to a published figure.
+    observed = sorted({item.env.judge_model for item in evidences if item.env.judge_model})
+    return format_rcb_trial_report(
+        trial,
+        contrast_log=contrast_log(Path(plan.treatment.worktree), plan.control.sha, plan.treatment.sha),
+        plan_digest=plan.digest,
+        judge_model=", ".join(observed) or plan.judge_model,
+        planned_judge_model=plan.judge_model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The fake operator
+# ---------------------------------------------------------------------------
+
+
+def fake_run(args: argparse.Namespace) -> int:
+    """Fabricate a workspace shaped exactly like a finished AutoR run.
+
+    Deliberately a real subprocess launched with ``start_new_session``: the state
+    machine, the lock, the process-group handling and the heartbeat are the parts most
+    likely to be wrong, and a fake that runs in-process would test none of them.
+    """
+    workspace = Path(args.workspace)
+    root = workspace / ".autor" / time.strftime("%Y%m%d_%H%M%S")
+    (root / "evolution").mkdir(parents=True, exist_ok=True)
+    (root / "prompt_cache").mkdir(parents=True, exist_ok=True)
+
+    # The treatment arm is the one that carries the settled-reasoning block; a run that
+    # argued nothing sends nothing, which is the zero-dose case the report refuses to
+    # call a test of the channel.
+    if args.arm == args.treatment_label:
+        (root / "prompt_cache" / "07_report_attempt_01.prompt.md").write_text(
+            # The channel's heading above the block, which is what a real Stage 07 prompt
+            # carries. Writing only `build_block`'s crux sub-heading here is what let the
+            # detector read that sub-heading and still look correct in the dry run.
+            f"{SETTLED_REASONING_HEADING}\n\n"
+            "## Methodological questions this run settled\n\nfake\n",
+            encoding="utf-8",
+        )
+    else:
+        (root / "prompt_cache" / "07_report_attempt_01.prompt.md").write_text(
+            "no settled reasoning\n", encoding="utf-8"
+        )
+
+    for beat in range(3):
+        with open(root / "logs_raw.jsonl", "a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"beat": beat, "at": time.time()}) + "\n")
+        time.sleep(0.2)
+    (root / "logs.txt").write_text("=== fake | run ===\nnothing went wrong\n", encoding="utf-8")
+    write_json(root / "run_manifest.json", {"run_status": "completed", "last_event": "run.completed"})
+    write_json(root / "run_config.json", {"model": args.model, "review_model": args.review_model})
+    write_json(root / "evolution" / "summary.json", {"stages": {f"0{n}_s": {} for n in range(1, 9)}})
+
+    (workspace / "report").mkdir(parents=True, exist_ok=True)
+    (workspace / "report" / "report.md").write_text(
+        f"# {args.task}\n\nFAKE_QUALITY: {args.quality}\n\n## Discussion\n\nfake.\n",
+        encoding="utf-8",
+    )
+    # On stdout, exactly where the real harness announces it, so `search_level` is
+    # exercised by the dry run rather than short-circuited for it.
+    print(json.dumps({"type": "progress", "stage": "web_search", "level": "info"}), flush=True)
+    write_json(
+        workspace / "_meta.json",
+        {
+            "task_id": args.task,
+            "run_id": workspace.name,
+            "status": "completed",
+            "report_source": "agent",
+            "pipeline_completed": True,
+            "duration_seconds": 1,
+            "workspace": str(workspace),
+        },
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def load_plan(path: Path) -> TrialPlan:
+    payload = read_json(path)
+    if not payload:
+        raise SystemExit(f"no plan at {path}")
+    plan = TrialPlan.from_dict(payload)
+    frozen = Path(plan.state_dir) / "plan.json"
+    if frozen.exists():
+        recorded = read_json(frozen).get("digest")
+        if recorded and recorded != plan.digest:
+            raise SystemExit(
+                f"the plan has changed since it was frozen ({recorded[:12]} -> "
+                f"{plan.digest[:12]}). Editing the plan mid-trial changes what the arms "
+                "mean, and an apparatus that can be re-planned while it runs is an "
+                "apparatus that can be stopped when the sign looks good."
+            )
+    return plan
+
+
+def cmd_plan(plan: TrialPlan) -> int:
+    frozen = Path(plan.state_dir) / "plan.json"
+    if frozen.exists():
+        print(f"already frozen: {read_json(frozen).get('digest', '')[:16]}")
+        return 0
+    payload = plan.to_dict()
+    payload["digest"] = plan.digest
+    payload["frozen_at"] = time.time()
+    write_json(frozen, payload)
+    print(f"frozen {plan.planned_pairs} planned pairs, digest {plan.digest[:16]}")
+    return 0
+
+
+def cmd_run(plan: TrialPlan) -> int:
+    if not (Path(plan.state_dir) / "plan.json").exists():
+        raise SystemExit("freeze the plan first: `rcb_trial.py plan --plan <path>`")
+    intruders = foreign_runs()
+    if intruders:
+        print("REFUSING TO START. AutoR is already running here:", file=sys.stderr)
+        for line in intruders:
+            print(f"  {line}", file=sys.stderr)
+        print(
+            "Two drivers is the concurrency that exhausts the quota that then kills "
+            "both. Wait, or kill those pids by pgid (never `pkill -f`).",
+            file=sys.stderr,
+        )
+        return 2
+
+    lock = acquire_lock(Path(plan.state_dir))
+    try:
+        while True:
+            states = all_states(plan)
+            done_marker = Path(plan.state_dir) / "final_pass.json"
+            action = next_action(
+                plan,
+                states,
+                now=time.time(),
+                # Only AutoR-shaped pids. A bare `/proc` listing would abort the trial on
+                # any pid the kernel happened to hand to somebody else's process after
+                # the driver died, which is the ordinary case rather than the rare one.
+                live_pids=autor_pids(),
+                final_pass_done=done_marker.exists(),
+            )
+            print(f"[{time.strftime('%H:%M:%S')}] {action}")
+            if action.kind == "done":
+                break
+            if action.kind == "abort":
+                print(action.reason, file=sys.stderr)
+                return 2
+            if action.kind == "abandon":
+                path = state_path(plan, action.task_id, action.arm, action.attempt)
+                state = read_json(path)
+                state["phase"] = "abandoned"
+                state["abandoned_reason"] = action.reason
+                write_json(path, state)
+                continue
+            if action.kind == "refuse":
+                path = state_path(plan, action.task_id, action.arm, 0)
+                write_json(
+                    path,
+                    {
+                        "task_id": action.task_id, "arm": action.arm, "attempt": 0,
+                        "phase": "refused", "classification": action.reason,
+                        "plan_digest": plan.digest,
+                    },
+                )
+                continue
+            if action.kind == "backoff":
+                print(f"  quota backoff {action.seconds}s: {action.reason}")
+                time.sleep(action.seconds)
+                launch(plan, action.task_id, action.arm, action.attempt)
+                continue
+            if action.kind == "launch":
+                finished = launch(plan, action.task_id, action.arm, action.attempt)
+                print(f"  classification: {finished.get('classification')}")
+                continue
+            if action.kind == "score":
+                path = state_path(plan, action.task_id, action.arm, action.attempt)
+                state = read_json(path)
+                out = score_path(
+                    plan, action.task_id, action.arm, action.attempt, "early", 0
+                )
+                score_once(plan, state, out)
+                # The in-loop score exists so a systematically-refusing gate is visible
+                # after run one instead of after day five. It never enters a number.
+                evidence_state = dict(state)
+                state["scored"] = True
+                state["early_score_path"] = str(out) if out.exists() else ""
+                write_json(path, state)
+                _announce_admission(plan, evidence_state, out)
+                continue
+            if action.kind == "final_pass":
+                final_pass(plan)
+                continue
+    finally:
+        release_lock(lock)
+
+    report = build_report(plan)
+    (Path(plan.state_dir) / "report.md").write_text(report, encoding="utf-8")
+    print(report)
+    return 0
+
+
+def _announce_admission(plan: TrialPlan, state: Mapping[str, Any], out: Path) -> None:
+    """Say straight away whether that run can ever become a number.
+
+    Ten clauses of heuristic over internal artifacts can plausibly admit nothing at
+    all: of four real workspaces on this box, one has ``report_source == "synthesized"``
+    and one was still running. Finding that out after the first run costs hours;
+    finding it out from the report costs the whole trial.
+    """
+    from src.rcb_trial import admit_arm
+
+    if not out.exists():
+        print("  admission: no score file — the scorer refused or the judge failed")
+        return
+    payload = read_json(out)
+    probe = dict(state)
+    probe["early"] = True
+    evidence = ArmEvidence(
+        task_id=str(state.get("task_id") or ""),
+        arm=str(state.get("arm") or ""),
+        run_id=str(state.get("run_id") or ""),
+        workspace=str(state.get("workspace") or ""),
+        env=RunEnvironment(),
+        items=items_from_score_payloads([payload]),
+        published_total=float(payload.get("total_score") or 0.0),
+        judge_failures=tuple(str(x) for x in (payload.get("judge_failures") or [])),
+        checklist_items_expected=int(
+            payload.get("checklist_items_expected") or len(payload.get("items") or [])
+        ),
+        facts={
+            "meta_status": state.get("meta_status"),
+            "meta_pipeline_completed": state.get("meta_pipeline_completed"),
+            "meta_report_source": state.get("meta_report_source"),
+            "autor_run_count": state.get("autor_run_count"),
+            "images_under_outputs": state.get("images_under_outputs"),
+            "report_md_count": state.get("report_md_count"),
+            "report_md_present": state.get("report_md_present"),
+            "last_event": state.get("last_event"),
+            "resource_exhausted_hits": state.get("resource_exhausted_hits", 0),
+            "revision_at_launch": state.get("revision_at_launch"),
+            "revision_at_finish": state.get("revision_at_finish"),
+            "worktree_dirty": bool(state.get("worktree_dirty_at_launch")),
+        },
+    )
+    ok, failed = admit_arm(evidence)
+    print(f"  admission: {'ADMITTED' if ok else 'REFUSED — ' + ', '.join(failed)}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("plan", "run", "report"):
+        child = sub.add_parser(name)
+        child.add_argument("--plan", required=True, type=Path)
+    faker = sub.add_parser("fake-run")
+    faker.add_argument("--workspace", required=True)
+    faker.add_argument("--task", required=True)
+    faker.add_argument("--arm", required=True)
+    faker.add_argument("--sha", default="")
+    faker.add_argument("--model", default="")
+    faker.add_argument("--review-model", default="")
+    faker.add_argument("--quality", type=float, default=0.0)
+    faker.add_argument("--treatment-label", default="")
+    args = parser.parse_args(argv)
+
+    if args.command == "fake-run":
+        return fake_run(args)
+
+    plan = load_plan(args.plan)
+    if args.command == "plan":
+        return cmd_plan(plan)
+    if args.command == "run":
+        return cmd_run(plan)
+    report = build_report(plan)
+    (Path(plan.state_dir) / "report.md").write_text(report, encoding="utf-8")
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/score_rcb_run.py
+++ b/tools/score_rcb_run.py
@@ -257,6 +257,94 @@ def _first_json_object(text: str) -> Any:
     return None
 
 
+class ScoringRefused(ValueError):
+    """A total that is not a measurement, raised rather than returned.
+
+    The judge-failure refusal used to live only in ``main``. Anything that did
+    ``from score_rcb_run import score`` got back a dict whose ``total_score``
+    already had the failed calls folded in as zeros, with no exception and no
+    flag — a guarantee that held only at the printing layer. The result is
+    carried on the exception so the caller can still show the per-item table.
+    """
+
+    def __init__(self, message: str, result: dict, reasons: list[str]) -> None:
+        super().__init__(message)
+        self.result = result
+        self.reasons = reasons
+
+
+def refusal_reasons(result: dict) -> list[str]:
+    """Every way this total is a number rather than a measurement.
+
+    Pure, and separate from :func:`score`, so the rule is testable without a benchmark
+    checkout — the wiring gets an integration test, but the rule gets one everywhere.
+
+    The judge-failure clause is the original one. The two item-count clauses are the
+    same failure one step earlier: an empty or short checklist yields ``total_score:
+    0``, ``judge_failures: []``, exit 0 and a written ``--out`` file — a fully formed
+    zero indistinguishable from a report that missed every criterion, which is exactly
+    the shape of the 19.5-against-37.0 incident this file exists for.
+    """
+    reasons: list[str] = []
+    failures = result.get("judge_failures") or []
+    items = result.get("items") or []
+    expected = result.get("checklist_items_expected", 0)
+    if failures:
+        reasons.append(
+            f"{len(failures)} judge call(s) failed: " + "; ".join(str(item) for item in failures)
+        )
+    if not items:
+        reasons.append("zero items were scored, so the total is a zero over nothing")
+    elif expected and len(items) != expected:
+        reasons.append(
+            f"{len(items)} items scored against a checklist of {expected}; the missing "
+            "ones are absent from the total rather than visible in it"
+        )
+    return reasons
+
+
+def _self_description(bench: Path, workspace: Path, result: dict, scorer) -> None:
+    """Three keys that make the output stand on its own.
+
+    ``images_shown`` because 60.6% of the benchmark's weight is image criteria and
+    every one of them is shown the *same* first five of one list that sweeps
+    ``outputs/`` before ``report/`` — and ``IMAGE_EXTENSIONS`` is a ``set``, so which
+    five those are changes between interpreters. Nothing anywhere recorded them.
+    ``checklist_items_expected`` because an item count is only a fact next to what it
+    was supposed to be. ``bench_revision`` because item identity is a property of the
+    benchmark checkout and the output records only ``task_id``.
+    """
+    try:
+        images = scorer._find_generated_images(workspace)
+        result["images_shown"] = [str(path) for path in images[:5]]
+        # Beside the five, how many there were to choose from. Five of five and five of
+        # twelve are the same line in the score file otherwise, and they are not the same
+        # evidence: the two arms of a pair that produced different numbers of figures were
+        # judged on different figures across 60.6% of the benchmark's weight.
+        result["images_available"] = len(images)
+    except Exception:  # noqa: BLE001 - a missing helper must not lose a scored run
+        result["images_shown"] = []
+        result["images_available"] = 0
+
+    expected = 0
+    task_id = str(result.get("task_id") or "")
+    if task_id:
+        checklist = bench / "tasks" / task_id / "target_study" / "checklist.json"
+        try:
+            expected = len(json.loads(checklist.read_text(encoding="utf-8")))
+        except (OSError, json.JSONDecodeError):
+            expected = 0
+    result["checklist_items_expected"] = expected
+
+    import subprocess
+
+    revision = subprocess.run(
+        ["git", "-C", str(bench), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=False,
+    )
+    result["bench_revision"] = revision.stdout.strip() if revision.returncode == 0 else ""
+
+
 def score(workspace: Path, bench: Path, *, judge) -> dict:
     sys.path.insert(0, str(bench))
 
@@ -291,7 +379,36 @@ def score(workspace: Path, bench: Path, *, judge) -> dict:
     result["judge_model"] = judge.model
     result["judge_calls"] = judge.calls
     result["judge_failures"] = judge.failures
+    if "error" in result:
+        return result
+
+    _self_description(bench, workspace, result, scorer)
+
+    reasons = refusal_reasons(result)
+    if reasons:
+        raise ScoringRefused("this total is not a measurement", result, reasons)
     return result
+
+
+def write_result(out: Path, result: dict) -> None:
+    """Create the directory, then replace rather than truncate.
+
+    Both halves are paid for. The ``mkdir``: nothing else creates ``<state_dir>/scores/``
+    — the paired-trial driver builds the path and hands it over as ``--out`` — so with a
+    bare ``write_text`` the real judge path could not write a single result. Every test
+    was green because the dry run's fake judge writes through a helper that does create
+    the directory, and the failure needed a whole trial of real runs to surface: the
+    scorer judged every item, printed the total, and died on ``FileNotFoundError``, which
+    the driver reads as "scoring failed" and silently retries for four days.
+
+    The ``os.replace``: a kill during a plain ``write_text`` leaves a truncated JSON file
+    that ``final_pass`` will skip forever because it exists, and that the report cannot
+    parse. Re-running is then not a repair.
+    """
+    out.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out.with_name(out.name + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    os.replace(tmp, out)
 
 
 def main() -> int:
@@ -339,7 +456,11 @@ def main() -> int:
             model=args.model or FALLBACK_JUDGE_MODEL, project_id=args.project_id
         )
 
-    result = score(args.workspace, args.bench, judge=judge)
+    refused: ScoringRefused | None = None
+    try:
+        result = score(args.workspace, args.bench, judge=judge)
+    except ScoringRefused as exc:
+        refused, result = exc, exc.result
     if "error" in result:
         print(f"scoring failed: {result['error']}", file=sys.stderr)
         return 1
@@ -348,7 +469,6 @@ def main() -> int:
     # per-item table empty and printed "items judged: 0" beside a real total --
     # a scorer reporting that it scored nothing, right after scoring everything.
     items = result.get("items", [])
-    failures = result.get("judge_failures", [])
 
     print(f"judge:     {result['judge_model']}")
     print(f"workspace: {args.workspace}")
@@ -360,11 +480,12 @@ def main() -> int:
         )
 
     # The check that matters. A judge failure reads as a zero, so a total quoted
-    # without this is not a measurement of the run.
-    if failures:
+    # without this is not a measurement of the run. It is decided in `score` now, so
+    # a programmatic caller cannot get the number without it; this only prints it.
+    if refused is not None:
         print()
-        print(f"REFUSING TO QUOTE A TOTAL: {len(failures)} judge call(s) failed.")
-        for reason in failures:
+        print(f"REFUSING TO QUOTE A TOTAL: {len(refused.reasons)} reason(s).")
+        for reason in refused.reasons:
             print(f"  - {reason}")
         print("Every one of those is recorded as score 0 and is indistinguishable")
         print("from a criterion the report genuinely missed. Fix and re-run.")
@@ -375,7 +496,7 @@ def main() -> int:
     print(f"items judged: {len(items)}   judge calls: {result.get('judge_calls', 0)}")
 
     if args.out:
-        args.out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+        write_result(args.out, result)
         print(f"written: {args.out}")
     return 0
 


### PR DESCRIPTION
[#175](https://github.com/tangxiangru/AutoR/pull/175) argued from the rubric where the RCB headroom is. Nothing measured whether AutoR collects it. This is the apparatus that can — and its first job is to be **unable to produce a number that is not real**.

## The seam

`src/trials.py` already does the statistics properly: within-pair differences, a refusal to compare across a composition difference, the criterion decomposition, and the exact sign-flip p-value **floor** printed next to the p-value so *could not have shown an effect* stays distinguishable from *showed none*. Its only limitation was that the outcome measure is AutoR's own rubric.

So the RCB score enters as an ordinary `RunRecord` and all of that runs unmodified:

```python
stage_fitness     = {f"{task}|{env_digest}": total_score}
criterion_fitness = {f"{task}#{i:02d} {type} w={weight:g}": weight * score, ...}
```

One stage key, so a mean over one element is that element and `Pair.difference` is exactly the RCB total difference, in RCB's own 0–100 points. All 40 shipped checklists weigh exactly 1.0, so **within a run the decomposition sums to the scalar** — which AutoR's own decomposition does not — and `concentration` becomes literally "share of the movement sitting in one checklist item".

`env_digest` carries the judge, both models, the web-search level, the `INSTRUCTIONS.md` digest, the checklist bytes and the replicate count. A cross-arm environment difference therefore makes the two key sets **disjoint**, and the existing `shared_stages` refusal excludes the pair. A tested gate doing the job it was written for, rather than a new one to get wrong.

Two defaulted edits inside `trials.py`: a `unit` field (`"+24.6000 rubric points"` would be a lie for an RCB delta) and a pair-count column on the decomposition table (with one task per pair, every "mean" is a single observation printed as if it were a mean).

## Admission, and the ledger for what it refuses

A run becomes a measurement only after ten clauses: status, `report_source == "agent"`, exactly one `.autor` run root, zero images under `outputs/`, `report/report.md` present *and* the only `report/*.md`, no `run.backend_unavailable`, no quota in `logs.txt`, launch-SHA == finish-SHA == arm label, clean worktree, every item judged.

**Refused runs go to a ledger, never into an average.** Three treatment deaths against zero control deaths is a result even though it is not a score, so the per-arm count prints even at zero.

## What the adversaries found

Four adversaries attacked the first build and confirmed **18 defects**. The worst:

> `_QUOTA_MARKERS` contained the bare substring `"429"`, matched against the run's entire `logs.txt`.

Checked against four real logs on this box: 3, 50 and 7 hits of `429` — a chi² value, a `sources.json:429` grep line, and an arXiv `HTTP Error 429` on a fetch that then succeeded. **Zero** `RESOURCE_EXHAUSTED` in any of them. Every run would have been refused as a quota death. This is the same false-positive shape `src/backend_health.py` already argues about at length, reintroduced one module over — and `backend_health`'s own defence (the line must look like a reported error) would not have caught it, because arXiv's rate limit *is* an error-shaped line.

Others worth naming:

- `harvest()` returned `task_id: None` when a run died before writing `_meta.json`, and `launch()` merged that over the real id → infinite relaunch.
- Nothing created `<state_dir>/scores/`, so the scorer's bare `write_text` would `FileNotFoundError` on the first score.
- Lost replicates moved the published delta *and* shrank the stated uncertainty to `±0.00`. Now the draw count is in the digest, so unequal counts are excluded by the same composition refusal, and a single-draw arm prints **unmeasured** rather than a tighter interval.
- The refusal ledger could not see a driver-side refusal at all — only `phase == "finished"` states became evidence, so the arm-asymmetric death rate the report calls "a result" was structurally invisible.
- Stale-lock takeover was non-atomic: two drivers could both claim it, which is exactly the concurrency that exhausts the quota.

## Two I closed after the repair pass

- **`single_report_md` counted files instead of naming one.** `score.py` globs `report/*.md` unsorted when `report.md` is absent, so a workspace holding only `draft.md` satisfied "exactly one" and got its draft scored as the deliverable. The clause now reads both facts, and a missing presence fact refuses rather than passing — absence is the cheapest way to satisfy a check over declared keys.
- **"the decomposition sums to the scalar" was true per run and false at trial level**, where both sides are means and a reader adding raw per-pair contributions gets *n* times the total. Scoped in the docstring and the doc rather than left to be inferred twice.

## Verification

1,995 tests, all green. The repair pass reported 25 mutations with 25 kills; I did not take that on trust and re-ran the important ones myself:

| Mutant | Result |
|:---|:---|
| put `"429"` back in the quota markers | **killed** (verified independently) |
| clause back to counting only | killed (2) |
| `is True` → `is not False` (a missing fact stops refusing) | killed |
| `harvest` stops looking at the filename | **survived** → producer had no test; added three, now killed (2) |

That last row is the point of doing it myself: the clause was tested, its *producer* was not, so a constant would have passed.

## What this cannot show

It is an apparatus, not a result. No trial has been run. When one is, the honest reading is bounded by three things the report prints itself: n=3 pairs cannot reach p<0.05 at any effect size (the floor is 0.25); text criteria are judge-sensitive enough that a delta under ~30 raw points is noise; and the three tasks were chosen *because* the two channels under test could show there at all, which makes any number an upper bound on the benchmark-wide effect rather than an estimate of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)