### PR TITLE
Two knobs that were declared and never read

### DIFF
--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -598,6 +598,24 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         from src.effort import EffortPlan
 
         manager.effort_plan = EffortPlan(enabled=True)
+        # `--routine-model` was declared here and read nowhere, so the one flag whose whole
+        # job is to keep the strong model for the stages that need it did nothing on the
+        # only path where tiering is unconditionally on. `main.configure_effort` has always
+        # built the routine operator and recorded the model; this file parsed the flag and
+        # dropped it, which is the two-front-ends divergence this repo keeps finding rather
+        # than a missing feature.
+        if args.routine_model:
+            manager.routine_operator = create_operator(
+                # The execution backend, not the reviewer's: this operator runs stages.
+                operator_backend,
+                model=args.routine_model,
+                codex_sandbox=args.codex_sandbox,
+                fake_mode=args.fake_operator,
+                ui=ui,
+                stage_timeout=args.stage_timeout,
+                web_search_mcp=web_search_context is not None,
+            )
+            manager.concentration.routine_model = args.routine_model
         # `unattended=True` like every other reviewer this file builds. Without it the
         # routine-tier fallback is the one reviewer in an unattended run that still treats a
         # transport failure as grounds to abort, because attended is the constructor default

--- a/tests/test_cli_flags_are_read.py
+++ b/tests/test_cli_flags_are_read.py
@@ -1,0 +1,97 @@
+"""A flag that is declared and never read is worse than a missing flag.
+
+A missing flag fails loudly: argparse rejects it and the user tries something else. A flag
+that parses and is then dropped on the floor is silent — it appears in `--help`, it appears
+in the documentation, the run accepts it, and nothing happens. `--routine-model` was in that
+state on the `rcb_agent.py` path: declared, documented, and read by no line in the file, so
+the one knob whose whole job is to keep the strong model for the stages that need it did
+nothing on the only front-end where effort tiering is unconditionally on.
+
+It was found by an audit of the documentation, not by a test, which is the wrong way round.
+The scan below is a few lines and would have caught it the day it landed.
+
+The two front-ends are checked together on purpose. `main.py` and `rcb_agent.py` declare
+overlapping flag sets and have diverged before; a gate that covered only one of them would
+be the same defect written fresh.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+#: Flags this repository knowingly parses and does not act on, each with the reason.
+#: Deliberately exact rather than a prefix match: adding a third entry has to be a decision
+#: somebody wrote down, not a line that quietly grew.
+KNOWN_UNWIRED: dict[str, set[str]] = {
+    "main.py": {
+        # `resolve_cross_reviewer` is imported here and called only from `rcb_agent.py`, so
+        # neither `ResearchManager(...)` construction in this file passes `cross_reviewer=`.
+        # The cross-model veto is therefore live on the benchmark path alone. Recorded as a
+        # limitation in README.md rather than fixed, because wiring it would add a Gemini
+        # call to every approval on any machine with a key in the environment, which is a
+        # default worth choosing deliberately rather than inheriting from a bug fix.
+        "--cross-review",
+        "--cross-review-model",
+    },
+    "rcb_agent.py": set(),
+}
+
+
+def _declared_flags(source: str) -> list[str]:
+    return re.findall(r'add_argument\(\s*"(--[a-z0-9-]+)"', source)
+
+
+def _is_read(source: str, flag: str) -> bool:
+    attr = flag[2:].replace("-", "_")
+    return bool(
+        re.search(rf"\bargs\.{attr}\b", source)
+        or re.search(rf'getattr\(\s*args\s*,\s*"{attr}"', source)
+    )
+
+
+class EveryDeclaredFlagIsReadTests(unittest.TestCase):
+    def test_no_front_end_parses_a_flag_it_never_reads(self) -> None:
+        for name, exempt in KNOWN_UNWIRED.items():
+            with self.subTest(front_end=name):
+                source = (REPO / name).read_text(encoding="utf-8")
+                flags = _declared_flags(source)
+                self.assertGreater(len(flags), 20, f"{name}: the scan found no flags to check")
+
+                unwired = {flag for flag in flags if not _is_read(source, flag)}
+                self.assertEqual(
+                    unwired - exempt,
+                    set(),
+                    f"{name} declares these flags and reads none of them: "
+                    f"{sorted(unwired - exempt)}",
+                )
+
+    def test_the_exemptions_are_still_needed(self) -> None:
+        """An exemption for a flag that is now wired is a lie the next reader inherits."""
+        for name, exempt in KNOWN_UNWIRED.items():
+            source = (REPO / name).read_text(encoding="utf-8")
+            for flag in exempt:
+                with self.subTest(front_end=name, flag=flag):
+                    self.assertIn(flag, _declared_flags(source), f"{name} no longer declares {flag}")
+                    self.assertFalse(
+                        _is_read(source, flag),
+                        f"{name} now reads {flag}; drop it from KNOWN_UNWIRED",
+                    )
+
+    def test_the_scan_would_notice_a_dropped_flag(self) -> None:
+        """Guards the regex, not the tree.
+
+        `_is_read` matching too loosely is the way this test rots into a green no-op, and it
+        would rot silently: the assertion above passes either way. So a flag that is declared
+        and demonstrably absent from the body has to come back as unread.
+        """
+        fabricated = 'parser.add_argument(\n        "--a-flag-nobody-reads",\n        type=str,\n    )'
+        self.assertFalse(_is_read(fabricated, "--a-flag-nobody-reads"))
+        self.assertTrue(_is_read(fabricated + "\nprint(args.a_flag_nobody_reads)", "--a-flag-nobody-reads"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_score_rcb_run.py
+++ b/tests/test_score_rcb_run.py
@@ -45,6 +45,33 @@ class TrapDefaultsTest(unittest.TestCase):
     def test_the_time_limit_fits_a_multimodal_call(self) -> None:
         self.assertGreater(self.tool.JUDGE_TIME_LIMIT, 120)
 
+    def test_the_reference_judge_actually_passes_both_budgets(self) -> None:
+        """The two tests above hold the constants, and held nothing else.
+
+        `JUDGE_TIME_LIMIT` was read by no code at all, and `JUDGE_MAX_TOKENS` only by
+        `VertexJudge` -- so on the default `--judge reference` path the call went out
+        with the client's own defaults, and the pair of assertions above stayed green.
+        A test that asserts a constant's value does not know whether anything reads it;
+        this one captures the kwargs the client is actually handed.
+        """
+        sent: dict = {}
+
+        class _Responses:
+            def create(self, **kwargs):
+                sent.update(kwargs)
+                raise RuntimeError("stop after capturing the call")
+
+        judge = self.tool.ReferenceJudge.__new__(self.tool.ReferenceJudge)
+        judge.model = "gpt-5.1"
+        judge.calls = 0
+        judge.failures = []
+        judge._client = type("_C", (), {"responses": _Responses()})()
+
+        judge("score this", max_try=1)
+
+        self.assertEqual(sent.get("max_output_tokens"), self.tool.JUDGE_MAX_TOKENS)
+        self.assertEqual(sent.get("timeout"), self.tool.JUDGE_TIME_LIMIT)
+
     def test_scoring_is_serial(self) -> None:
         """Concurrent multimodal calls were the actual cause of most failures."""
         self.assertEqual(self.tool.JUDGE_WORKERS, 1)

--- a/tools/score_rcb_run.py
+++ b/tools/score_rcb_run.py
@@ -158,8 +158,18 @@ class ReferenceJudge:
         for _attempt in range(max_try):
             self.calls += 1
             try:
+                # Both budgets are passed here, not just declared above. They were
+                # module constants that only `VertexJudge` read, so the default judge
+                # ran with the client's own defaults: no wall limit on a multimodal
+                # call carrying six images, and no output budget on a reasoning model
+                # that can spend the whole of one thinking and return an empty body.
+                # An empty body is scored 0, which reads as a bad artifact rather than
+                # as a judge that never answered.
                 response = self._client.responses.create(
-                    model=self.model, input=[{"role": "user", "content": content}]
+                    model=self.model,
+                    input=[{"role": "user", "content": content}],
+                    max_output_tokens=JUDGE_MAX_TOKENS,
+                    timeout=JUDGE_TIME_LIMIT,
                 )
                 text = _response_text(response)
                 parsed = _first_json_object(text)


### PR DESCRIPTION
Both found by an adversarial pass over the documentation rather than by a test — which is the wrong way round. So each fix ships with the gate that would have caught it.

## 1. `--routine-model` did nothing on the benchmark path

`main.configure_effort` reads it, builds `manager.routine_operator`, and records `concentration.routine_model`. `rcb_agent.py` declared the flag, documented it in `--help`, and read it **nowhere** — `grep -n routine rcb_agent.py` returned only help text.

So on the one front-end where effort tiering is unconditionally on (`manager.effort_plan = EffortPlan(enabled=True)`), the knob whose entire job is to keep the strong model for the stages that need it was inert. This is the two-front-ends divergence this repo keeps finding rather than a missing feature: the wiring already existed, on the other side.

## 2. The reference judge ran with no timeout and no token budget

`JUDGE_TIME_LIMIT = 600` was read by **no code at all**. `JUDGE_MAX_TOKENS = 4096` was read only by `VertexJudge`. The default `--judge reference` path called:

```python
self._client.responses.create(model=self.model, input=[...])
```

— no wall limit on a multimodal call carrying a target image plus five agent images, and no output budget on a reasoning model that can spend the whole of one thinking and return an empty body. An empty body is scored **0**, which reads as a bad artifact rather than as a judge that never answered. That is precisely the failure this scorer already had once, and the constants were added to prevent it.

### The tests that were meant to hold this are the interesting part

```python
def test_the_token_budget_leaves_room_for_a_reasoning_judge(self):
    self.assertGreater(self.tool.JUDGE_MAX_TOKENS, 500)

def test_the_time_limit_fits_a_multimodal_call(self):
    self.assertGreater(self.tool.JUDGE_TIME_LIMIT, 120)
```

Green throughout. A test that asserts a constant's *value* does not know whether anything reads it — these two would have survived deleting the feature entirely. They stay (the values are still worth pinning) and a third now captures the kwargs the client is actually handed. It fails against the unwired code with `None != 4096`.

## The gate for the first one

`tests/test_cli_flags_are_read.py` scans both front-ends for a flag that is declared and never read. Without this PR's fix it fails with `--routine-model` in the set.

It also independently rediscovers `--cross-review` and `--cross-review-model` in `main.py`, which **are** genuinely unwired. Those are named as exemptions carrying the reason rather than fixed: `resolve_cross_reviewer` is imported in `main.py` and called only from `rcb_agent.py`, and wiring it here would add a Gemini call to every approval on any machine with a key in the environment. That is a default worth choosing deliberately, not one to inherit from a bug fix. `README.md` already records it under Limits.

Three tests, because an exemption list is how a gate like this rots:

| Test | Holds |
| --- | --- |
| `test_no_front_end_parses_a_flag_it_never_reads` | the property, minus named exemptions |
| `test_the_exemptions_are_still_needed` | fails if an exemption becomes wired — an exemption for a fixed flag is a lie the next reader inherits |
| `test_the_scan_would_notice_a_dropped_flag` | the regex itself, since `_is_read` matching too loosely would turn the whole file into a silent no-op |

## Testing

`python -m unittest discover -s tests -p "test_*.py"` — **2023 pass**, 1 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)