### PR TITLE
A review panel nobody could reach approved the stage

### DIFF
--- a/docs/review-panel.md
+++ b/docs/review-panel.md
@@ -180,12 +180,22 @@ This is deliberately mechanical. The chair is a model, and a model asked to weig
 be argued into discounting it. A prompt-level rule the chair can talk itself out of is not a
 rule, and a gate that cannot say no is not a gate.
 
-Two guards sit alongside it:
+Three guards sit alongside it:
 
 - A member that could not be reached is **not** counted as agreeing. It breaks unanimity and
   forces deliberation.
 - An unparseable answer degrades to `abort`, and cannot also count as a blocking veto — one
   malformed response should not be able to stop a run.
+- **A panel nobody could reach refuses rather than approves.** When the chair is unreachable
+  the panel falls back to its own seats' objections, and an unreachable seat is filtered out of
+  that list because it has no opinion to weigh. With *every* seat down — the ordinary shape of a
+  backend outage, five seats and a chair against one dead endpoint — the objection list came out
+  empty and the empty list read as consent, so a total review outage approved the stage.
+  `_decision_from_dissent` now takes an outage arm first, and the refusal it returns carries
+  `CRASHED_REASON`, so `is_degraded_verdict` keeps it out of `review_policy.json`: an outage is
+  not a correction anybody demanded. The guard is `all(...)` and not `any(...)` on purpose — four
+  dead seats and one that answered is a panel degraded to a solo reviewer, which is thin but is
+  still a judgement somebody made, and refusing on one flaky seat would make the panel unusable.
 
 ## The persona
 

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -36,7 +36,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .approval_agent import DECISION_TO_CHOICE, AutomatedReviewer, ReviewDecision
+from .approval_agent import (
+    CRASHED_REASON,
+    DECISION_TO_CHOICE,
+    AutomatedReviewer,
+    ReviewDecision,
+)
 from .terminal_ui import TerminalUI
 from .utils import RunPaths, StageSpec, append_log_entry, read_text, truncate_text, write_text
 
@@ -873,6 +878,31 @@ class ReviewPanel:
         return overridden
 
     def _decision_from_dissent(self, verdicts: list[PanelVerdict], *, reason: str) -> ReviewDecision:
+        # A room nobody could reach did not agree; it did not meet. `objections` filters
+        # out `failed` seats because an unreachable seat has no opinion to weigh -- but
+        # when *every* seat failed that leaves an empty list, and the arm below reads an
+        # empty objection list as consent. This method is only called when the chair is
+        # also gone, so "every seat failed" is the ordinary shape of a review-backend
+        # outage: five seats and a chair against one dead endpoint. Approving there is
+        # the one outcome the whole apparatus exists to prevent, and it is the only place
+        # in the tree where silence is upgraded to a pass.
+        #
+        # Refused with CRASHED_REASON on purpose, so `is_degraded_verdict` recognises it
+        # and `_record_review_correction` keeps it out of `review_policy.json`: an outage
+        # is not a correction anyone demanded, and recording it as a standing rule would
+        # teach every later review a lesson no reviewer taught.
+        if verdicts and all(verdict.failed for verdict in verdicts):
+            return ReviewDecision(
+                choice="4",
+                decision_token="revise",
+                reason=f"{CRASHED_REASON} No panel seat could be reached, and neither could the chair.",
+                feedback=(
+                    "The review panel could not be reached, so this stage was not approved. "
+                    "Re-examine the draft against the stage contract and the artifacts it "
+                    "claims, strengthen whatever is weakest, and restate the summary."
+                ),
+            )
+
         objections = [v for v in verdicts if not v.approves and not v.failed]
         if not objections:
             return ReviewDecision(choice="5", decision_token="approve", reason=reason)

