### PR TITLE
The scorecard could never see the review panel

### DIFF
--- a/src/scorecard.py
+++ b/src/scorecard.py
@@ -39,8 +39,14 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any, Callable
 
+from .deliberation import LEDGER_FILENAME as DELIBERATIONS_FILENAME
+from .effort import LEDGER_FILENAME as EFFORT_FILENAME
+from .ideation_panel import IDEA_POOL_FILENAME
+from .review_panel import PANEL_EFFECT_FILENAME
+from .stage_comments import COMMENT_LEDGER_FILENAME
 from .utils import RunPaths, read_text, write_text
 
 
@@ -117,11 +123,18 @@ class Scorecard:
 # ---------------------------------------------------------------------------
 
 
-def _load(paths: RunPaths, filename: str) -> tuple[dict[str, Any] | None, bool]:
-    """Return (payload, readable). A missing file is not the same as a broken one."""
-    path = paths.reviews_dir / filename
-    if not path.exists():
-        path = paths.notes_dir / filename
+def _load(paths: RunPaths, locate: Callable[[RunPaths], Path]) -> tuple[dict[str, Any] | None, bool]:
+    """Return (payload, readable). A missing file is not the same as a broken one.
+
+    ``locate`` rather than a filename plus a search, because the search was wrong and had no
+    way to say so. It looked in ``reviews_dir`` then ``notes_dir``; ``record_panel_effect``
+    writes to ``reviews_dir/panel/``, which is neither, so on every real ``--review-panel``
+    run this reported the panel ``unused`` -- "Not enabled on this run." -- while its ledger
+    sat on disk saying the panel had changed two of three gate decisions. A guessed location
+    degrades into a false negative shaped exactly like a feature nobody switched on, which is
+    the confusion this module's docstring exists to refuse.
+    """
+    path = locate(paths)
     if not path.exists():
         return None, True
     try:
@@ -137,10 +150,11 @@ def _report(
     name: str,
     flag: str,
     filename: str,
+    locate: Callable[[RunPaths], Path],
     paths: RunPaths,
     assess: Callable[[dict[str, Any]], tuple[str, str, int | None]],
 ) -> FeatureReport:
-    payload, readable = _load(paths, filename)
+    payload, readable = _load(paths, locate)
     if not readable:
         return FeatureReport(
             key=key, name=name, flag=flag, verdict=UNREADABLE, ledger=filename,
@@ -238,17 +252,28 @@ def _assess_effort(payload: dict[str, Any]) -> tuple[str, str, int | None]:
 
 
 #: Every optional feature that measures itself, and how to read its verdict.
+#: Each feature names its own ledger path. The filenames come from the producing modules
+#: rather than from literals here, so a rename moves both ends at once; the *directory* is
+#: the half that drifted, so it is spelled out per feature -- four of the five agree and the
+#: fifth does not.
 FEATURES: tuple[dict[str, Any], ...] = (
     {"key": "review_panel", "name": "Review panel", "flag": "--review-panel",
-     "filename": "panel_effect.json", "assess": _assess_review_panel},
+     "filename": PANEL_EFFECT_FILENAME, "assess": _assess_review_panel,
+     # `record_panel_effect` writes beside the per-gate transcripts, one directory down.
+     # This is the one that was being looked for a level too high.
+     "locate": lambda p: p.reviews_dir / "panel" / PANEL_EFFECT_FILENAME},
     {"key": "ideation_panel", "name": "Ideation panel", "flag": "--ideation-panel",
-     "filename": "idea_pool.json", "assess": _assess_ideation},
+     "filename": IDEA_POOL_FILENAME, "assess": _assess_ideation,
+     "locate": lambda p: p.notes_dir / IDEA_POOL_FILENAME},
     {"key": "anchored_comments", "name": "Anchored review comments", "flag": "(automatic)",
-     "filename": "comment_ledger.json", "assess": _assess_comments},
+     "filename": COMMENT_LEDGER_FILENAME, "assess": _assess_comments,
+     "locate": lambda p: p.reviews_dir / COMMENT_LEDGER_FILENAME},
     {"key": "deliberation", "name": "Crux deliberation", "flag": "--deliberation",
-     "filename": "deliberations.json", "assess": _assess_deliberation},
+     "filename": DELIBERATIONS_FILENAME, "assess": _assess_deliberation,
+     "locate": lambda p: p.reviews_dir / DELIBERATIONS_FILENAME},
     {"key": "effort_tiers", "name": "Effort tiers", "flag": "--effort-tiers",
-     "filename": "effort.json", "assess": _assess_effort},
+     "filename": EFFORT_FILENAME, "assess": _assess_effort,
+     "locate": lambda p: p.reviews_dir / EFFORT_FILENAME},
 )
 
 