--- a/tests/test_review_panel.py
+++ b/tests/test_review_panel.py
@@ -13,7 +13,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from src.approval_agent import ReviewDecision
+from src.approval_agent import AutomatedReviewer, ReviewDecision
 from src.review_panel import (
     DEFAULT_PANEL,
     PANEL_EFFECT_FILENAME,
@@ -425,6 +425,69 @@ class MemberFailureTests(unittest.TestCase):
 
         self.assertEqual(decision.choice, "4")
         self.assertIn("Add an ablation.", decision.feedback)
+
+
+class TotalOutageTests(unittest.TestCase):
+    """A room nobody could reach did not agree; it did not meet.
+
+    Found by asking what happens to `--review-panel` when the reviewer backend is simply
+    down. `_decision_from_dissent` filters `failed` seats out of `objections` — correctly,
+    an unreachable seat has no opinion to weigh — and then reads an empty objection list as
+    consent. With every seat *and* the chair gone, that returned `choice="5"`: a total
+    review outage approved the stage. Nothing pinned it, and it is the one outcome the whole
+    apparatus exists to prevent, so the tests are here rather than folded into
+    `MemberFailureTests` where a partial failure is the subject.
+    """
+
+    ALL_DEAD = {role.key: ["__FAIL__", "__FAIL__"] for role in DEFAULT_PANEL} | {
+        "__chair__": ["__FAIL__", "__FAIL__"]
+    }
+
+    def test_a_total_outage_refuses_instead_of_approving(self) -> None:
+        decision = _ScriptedPanel(self, dict(self.ALL_DEAD)).review()
+
+        self.assertEqual(decision.choice, "4", "a review nobody could reach approved the stage")
+        self.assertNotEqual(decision.decision_token, "approve")
+
+    def test_the_outage_refusal_is_degraded_so_it_never_becomes_a_standing_rule(self) -> None:
+        # `_record_review_correction` early-returns on a degraded verdict, so carrying
+        # CRASHED_REASON is what stops one outage from teaching every later review a
+        # lesson no reviewer taught. A refusal that merely says "revise" would be
+        # recorded in review_policy.json as a correction somebody demanded.
+        decision = _ScriptedPanel(self, dict(self.ALL_DEAD)).review()
+
+        self.assertTrue(
+            AutomatedReviewer.is_degraded_verdict(decision),
+            f"outage refusal would be recorded as a reviewer's demand: {decision.reason!r}",
+        )
+
+    def test_one_reachable_seat_still_decides(self) -> None:
+        """The guard is `all(...)`, not `any(...)`, and that is deliberate.
+
+        Four dead seats and one that approved is a panel degraded to a solo reviewer,
+        which is thin but is still a judgement somebody made. Widening the guard to
+        `any` would turn one unreachable seat into a refusal and make the panel
+        unusable on a flaky backend, so the narrow scope is pinned here to make
+        widening it a deliberate act rather than a drive-by.
+        """
+        script = {role.key: ["__FAIL__", "__FAIL__"] for role in DEFAULT_PANEL}
+        script["pi"] = [_verdict_json("approve"), _verdict_json("approve")]
+        script["__chair__"] = ["__FAIL__"]
+
+        decision = _ScriptedPanel(self, script).review()
+
+        self.assertEqual(decision.choice, "5")
+
+    def test_an_empty_verdict_list_is_not_read_as_a_total_outage(self) -> None:
+        # `all()` over an empty list is True, so the `verdicts and` guard is load-bearing:
+        # without it a panel that produced no verdicts at all would take the outage arm
+        # and mask a different bug as a backend failure.
+        panel = ReviewPanel(DEFAULT_PANEL, backend_name="claude", model="sonnet")
+
+        decision = panel._decision_from_dissent([], reason="nobody voted")
+
+        self.assertEqual(decision.choice, "5")
+        self.assertEqual(decision.reason, "nobody voted")
 
 
 class RecordTests(unittest.TestCase):


### PR DESCRIPTION
## The defect

`ReviewPanel._decision_from_dissent` is the fallback taken when the chair cannot be reached, or when its verdict cannot be read. It decides from the seats' own objections instead:

```python
objections = [v for v in verdicts if not v.approves and not v.failed]
if not objections:
    return ReviewDecision(choice="5", decision_token="approve", reason=reason)
```

Filtering out `failed` seats is right — a seat that was never reached has no opinion to weigh. Reading the resulting empty list as **consent** is not.

With every seat failed, that list is empty. And "every seat failed" is not an exotic case: it is the ordinary shape of a review-backend outage — five seats and a chair against one dead endpoint. Nothing upstream catches it. `review_stage` runs round 1, goes straight to `_synthesize`, the chair fails too, and `_enforce_blocking_objections` cannot help because no seat carried `blocking=True`.

**So under `--review-panel`, a quota exhaustion or a network outage approved the stage.** Reproduced against `main` before the fix:

```
seats: 5 | all failed: True | none approves: True
  choice         = '5'
  decision_token = 'approve'
```

This is the one outcome the whole apparatus exists to prevent, and as far as I can tell it was the only place in the tree where silence was upgraded to a pass. `cross_reviewer.py` gets the same situation right and says so out loud — an auditor that errored is recorded `unavailable`, "never as agreement".

## The fix

An outage arm before the empty-objections arm, ~12 lines plus the comment explaining why the arm exists.

The refusal carries `CRASHED_REASON` deliberately, so `is_degraded_verdict` recognises it and `_record_review_correction` keeps it out of `review_policy.json`. An outage is not a correction anybody demanded, and recording it as a standing rule would inject AutoR's own error message into every later review in the run — the exact failure that function's existing comment was written to prevent.

**The guard is `all(...)`, not `any(...)`**, and the narrow scope is pinned by a test. Four dead seats and one that answered is a panel degraded to a solo reviewer — thin, but still a judgement somebody made — and refusing on a single flaky seat would make the panel unusable. It is also guarded on `verdicts` being non-empty, because `all()` over an empty list is `True` and a panel that produced no verdicts at all is a different bug that should not be masked as an outage.

## Tests

Four, in a new `TotalOutageTests` class rather than folded into `MemberFailureTests`, where a *partial* failure is the subject.

| Test | Against unfixed code |
| --- | --- |
| `test_a_total_outage_refuses_instead_of_approving` | **FAILS** — `'5' != '4' : a review nobody could reach approved the stage` |
| `test_the_outage_refusal_is_degraded_so_it_never_becomes_a_standing_rule` | **FAILS** — `is_degraded_verdict` is False |
| `test_one_reachable_seat_still_decides` | passes both ways, on purpose |
| `test_an_empty_verdict_list_is_not_read_as_a_total_outage` | passes both ways, on purpose |

The first two are the ones that hold the fix; the last two pin the scope so widening the guard later is a deliberate act rather than a drive-by. The end-to-end tests drive the real `ReviewPanel` through the existing `_ScriptedPanel` harness with only the transport stubbed, so the round loop, the chair call and the fallback are all exercised for real.

`docs/review-panel.md` gains the third guard beside the two already documented there.

## How it was found

Diagnosing why a ResearchClawBench run lost its entire Stage 02. That run's cause was different — eight consecutive `UNREADABLE_REASON` send-backs from a verdict parser that has since been fixed by #176, which exhausted the stage's attempt budget and auto-skipped the hypothesis stage. This one was on the path next door, and it is worse: that failure mode fails **closed** (the stage is refused and eventually skipped, loudly), this one fails **open**.

The wider question that run raises — that a reviewer transport failure is charged to the *stage's* retry budget at all, when the budget's own comment says it exists for "a try that failed" and already excludes AutoR's own polish rounds — is a larger behaviour change with several open policy questions, and is not in this PR.

## Testing

`python -m unittest discover -s tests -p "test_*.py"` — **1830 pass**, 1 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)