--- a/tests/test_scorecard.py
+++ b/tests/test_scorecard.py
@@ -24,7 +24,23 @@ from src.scorecard import (
     render_markdown,
     write_scorecard,
 )
+from src.scorecard import FEATURES
 from src.utils import build_run_paths, ensure_run_layout, read_text, write_text
+
+
+def _ledger_path(paths, key: str) -> Path:
+    """Where the producer for `key` actually writes.
+
+    Every fixture here used to go to `paths.reviews_dir / <filename>`. Four of the five
+    producers do write there; `record_panel_effect` writes to `reviews_dir / "panel" / ...`,
+    so the review-panel half of this file was green against a path that never occurs in a
+    run, while the scorecard reported the panel `unused` on every real one. Routing the
+    fixtures through the same `locate` the reader uses makes a future divergence fail here.
+    """
+    feature = next(f for f in FEATURES if f["key"] == key)
+    path = feature["locate"](paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
 
 
 def _paths(testcase: unittest.TestCase):
@@ -61,18 +77,18 @@ class UnusedVersusNullTests(unittest.TestCase):
 
     def test_an_unreadable_ledger_is_never_reported_as_no_effect(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "panel_effect.json", "{ not json")
+        write_text(_ledger_path(paths, "review_panel"), "{ not json")
         # "I could not measure this" must not wear the same badge as "this did nothing".
         self.assertEqual(_verdict_for(paths, "review_panel"), UNREADABLE)
 
     def test_a_ledger_of_the_wrong_shape_is_unreadable_too(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "panel_effect.json", json.dumps(["not", "a", "dict"]))
+        write_text(_ledger_path(paths, "review_panel"), json.dumps(["not", "a", "dict"]))
         self.assertEqual(_verdict_for(paths, "review_panel"), UNREADABLE)
 
     def test_a_ledger_missing_its_summary_does_not_crash_the_card(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "panel_effect.json", json.dumps({"gates": []}))
+        write_text(_ledger_path(paths, "review_panel"), json.dumps({"gates": []}))
         # No summary means no gates reviewed, which is unproven rather than a null result.
         self.assertEqual(_verdict_for(paths, "review_panel"), UNPROVEN)
 
@@ -80,18 +96,18 @@ class UnusedVersusNullTests(unittest.TestCase):
 class ReviewPanelTests(unittest.TestCase):
     def test_a_panel_that_changed_nothing_is_dropped(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "panel_effect.json", _panel())
+        write_text(_ledger_path(paths, "review_panel"), _panel())
         self.assertEqual(_verdict_for(paths, "review_panel"), DROP)
 
     def test_a_panel_that_changed_a_decision_is_kept(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "panel_effect.json",
+        write_text(_ledger_path(paths, "review_panel"),
                    _panel(gates_where_the_panel_changed_the_decision=2))
         self.assertEqual(_verdict_for(paths, "review_panel"), KEEP)
 
     def test_a_panel_that_never_reached_a_gate_is_unproven(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "panel_effect.json", _panel(gates_reviewed=0))
+        write_text(_ledger_path(paths, "review_panel"), _panel(gates_reviewed=0))
         self.assertEqual(_verdict_for(paths, "review_panel"), UNPROVEN)
 
 
@@ -104,24 +120,24 @@ class IdeationTests(unittest.TestCase):
 
     def test_a_pool_nobody_adopted_beyond_the_baseline_is_dropped(self) -> None:
         paths = _paths(self)
-        write_text(paths.notes_dir / "idea_pool.json", self._pool())
+        write_text(_ledger_path(paths, "ideation_panel"), self._pool())
         self.assertEqual(_verdict_for(paths, "ideation_panel"), DROP)
 
     def test_a_pool_adopted_beyond_the_baseline_is_kept(self) -> None:
         paths = _paths(self)
-        write_text(paths.notes_dir / "idea_pool.json", self._pool(adopted_from_other_proposers=2))
+        write_text(_ledger_path(paths, "ideation_panel"), self._pool(adopted_from_other_proposers=2))
         self.assertEqual(_verdict_for(paths, "ideation_panel"), KEEP)
 
     def test_widening_without_uptake_measured_is_unproven_not_a_win(self) -> None:
         paths = _paths(self)
-        write_text(paths.notes_dir / "idea_pool.json",
+        write_text(_ledger_path(paths, "ideation_panel"),
                    self._pool(adoption_measured=False, adopted_from_other_proposers=3))
         # Widening is not usefulness; the pool itself says so until Stage 02 is approved.
         self.assertEqual(_verdict_for(paths, "ideation_panel"), UNPROVEN)
 
     def test_the_pool_is_found_in_the_notes_directory(self) -> None:
         paths = _paths(self)
-        write_text(paths.notes_dir / "idea_pool.json", self._pool(adopted_from_other_proposers=1))
+        write_text(_ledger_path(paths, "ideation_panel"), self._pool(adopted_from_other_proposers=1))
         # It lives beside Stage 02's artifacts, not with the reviews.
         self.assertEqual(_verdict_for(paths, "ideation_panel"), KEEP)
 
@@ -135,23 +151,23 @@ class DeliberationTests(unittest.TestCase):
 
     def test_escalations_that_only_confirmed_the_agent_are_dropped(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "deliberations.json", self._ledger())
+        write_text(_ledger_path(paths, "deliberation"), self._ledger())
         self.assertEqual(_verdict_for(paths, "deliberation"), DROP)
 
     def test_a_changed_answer_is_kept(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "deliberations.json", self._ledger(changed_the_agents_answer=1))
+        write_text(_ledger_path(paths, "deliberation"), self._ledger(changed_the_agents_answer=1))
         self.assertEqual(_verdict_for(paths, "deliberation"), KEEP)
 
     def test_no_crux_raised_is_unproven(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "deliberations.json",
+        write_text(_ledger_path(paths, "deliberation"),
                    self._ledger(cruxes_raised=0, confirmed_the_agents_answer=0))
         self.assertEqual(_verdict_for(paths, "deliberation"), UNPROVEN)
 
     def test_escalated_with_no_working_answer_is_unproven(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "deliberations.json",
+        write_text(_ledger_path(paths, "deliberation"),
                    self._ledger(confirmed_the_agents_answer=0))
         # Nothing to compare against is not the same as nothing changed.
         self.assertEqual(_verdict_for(paths, "deliberation"), UNPROVEN)
@@ -167,18 +183,18 @@ class EffortTests(unittest.TestCase):
 
     def test_tiering_switched_off_reads_as_unused(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "effort.json", self._ledger(enabled=False))
+        write_text(_ledger_path(paths, "effort_tiers"), self._ledger(enabled=False))
         self.assertEqual(_verdict_for(paths, "effort_tiers"), UNUSED)
 
     def test_a_run_that_tiered_nothing_routine_is_dropped(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "effort.json", self._ledger(routine=0))
+        write_text(_ledger_path(paths, "effort_tiers"), self._ledger(routine=0))
         # Everything deliberative is the state tiering exists to move away from.
         self.assertEqual(_verdict_for(paths, "effort_tiers"), DROP)
 
     def test_the_concentration_verdict_is_folded_into_the_detail(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "effort.json",
+        write_text(_ledger_path(paths, "effort_tiers"),
                    self._ledger(concentration={"verdict": "All 5 rounds went to deliberative."}))
         report = next(r for r in build_scorecard(paths).features if r.key == "effort_tiers")
         self.assertEqual(report.verdict, KEEP)
@@ -191,8 +207,8 @@ class HeadlineTests(unittest.TestCase):
 
     def test_the_headline_totals_the_extra_calls(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "panel_effect.json", _panel(panel_calls=40))
-        write_text(paths.reviews_dir / "deliberations.json", json.dumps({"summary": {
+        write_text(_ledger_path(paths, "review_panel"), _panel(panel_calls=40))
+        write_text(_ledger_path(paths, "deliberation"), json.dumps({"summary": {
             "cruxes_raised": 1, "changed_the_agents_answer": 1, "voice_calls": 12, "verdict": "v"}}))
         card = build_scorecard(paths)
         self.assertEqual(card.optional_calls, 52)
@@ -202,18 +218,18 @@ class HeadlineTests(unittest.TestCase):
 
     def test_an_unreadable_ledger_is_not_counted_as_a_feature_that_ran(self) -> None:
         paths = _paths(self)
-        write_text(paths.reviews_dir / "panel_effect.json", "{ not json")
+        write_text(_ledger_path(paths, "review_panel"), "{ not json")
         self.assertIn("No optional machinery", build_scorecard(paths).headline())
 
 
 class RenderTests(unittest.TestCase):
     def _mixed(self):
         paths = _paths(self)
-        write_text(paths.reviews_dir / "panel_effect.json", _panel())
-        write_text(paths.reviews_dir / "deliberations.json", json.dumps({"summary": {
+        write_text(_ledger_path(paths, "review_panel"), _panel())
+        write_text(_ledger_path(paths, "deliberation"), json.dumps({"summary": {
             "cruxes_raised": 1, "changed_the_agents_answer": 1, "voice_calls": 12,
             "verdict": "changed one answer"}}))
-        write_text(paths.notes_dir / "idea_pool.json", json.dumps({"effect": {
+        write_text(_ledger_path(paths, "ideation_panel"), json.dumps({"effect": {
             "proposer_calls": 6, "adoption_measured": False, "verdict": "not yet measured"}}))
         return paths
 
@@ -267,7 +283,7 @@ class ManagerIntegrationTests(unittest.TestCase):
 
     def test_a_finished_run_writes_the_scorecard(self) -> None:
         manager, paths = self._manager_and_paths()
-        write_text(paths.reviews_dir / "panel_effect.json", _panel())
+        write_text(_ledger_path(paths, "review_panel"), _panel())
         manager._report_optional_machinery(paths)
         self.assertTrue((paths.reviews_dir / SCORECARD_MD).exists())
         self.assertIn("scorecard", read_text(paths.logs))
@@ -293,3 +309,72 @@ class ManagerIntegrationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class LedgerLocationsMatchTheProducersTests(unittest.TestCase):
+    """The reader's idea of where a ledger lives, checked against the writer's.
+
+    `scorecard._load` used to guess -- `reviews_dir` then `notes_dir` -- and the guess was
+    wrong for the review panel, which writes into `reviews_dir/panel/`. The consequence was
+    not a crash: `_load` returned "no file", `_report` turned that into `unused` / "Not
+    enabled on this run.", and the feature this whole module leads with was reported as
+    switched off on every run where it was switched on. Every existing test in this file
+    wrote its fixture to the reader's path, so all of them agreed with the reader and none
+    with the writer.
+
+    Rather than assert a list of paths -- the same guess written a third time -- each case
+    drives the actual producer and asks the scorecard whether it found anything.
+    """
+
+    def test_the_review_panel_ledger_is_found_where_the_panel_writes_it(self) -> None:
+        from src.review_panel import PanelDeliberation, record_panel_effect
+
+        paths = _paths(self)
+        record_panel_effect(
+            paths,
+            PanelDeliberation(stage_slug="01_literature_survey", attempt_no=1, chair_key="pi"),
+        )
+
+        report = next(r for r in build_scorecard(paths).features if r.key == "review_panel")
+        self.assertNotEqual(
+            report.verdict,
+            UNUSED,
+            "the panel wrote a ledger and the scorecard called the feature never-enabled",
+        )
+
+    def test_every_feature_is_looked_for_where_something_could_write_it(self) -> None:
+        """A `locate` pointing outside the run tree is the same defect in a new shape."""
+        paths = _paths(self)
+        for feature in FEATURES:
+            with self.subTest(feature=feature["key"]):
+                path = feature["locate"](paths)
+                self.assertEqual(path.name, feature["filename"])
+                self.assertTrue(
+                    str(path).startswith(str(paths.run_root)),
+                    f"{feature['key']} is looked for outside the run directory: {path}",
+                )
+
+    def test_a_ledger_at_the_wrong_path_is_not_silently_treated_as_absent(self) -> None:
+        """Pins the failure mode, not just today's instance of it.
+
+        A file at a path the reader does not check is indistinguishable from no file, and
+        `unused` is the most misleading of the five verdicts to land on: it says the feature
+        was never switched on. If a refactor reintroduces a search, this is what it has to
+        get past.
+        """
+        paths = _paths(self)
+        feature = next(f for f in FEATURES if f["key"] == "review_panel")
+        correct = feature["locate"](paths)
+        wrong = paths.reviews_dir / feature["filename"]
+        self.assertNotEqual(correct, wrong, "the panel ledger no longer sits in a subdirectory")
+
+        wrong.parent.mkdir(parents=True, exist_ok=True)
+        write_text(wrong, _panel())
+        self.assertEqual(
+            _verdict_for(paths, "review_panel"),
+            UNUSED,
+            "a ledger at the reader's old path should read as absent, not as a measurement",
+        )
+
+        write_text(correct, _panel(gates_where_the_panel_changed_the_decision=2))
+        self.assertEqual(_verdict_for(paths, "review_panel"), KEEP)


### PR DESCRIPTION
## The defect

`record_panel_effect` writes to `workspace/reviews/panel/panel_effect.json`, beside the per-gate transcripts. `scorecard._load` looked in `reviews_dir`, then `notes_dir`, and nowhere else.

A missing ledger is not an error here — correctly, since all five features are optional — so `_load` returned "no file", `_report` turned that into `unused` / **"Not enabled on this run."**, and the scorecard reported the review panel as switched off. On every run where it was switched on.

Same payload, two paths:

```
reviews/panel/panel_effect.json  ->  unused | Not enabled on this run.
reviews/panel_effect.json        ->  keep   | The panel changed 2 of 3 gate decisions.
```

The first is where the panel writes. The second is where **every fixture in `tests/test_scorecard.py` wrote** — 24 call sites, all agreeing with the reader and none with the writer. That is why 28 green tests held nothing about the feature this module leads with.

It is also, specifically, the feature that produces the sentence the scorecard exists to deliver — *"it did not earn that cost; consider dropping the panel"* — and the one whose verdict could never be reached.

The module docstring says that confusing "I could not measure this" with "this did nothing" would make it *"exactly the kind of instrument the rest of this work exists to avoid."* A guessed location degrades into something worse than either: a feature that ran, measured itself, and is reported as never enabled.

The other four resolve correctly — `idea_pool.json` in `notes/`, and `comment_ledger.json` / `deliberations.json` / `effort.json` in `reviews/` — verified by reading each producer, not by assuming.

## The fix

Each feature carries a `locate` callable naming its own path. Filenames now come from the producing modules (`PANEL_EFFECT_FILENAME`, `IDEA_POOL_FILENAME`, …) rather than literals in `scorecard.py`, so a rename moves both ends together; the *directory* is the half that actually drifted, so it is spelled out per feature with the panel's exception commented.

`_load` takes the locator instead of a filename plus a search. The search is gone — it was a guess that could not announce it was wrong.

## Tests

| Test | Holds |
| --- | --- |
| `test_the_review_panel_ledger_is_found_where_the_panel_writes_it` | drives the real `record_panel_effect`, then asks the scorecard whether it found anything — it cannot drift the way an asserted path list can, because that list would be the same guess written a third time |
| `test_a_ledger_at_the_wrong_path_is_not_silently_treated_as_absent` | pins the *failure mode*: a file at a path the reader does not check is indistinguishable from no file, and `unused` is the most misleading of the five verdicts to land on |
| `test_every_feature_is_looked_for_where_something_could_write_it` | a `locate` pointing outside the run tree is the same defect in a new shape |

Against the unfixed reader the suite goes to `1 failure, 30 errors`. The 24 existing fixture writes now route through the same `locate` the reader uses, so a future divergence fails here instead of passing.

## How it was found

An adversarial verification pass over `docs/framework.md`, which claims the scorecard "reads all five ledgers at the end of every run". It read four.

## Testing

`python -m unittest discover -s tests -p "test_*.py"` — **2026 pass**, 1 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)