### PR TITLE
The other seven documents, through three adversarial rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ naming them.
 | Flags on `main.py` / `rcb_agent.py` | `parse_args` | 61 / 37 |
 | Python modules / lines / tests | the tree | 150 / 62 k / 1826 |
 
-`python -m unittest discover -s tests -p "test_*.py"` runs **1826 tests in ~69 s** across 83 test
+`python -m unittest discover -s tests -p "test_*.py"` runs **1826 tests in ~69 s** across 82 test
 modules, with no third-party dependency.
 
 ## Quick start
@@ -193,11 +193,16 @@ Every flag, its default, and what is preserved on resume:
 **[docs/cli-reference.md](docs/cli-reference.md)**. Stage identifiers accept `03`, `3` or
 `03_study_design`; `--venue` defaults to `neurips_2025`.
 
-> **Four paths remove the human from the gate**, not two. `resolve_unattended` returns `True` for
-> `--unattended`, `--full-auto`, `--review-panel` *and* `--approval-mode agent`, and `approval_mode`
-> becomes `agent` for `--full-auto` or `--review-panel`. Because `--rigor` is resolved **before**
-> `resolve_unattended` runs, a plain `--rigor max` sets `review_panel = True` and silently converts an
-> interactive run into an unattended agent-gated one. Under a badge reading *Human approval required*,
+> **Three flags put an agent in the approval seat, not two** — and a fourth removes the human
+> without replacing them. `approval_mode` becomes `agent` for `--approval-mode agent`, `--full-auto`
+> and `--review-panel`, and `create_reviewer` is called only when it does. `--unattended` on its own
+> is the odd one: `resolve_unattended` returns `True` for all four, but with `approval_mode` still
+> `manual` there is no reviewer to install, so the first approval menu raises `UnattendedInputError`
+> rather than being decided. For a run with nobody at the terminal, pass `--full-auto`.
+>
+> Because `--rigor` is resolved **before** `resolve_unattended` runs, a plain `--rigor max` sets
+> `review_panel = True` and silently converts an interactive run into an unattended agent-gated one.
+> Under a badge reading *Human approval required*,
 > the flag that looks like more review is the flag that removes the reviewer. Three headline
 > mechanisms — obligations, the standing review policy, the cross-model veto — also run only behind
 > that agent gate, as do anchored comments. Manual approval is the default and remains the path for

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,42 +1,76 @@
 # CLI Reference
 
-Complete reference for AutoR's entry points:
+The commands AutoR is meant to be run with, each with a section below:
 
-- `python main.py` — the terminal research workflow ([source](../main.py))
-- `python studio.py` — the local browser workspace
-  ([source](../src/backend/studio_http.py))
-- `python rcb_agent.py` — the unattended ResearchClawBench agent
-  ([source](../rcb_agent.py))
-- `python tools/web_search.py` — Gemini-backed web search
-  ([source](../src/web_search.py))
+| Command | What it is |
+| --- | --- |
+| `python main.py` | The terminal research workflow. ([source](../main.py)) |
+| `python studio.py` | The local browser workspace. ([source](../src/backend/studio_http.py)) |
+| `python rcb_agent.py` | The unattended ResearchClawBench agent. ([source](../rcb_agent.py)) |
+| `python tools/web_search.py` | Gemini-backed web search. ([source](../src/web_search.py)) |
+| `python tools/score_rcb_run.py` | Scores a finished benchmark workspace. ([source](../tools/score_rcb_run.py)) |
+| `python tools/archive_sample_complexity.py` | How many runs the archive needs before it can steer. ([source](../tools/archive_sample_complexity.py)) |
+
+Two further modules are executable and are deliberately not listed as commands,
+because nothing expects a person to type them:
+[`src/mcp_web_search.py`](../src/mcp_web_search.py) is the MCP stdio server the
+Claude operator launches for itself (see [How the agent reaches
+it](#how-the-agent-reaches-it)), and `docs/ui-design/generate_progress_docx.py`
+regenerates one design document and needs `python-docx`.
+
+Every flag on those six is named below: `main.py`'s 61, `studio.py`'s 5,
+`tools/web_search.py`'s 4 and `tools/score_rcb_run.py`'s 8 each get their own
+table row, and `rcb_agent.py`'s 37 are covered as the six that are its own plus
+the 31 it shares with `main.py`, every one of the 31 spelled out by name.
+`tools/archive_sample_complexity.py` has none.
+
+Two of the six synopsis blocks are **subsets** — the common flags — and say so
+underneath: `main.py`'s and `rcb_agent.py`'s. The other four are not. `studio.py`,
+`tools/web_search.py` and `tools/score_rcb_run.py` show every flag their command
+declares, and `tools/archive_sample_complexity.py` has nothing to omit. Either
+way the tables are the surface.
 
 For a task-oriented introduction, read the [English Guide](tutorial_en.md)
-instead. This page is the exhaustive list.
+instead.
 
 ---
 
 ## `main.py`
 
 ```
-python main.py [--goal GOAL] [--goal-file PATH] [--runs-dir DIR] [--fake-operator]
-               [--model MODEL] [--operator {claude,codex}]
-               [--codex-sandbox {read-only,workspace-write,danger-full-access}]
-               [--approval-mode {manual,agent}] [--full-auto]
-               [--unattended] [--max-auto-skips N]
-               [--review-operator {claude,codex}] [--review-model MODEL]
-               [--web-search {auto,gemini,native}]
-               [--venue VENUE] [--resume-run RUN_ID] [--redo-stage STAGE]
-               [--rollback-stage STAGE] [--resources PATH [PATH ...]]
-               [--skip-intake] [--research-diagram]
-               [--project-root PATH] [--paper-corpus PATH]
-               [--stage-timeout SECONDS] [--max-attempts N]
+python main.py [--goal GOAL | --goal-file PATH] [--runs-dir DIR]
+               [--operator {claude,codex}] [--model MODEL]
+               [--rigor {fast,standard,thorough,max}]
+               [--approval-mode {manual,agent}] [--full-auto] [--unattended]
+               [--resources PATH [PATH ...]] [--venue VENUE]
+               [--output-format {markdown,md,latex,tex}]
+               [--resume-run RUN_ID] [--redo-stage STAGE] [--rollback-stage STAGE]
+               [--final-stage STAGE] [--stage-timeout SECONDS] [--max-attempts N]
+               [--fake-operator]
 ```
+
+**That synopsis is a subset, not the surface.** `parse_args` declares 61 flags;
+the 19 shown above are the ones a first run usually needs. Every one of the 61
+has a row in the tables that follow, grouped by what it does, and
+`python main.py --help` prints the same set in declaration order.
+
+Four of them — `--effort-tiers`, `--deliberation`, `--ideation-panel` and
+`--review-panel` — are `argparse.BooleanOptionalAction` switches with
+`default=None`, which does not mean "off". It means *nobody said*, and
+[`--rigor`](#rigor) then decides; `--rigor` itself defaults to `standard`, which
+turns effort tiers **on**. Passing either direction of the switch overrides the
+level. `--evolve` and `--archive-steer` are the same kind of switch but are not
+rigor-controlled: their unset values are filled in by `normalize_walk_settings`,
+from `DEFAULT_EVOLVE_MEASURE` (on) and `DEFAULT_ARCHIVE_STEER` (off). The
+switches that behave this way are the ones `main.py` declares with
+`action=argparse.BooleanOptionalAction`, and every one of them is declared
+`default=None`.
 
 ### Goal and run location
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--goal GOAL` | prompted interactively | The research goal. If omitted, AutoR reads a multi-line goal from stdin and stops at the first empty line. An empty goal is an error. Unattended runs cannot be prompted, so one of `--goal` or `--goal-file` is required there. |
+| `--goal GOAL` | prompted interactively | The research goal. If omitted, AutoR reads a multi-line goal from stdin, skipping leading blank lines and stopping at the first blank line *after* some text. An empty goal is an error (`Research goal cannot be empty.`). Unattended runs cannot be prompted, so one of `--goal` or `--goal-file` is required there. |
 | `--goal-file PATH` | — | Read the goal from a file instead. Mutually exclusive with `--goal`. Use this when the goal is too long to pass as a shell argument. |
 | `--runs-dir DIR` | `runs` | Where run directories are created. Resolved **relative to the repository root**, not the current working directory. Point this at a large disk for heavy experiments. |
 
@@ -81,11 +115,25 @@ automated dry runs.
 
 Replacing the human approval gate is not by itself enough to make a run
 unattended: a handful of prompts sit outside that gate. `--unattended` closes
-them, and is implied by `--full-auto` and by `--approval-mode agent`.
+them.
+
+`resolve_unattended` returns true for **four** things, not one:
+
+- `--unattended`
+- `--full-auto`
+- `--approval-mode agent`
+- `--review-panel`
+
+The last one has a consequence worth stating on its own. `--rigor` is resolved
+*before* `resolve_unattended` runs, and `--rigor max` is the level that turns the
+review panel on — so **`--rigor max` silently makes a run unattended**, with no
+`--unattended` anywhere on the command line. If you want the panel and a human at
+the gate, you cannot have both: there is no one left to answer the prompts,
+which is the reasoning the function's own docstring gives.
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--unattended` | off (implied by `--full-auto`) | Never block on terminal input. The resource prompt is skipped even on a TTY, and any interactive prompt that is still reachable raises `UnattendedInputError` instead of waiting. |
+| `--unattended` | off (implied by `--full-auto`, `--approval-mode agent`, `--review-panel`, and therefore by `--rigor max`) | Never block on terminal input. The resource prompt is skipped even on a TTY, and any interactive prompt that is still reachable raises `UnattendedInputError` instead of waiting. |
 | `--max-auto-skips N` | `3` | How many stages may be auto-skipped after exhausting their retry budget before the run aborts. Only applies unattended. |
 
 Two behaviours change unattended:
@@ -184,13 +232,26 @@ approval. See [Stage Contract](stage-contract.md#2-the-artifact-gate).
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--review-panel` | off | Replace the single reviewer agent with a deliberating panel: independent round, cross-examination on disagreement, then a chair synthesis. Implies `--approval-mode agent`. |
-| `--panel-roles ROLE...` | all five | Seat only these roles, in this order: `pi`, `domain`, `method`, `repro`, `skeptic`. The first seat chairs unless `pi` is present. An unknown name is an error. |
+| `--review-panel` / `--no-review-panel` | off at `fast`, `standard` and `thorough`; **on at `--rigor max`** | Replace the single reviewer agent with a deliberating panel: independent round, cross-examination on disagreement, then a chair synthesis. Implies `--approval-mode agent` **and** unattended — see [Unattended execution](#unattended-execution). |
+| `--panel-roles ROLE...` | the default panel — `pi`, `domain`, `method`, `repro`, `skeptic` | Seat only these roles, in this order. `resolve_roles` accepts six keys, not five: the default panel above plus `reader`, the **Area Chair**, which is in `OPTIONAL_ROLES` rather than `DEFAULT_PANEL` and is seated only when you name it here — it is the one seat that reads the artifact as a document. The first seat chairs unless `pi` is present, so `--panel-roles reader domain` puts the Area Chair in the chair. An unknown name raises `Unknown panel role: <value>. Known roles: domain, method, pi, reader, repro, skeptic.` (`main.py --help` lists only the default five; the error message is the complete set.) |
 | `--panel-rounds N` | `2` | Maximum deliberation rounds. Round 1 is always independent; later rounds run only on disagreement. |
 | `--panel-models ROLE=MODEL...` | — | Assign a model per seat, as `role=model` or `role=backend:model` (`pi=opus skeptic=codex:default`). Heterogeneity is the lever with the best evidence behind it. |
 | `--persona PATH` | — | Markdown description of the researcher the panel stands in for, injected into every seat so they hold one consistent bar. |
-| `--cross-review {auto,gemini,off}` | `auto` | Independent second opinion on each approval, from a different model family. It can veto an approval it cannot defend and can never override a refusal, so it only makes the gate stricter. `auto` enables it when a Gemini backend is configured. Only meaningful with an agent approval gate. |
-| `--cross-review-model MODEL` | `gemini-3.1-pro-preview` | Model for the cross-model reviewer (`DEFAULT_CROSS_REVIEW_MODEL`, `src/cross_reviewer.py`). |
+| `--cross-review {auto,gemini,off}` | `auto` | Independent second opinion on each approval, from a different model family. It can veto an approval it cannot defend and can never override a refusal, so it only makes the gate stricter. `auto` enables it when a Gemini backend is configured. **Accepted but inert here** — see below. |
+| `--cross-review-model MODEL` | `gemini-3.1-pro-preview` | Model for the cross-model reviewer (`DEFAULT_CROSS_REVIEW_MODEL`, `src/cross_reviewer.py`). Inert on `main.py` for the same reason. |
+
+> **Both cross-review flags do nothing on `main.py` today.** `main.py` imports
+> `resolve_cross_reviewer` and never calls it; the only production caller is
+> `rcb_agent.py`, which passes the result to `ResearchManager` as
+> `cross_reviewer`. The flags parse and are then **dropped** — nothing in
+> `main.py` reads `args.cross_review` or `args.cross_review_model` after
+> `parse_args`, and neither value is recorded anywhere: `initialize_run_config`
+> has no such key, and `main.py` never dumps its argv. So a resumed or audited
+> run carries no trace that they were passed, which makes the inertness harder
+> to notice than it would be if the values were written down. Tracked in
+> [Framework → What has not been
+> established](framework.md#7-what-has-not-been-established) and in the README's
+> Limits section.
 
 A blocking objection from any member cannot be approved over — the chair's approval is
 converted to a refinement in code. Each run also writes
@@ -205,9 +266,13 @@ pre-registered evidence against multi-agent deliberation, in [Review Panel](revi
 | `--rigor {fast,standard,thorough,max}` | `standard` | How much optional machinery to run. One dial in place of four switches. |
 
 `fast` nothing · `standard` effort tiers · `thorough` + crux deliberation and the ideation
-panel · `max` + the review panel. The levels nest, and every individual switch below still
-works as an override in both directions (`--no-ideation-panel`, `--review-panel`). Full
-description in [Rigor](rigor.md).
+panel · `max` + the review panel. The levels nest (`_LEVEL_FEATURES`), and every individual
+switch below still works as an override in both directions (`--no-ideation-panel`,
+`--review-panel`). Full description in [Rigor](rigor.md).
+
+`--rigor max` has one effect that is not on the list: because it turns the review panel on,
+and the review panel is one of the things `resolve_unattended` reads, `--rigor max` also
+makes the run unattended. `--rigor max --no-review-panel` does not.
 
 ### Effort tiers
 
@@ -223,7 +288,7 @@ Under tiering, polish rounds — the run's most expensive setting — are withhe
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--deliberation` | off | Let a stage stop and pull in a panel when it hits a genuine crux. The agent names the question, finishes with its working answer, and the resolution reaches the next pass. |
+| `--deliberation` / `--no-deliberation` | off at `fast` and `standard`; **on at `--rigor thorough` and `max`** | Let a stage stop and pull in a panel when it hits a genuine crux. The agent names the question, finishes with its working answer, and the resolution reaches the next pass. |
 | `--max-deliberations N` | `3` | Cruxes a run may escalate. Scarcity is what makes "think hard here" mean anything. |
 | `--deliberation-voices VOICE...` | all four | `theorist`, `empiricist`, `critic`, `pragmatist`. |
 | `--deliberation-models VOICE=MODEL...` | - | Assign a model per voice. |
@@ -235,7 +300,7 @@ description in [Raising a Crux](deliberation.md).
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--ideation-panel` | off | Widen Stage 02's hypotheses with proposers working from distinct lenses. Candidates are deduplicated, scored, and injected as material. It decides nothing. |
+| `--ideation-panel` / `--no-ideation-panel` | off at `fast` and `standard`; **on at `--rigor thorough` and `max`** | Widen Stage 02's hypotheses with proposers working from distinct lenses. Candidates are deduplicated, scored, and injected as material. It decides nothing. |
 | `--ideation-lenses LENS...` | all five | Seat only these lenses: `mechanism`, `contrarian`, `adjacent`, `null`, `regime`. |
 | `--ideation-models LENS=MODEL...` | - | Assign a model per lens, as `lens=model` or `lens=backend:model`. |
 | `--ideas-per-proposer N` | `2` | Candidates each proposer may return. |
@@ -296,7 +361,7 @@ mechanism and the reasoning behind each refusal.
 | `--routing {off,auto,agent}` | `auto` | Who chooses the move out of a completed stage. `auto` asks the backend only where more than one move is live, so a linear run never pays for it. `agent` asks at every node; `off` always takes the graph's default edge. AutoR decides which moves are available by evaluating guards against artifacts on disk; the backend only chooses among those, and a choice outside the menu falls back to the forward edge. Preserved on resume. |
 | `--graph-max-steps N` | `20` | Stage executions allowed in one walk. Only bites in adaptive mode; a linear walk cannot exceed eight. |
 | `--graph-max-visits N` | `3` | Times one stage may be entered. A revisit is a productive move; the fourth entry into the same stage is a loop. |
-| `--evolve` / `--no-evolve` | on | Score every valid draft against a rigour rubric read off disk and run the champion ratchet: the best-scoring draft is promoted, not the last one, and a self-initiated round that scores worse is reverted. Costs nothing — the rubric never calls a backend. `--no-evolve` restores the old behaviour, where whichever draft came last was promoted. Preserved on resume. |
+| `--evolve` / `--no-evolve` | on | Score every valid draft against a rigour rubric read off disk and run the champion ratchet: the best-scoring draft is promoted, not the last one, and a self-initiated round that scores worse is reverted. Costs nothing — the rubric never calls a backend. `--no-evolve` restores the old behaviour, where whichever draft came last was promoted, and in `resolve_walk_settings` it also sets the rounds budget to zero — the rounds are steered by the score, so without a score there is nothing to steer them with. Passing `--evolve-rounds` above zero in the same command reverses both. Preserved on resume. |
 | `--evolve-rounds N` | `2` | Improvement rounds per stage beyond the first draft. This is the half that costs backend calls. A stage whose rubric has no shortfall worth acting on spends none of them, and a `--fake-operator` run spends none at all. Budgeted separately from `--max-attempts`, which bounds a stage that is failing rather than one being improved. `0` measures without polishing. Preserved on resume. |
 | `--evolve-stages STAGE [...]` | all | Restrict improvement rounds to these stage slugs or numbers, e.g. `06_analysis` or `5 6 7`. |
 | `--archive PATH` | `~/.autor/archive` | Where the cross-run archive lives. Each finished run records its route and measured fitness, and each edge is compared against runs that reached the same node and did not take it. Recording only. |
@@ -317,10 +382,11 @@ mechanism and the reasoning behind each refusal.
 
 ### Reliability
 
-The Gemini call retries and times out. Stage 01 issues dozens of searches over
-hours, and the SDK's defaults are one attempt and no timeout, so a single `429`
-killed a search outright and a hung connection could burn the whole
-`--stage-timeout` (4 hours by default).
+The Gemini **search** call retries and times out (`SEARCH_TIMEOUT_MS`,
+`SEARCH_RETRY_ATTEMPTS` and the two delay bounds in `src/web_search.py`). Stage
+01 issues dozens of searches over hours, and the SDK's defaults are one attempt
+and no timeout, so a single `429` killed a search outright and a hung connection
+could burn the whole `--stage-timeout` (4 hours by default).
 
 | | Value |
 | --- | --- |
@@ -358,9 +424,8 @@ control commands are accepted where the UI offers a recovery prompt:
 Anything else is rejected with
 `Unknown control command. Supported commands are '/skip' and '/back <stage>'.`
 
-A stage gets at most `--max-attempts` attempts (default `MAX_STAGE_ATTEMPTS`, 5, in
-[`src/utils.py`](../src/utils.py))
-attempts before AutoR stops and escalates to you.
+A stage gets at most `--max-attempts` attempts (default `MAX_STAGE_ATTEMPTS`, 5,
+in [`src/utils.py`](../src/utils.py)) before AutoR stops and escalates to you.
 
 ### Examples
 
@@ -444,28 +509,107 @@ Runs AutoR unattended against a
 and exports the benchmark's deliverables. Never reads stdin.
 
 ```
-python rcb_agent.py [--workspace PATH] [--prompt TEXT | --prompt-file PATH]
+python rcb_agent.py [--workspace PATH] [--prompt TEXT] [--prompt-file PATH]
                     [--operator {claude,codex}] [--model MODEL]
                     [--review-operator {claude,codex}] [--review-model MODEL]
                     [--codex-sandbox MODE] [--venue VENUE]
-                    [--stage-timeout SECONDS] [--max-attempts N]
-                    [--max-auto-skips N]
+                    [--rigor {fast,standard,thorough,max}]
+                    [--output-format {markdown,md,latex,tex}] [--final-stage STAGE]
+                    [--stage-timeout SECONDS] [--max-attempts N] [--max-auto-skips N]
                     [--intake] [--web-search {auto,gemini,native}]
                     [--no-synthesis] [--export-only] [--fake-operator]
 ```
 
+Again a subset: `rcb_agent.py`'s own `parse_args` declares 37 flags.
+
+### The six flags that are its own
+
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--workspace PATH` | `.` | Benchmark workspace. The harness runs the agent with this as its working directory, so the default is usually right. |
+| `--workspace PATH` | `.` | Benchmark workspace. The harness runs the agent with this as its working directory, so the default is usually right. Run directories are created under `<workspace>/.autor/`, which is why there is no `--runs-dir`. |
 | `--prompt TEXT` | — | Benchmark instructions as a literal string. This is what the harness's `<PROMPT>` placeholder expands to. |
-| `--prompt-file PATH` | `<workspace>/INSTRUCTIONS.md` | Read the instructions from a file instead. |
-| `--stage-timeout SECONDS` | `14400` | The benchmark harness imposes no timeout of its own — neither the UI runner nor the batch CLI puts one on the agent subprocess — so this is the only thing that can cut a stage short. |
-| `--max-attempts N` | `8` | Higher than `main.py`'s default. An exhausted stage is auto-skipped, and a skipped stage costs real score, so the extra retries are worth their wall-clock. |
-| `--intake` | off | Run Stage 00. Off by default: the benchmark instructions are already a complete task specification. |
+| `--prompt-file PATH` | `<workspace>/INSTRUCTIONS.md` | Read the instructions from a file. Not mutually exclusive with `--prompt`: `resolve_instructions` takes `--prompt` when it is non-empty, then the first of `--prompt-file` and `<workspace>/INSTRUCTIONS.md` that exists and is non-empty. A `--prompt-file` that does not exist therefore falls through to the workspace default rather than failing. With none of the three available it raises `No benchmark instructions found.` |
+| `--intake` | off | Run Stage 00. Off by default: the benchmark instructions are already a complete task specification. This is the inverse of `main.py`'s `--skip-intake`, not a copy of it. |
 | `--no-synthesis` | off | Skip the operator-backed report synthesis pass and use only the deterministic fallback. |
 | `--export-only` | off | Re-export the most recent run in the workspace without re-running the pipeline. Use this to recover deliverables from an interrupted job. |
 
-Every other flag mirrors its `main.py` counterpart.
+### The 31 it shares, and where they diverge
+
+The remaining 31 have the same names as `main.py`'s and, unless noted below, the
+same defaults and the same meaning. All 31, by name:
+
+| Group | Shared flags |
+| --- | --- |
+| Backend | `--operator`, `--model`, `--codex-sandbox`, `--fake-operator`, `--stage-timeout`, `--max-attempts` |
+| Reviewer | `--review-operator`, `--review-model` |
+| Unattended | `--max-auto-skips` |
+| Web search | `--web-search` |
+| Output and stopping | `--output-format`, `--venue`, `--final-stage` |
+| Rigor dial | `--rigor` |
+| Effort tiers | `--effort-tiers` / `--no-effort-tiers`, `--routine-model` |
+| Crux deliberation | `--deliberation` / `--no-deliberation`, `--max-deliberations`, `--deliberation-voices`, `--deliberation-models` |
+| Ideation panel | `--ideation-panel` / `--no-ideation-panel`, `--ideation-lenses`, `--ideation-models`, `--ideas-per-proposer` |
+| Review panel | `--review-panel` / `--no-review-panel`, `--panel-roles`, `--panel-rounds`, `--panel-models`, `--persona`, `--cross-review`, `--cross-review-model` |
+
+Read the `main.py` tables above for what each one does. Three of them differ in
+kind rather than in default, and the two parsers are mirror images about it —
+each declares a flag the other one honours and it does not:
+
+- **`--cross-review` and `--cross-review-model` are live here and inert on
+  `main.py`.** `rcb_agent.py` is the only production caller of
+  `resolve_cross_reviewer`, and it hands the result to `ResearchManager` as
+  `cross_reviewer`, so the second opinion described in [Review
+  panel](#review-panel) actually runs on this path. Defaults match `main.py`'s:
+  `auto`, and `gemini-3.1-pro-preview` for the model.
+- **`--routine-model` is inert here and live on `main.py`.** It parses, and its
+  `--help` text promises a cheaper model for routine-tier stages, but
+  `args.routine_model` is read nowhere in `rcb_agent.py`: under `--effort-tiers`
+  the adapter builds `EffortPlan(enabled=True)` and never constructs the second
+  operator that `main.py` builds for the routine tier. Tiering still applies —
+  lean prompts, one reviewer, no escalation offer — but every stage runs on
+  `--model`.
+
+Every remaining divergence is a default or a validation. Diffing the two
+parsers' actions turns up four, and the last row below is the one behavioural
+consequence of the adapter being unattended by construction:
+
+| Flag | `main.py` | `rcb_agent.py` | Why |
+| --- | --- | --- | --- |
+| `--max-attempts N` | `5` | `8` | An exhausted stage is auto-skipped, and a skipped stage costs real score, so the extra retries are worth their wall-clock. |
+| `--final-stage STAGE` | run every stage | `07_writing` | The benchmark scores `report/report.md`, which Stage 07 writes. Stage 08 produces posters, slides and release notes the judge never opens. Pass `08_dissemination` for the full workflow. |
+| `--operator`, `--venue`, `--output-format`, `--web-search` | declared unset, so a resumed run's recorded value can win | the literal default (`claude`, `neurips_2025`, `markdown`, `auto`) | Same effective value on a fresh run. There is no resume path here, so nothing has to be reconciled. |
+| `--codex-sandbox MODE` | validated by argparse against `CODEX_SANDBOX_CHOICES`, declared unset | any string is accepted, defaulting to the literal `workspace-write` | The adapter declares no `choices`. An invalid mode is caught by `CodexOperator` as a runtime `ValueError` rather than as a usage error — and only if `--operator codex` is actually in play, since nothing else reads it. |
+| `--review-panel`, `--rigor max` | make the run unattended | no additional effect | The run is unattended either way: `ResearchManager` is constructed with `unattended=True` unconditionally. |
+
+`--stage-timeout` is `14400` on both. The benchmark harness imposes no timeout of
+its own — neither the UI runner nor the batch CLI puts one on the agent
+subprocess — so on this path it is the only thing that can cut a stage short.
+
+### The 30 flags it does not have
+
+`rcb_agent.py` is **not** a mirror of `main.py`. Of `main.py`'s 61 flags it
+carries 31; the other 30 are not declared, and passing one is an argparse error
+(`unrecognized arguments`), not a no-op:
+
+| Group | Absent | Why |
+| --- | --- | --- |
+| Goal | `--goal`, `--goal-file` | The goal is built from the benchmark instructions by `build_benchmark_goal`. |
+| Run location and resume | `--runs-dir`, `--resume-run`, `--redo-stage`, `--rollback-stage` | The run directory is derived from `--workspace`. There is no resume; `--export-only` is the only recovery path. |
+| Interactive gate | `--approval-mode`, `--full-auto`, `--unattended` | Hardwired: the adapter constructs `ResearchManager` with `approval_mode="agent"` and `unattended=True`. There is nothing to switch. |
+| Intake and priming | `--skip-intake`, `--resources`, `--project-root`, `--paper-corpus` | Intake is off unless `--intake` says otherwise, and the benchmark's own reference material is collected by `collect_reference_resources`. |
+| Stage graph | `--stage-graph`, `--routing`, `--graph-max-steps`, `--graph-max-visits` | Not exposed. The manager's defaults still apply: adaptive graph, `auto` routing, and the step and visit ceilings. |
+| Improvement loop | `--evolve`, `--evolve-rounds`, `--evolve-stages`, `--max-rounds` | Not exposed. The defaults still apply: the champion ratchet is on with 2 rounds, and Stages 03-06 run once. |
+| Archive | `--archive`, `--no-archive`, `--archive-steer`, `--archive-report` | A benchmark run records nothing into the cross-run archive: `rcb_agent.py` never constructs an `Archive`. |
+| Paired trials | `--trial`, `--capability`, `--arm`, `--trial-report` | Same reason — a trial arm is an archive row. |
+| Report extras | `--research-diagram` | The benchmark judge scores the report's own figures. |
+
+31 shared + 30 absent = `main.py`'s 61; 31 shared + 6 of its own = 37.
+
+The shape of the difference is the point: what is missing is the **interactive**
+surface (goal prompting, approval modes, resume and rollback) and the
+**cross-run** surface (archive, trials, topology search). Neither has a meaning
+inside a benchmark harness that launches one process per task, hands it a
+workspace, and reads a report out of it.
 
 ### Exit codes
 
@@ -491,7 +635,11 @@ agent's built-in `WebSearch` tool is disabled.
 
 ```
 python tools/web_search.py QUERY... [--json] [--model MODEL] [--max-results N]
+                                    [--no-resolve-urls]
 ```
+
+`QUERY...` is a required positional taking one or more words, joined with spaces.
+Those four options are the whole flag surface.
 
 | Flag | Default | Description |
 | --- | --- | --- |
@@ -509,6 +657,11 @@ Two backends are supported and auto-detected:
   location from `AUTOR_VERTEX_LOCATION` or `GOOGLE_CLOUD_LOCATION` (default `global`).
 
 An explicit API key wins; `AUTOR_WEB_SEARCH_BACKEND=vertex|api_key` forces the choice.
+
+Either backend needs `google-genai`, which is **not** a default dependency —
+`pip install google-genai`. The Vertex probe uses `google.auth`, a different
+distribution that can be present without it, so credentials alone are not enough
+(see [What "can actually run" means](#what-can-actually-run-means)).
 
 ### Exit codes
 
@@ -532,3 +685,128 @@ under a source link reads as a quotation, which is how a real paper acquires a s
 it never contained.
 
 To quote a source, fetch it and quote what it says.
+
+---
+
+## `tools/score_rcb_run.py`
+
+Scores a finished ResearchClawBench workspace. It drives the benchmark's own
+`score_workspace`, so every number it prints is that scorer's rather than a
+reimplementation; what it changes is the judge object and the helper that runs the
+judge calls, which is where a failed call becomes a score of zero, and it refuses
+to print a total while any call failed.
+
+```
+python tools/score_rcb_run.py --workspace PATH --bench PATH
+                              [--judge {reference,vertex}] [--model MODEL]
+                              [--key-file PATH] [--endpoint URL]
+                              [--project-id ID] [--out PATH]
+```
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--workspace PATH` | **required** | The finished benchmark workspace to score. |
+| `--bench PATH` | **required** | A checkout of ResearchClawBench. It is prepended to `sys.path` so `evaluation.score` can be imported; the scoring logic is the bench's, not this repo's. |
+| `--judge {reference,vertex}` | `reference` | Which judge scores the run. See below — this is the single most consequential flag on the tool. |
+| `--model MODEL` | `gpt-5.1` under `reference` (`REFERENCE_JUDGE_MODEL`), `claude-opus-4-5@20251101` under `vertex` (`FALLBACK_JUDGE_MODEL`) | Override the judge model id. Whatever it resolves to is printed twice — the `judge:` header line and the `TOTAL (judge …)` line — and recorded as `judge_model` in the `--out` JSON. The per-item lines carry no judge. |
+| `--key-file PATH` | `~/api.txt` (`DEFAULT_KEY_FILE`) | File holding the reference judge's key. Outside any repository on purpose: a default inside the tree is one `git add -A` away from a leak. There is deliberately no flag that takes the key itself — it would land in the shell history and in the process table. The file may be a bare token, `KEY=token`, or a quoted value. |
+| `--endpoint URL` | `REFERENCE_JUDGE_ENDPOINT` | The OpenAI-compatible base URL the reference judge is served from. Only read under `--judge reference`. |
+| `--project-id ID` | `$ANTHROPIC_VERTEX_PROJECT_ID`, else empty | Vertex project for `--judge vertex`. Empty and unset exits `2` with `Set ANTHROPIC_VERTEX_PROJECT_ID or pass --project-id.` |
+| `--out PATH` | — | Also write the full result, including `judge_model`, `judge_calls` and `judge_failures`, as JSON. |
+
+### `--judge reference` is the default, and the only comparable one
+
+`reference` means **gpt-5.1**, which is what ResearchClawBench itself scores with
+(`evaluation/.env.example`). Use it unless you cannot.
+
+The judge is part of the result, not a detail of how it was obtained. On
+identical artifacts, Gemini 2.5 Flash scored 37.0 where Claude Opus scored 20.8 —
+a spread of about sixteen points that is a property of the judge and not of the
+run. A benchmark number quoted without its judge is therefore not comparable to
+anything, which is why the tool leads with a `judge:` line, repeats the judge
+inside the `TOTAL (judge …)` line so the number cannot be copied out without it,
+and stores `judge_model` in the `--out` JSON. (The module docstring claims the
+judge is on *every* line of output; it is not — the per-item rows, the
+`workspace:` line and the `items judged:` line carry none.)
+`--judge vertex` exists for when no reference key is available;
+its numbers are internally consistent and are **not** comparable to a published
+figure.
+
+### The default only works on one kind of box
+
+`REFERENCE_JUDGE_ENDPOINT` is a site-specific Azure AI OpenAI-compatible URL, and
+the key is read from `~/api.txt`. Out of the box the tool therefore only runs
+where both of those hold: that tenancy plus a key file at that path. Elsewhere,
+either point `--endpoint` and `--key-file` at your own OpenAI-compatible
+deployment of the reference model, or fall back to `--judge vertex` and quote the
+number with its judge attached. The endpoint is in source deliberately — an
+endpoint is not a secret, the key that opens it is, and keeping the two visibly
+different is what stops the second from being pasted next to the first.
+
+### The stock defaults this tool does not inherit
+
+Each of the failure modes below records as
+`{"score": 0, "reasoning": "Failed to parse scoring response."}`, which is
+indistinguishable in the output from a criterion the report genuinely missed.
+
+None of them is fixed by raising a stock number. `score` replaces the bench's
+judge object outright (`scorer.LLMAgent = lambda **_: judge`) and its concurrency
+helper with a serial loop (`scorer.multi_thread = serial`), so the stock settings
+below are discarded rather than tuned, and what applies instead is whatever the
+tool's own judge class sends on the call.
+
+| Stock setting | Why it fails | What applies instead |
+| --- | --- | --- |
+| `max_tokens=500` | a reasoning judge spends the budget thinking and returns an empty body | `VertexJudge.__call__` sends `max_tokens=JUDGE_MAX_TOKENS` (4096). `ReferenceJudge.__call__` — the default judge — sends no token cap at all, so the bound there is the `openai` client's, not one this tool sets. |
+| `time_limit=120` | too short for a multimodal call carrying a target image plus five agent images | Neither judge class passes a timeout, so each call is bounded by whatever its client defaults to. `JUDGE_TIME_LIMIT` states the intended bound but is not passed to either judge. |
+| `multi_thread(max_workers=min(len(checklist), 16))` | concurrent multimodal calls were the actual cause of most failures | The `serial` replacement calls the judge once per checklist item, in order. It accepts a `max_workers` argument and ignores it; `JUDGE_WORKERS` records the intent, the serial loop is what enforces it. |
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Every item was judged. The total is printed with the judge's name beside it. |
+| `1` | `score_workspace` returned an error, **or** at least one judge call failed — in which case the tool prints each reason and refuses to quote a total at all. |
+| `2` | `--judge vertex` with no project id. |
+
+Requires the `openai` package for `reference`, `anthropic` for `vertex`, plus the
+bench's `structai` — `evaluation.score` imports it at module load, before the
+judge is swapped in. The two client imports sit inside the judge classes, so
+importing this module needs neither of them; the AutoR package itself still has
+no third-party runtime dependency.
+
+The same tool is described from the benchmark's side, with the worked example, in
+[researchclawbench.md](researchclawbench.md#scoring-a-run-locally).
+
+---
+
+## `tools/archive_sample_complexity.py`
+
+```
+python tools/archive_sample_complexity.py
+```
+
+**No flags.** It takes no arguments and reads nothing off disk; the sweep
+constants (`POLICIES`, `SAMPLE_SIZES`, `REPLICATES`) are edited in the file.
+
+It answers one question: how many runs the cross-run archive needs before
+`--archive-steer` would be deciding on signal rather than on noise. It walks the
+real `StageGraph.adaptive()` under synthetic routing policies, feeds the
+resulting records to the real `edge_payoffs`, and counts how many edges satisfy
+the real `EdgePayoff.believable`. Nothing in it reimplements the payoff
+arithmetic, so every number it prints is a property of `src/archive.py` and
+`src/stage_graph.py` as they stand.
+
+It prints three things and exits: a believable-edge count per policy and sample
+size, a per-edge table at the most generous policy, and a precision sweep — how
+often the edge `propose_variant` would pick turns out to be one with no true
+effect at all. Standard library only. It is not instant. `len(POLICIES) ×
+len(SAMPLE_SIZES) × REPLICATES` is 9,600 replicate *cells*, and each cell of the
+main sweep builds `n` records rather than one, so the work is
+`len(POLICIES) × REPLICATES × sum(SAMPLE_SIZES)` = 6 × 200 × 1,890 = 2,268,000
+simulated runs, plus 1,000 for the per-edge pass and 685,000 for the precision
+sweep. It is single-threaded; a full run measured 3m38s of CPU here. Run it once
+and read the tables, rather than in a loop.
+
+The reading of its output, and what it implies for `--archive-steer`, is in
+[Recursive Self-Improvement](self-improvement.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,10 @@ Three things are configurable:
 3. **Optional diagram generation** — `configs/diagram_config.yaml` or
    environment variables.
 
+One thing is *state* rather than configuration: the cross-run archive at
+`~/.autor/archive`, the only place AutoR writes outside the repository and
+outside a run directory. See [Filesystem locations](#filesystem-locations).
+
 ---
 
 ## Requirements
@@ -22,12 +26,35 @@ Three things are configurable:
 | `claude` on `PATH` ([Claude Code](https://docs.claude.com/en/docs/claude-code)) | real runs with `--operator claude`, and all Studio runs |
 | `codex` on `PATH` ([Codex CLI](https://developers.openai.com/codex/cli)) | real runs with `--operator codex` |
 | A LaTeX toolchain (`pdflatex`/`latexmk`) | Stage 07 compiling a PDF — only with `--output-format latex`; the default markdown mode needs no TeX |
-| `pip install google-genai pyyaml` | `--research-diagram` only |
+| `pip install google-genai` | the three Gemini-backed optional paths: `--web-search gemini`, `--research-diagram`, and `--cross-review` (which is wired on the `rcb_agent.py` entry point only — `main.py` accepts the flag and never uses it) |
+| `pip install pyyaml` | reading the API key out of `configs/diagram_config.yaml`; not needed if you set the key in the environment |
 
-**AutoR itself has no third-party Python dependencies.** Everything but the
-optional diagram feature runs on the standard library, which is why there is
-no `requirements.txt` — there is nothing to put in it. `pip install` is
-never a step in setting AutoR up.
+**AutoR itself has no third-party Python dependencies.** Every import of one is
+optional and guarded, which is why there is no `requirements.txt` — there is
+nothing to put in it, and setting AutoR up needs no `pip install`. The table
+above is not an exhaustive list of those guarded imports: `--paper-corpus` also
+reaches for PyMuPDF (`import fitz` in `_extract_pdf_text`), and unlike the rows
+above it degrades **silently** — every PDF in the corpus becomes a one-line
+`[PDF file: … — install PyMuPDF …]` placeholder in the researcher profile that
+seeds later stages, with no warning and no error. `pip install pymupdf` if you
+point `--paper-corpus` at PDFs. To enumerate the rest rather than trust a list,
+grep the tree for imports inside a `try`.
+
+The three do not fail alike, and only one of them is a soft *unavailable*:
+
+- **`--web-search gemini` is refused, not degraded.** `resolve_search_context`
+  in `main.py` raises whenever `SearchReadiness.hard_blocker` is set — that is,
+  when no Gemini backend is configured or `google-genai` is not importable by
+  this interpreter — so the run exits during setup, before Stage 01. It is
+  `--web-search auto`, not `gemini`, that falls back to the backend's native
+  search. (A network-restricted Codex sandbox is deliberately *not* a hard
+  blocker: it is inferred rather than observed, so it warns.)
+- **`--research-diagram` warns and continues.** The call is wrapped; a missing
+  package or key prints `Diagram generation failed: ...` and the stage stands.
+- **`--cross-review` records an unavailable verdict** — on the `rcb_agent.py`
+  path, the only one where the flag is wired. `CrossVerdict` keeps
+  `unavailable` distinct from agreement, so a reviewer that could not run is
+  not counted as one that approved.
 
 Neither CLI backend is needed for `--fake-operator` runs or for the test
 suite.
@@ -36,7 +63,8 @@ suite.
 
 ## `run_config.json`
 
-Written to each run root. Full field reference in
+Written to each run root. Every field it can hold is in the table below;
+per-field value ranges are in
 [Run Artifacts](run-artifacts.md#run_configjson).
 
 ### What is preserved on resume
@@ -51,10 +79,26 @@ The precedence rules differ slightly per field:
 | `codex_sandbox` | recorded value | |
 | `venue` | recorded value | |
 | `output_format` | recorded value | `markdown` for new runs. A run started as `latex` stays `latex` on resume unless `--output-format` says otherwise. |
-| `approval_mode` | recorded value | `--full-auto` always forces `agent`. |
+| `approval_mode` | recorded value | Three flags put an agent in the approval seat: `--approval-mode agent`, `--full-auto` and `--review-panel`. The last two force `agent` outright, on a resume as well as on a fresh run; `--approval-mode` is otherwise `None` on the CLI, which is what lets the recorded value survive. `--unattended` on its own is *not* one of them — it removes the human without installing a reviewer, so the first approval menu raises `UnattendedInputError` rather than being decided. |
 | `review_operator` | recorded value, else `operator` | |
 | `review_model` | recorded value | If you pass `--review-operator` without `--review-model`, the new reviewer backend's default is used. |
+| `stage_graph` | recorded value | `--stage-graph` defaults to `None` on the CLI, not to `DEFAULT_STAGE_GRAPH`, so resuming a `linear` run without repeating the flag keeps it linear. |
+| `routing_mode` | recorded value | Same mechanism as `stage_graph`. |
+| `evolve_rounds` | recorded value | `2` for new runs. `0` measures without polishing. `--no-evolve` also forces it to `0`, because rounds steered by a score you are not computing mean nothing. |
+| `evolve_measure` | recorded value | `true` for new runs. `--evolve-rounds N` with `N > 0` turns it back on. |
+| `archive_steer` | recorded value | `false` for new runs. |
+| `web_search` | recorded value | The *mode* (`auto`/`gemini`/`native`) is stored, never the resolved backend: `auto` is a question about the current environment, and freezing today's answer would make a resumed run assert something about the deployment that may no longer be true. |
+| `min_report_figures` | recorded value | The Stage 07 figure floor, clamped into `[1, MAX_REPORT_FIGURES]` by `resolve_min_report_figures`. `1` for new runs; `rcb_agent.py` sets it to `BENCHMARK_MIN_REPORT_FIGURES` (3). No `main.py` flag sets it. |
 | `created_at` | preserved | Never rewritten. |
+
+The settings above are the whole of `run_config.json`: `initialize_run_config`
+writes exactly this key set, and `default_run_config` returns the same one minus
+`created_at`, which only a real run can have. The five walk settings
+(`stage_graph`, `routing_mode`, `evolve_rounds`, `evolve_measure`,
+`archive_steer`) go through `normalize_walk_settings`, which exists so the field
+list is defined once instead of being restated by each reader and writer.
+Per-field value ranges are in
+[Run Artifacts](run-artifacts.md#run_configjson).
 
 The one thing that is *not* configurable per run is the runs directory itself:
 `--runs-dir` is where AutoR looks for the run, so it must match the directory
@@ -117,25 +161,47 @@ budget, and citation style, and switching late means rewriting the manuscript.
 Append a block to `templates/registry.yaml`:
 
 ```yaml
+# venue_type is "conference" or "journal".
+# style_package is matched against main.tex; use "" for a venue with none.
+# page_limit is an integer, or the string "flexible".
 my_venue_2027:
   display_name: "My Venue 2027"
-  venue_type: "conference"        # conference | journal
+  venue_type: "conference"
   official_url: "https://..."
-  style_package: "myvenue2027"    # matched against main.tex; "" for none
+  style_package: "myvenue2027"
   bib_style: "plainnat"
   citation_style: "natbib"
-  page_limit: 8                   # integer, or "flexible"
+  page_limit: 8
   refs_in_limit: false
 ```
 
-No code change is needed — the registry is read at runtime. Note that the
-parser is a small purpose-built one in `_load_template_registry`
-([`src/utils.py`](../src/utils.py)), not a full YAML parser: keep entries to
-flat `key: value` pairs under a top-level venue key, as the existing ones are.
+No code change is needed — the registry is read at runtime.
 
-`style_package` is what the [Stage 07 artifact gate](stage-contract.md#venue-matching)
-looks for in `main.tex`. A run can always override the detection with a
-`% AutoR venue: my_venue_2027` comment.
+**Two things the parser will not forgive.** `_load_template_registry`
+([`src/utils.py`](../src/utils.py)) is a small purpose-built reader, not a YAML
+implementation:
+
+- **Keep entries flat.** `key: value` pairs, indented two spaces under a
+  top-level venue key, exactly as the existing entries are. A nested mapping or
+  a list is not understood.
+- **No trailing comments.** A whole line beginning with `#` is skipped — which is
+  why the explanations above sit above the block rather than beside the fields —
+  but a comment *after* a value is swallowed into that value. The reader splits
+  on the first `:` and strips only whitespace and one layer of quotes, so
+  `venue_type: "conference"   # conference | journal` is stored as
+  `conference"   # conference | journal`. Nothing in the shipped registry carries
+  an inline comment, so nothing in the repo would catch it for you, and nothing
+  refuses the file either: `resolve_venue_key` still finds the venue by its key,
+  and the damage surfaces downstream. `format_venue_for_prompt` sends
+  `venue_type`, `page_limit`, `citation_style` and `style_package` into the
+  Stage 07 prompt verbatim, comment and all, and the corrupted `style_package`
+  becomes a marker no `main.tex` can match — the venue key and `display_name`
+  are what keep the gate passing, which is precisely why the failure is quiet.
+
+The `style_package` — along with the venue key and the `display_name` — is what
+the [Stage 07 artifact gate](stage-contract.md#venue-matching) looks for in
+`main.tex`; a venue with no style package is matched on the other two. A run can
+always override the detection with a `% AutoR venue: my_venue_2027` comment.
 
 ---
 
@@ -178,9 +244,23 @@ fail on first use. Details in
 
 ## Diagram generation (optional)
 
-`--research-diagram` generates a method illustration with the Gemini API after
-Stage 07 and injects it into the LaTeX paper. It is an enhancement: if it is
-not configured, the step prints a failure line and the run continues.
+`--research-diagram` generates a method illustration with the Gemini API once
+Stage 07 is approved, and injects it into whichever deliverable the run
+produces. `post_writing_diagram_hook` branches on the run's `output_format`:
+
+| Output format | Reads the method text from | Injects into |
+| --- | --- | --- |
+| `markdown` (the default) | the method section of `report/report.md` | `report.md`, as `![...](images/method_overview.png)`, with the image saved under `report/images/` so the path resolves relative to the report as the benchmark judge needs. The backend returns JPEG bytes whatever the filename says, so the file is re-encoded to PNG when Pillow is importable and left as `method_overview.jpg` when it is not — an honest `.jpg` beats a `.png` holding JPEG bytes |
+| `latex` | `writing/sections/method.tex` | `method.tex`, as a `figure*` block referencing `../figures/method_overview.jpg`, which is the path `pdflatex` resolves from `main.tex` rather than from the included section |
+
+Because `DEFAULT_OUTPUT_FORMAT` is `markdown`, the markdown row is what a run
+gets unless it was started with `--output-format latex`. Either way the step
+skips itself rather than failing the stage when the source text is missing or
+shorter than 100 characters.
+
+It is an enhancement, never a gate: the call is wrapped, so if it is not
+configured the run logs and prints `Diagram generation failed: ...` and
+continues.
 
 ### Setup
 
@@ -201,11 +281,15 @@ cp configs/diagram_config.template.yaml configs/diagram_config.yaml
 ```yaml
 api_keys:
   google_api_key: ""        # or gemini_api_key
-
-defaults:
-  model_name: "gemini-2.5-flash"
-  max_critic_rounds: 2
 ```
+
+That is the whole of the file AutoR reads. The shipped
+`configs/diagram_config.template.yaml` also carries a `defaults:` block
+(`model_name`, `max_critic_rounds`), and nothing consumes it:
+`_api_key_from_config_file` in [`src/web_search.py`](../src/web_search.py) is
+the file's only reader and looks at `api_keys` alone, while `src/manager.py`
+calls `post_writing_diagram_hook` without a `model_name`, so the function's own
+parameter defaults are what run. Editing those two values changes nothing.
 
 Key resolution order: `GOOGLE_API_KEY`, then `GEMINI_API_KEY`, then
 `api_keys.google_api_key`, then `api_keys.gemini_api_key` from the config file.
@@ -228,7 +312,7 @@ AutoR reads very few environment variables of its own.
 
 | Variable | Read by | Effect |
 | --- | --- | --- |
-| `GOOGLE_API_KEY` | `src/web_search.py` | Gemini key for `--research-diagram` and for `--web-search gemini`. |
+| `GOOGLE_API_KEY` | `src/web_search.py` | Gemini key for all three Gemini paths: `--research-diagram`, `--web-search gemini`, and `--cross-review`. `resolve_gemini_api_key` is the single resolver; `src/diagram_gen.py` delegates to it so the features cannot drift apart. |
 | `GEMINI_API_KEY` | `src/web_search.py` | Same, checked second. |
 | `AUTOR_WEB_SEARCH_MODEL` | `src/web_search.py` | Model for Gemini-backed web search. Defaults to `gemini-2.5-flash` on the Gemini API and `gemini-3.6-flash` on Vertex AI. |
 | `GEMINI_MODEL` | `src/web_search.py` | Same, checked second. |
@@ -247,6 +331,7 @@ Everything else — API keys, authentication, model access — belongs to the
 | Path | Default | Override |
 | --- | --- | --- |
 | Runs | `<repo>/runs/` | `--runs-dir` (resolved relative to the repository root) |
+| **Cross-run archive** | **`~/.autor/archive`** (`DEFAULT_ARCHIVE_DIR`) | **`--archive PATH`; `--no-archive` writes nothing** |
 | Studio project index | `<repo>/.autor/projects.json` | `python studio.py --metadata-root` |
 | Prompt templates | `<repo>/src/prompts/` | — (derived from `--repo-root` in the Studio) |
 | Venue registry | `<repo>/templates/registry.yaml` | — |
@@ -254,17 +339,84 @@ Everything else — API keys, authentication, model access — belongs to the
 
 `runs/`, `.autor/`, and `configs/diagram_config.yaml` are all gitignored.
 
+**The archive is the only state AutoR writes outside the repository and outside
+a run directory.** It lives under the user's home rather than the checkout on
+purpose: it outlives any one clone, and an archive inside a clone would be
+deleted with it. Each finished run records its route and measured fitness there,
+and each graph edge is compared against runs that reached the same node and
+*declined* it. Recording is best-effort — a failure to record warns and does not
+end the run — and it is recording only: the archive cannot change the topology a
+run uses unless `--archive-steer` says so, and even then it may only reorder
+edge preferences, never open a guarded edge. `--archive-report` and
+`--trial-report` read it and exit; both are refused under `--no-archive`,
+because there is nothing to read.
+
 ---
 
 ## Hard-coded limits
 
-These are constants in [`src/utils.py`](../src/utils.py) rather than settings.
-Change them in source if you must, and expect the tests to have an opinion.
+Constants rather than settings. Change them in source if you must, and expect
+the tests to have an opinion. These tables are a **selection, not an
+inventory**: they cover the defaults a flag overrides and the thresholds most
+likely to explain a refusal you are looking at, but there are gating constants
+under `src/` that are not here. `grep -rnE '^[A-Z_]+ *=' src/` is the
+authoritative list.
 
-| Constant | Value | Meaning |
-| --- | --- | --- |
-| `MAX_STAGE_ATTEMPTS` | 5 | Default attempts before a stage escalates to you. This one *is* overridable per run, with `--max-attempts`. |
-| `DEFAULT_VENUE` | `neurips_2025` | Venue when `--venue` is omitted. |
-| `DEFAULT_CODEX_SANDBOX` | `workspace-write` | Codex sandbox when unspecified. |
-| stage timeout | 14400 s | Per-attempt ceiling — this one *is* a flag, `--stage-timeout`. |
-| handoff window | 4 stages | How many prior handoff summaries enter a prompt. |
+### Defaults a flag can override
+
+| Constant | Module | Value | Flag |
+| --- | --- | --- | --- |
+| `MAX_STAGE_ATTEMPTS` | `utils.py` | 5 | `--max-attempts` — attempts per stage before it escalates or is auto-skipped. `rcb_agent.py` defaults to 8 instead. |
+| `DEFAULT_VENUE` | `utils.py` | `neurips_2025` | `--venue` |
+| `DEFAULT_CODEX_SANDBOX` | `utils.py` | `workspace-write` | `--codex-sandbox` |
+| `DEFAULT_OUTPUT_FORMAT` | `utils.py` | `markdown` | `--output-format` |
+| `DEFAULT_STAGE_GRAPH` | `utils.py` | `adaptive` | `--stage-graph` |
+| `DEFAULT_ROUTING_MODE` | `utils.py` | `auto` | `--routing` (the flag is not named after the field) |
+| `DEFAULT_WEB_SEARCH_MODE` | `utils.py` | `auto` | `--web-search` |
+| `DEFAULT_EVOLVE_ROUNDS` | `utils.py` | 2 | `--evolve-rounds` (`DEFAULT_ROUNDS` in `evolution.py` is the same number) |
+| `DEFAULT_MAX_STEPS` | `stage_graph.py` | 20 | `--graph-max-steps` — stage executions in one walk, whatever the per-node budgets allow |
+| `DEFAULT_MAX_VISITS` | `stage_graph.py` | 3 | `--graph-max-visits` — entries into one stage; the fourth is a loop |
+| `DEFAULT_MAX_DELIBERATIONS` | `deliberation.py` | 3 | `--max-deliberations` — cruxes a run may escalate to a panel before the budget is refused |
+| `DEFAULT_ARCHIVE_DIR` | `main.py` | `~/.autor/archive` | `--archive`, `--no-archive` |
+| stage timeout | `main.py` argparse default | 14400 s (4 h) | `--stage-timeout` |
+| auto-skip budget | `main.py` argparse default | 3 stages | `--max-auto-skips` |
+| rounds of Stages 03–06 | `main.py` argparse default | 1 | `--max-rounds` |
+
+### The Stage 07 deliverable
+
+No `main.py` flag reaches any of these; they are the shape of the deliverable.
+
+| Constant | Module | Value | Meaning |
+| --- | --- | --- | --- |
+| `MIN_REPORT_CHARS` | `utils.py` | 1200 | Below this, `report.md` is a stub rather than a deliverable. |
+| `MIN_REPORT_FIGURES` | `utils.py` | 1 | The published-figure floor for an ordinary run, and the `default_run_config` value of `min_report_figures`. |
+| `BENCHMARK_MIN_REPORT_FIGURES` | `utils.py` | 3 | The floor `rcb_agent.py` sets instead. Most ResearchClawBench tasks carry two or more image criteria. |
+| `MAX_REPORT_FIGURES` | `utils.py` | 5 | The ceiling, and what `resolve_min_report_figures` clamps the floor to. Only the first five images a judge finds are shown, in filesystem order. |
+| `MAX_HEADLINE_NUMBERS` | `report_plan.py` | 8 | Numbers the report leads with, not an inventory of everything measured. |
+| `MIN_SHOWS_CHARS` | `report_plan.py` | 40 | A figure slot's `shows` sentence; also the floor on `no_figures_because`. |
+| `MIN_DROP_REASON_CHARS` | `report_plan.py` | 20 | A `dropped_because`; also `MIN_BRANCH_CHARS` for `if_supported`/`if_refuted`, and for the `why_not` on an unattempted `task_output`. |
+| `MIN_EXPLORATORY_SLUG_CHARS` | `report_plan.py` | 3 | A slot that supports `exploratory:<slug>` needs a slug this long, so `exploratory:` cannot be a wildcard five slots share. |
+| `JUDGE_VISIBLE_PREFIX_CHARS` | `report_plan.py` | 10000 | How much of the prose a figure grader reads, so the lead figure has to be referenced inside it. |
+
+### Evidence, review and the archive
+
+| Constant | Module | Value | Meaning |
+| --- | --- | --- | --- |
+| `MIN_SEEDS_FOR_A_VERDICT` | `experimental_protocol.py` | 2 | A `supported`/`refuted` verdict on one run needs a written `single_run_justification`. Not a statistical threshold — a floor under "we ran it more than once". |
+| `MIN_ARTIFACT_BYTES` | `rubric.py` | 32 | Below this a file is not evidence a stage produced anything. |
+| `MIN_QUOTE_CHARS` | `stage_comments.py` | 12 | An anchored comment must quote at least this much to be locatable. |
+| `MIN_OBLIGATION_CHARS` / `MAX_OBLIGATIONS` | `obligations.py` | 20 / 30 | What a later stage owes, and how much of it may accumulate. |
+| `MIN_RULE_CHARS` / `MAX_RULES` | `review_policy.py` | 25 / 40 | Standing rules learned from this run's own refusals. |
+| `MIN_REASON_CHARS` | `cross_reviewer.py` | 40 | A cross-model *refusal* shorter than this is ignored and recorded as agreement: a veto that cannot be acted on should not bounce a stage. |
+| `MIN_QUESTION_CHARS` | `deliberation.py` | 25 | A crux request shorter than this is dropped before the panel is seated — "what should we do about the data?" has no answer. |
+| `DEFAULT_MIN_GAIN` | `evolution.py` | 0.005 | Rubric total a polish round must gain to count as an improvement. |
+| `DEFAULT_PATIENCE` | `evolution.py` | 2 | Flat rounds before a stage is declared polished. |
+| `DEFAULT_MIN_GAIN` | `archive.py` | 0.02 | Mean fitness a challenger topology must beat the incumbent by. Roughly one rubric criterion moving a quarter of its range. |
+| `DEFAULT_MIN_OBSERVATIONS` | `archive.py` | 6 | Runs an edge needs before the archive will act on it. **Derived, not written down**: `minimum_arms_for(ALPHA, family=len(REVISIT_EDGES) + len(STAGES))`, so adding an edge re-corrects it instead of silently under-correcting. |
+| `MIN_PAIRS_FOR_SIGNIFICANCE` | `trials.py` | 6 | Below this, an exact two-sided sign-flip test cannot reach p < 0.05 at *any* effect size, because it bottoms out at 2 / 2ⁿ. A smaller trial is labelled `underpowered`. |
+
+### Prompt assembly
+
+| What | Where | Value | Meaning |
+| --- | --- | --- | --- |
+| handoff window | `build_handoff_context(max_stages=…)` in `utils.py` | 4 stages | How many prior handoff summaries enter a prompt. A default parameter, not a module constant. |

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,26 +21,51 @@ python -m unittest discover -s tests -p "test_*.py"
 That is the whole setup. There is no virtualenv step, no `pip install`, and no
 build.
 
-**AutoR has no third-party Python dependencies.** Everything except optional
-diagram generation runs on the standard library. Python 3.10+ is the only hard
-requirement; CI runs 3.12.
+**AutoR has no third-party Python dependencies.** The runtime imports nothing
+outside the standard library — even the venue registry is read by a hand-rolled
+line parser in `src/utils.py` rather than by a YAML library, and the skill
+frontmatter reader (`_parse_frontmatter`) is deliberately minimal for the same
+reason. Python 3.10 is the floor; CI runs 3.12. The full suite passes on both.
 
 Neither backend CLI is needed for development — the test suite runs against
 fakes and temp directories, and `--fake-operator` exercises the full workflow
 without a backend.
 
-Optional, for `--research-diagram` work only:
+Optional packages, none of them needed by any test. The two worth installing
+first:
 
 ```bash
 pip install google-genai pyyaml
 ```
+
+`google-genai` is used by three paths — `--web-search gemini` and
+`--cross-review`, which both reach it through `build_genai_client` in
+`src/web_search.py`, and `--research-diagram` in `src/diagram_gen.py`. `pyyaml`
+is used by exactly one function, `_api_key_from_config_file` in
+`src/web_search.py`, which reads a key out of `configs/diagram_config.yaml` if
+you keep one there. Both degrade to a recorded *unavailable* or a printed
+warning rather than to a crash, which is why the suite never installs them.
+
+`src/diagram_gen.py` also reaches for `pillow` and `json_repair`, each inside a
+`try` with a working fallback — `_convert_to_jpeg_b64` returns the base64 string
+it was handed, `_convert_to_png` returns the original path, and the critic's
+reply falls back to `json.loads`. They are worth installing if you work on
+diagrams, and they are not dependencies.
+
+One tool is the exception to *optional*. `tools/score_rcb_run.py` builds a judge,
+and the constructor's first statement is a bare import: `from openai import
+OpenAI` in `ReferenceJudge.__init__`, which is the default `--judge reference`,
+and `from anthropic import AnthropicVertex` in `VertexJudge.__init__` under
+`--judge vertex`. Neither import sits in a `try`, so a missing package raises
+`ModuleNotFoundError` rather than degrading. No test calls either `__init__`,
+which is why the suite still installs nothing.
 
 ---
 
 ## Tests
 
 ```bash
-# Everything (~69s, 1826 tests across 83 modules, no third-party dependency)
+# Everything (~70s, 1826 tests across 82 modules, no third-party dependency)
 python -m unittest discover -s tests -p "test_*.py"
 
 # Verbose
@@ -55,32 +80,61 @@ python -m unittest tests.test_manager_smoke.ManagerSmokeTests.test_manager_run_c
 
 Tests are stdlib `unittest`. They create temporary run directories, drive the
 manager with a fake operator, and assert on files. They do not call any
-network service, and they do not need a backend CLI installed.
+network service, and they do not need a backend CLI installed. One test skips
+by design (the markdown-report assertion in LaTeX mode); everything else runs
+everywhere.
 
 ### Coverage map
 
-| Area | Tests |
+Every test module in `tests/` is listed. Two files there are not test modules
+and so do not appear: `__init__.py`, and `prereg_support.py`, which builds the
+minimal valid validity-chain artifacts a hand-assembled run needs. Rebuild the
+list with `ls tests/test_*.py`.
+
+Some rows below are genuinely arbitrary. A test that drives the whole manager
+in order to pin one validator could sit in either place, and several modules
+import six `src` modules apiece; the row records what the module is *about*, per
+its own docstring, not everything it touches.
+
+| Area | Test modules |
 | --- | --- |
-| Workflow end to end | `test_manager_smoke.py`, `test_manager_workflow.py`, `test_cli_smoke.py` |
-| Operator sessions, resume fallback, repair | `test_operator_recovery.py`, `test_bounded_recovery.py`, `test_operator_codex.py` |
-| Stage contract and validation | `test_utils_contracts.py`, `test_decision_ledger.py`, `test_revision_delta.py` |
-| Run state, rollback, handoff | `test_run_manifest.py`, `test_stage_rollback.py`, `test_stage_handoff.py` |
-| Manifests and ledgers | `test_artifact_index.py`, `test_experiment_manifest.py`, `test_hypothesis_manifest.py`, `test_evidence_ledger.py` |
-| Writing and packaging | `test_writing_pipeline.py`, `test_foundry_paper_package.py`, `test_release_package.py` |
+| Workflow end to end | `test_manager_smoke.py`, `test_manager_workflow.py`, `test_cli_smoke.py`, `test_fake_pipeline_end_to_end.py`, `test_graph_walk.py`, `test_auto_skip_preserves_a_valid_draft.py`, `test_unattended.py` |
+| Graph, routing, rounds | `test_stage_graph.py`, `test_router.py`, `test_graph_cost.py`, `test_research_rounds.py` |
+| Policy dials | `test_rigor.py`, `test_effort.py` |
+| Stage contract and stage summaries | `test_utils_contracts.py`, `test_stage_handoff.py`, `test_decision_ledger.py`, `test_revision_delta.py`, `test_listed_file_patterns.py`, `test_path_reference_heuristic.py`, `test_prompt_gate_correspondence.py` |
+| Prompt assembly and context | `test_information_flow.py`, `test_settled_reasoning.py`, `test_prompt_fragments.py`, `test_run_skills.py` |
+| The validity chain | `test_preregistration.py`, `test_experimental_protocol.py`, `test_validity_review.py`, `test_hypothesis_manifest.py`, `test_evidence_ledger.py`, `test_report_plan.py`, `test_report_plan_robustness.py`, `test_report_plan_stamping.py`, `test_task_deliverables_contract.py` |
+| Manifests, indexes, rollback | `test_run_manifest.py`, `test_stage_rollback.py`, `test_artifact_index.py`, `test_experiment_manifest.py`, `test_writing_pipeline.py` |
+| Improvement loop | `test_rubric.py`, `test_evolution.py` (also covers `pareto.py`), `test_ideation_panel.py` |
+| Review and approval | `test_review_panel.py`, `test_panel_unreachable.py`, `test_cross_reviewer.py`, `test_review_policy.py`, `test_obligations.py`, `test_stage_comments.py`, `test_deliberation.py`, `test_crux_repeat.py`, `test_verdict_extraction.py`, `test_reviewer_unreadable_verdict.py` |
+| Archive and self-measurement | `test_archive.py`, `test_archive_evidence.py`, `test_archive_exploration.py`, `test_archive_exploration_wiring.py`, `test_decisions.py`, `test_trials.py`, `test_scorecard.py` |
+| Operators, recovery, backend health | `test_operator_recovery.py`, `test_operator_codex.py`, `test_bounded_recovery.py`, `test_backend_health.py` |
+| Web search | `test_web_search.py`, `test_mcp_web_search.py` |
+| Report output and the benchmark adapter | `test_markdown_report.py`, `test_report_figure_floor.py`, `test_rcb_adapter.py`, `test_rcb_report_source.py`, `test_rcb_scoring.py`, `test_score_rcb_run.py` (which also holds the repository-wide secret scan), `test_score_rcb_run_wiring.py` |
 | Intake and bootstrap | `test_intake.py`, `test_bootstrap.py`, `test_project_bootstrap.py` |
+| Packaging and diagrams | `test_foundry_paper_package.py`, `test_release_package.py`, `test_diagram_gen.py` |
 | Studio | `test_studio_service.py`, `test_studio_http.py` |
-| Terminal UI | `test_terminal_ui.py` |
-| Diagram generation | `test_diagram_gen.py` |
+| Terminal UI | `test_terminal_ui.py`, `test_result_panel.py` |
+| The docs themselves | `test_doc_counts.py` (see [Documentation gates](#documentation-gates)) |
+
+Two of these modules are worth knowing about before you write a test that
+duplicates them. `test_prompt_gate_correspondence.py` treats the prompt
+templates and the validators as two encodings of one contract and fails when
+they drift, and `test_doc_counts.py` does the same for prose. Neither is
+optional scaffolding; both have caught real drift.
 
 ### Before you push
 
 ```bash
-python -m py_compile main.py studio.py src/*.py src/*/*.py tests/*.py
+python -m py_compile main.py studio.py rcb_agent.py src/*.py src/*/*.py tools/*.py tests/*.py
 python -m unittest discover -s tests -p "test_*.py"
 ```
 
-The compile step catches syntax errors in modules no test happens to import.
-Note that it covers more than CI does — see below.
+The compile step catches syntax errors in modules no test happens to import —
+`tools/` and `rcb_agent.py` are the ones with the least test pressure on them.
+Note that it covers more than CI does; see below. (CONTRIBUTING.md prints a
+narrower form of the same command. The line above is a superset of it and costs
+nothing extra.)
 
 ---
 
@@ -93,12 +147,89 @@ pushes to `main`, and manual dispatch:
 2. `python -m py_compile main.py src/*.py tests/*.py`
 3. `python -m unittest discover -s tests -p "test_*.py" -v`
 
-The compile step's globs are one level deep, so `src/backend/`,
-`src/platform/`, and `studio.py` are compiled only insofar as a test imports
-them. Run the wider compile locally.
+The compile step's globs are one level deep and rooted at three paths, so
+`studio.py`, `rcb_agent.py`, `tools/`, `src/backend/` and `src/platform/` are
+compiled only insofar as a test imports them. Run the wider compile locally.
 
 CI installs nothing. Adding a third-party dependency would change that, which
 is a good reason to avoid one.
+
+---
+
+## Documentation gates
+
+Two tests police the documentation, and both fail the ordinary suite rather
+than a separate docs job. You will meet them if you edit a `.md` file.
+
+### `tests/test_doc_counts.py`
+
+**A spelled-out numeral immediately before a countable noun must equal the live
+symbol.** The scan is deliberately narrow: a fixed list of `(noun, value)` pairs
+in `COUNTED_NOUNS`, matched case-insensitively across line breaks, over the
+three files in `TRACKED_DOCS`. Only word numerals are checked — `NUMBER_WORDS`
+runs from one to twenty-five — so writing the digit is always safe, and is the
+right move when you are unsure. Three further assertions in the same module pin
+the rubric-criteria count in `docs/self-improvement.md`, the stage count in the
+README, and the number of dotted edges the README's mermaid diagram actually
+draws against `len(REVISIT_EDGES)`.
+
+To protect a new claim, add a row:
+
+```python
+# tests/test_doc_counts.py
+from src.ideation_panel import DEFAULT_LENSES        # import the live symbol
+from src.information_flow import CHANNELS
+
+COUNTED_NOUNS: tuple[tuple[str, int], ...] = (
+    ("typed channels", len(CHANNELS)),
+    ...
+    ("proposer lenses", len(DEFAULT_LENSES)),        # your new row
+)
+```
+
+Three things to get right. The value must be `len(SYMBOL)` or a call that
+derives it — a literal here is the same rot you are trying to prevent, moved
+one file over. The noun must be the *whole* phrase you want matched, because
+the pattern anchors on a word boundary at each end: `"typed channels"` does not
+also catch a bare `"channels"`. And the live value must stay inside
+`NUMBER_WORDS`; a symbol that grows past twenty-five raises a `KeyError` from
+`spelled()` instead of reporting a mismatch, so extend the table in the same
+commit.
+
+**No doc may cite a line number in this repo's own source.** Every
+`something.py:123` in a `*.md` file at the repo root or in `docs/` is put to
+`_is_in_this_repo`, which resolves exactly three ways: the reference as a path
+relative to the repo root, its basename found by `rglob` under `src/`, or its
+basename sitting at the repo root. `EXTERNAL_REFERENCE_PREFIXES` exempts
+references into a pinned outside artifact.
+
+Read that list as a floor, not as coverage. A *bare basename* belonging to
+`tools/` or `tests/` resolves none of the three ways, so `score_rcb_run.py:42`
+passes the gate — while the same citation written with its directory in front
+of it is caught by the first resolution and fails. The rule is the same whether
+or not the test can see you break it: cite the symbol —
+`validate_stage_artifacts`, not a line — because a grep finds a symbol wherever
+it moved and a line number rots on the next edit above it.
+
+### `tests/test_score_rcb_run.py`
+
+`NoSecretInTheRepositoryTest` runs `git ls-files`, reads every tracked file
+under 2 MB, and fails on any match for the regex `sk-[A-Za-z0-9_-]{16,}` — an
+OpenAI-shaped judge key. It skips itself when the tree is not a git checkout,
+and it does not see untracked files, so `git add` first if you want the answer.
+
+The trap is that it is a plain regex over prose, not over code. Anywhere the
+letters `sk` are followed by a hyphen and then 16 or more characters drawn from
+letters, digits, underscores and further hyphens, the scan sees a key — and an
+ordinary hyphenated English phrase can produce exactly that, with no secret
+anywhere near it. That has already flagged one innocent sentence in these docs.
+Before you push a docs change:
+
+```bash
+git grep -nE 'sk-[A-Za-z0-9_-]{16,}'
+```
+
+If it hits your sentence, rewrite the sentence — do not add an exemption.
 
 ---
 
@@ -106,11 +237,24 @@ is a good reason to avoid one.
 
 Match the file you are editing. The house style, as it stands:
 
-- **`from __future__ import annotations`** at the top of every module, with
-  modern annotations (`str | None`, `list[str]`) throughout.
+- **`from __future__ import annotations`** in every module, with modern
+  annotations (`str | None`, `list[str]`) throughout. Sweeping every `.py`
+  under `src/` plus `main.py`, `studio.py`, `rcb_agent.py` and `tools/` turns up
+  five files without it: the two package `__init__.py` files, the two re-export
+  shims (`src/studio_http.py` and `src/studio_service.py`, each a single import
+  plus an `__all__`), and `studio.py`, which is not a shim — it imports `main`
+  out of `src/backend/studio_http` and calls it under a `__main__` guard.
 - **Frozen dataclasses** for anything serialized, with explicit `to_dict` and
-  `from_dict`. Do not rely on `asdict`; the round trip is written out so the
-  on-disk shape is visible in one place.
+  `from_dict`. Most dataclasses in `src/` are `frozen=True`, but the mutable
+  remainder is not only ledgers, so do not read the pattern as "frozen unless it
+  accumulates". Alongside the genuine ledgers (`GraphState`, `ObligationLedger`,
+  `EffortPlan`, `IdeaPool`) sit one-shot scan results — `src/bootstrap.py` and
+  `src/project_bootstrap.py` between them declare more than a dozen plain
+  `@dataclass` types — plus small verdict records such as `TierDecision`,
+  `Resolution`, `Scorecard` and `RevisionOutcome`. Freeze by default; leave it
+  off when a field is assigned after construction, and match the file you are
+  in. Write the round trip out as named methods even when the body is one
+  `asdict` call, so the on-disk shape is visible in one place.
 - **Defensive `from_dict`.** Coerce, default, and skip malformed entries
   rather than raising. A corrupt artifact should degrade a view, not kill a
   six-hour run.
@@ -119,10 +263,12 @@ Match the file you are editing. The house style, as it stands:
   what to do.
 - **Paths come from `RunPaths`.** Never join run paths by hand — add a field
   to `RunPaths` and `build_run_paths` instead.
-- **Rendering goes through `TerminalUI`.** The manager does not print.
-- **Local imports for cycles.** `src/utils.py` imports validators inside
-  functions to avoid import cycles; keep that pattern rather than
-  restructuring around it.
+- **Rendering goes through `TerminalUI`.** The manager does not print: there is
+  no bare `print(` anywhere in `src/manager.py`, and its own `_print` helper is
+  a one-line forward to `self.ui.write`.
+- **Local imports for cycles.** `src/utils.py` imports its validators inside
+  the functions that call them to avoid import cycles; keep that pattern rather
+  than restructuring around it.
 - **Comments explain *why*.** The existing comments mostly record a decision
   or a trap — for example why `claims.json` accepts both `statement` and
   `claim`. Match that density; do not narrate the code.
@@ -133,9 +279,21 @@ Match the file you are editing. The house style, as it stands:
 
 ### Change what a stage asks for
 
-Edit `src/prompts/<slug>.md`. No code change, no test change. This is the
-right lever for most behaviour changes, and it is worth trying before
-reaching for anything below.
+Edit the stage's template under `src/prompts/`. The default name is the slug on
+the `StageSpec`, which already carries the stage number (`03_study_design.md`).
+No code change, no test change. This is the right lever for most behaviour
+changes, and it is worth trying before reaching for anything below.
+
+**Check which file the run actually loads first.** `load_prompt_template` builds
+two candidates and takes the first that exists: `<slug>_<format>.md`, where the
+format comes from `resolve_output_format`, and only then `StageSpec.filename`
+(the plain `<slug>.md`). Stage 07 is the one stage that ships a variant, and
+because `DEFAULT_OUTPUT_FORMAT` is `markdown` and every `load_prompt_template`
+call in `src/manager.py` — `_build_stage_prompt` and the two bootstrap prompt
+builders — passes `selected_output_format(paths)`, an ordinary run reads
+`07_writing_markdown.md`. Editing `07_writing.md` moves nothing until the run is
+started with `--output-format latex`. Every other stage has one template, so the
+fall-through is the only path it ever takes.
 
 ### Add a venue
 
@@ -168,19 +326,46 @@ Requirements are cumulative — a check under `>= 5` also applies at Stage 8.
 ### Add a stage
 
 1. Add a `StageSpec` to `STAGES` in `src/utils.py`.
-2. Create `src/prompts/<NN>_<slug>.md`.
+2. Create `src/prompts/<slug>.md` — `StageSpec.filename` is just
+   `f"{slug}.md"`, so the file has to be named for the slug exactly.
 3. Extend `validate_stage_artifacts` if the stage owns an artifact class.
-4. Check anything that hard-codes stage numbers — the artifact gate, the
-   Stage 02 hypothesis rules, `writing_manifest`, Studio stage display names.
+4. Check everything that hard-codes a stage number — and enumerate it with
+   `grep -rn 'stage.number' src/` rather than from a list in a doc, because the
+   list is longer than the places you would think to look. It runs past the
+   `stage.number >= N` ladder in `validate_stage_artifacts` into the per-stage
+   rubric checks in `src/rubric.py`, the fake operator's per-stage artifact
+   writer (`_write_fake_stage_artifacts`), the gates inside
+   `_build_stage_prompt` in `src/manager.py` that freeze the preregistration,
+   stamp the report plan and inject a missing-hypotheses block, and the extra
+   prompt rule `_prohibitions` in `src/evolution.py` appends from Stage 05 on.
+   Equality tests are their own set: `src/prompt_fragments.py`, `reviewed_stage_for` in
+   `src/validity_review.py` (Stage 06 answers 05, Stage 07 answers 06), and
+   `ROUND_CLOSING_STAGE_NUMBER` in `src/research_rounds.py`. The stage graph is
+   the other half: it keys its edge table and `_ADVANCE_GUARDS` on slugs rather
+   than numbers, so both need a new entry.
 
 Stage numbers appear in enough places that this is the most invasive change on
-this list. Grep for `stage.number` before you start.
+this list.
+
+The Studio is *not* on that list. It holds no table of stage display names: the
+SPA renders `StageSpec.stage_title` exactly as `run_manifest.json` recorded it,
+`studio_runner` finds the stage after a gate by taking the first `STAGES` entry
+whose number is larger, and `studio_service` only ever compares one
+`StageSpec.number` against another. All of that absorbs a new stage untouched.
+The exception is the project card's progress ring in
+`src/frontend/static/app.js`, which hard-codes the stage count more than once:
+the approved-stage count is divided by 8 for the percentage, printed as
+`${approvedCount}/8` in the ring label, and compared against 8 to decide the
+"done" state. Search the file for the literal, not for the division.
 
 ### Add an execution backend
 
 Implement [`OperatorProtocol`](../src/operator_protocol.py), or subclass
-`ClaudeOperator` and override `_prepare_invocation` — that is all
-`CodexOperator` does, in about 100 lines.
+`ClaudeOperator` and override `_prepare_invocation`. `CodexOperator` is the
+worked example, and it is five methods: `__init__`, where the Codex-specific
+construction lands; `_prepare_invocation`; `_select_effective_session_id`; and
+the two workspace-alias helpers, `_ensure_workspace_alias` and
+`_rewrite_prompt_for_alias`.
 
 You will need to handle:
 
@@ -197,52 +382,162 @@ name to the `--operator` choices.
 ### Change the approval policy
 
 `AutomatedReviewer` in [`src/approval_agent.py`](../src/approval_agent.py)
-returns a `ReviewDecision`. It is the only thing standing between a
-`--full-auto` run and unattended advancement, so changes here should make it
-stricter, not more permissive.
+returns a `ReviewDecision`. Changes here should make it stricter, not more
+permissive — but know which runs it is actually the gate for.
+
+`create_reviewer` returns a `ReviewPanel` instead whenever `use_panel` is set,
+and `use_panel` is `args.review_panel`, which `--rigor max` turns on through
+`_LEVEL_FEATURES` before the reviewer is built. Two separate questions, then.
+Whether a reviewer is built at all is `approval_mode == "agent"`, which
+`--full-auto`, `--review-panel` and `--approval-mode agent` each reach on their
+own. Which reviewer it is turns only on `args.review_panel`: `--full-auto` or
+`--approval-mode agent` alone gets `AutomatedReviewer`, and anything that sets
+`review_panel` — `--review-panel`, or `--rigor max` with no other flag — gets
+the panel. Under a panel, `main.py` still builds an `AutomatedReviewer` and
+hands it to the manager as `solo_reviewer`,
+but the manager only reaches for it when `effort_plan.is_routine(stage)` — so
+editing this class then changes the routine-stage fallback and nothing else.
+`ReviewPanel` in [`src/review_panel.py`](../src/review_panel.py) is the other
+half of the same decision; both satisfy one `review_stage` contract, which is
+why the manager never learns which it got.
 
 ---
 
 ## Repository layout
 
+Where things live, one line each. This is a layout, not a module reference:
+[architecture.md](architecture.md) has the responsibility table, and
+[framework.md](framework.md) has the argument for why the groups are separated
+at all. Every module under `src/` appears here except the two package
+`__init__.py` files; re-derive with `find src -name '*.py'`.
+
+Two mismatches to expect when you read the two pages side by side. Not every
+module below has a row of its own in architecture.md's module map:
+`settled_reasoning.py` is absent from that page altogether, while
+`run_skills.py` and the two top-level Studio shims are mentioned only inside
+another row's prose or in the paragraph after the Studio table. Diff the two
+lists rather than trusting either. And the grouping is close but not identical:
+architecture.md orders Improvement →
+Self-measurement → Review where this page orders Improvement → Review →
+Self-measurement, it files `archive.py` under Improvement and
+`ideation_panel.py` under Review, and it calls the group named "Output and
+adapters" below plain "Output". Neither page is generated from the other, so
+adding a module means adding it twice.
+
 ```
-main.py                     terminal entry point
-studio.py                   Studio entry point (shim)
+main.py                     terminal entry point: CLI parsing, no workflow logic
+studio.py                   Studio entry point (shim over src/backend/studio_http)
+rcb_agent.py                ResearchClawBench adapter entry point
+```
+
+```
 src/
-  manager.py                the control loop
-  operator*.py              backend adapters + protocol
+  # Policy — which optional machinery this run uses at all
+  rigor.py                  the one dial: fast / standard / thorough / max
+  effort.py                 routine vs deliberative stages, and what that spent
+
+  # The walk — which move is admissible, and which one is taken
+  manager.py                ResearchManager, the control loop
+  stage_graph.py            nodes, edges, guards, visit budgets, both topologies
+  router.py                 the agent's pick among admissible moves, and refusals
+  research_rounds.py        Stages 03-06 as a repeatable round
+  terminal_ui.py            all terminal rendering
+
+  # Gates — what a stage must produce to be accepted
   utils.py                  contract layer: stages, paths, prompts, validation
-  manifest.py               run_manifest.json
-  artifact_index.py         artifact scanning and schema inference
-  experiment_manifest.py    results/experiment_manifest.json
-  evidence_ledger.py        literature + citation validation
-  hypothesis_manifest.py    Stage 02 typed claims
-  writing_manifest.py       Stage 07 support and layout review
-  intake.py                 Stage 00 and resource ingestion
+  manifest.py               run_manifest.json: lifecycle, rollback, staleness
+  preregistration.py        freeze, amend, adjudicate, trace
+  hypothesis_manifest.py    Stage 02 typed T*/H*/C* claims
+  experimental_protocol.py  primary metric, seeds, per-baseline competence
+  report_plan.py            figures committed at Stage 03, enforced at 03/06/07
+  deliverables.py           did the run answer what the task actually asked?
+  evidence_ledger.py        sources.json / claims.json, and citation verification
+  artifact_index.py         scans data/, results/, figures/ into artifact_index.json
+  experiment_manifest.py    results/experiment_manifest.json over that index
+  writing_manifest.py       Stage 07 support scan and layout review
+  validity_review.py        the adversarial pass after Stages 05 and 06
+
+  # Improvement — which draft survives
+  rubric.py                 weighted criteria read off disk, no backend call
+  evolution.py              the champion ratchet and the verdict-drift rejection
+  pareto.py                 non-dominated drafts kept beside the champion
+  ideation_panel.py         Stage 02 divergence into a scored candidate pool
+
+  # Review — the critics, two of which are the gate
+  approval_agent.py         AutomatedReviewer, the solo approval gate
+  review_panel.py           five seats, cross-examination, chair synthesis
+  cross_reviewer.py         a second model family auditing an approval; veto only
+  deliberation.py           the crux panel: 4 voices, resolved into a falsifiable answer
+  stage_comments.py         anchored comments, diffed for collateral change
+  obligations.py            what an approval says a later stage still owes
+  review_policy.py          standing rules learned from this run's own refusals
+
+  # Self-measurement — did any of the above earn its cost?
+  scorecard.py              reads the feature ledgers into one end-of-run verdict
+  archive.py                cross-run routes and edge payoffs (~/.autor/archive)
+  decisions.py              "was offered the edge and declined" — the control arm
+  trials.py                 paired A/B trials over archived runs
+  inference.py              exact permutation tests and attainable-p floors
+
+  # Context and inputs — what a stage gets to see
+  information_flow.py       the typed channels, with declared readers per stage
+  settled_reasoning.py      builds the settled-reasoning channel for Stage 07
+  prompt_fragments.py       the rules every stage prompt shares, held once
+  intake.py                 Stage 00 clarification and resource ingestion
   bootstrap.py              --paper-corpus
   project_bootstrap.py      --project-root
-  approval_agent.py         --full-auto reviewer
-  terminal_ui.py            all terminal rendering
-  diagram_gen.py            optional Gemini diagrams
-  platform/foundry.py       paper and release packaging
-  prompts/                  per-stage templates
+  prompts/                  stage templates by slug, plus intake, bootstrap, 07 markdown
   skills/                   agent skills installed into each run
   run_skills.py             installs src/skills/ into <run>/.claude/skills/
-  backend/                  Studio service, HTTP, runner, sessions, notebook
-  frontend/static/          the Studio SPA (no build step)
-templates/registry.yaml     venue registry
-configs/                    optional diagram config template
-tests/                      unittest suite
-docs/                       this documentation
+
+  # Execution — the backend, and everything around it
+  operator_protocol.py      the interface the manager depends on
+  operator.py               ClaudeOperator: sessions, streaming, resume, repair
+  operator_codex.py         CodexOperator: subclass overriding the invocation
+  web_search.py             Gemini-backed search and pre-run readiness assessment
+  mcp_web_search.py         stdlib JSON-RPC MCP stdio server exposing that tool
+  backend_health.py         "unreachable" told apart from "the research failed"
+
+  # Output and adapters
+  platform/foundry.py       paper package and release package
+  diagram_gen.py            optional Gemini method diagram
+  rcb.py                    the ResearchClawBench export contract
+
+  # Studio
+  backend/studio_http.py    stdlib ThreadingHTTPServer, routing, static assets, SSE
+  backend/studio_service.py projects, runs, documents, previews, version history
+  backend/studio_runner.py  drives real runs under the Studio's approval gate
+  backend/sessions.py       logs_raw.jsonl parsed into renderable trace events
+  backend/notebook.py       the Notebook view's conversation over a run
+  frontend/static/          the Studio SPA: index.html, app.js, notebook.js, styles.css
+  studio_http.py            back-compat shim re-exporting src/backend/studio_http
+  studio_service.py         back-compat shim re-exporting src/backend/studio_service
 ```
+
+```
+tools/
+  score_rcb_run.py          scores a finished benchmark workspace
+  archive_sample_complexity.py   how many runs an archive edge needs to be believable
+  web_search.py             standalone search entry point handed to operators by path
+templates/registry.yaml     venue registry (parsed by hand, no YAML dependency)
+configs/                    optional diagram config template
+assets/                     screenshots, example figures, the paper gallery
+tests/                      the unittest suite
+docs/                       this documentation
+.github/workflows/ci.yml    the only CI job
+```
+
+New code importing the Studio should use `src.backend.*`; the two top-level
+shims exist for callers that predate the move.
 
 ### Agent skills
 
-`src/skills/` holds long-form craft guidance — writing principles, citation
+`src/skills/` holds long-form craft guidance — paper writing, citation
 discipline, venue checklists, LaTeX repair, results tables, reproducibility
-review. Each is a directory with a `SKILL.md` carrying YAML frontmatter
-(`name` matching the directory, plus a `description` specific enough for the
-model to route on) and optionally a `reference.md` for the long tail.
+review. Each is a directory with a `SKILL.md` carrying YAML frontmatter (`name`
+matching the directory, plus a `description` of at least 40 characters, since
+that string is the only thing the model sees when deciding whether to open the
+skill) and optionally a `reference.md` for the long tail.
 
 `install_run_skills` copies the pack into `<run_root>/.claude/skills/` when a
 run is created and again on resume. That location is not incidental: the
@@ -256,8 +551,10 @@ in one situation belongs in a skill, which is read only when the model judges
 it relevant. Adding a skill costs nothing in prompts that do not use it.
 
 To add one: create `src/skills/<name>/SKILL.md` with matching frontmatter.
-`tests/test_run_skills.py` asserts the pack is well-formed and installs, so a
-malformed skill fails the suite rather than silently never loading.
+`validate_skill_pack` is what defines "well-formed", and
+`tests/test_run_skills.py` runs it over the shipped pack and then checks the
+install lands where the CLI looks — so a malformed skill fails the suite rather
+than silently never loading.
 
 ---
 

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -308,7 +308,7 @@ The chain that runs unconditionally at every rigor level, `fast` included:
 | Stage 06+ | Exactly one verdict per frozen hypothesis, nothing unpreregistered adjudicated, every `supported`/`refuted` verdict citing an evidence file that exists | `validate_hypothesis_outcomes` |
 | Stage 06+ | A verdict carries `n_seeds`, a `dispersion_type` from a fixed vocabulary, and a written justification if a single seed settled it | `validate_outcome_statistics` |
 | Stage 06 close | `converged` is refused when nothing came out supported, unless the round declares `negative_result: true` | `validate_round_decision` |
-| Stage 06→07 edge | The router keeps writing closed until every empirical id has a verdict and a figure exists | `_guard_validity_chain` |
+| Stage 06→07 edge | The move into Writing is taken off the agent's menu until every empirical id has a verdict and a figure exists — a routing preference, not the gate; see below | `_guard_validity_chain` |
 | Stage 07+ | Every manuscript claim is `confirmatory` on a `supported` hypothesis, or labelled `exploratory` — and cites a file that exists | `validate_claim_provenance` |
 | Stage 07 | The report answers every demanding sentence of the task statement, quoting the task verbatim | `validate_deliverables_coverage` |
 
@@ -439,12 +439,23 @@ Many systems ask a model to state hypotheses before experimenting. AutoR makes t
 echoed into the outcomes file at Stage 06, and `validate_hypothesis_outcomes` refuses a run that
 adjudicates something not in the frozen set, omits something that is, or cites an evidence path that
 does not resolve. Changing the set later is legal, but only as an `amendment` row carrying
-`previous_digest`. A dropped hypothesis leaves a trace; it cannot be silently deleted.
+`previous_digest`, so a dropped hypothesis leaves a trace on the path the run is meant to take.
+It is not tamper-proof, and §7 says how far short it falls.
 
 The distinctive part is not the freeze — it is the **chain**: freeze at 04, adjudicate at 06 against
 a file that exists, trace every manuscript claim at 07 to a `supported` hypothesis or an explicit
-`exploratory` label, and close the router edge into writing until all of that holds. Each link is a
-function that returns problems, and a run cannot advance while any of them does.
+`exploratory` label. Each link is a function that returns problems, and a run cannot be *approved*
+while any of them does.
+
+Be precise about which of those refusals is load-bearing, because the router's is not.
+`_guard_validity_chain` takes the move into Writing off the agent's menu, but `StageGraph.default_move`
+returns a guard-blocked advance edge anyway with `last_resort=True` — its own docstring is titled
+"When nothing is live, the forward edge is taken anyway", and `router.py` says in a comment that "a
+guard is a routing preference, not a correctness gate". So a run nobody is steering, or one whose
+routing answer was refused, still arrives at Stage 07 with hypotheses unadjudicated. What stops it
+there is `validate_stage_artifacts`, which refuses the stage. That is the design — §3.2's third
+property is exactly this, and halting instead would throw the evidence away — but a document that
+said the edge "stays shut" would be describing a stronger system than the one in the tree.
 
 We are not aware of another agentic research harness in which the post-hoc hypothesis is refused by a
 validator rather than discouraged by a prompt.
@@ -463,8 +474,16 @@ an assertion, so there is no gradient toward a nicer conclusion. And it is backe
 independent guard: `verdict_digest()` hashes the `(id, verdict)` set, and an AutoR-initiated polish
 round that moves it is rejected outright with a `verdict_drift` row — whatever it scored.
 
-The pairing is the point. Verdict-blindness removes the *incentive* to improve the answer; drift
-rejection removes the *possibility*. A revision a **human** asked for is exempt by design: the
+The pairing is the point, with one limit worth stating rather than glossing. Verdict-blindness
+removes the *incentive* to improve the answer; drift rejection removes the *reward* — the round is
+refused and a `verdict_drift` row is written. It does not undo the edit: `_revert` copies the
+champion markdown back over the draft and touches nothing else, so a polish round that rewrote
+`hypothesis_outcomes.json` leaves it rewritten, and the promoted summary and the outcomes file end
+up disagreeing. Detection is real; restoration is not implemented. Nor is the exemption human-only —
+`consider` returns "directed" for any attempt with `is_polish_round=False`, and the manager sets
+that for a *reviewer's* decision as well as a human's, its own comment reading "a human or reviewer
+decision". Unattended, the reviewer is a model, so a model-directed revision can move a verdict
+without meeting the drift check at all. A revision a **human** asked for is exempt by design: the
 ratchet governs AutoR's own rounds, not the direction it is given.
 
 ### 5.3 Machinery that reports on itself, in the unflattering direction
@@ -891,6 +910,25 @@ any.
   benchmark score. It is not enough to quantify the relationship, and it does not establish that the
   rubric is measuring nothing: rigour and rubric-coverage are different objectives, and §2.4 chose
   the first deliberately. What it does establish is that the second is not a corollary of the first.
+- **The freeze can be reset, not just edited.** `_build_stage_prompt` calls
+  `_freeze_preregistration` unconditionally for every stage from 05 on, and `freeze_preregistration`
+  writes a fresh freeze from the current manifest whenever `preregistration.json` is absent — with
+  `amendments: []`. `_amend_preregistration` early-returns when the file is gone, so no amendment is
+  ever considered. Both files live under the agent's own `workspace/notes/`, so deleting the freeze
+  and rewriting the manifest yields a clean, unamended preregistration for a different hypothesis
+  set, and every downstream validator passes. The only residue is a second `preregistration frozen`
+  line in a log no validator reads.
+- **A rejected polish round is not undone, only refused.** `_revert` restores the champion stage
+  summary and nothing else, so a round that rewrote `hypothesis_outcomes.json` and was rejected for
+  `verdict_drift` leaves the new verdicts on disk, disagreeing with the summary that was promoted.
+- **The drift check exempts a reviewer, not just a human.** `consider` returns "directed" whenever
+  `is_polish_round` is false, and the manager sets that for a reviewer's decision as well as a
+  person's. Unattended — the only mode the benchmark uses — the reviewer is a model, so a
+  model-directed revision can move a verdict without meeting the check.
+- **The router does not close the edge into Writing.** `_guard_validity_chain` removes it from the
+  agent's menu, but `default_move` takes a guard-blocked advance as a last resort. The refusal that
+  actually stops an unadjudicated Stage 07 is `validate_stage_artifacts`. This is deliberate — see
+  §5.4 — but it means "the graph will not let you write up" is the wrong mental model.
 - **The frozen preregistration is not checked against itself.** `validate_preregistration` compares
   the *manifest's* digest to the recorded `source_digest`; it never recomputes the digest of the
   frozen file. Editing `preregistration.json` in place passes. The honest claim is that a manifest

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -32,7 +32,9 @@ a hard error rather than a hang.
 The harness substitutes `<WORKSPACE>` with the absolute workspace path and `<PROMPT>` with
 the contents of the generated `INSTRUCTIONS.md`. Both flags are optional when running by
 hand: the workspace defaults to the current directory (which is what the harness sets it
-to) and the instructions default to `<workspace>/INSTRUCTIONS.md`.
+to) and the instructions default to `<workspace>/INSTRUCTIONS.md`. `logo` is only an icon —
+point it at whatever exists under the bench's own `static/logos/`; `rcb_agent.py`'s module
+docstring shows the same entry with `autor.svg`.
 
 Run one task manually:
 
@@ -75,13 +77,32 @@ After the pipeline finishes — **whether or not it succeeded** — the adapter 
 | Benchmark path | Source |
 |:---|:---|
 | `report/report.md` | see below |
-| `report/images/*.png` | `workspace/report/images` first, then `figures`, `writing`, `results`, `artifacts` (PNG only, capped — see below) |
+| `report/images/*.png` | whatever is already at the benchmark path, then the run tree's `workspace/report/images`, `figures`, `writing`, `results`, `artifacts`, and the benchmark's own `outputs/` **last** (PNG only, capped — see below) |
 | `code/` | `workspace/code` |
-| `outputs/` | `workspace/results` and `workspace/notes`, **images excluded** — and any image a stage wrote straight to `<workspace>/outputs/`, or anywhere under `<workspace>/report/` other than a published slot, is deleted; see below |
+| `outputs/` and `outputs/notes/` | `workspace/results` and `workspace/notes`, **images excluded** |
 
 Run-tree figures under `report/images/` keep their filenames, because those are the names
 `report.md` references. A same-named figure swept up from elsewhere is the one that gets
-qualified.
+qualified — `_figure_candidates` prefixes it with the directory it came from. The benchmark's
+own `outputs/` is ranked last on purpose: an image there must never outrank a figure the
+report argues with, but a run whose only plots landed there is published from them rather
+than shipped with an empty `report/images/`.
+
+> **Warning — the export deletes files.** `collect_figures` finishes by walking
+> `<workspace>/outputs/` and `<workspace>/report/` exactly as far as the scorer's sweep does —
+> `rglob` over both whole trees, nested and hidden files included — and **unlinks every image
+> it finds that is neither a published slot nor a file the winning report links directly**.
+> "Image" there is the scorer's set (`JUDGE_IMAGE_SUFFIXES`: `.png`, `.jpg`, `.jpeg`, `.gif`,
+> `.bmp`, `.webp`, `.svg`, matched case-insensitively), while only `.png` is eligible to be
+> published — so an `.svg` or a `.jpg` under `outputs/` is always deleted and could never have
+> filled a slot. The prune runs on every export: after a completed run, after a crashed one,
+> and again on each `--export-only`. A figure a stage wrote somewhere sensible but
+> unpublished — `outputs/diagnostics/fit.png`, a loose `report/panel.png` — is **lost**, not
+> merely unscored. Anything the pipeline produced inside the run tree still exists under
+> `<workspace>/.autor/<run_id>/workspace/`, which the prune never touches; a file written only
+> to the benchmark workspace has no second copy. Why it is a delete rather than a warning is
+> the next section: the scorer sweeps `outputs/` before `report/`, so a stray plot does not
+> add a figure, it takes a slot away from one.
 
 #### The five image slots
 
@@ -123,9 +144,12 @@ Four consequences drive the export, and the plan the run writes at Stage 03:
    The prune is the *same walk* as the sweep, over both trees: `rglob` over `outputs/` and
    over `report/`, not `iterdir()` over `report/images/`. `report/images/` is not the only
    place under `report/` the scorer looks, so a loose `report/panel.png` or a nested
-   `report/images/panels/*.png` takes a slot exactly the way a stray `outputs/` plot does —
-   and both sort *ahead* of `report/images/` in the walk. The only images that survive the
-   prune are the published slots and any image the winning report links directly.
+   `report/images/panels/*.png` takes a slot exactly the way a stray `outputs/` plot does.
+   The loose one is worse: `rglob` yields a directory's own entries before it descends, so
+   `report/panel.png` is reached *ahead* of everything in `report/images/`, while the nested
+   one is reached after — but both are competing for the same five slots. The only images
+   that survive the prune are the published slots and any image the winning report links
+   directly.
 3. **No shipped task has more than five image criteria**, and 34 of 40 have three or fewer
    (distribution over image criteria per task: 0×3, 1×10, 2×9, 3×12, 4×3, 5×3). Five is a
    ceiling, not a target. The weight is earned by figures that settle *different* questions;
@@ -138,9 +162,11 @@ Four consequences drive the export, and the plan the run writes at Stage 03:
    is "forfeited" past 10,000 characters would cut methodology and discussion that were
    still being scored. The headline numbers, the results and the figure captions come
    first; everything else comes after them, not instead of them.
-   That number is the benchmark's, not AutoR's: it lives in this file and in
-   `build_benchmark_goal`'s prose, and deliberately not as a constant in `src/` — nothing in
-   AutoR should start truncating on it.
+   That number is the benchmark's, not AutoR's. It reaches the run as prose, through
+   `build_benchmark_goal`, and it exists in `src/` in exactly one place — `report_plan.py`'s
+   `JUDGE_VISIBLE_PREFIX_CHARS` — where it is used as an *ordering* gate and nothing else:
+   Stage 07 refuses a markdown report longer than the window whose highest-ranked planned
+   figure is referenced for the first time past it. Nothing in AutoR truncates on it.
 
 A sixth figure does not add a sixth chance to match. It randomises which five are seen.
 
@@ -150,10 +176,13 @@ Not at export, and not at Stage 07. The run commits to its figures at **Stage 03
 `workspace/notes/report_plan.json`: one entry per slot, each naming the claim it settles,
 what the reader should see, what the figure looks like if that claim holds and if it does
 not, and the result file it will be computed from. Stage 06 produces them, Stage 07
-publishes them in slot order, and — in markdown mode, which is what the benchmark runs — a
-planned figure that was neither published nor explicitly dropped is a refusal rather than a
-silence. `docs/stage-contract.md` carries the gate rows and `src/report_plan.py` the
-validator.
+publishes them in slot order, and — in markdown mode, which is what the benchmark runs —
+`validate_report_plan_coverage` turns three silences into refusals: a planned slot that was
+not both published under `report/images/` *and* referenced from `report.md`, unless it
+carries a `dropped_because` of at least `MIN_DROP_REASON_CHARS` characters; a plan whose
+every slot is dropped, so the report argues for nothing the reader can see; and a report
+past the judge's window whose highest-ranked surviving slot is first referenced after it.
+`docs/stage-contract.md` carries the gate rows and `src/report_plan.py` the validator.
 
 That machinery is **not** benchmark-specific. It is the discipline
 `hypothesis_manifest.json` and `experimental_protocol.json` already apply — commit to the
@@ -161,9 +190,15 @@ choice before the results can influence it — applied a third time, to figures,
 AutoR run gets it. What *is* benchmark-specific is everything above: the ~61% image weight,
 the one fixed set of five, the 10,000-character excerpt and the `outputs/`-before-`report/`
 sweep. Those reach the run through one place only, `build_benchmark_goal`, which a
-non-benchmark run never receives. Outside the benchmark a markdown run is told only that at
-most `MAX_REPORT_FIGURES` figures reach its reader — which `validate_markdown_report` has
-always enforced — and a LaTeX run is told there is no ceiling at all.
+non-benchmark run never receives. Outside the benchmark the `report_contract` channel still
+describes the deliverable's shape: to a markdown run it gives the ceiling, interpolated from
+`MAX_REPORT_FIGURES` so the prompt cannot drift away from the gate that enforces it; to a
+LaTeX run it says the venue named in `## Run Configuration` sets the count, since a conference
+paper routinely carries eight or ten. Read `_report_contract` for the wording it actually
+sends — and do not read that block as the whole of the figure rule, because the floor is not
+in it. Its markdown text tells the run there is no floor, while `validate_markdown_report`
+refuses a report that references no figures and `resolve_min_report_figures` clamps every
+run's floor to at least one.
 
 #### Reference papers
 
@@ -178,18 +213,27 @@ cannot cite the very work it is reproducing.
 and readiness checklists that the judge never opens; the wall-clock is better spent on
 analysis. Pass `--final-stage 08_dissemination` for the full workflow.
 
-The report comes from the first of four paths that yields real content:
+The report comes from the first of four paths that yields real content — "real" meaning at
+least `MIN_REPORT_CHARS` (1,200) characters, below which the candidate is treated as a stub:
 
 1. **`agent`** — something wrote `report/report.md` at the benchmark path directly. The goal
-   contract injected into every stage prompt names the exact path.
+   contract injected into every stage prompt names the exact path. A report AutoR exported on
+   an earlier pass does not count as the agent's: `_publish_report` records its digest in
+   `.autor_export.json`, which is what stops `--export-only` re-publishing the first fallback
+   forever.
 2. **`stage`** — Stage 07 ran in markdown mode, so its gate-checked report already exists in
    the run tree and is promoted verbatim. **This is the normal case.**
 3. **`synthesized`** — one extra operator call converts the approved artifacts into the
-   benchmark's markdown format. This is what a `latex` run uses.
+   benchmark's markdown format. This is what a `latex` run uses. The call is retried up to
+   `ReportSynthesizer.MAX_ATTEMPTS` times, and a thin answer is retried like a failed one.
 4. **`fallback`** — pure-Python assembly from the approved stage summaries, with any
-   auto-skipped stages named explicitly. AutoR's own control-loop headings
-   (`Your Options`, `Decision Ledger`, `Previously Approved Stage Summaries`) are stripped:
-   a judge told to be skeptical reads them as an agent's run log, not as research.
+   auto-skipped stages named explicitly. When *no* stage was approved it falls back further,
+   to each stage's champion draft under `evolution/` (or, absent a champion, that stage's
+   newest attempt), labelled "unapproved draft" — unapproved work is worth less than approved
+   work, not less than nothing. AutoR's own control-loop headings are stripped, all five of
+   them: `Previously Approved Stage Summaries`, `Decision Ledger`, `Suggestions for
+   Refinement`, `Your Options`, `Files Produced`. A judge told to be skeptical reads them as
+   an agent's run log, not as research.
 
 A partial report scores better than no report, so a crashed or incomplete pipeline still
 exports everything it produced. The exit code tracks whether a report reached the harness,
@@ -204,16 +248,30 @@ not whether every stage was approved.
 | Figures | `workspace/report/images/*.png`, referenced as `images/<name>.png` | `workspace/figures`, `\includegraphics` |
 | Triage artifact | `artifacts/report_review.json` | `artifacts/layout_review.json` |
 | Also required | `citation_verification.json`, `self_review.json` | same, plus `build_log.txt` and a `.bib` |
-| Figure budget | at most 5, all referenced | none |
-| Report plan | required at Stage 03; every slot must be published or carry `dropped_because` | required at Stage 03; coverage not checked |
+| Figure budget | at least 3 on this path (`BENCHMARK_MIN_REPORT_FIGURES`), 1 on an ordinary run; at most 5; every one referenced | set by the venue, not by AutoR |
+| Report plan | required at Stage 03; every slot must be published *and* referenced, or carry `dropped_because` | required at Stage 03; coverage not checked |
 | Post-approval | — | `writing/paper_package/` bundle |
 
-The markdown gates are not "a file exists". Stage 07 fails and retries if `report.md` is
-shorter than 1,200 characters, references no figures, still holds placeholder text, or
-carries a figure reference that is absolute, remote, unrenderable, or points at a file that
-is not there, or publishes more than five figures, or leaves a figure the Stage 03 plan
-committed to neither published nor explicitly dropped. A broken figure link is the expensive
-defect here: the judge reads the prose promising a figure and is shown nothing.
+The markdown gates are not "a file exists". `validate_markdown_report` fails Stage 07, which
+retries it, if `report.md` is missing, is shorter than `MIN_REPORT_CHARS` (1,200) characters,
+references no figures, still holds placeholder text, or carries a figure reference that is
+absolute, remote, unrenderable, or points at a file that is not there — or if
+`report/images/` holds more than `MAX_REPORT_FIGURES` (5) rendered figures, or fewer than the
+run's floor. `validate_report_plan_coverage` adds the plan gates listed above. A broken figure
+link is the expensive defect here: the judge reads the prose promising a figure and is shown
+nothing.
+
+**The floor is 3 on this path and 1 everywhere else.** `rcb_agent.py` passes
+`min_report_figures=BENCHMARK_MIN_REPORT_FIGURES` (`src/utils.py`), against the ordinary
+`MIN_REPORT_FIGURES = 1`; the value is clamped into `[1, MAX_REPORT_FIGURES]` by
+`resolve_min_report_figures`, written into `run_config.json`, and read back by the gate. The
+argument for raising it is the benchmark's, not a general one: its instructions ask every
+agent for "data overview, main results, and validation/comparison plots" — three distinct
+questions — and 27 of the 40 shipped tasks carry two or more image criteria, together holding
+most of the weight. A one-figure report clears the ordinary gate while structurally forfeiting
+criteria it never addressed, because one image cannot answer two different questions. It is a
+count of *distinct* figures and never a target to pad toward: the ceiling is still 5, and a
+sixth is not shown to the judge at all.
 
 The coverage check is narrowed to markdown on purpose: a LaTeX run has no single
 well-defined published-figure location for it to match against, and `layout_review.json`
@@ -325,62 +383,161 @@ prompt telling the operator that `WebSearch` is disabled, how to call the replac
 that every citation must come from a URL the tool actually returned. `auto` degrades to
 native rather than advertising a tool that would fail on first use.
 
-The search model defaults to `gemini-2.5-flash` and is overridable with
-`AUTOR_WEB_SEARCH_MODEL` or `GEMINI_MODEL`.
+The search model defaults per backend — `gemini-2.5-flash` on the Developer API,
+`gemini-3.6-flash` on Vertex, as in the table above — and `resolve_search_model` lets an
+explicit `--model` win over `AUTOR_WEB_SEARCH_MODEL` or `GEMINI_MODEL`, which in turn win over
+both defaults.
 
 ---
 
 ## Options
 
+All 37 of them, in `parse_args`'s own order. `rcb_agent.py` does **not** mirror `main.py`: 31
+flags are shared, 6 exist only here (`--workspace`, `--prompt`, `--prompt-file`, `--intake`,
+`--no-synthesis`, `--export-only`), and the 30 of main.py's it does not declare —
+`--full-auto`, `--unattended`, `--approval-mode`, `--resume-run`, `--max-rounds`,
+`--stage-graph`, `--evolve`, `--archive`, `--trial`, and the rest — are argparse errors here,
+not no-ops. The adapter is unattended by construction, which is why it needs no approval-mode
+or unattended switch of its own.
+
 ```
---workspace PATH        Benchmark workspace. Defaults to the current directory.
+--workspace PATH        Benchmark workspace. Default: the current directory, which is what
+                        the harness sets it to.
 --prompt TEXT           Instructions as a literal string (this is what <PROMPT> expands to).
---prompt-file PATH      Instructions from a file. Defaults to <workspace>/INSTRUCTIONS.md.
+--prompt-file PATH      Instructions from a file. Default: <workspace>/INSTRUCTIONS.md.
 
---operator {claude,codex}       Execution backend. Default: claude.
---model NAME                    Execution model. Default: the backend default.
---review-operator {claude,codex}  Reviewer backend. Default: the execution backend.
---review-model NAME             Reviewer model. Default: the backend default.
-
---stage-timeout SECONDS  Per stage attempt. Default: 14400. The harness enforces no wall
-                         clock of its own, so this is the only thing that can cut a stage
-                         short.
---max-attempts N         Attempts per stage before it is auto-skipped. Default: 8, higher
-                         than the interactive default because a skipped stage costs score.
---max-auto-skips N       Stages that may be auto-skipped before aborting. Default: 3.
---intake                 Run the intake stage. Off by default: the benchmark instructions
-                         are already a complete task specification.
+--operator {claude,codex}         Execution backend. Default: claude.
+--model NAME                      Execution model. Default: sonnet for claude, "default"
+                                  for codex.
+--review-operator {claude,codex}  Backend for the reviewer agent that replaces the human
+                                  approval gate. Default: the execution backend.
+--review-model NAME               Reviewer model. Default: the backend default, as above.
+--codex-sandbox MODE              Codex CLI sandbox, used only with --operator codex.
+                                  Default: workspace-write — which restricts outbound
+                                  network access and so blocks the Gemini search fallback.
+--venue KEY                       Venue profile for Stage 07 writing. Default: neurips_2025.
+                                  It reaches every stage through `## Run Configuration`; the
+                                  manuscript-style gate that reads it is latex-only.
 --output-format {markdown,md,latex,tex}
-                         Stage 07's deliverable. Default: markdown, which writes
-                         report/report.md directly. Use latex to produce the paper package
-                         and leave the report to the synthesis step.
---final-stage STAGE      Stop after this stage. Default: 07_writing, because Stage 08
-                         produces nothing the judge reads.
+                        Stage 07's deliverable. Default: markdown, which writes
+                        report/report.md directly. Use latex to produce the paper package
+                        and leave the report to the synthesis step.
+--final-stage STAGE     Stop after this stage. Default: 07_writing, because Stage 08
+                        produces nothing the judge reads.
+--stage-timeout SECONDS Per stage attempt. Default: 14400. The harness enforces no wall
+                        clock of its own, so this is the only thing that can cut a stage
+                        short.
+
+--rigor {fast,standard,thorough,max}
+                        How much optional machinery to run. Default: standard, which turns
+                        --effort-tiers ON. thorough adds --deliberation and
+                        --ideation-panel; max adds --review-panel; fast turns all four off.
+                        The four switches below are argparse BooleanOptionalAction with
+                        default=None, so omitting one means "the level decides" rather than
+                        "off": `--rigor thorough --no-ideation-panel` does what it says, and
+                        `--effort-tiers` is already on unless you pass --no-effort-tiers or
+                        --rigor fast.
+--review-panel / --no-review-panel
+                        Replace the single reviewer agent with a deliberating panel of
+                        role-differentiated reviewers (pi, domain, method, repro, skeptic).
+                        A blocking objection cannot be approved over. On at --rigor max.
+--panel-roles ROLE [ROLE ...]     Seat only these panel roles, in this order.
+--panel-models ROLE=MODEL [...]   Model per seat, as role=model or role=backend:model
+                                  (pi=opus skeptic=codex:default). Unassigned seats use the
+                                  reviewer default.
+--effort-tiers / --no-effort-tiers
+                        Run each stage as routine or deliberative rather than treating them
+                        alike. On at --rigor standard, which is the default.
+--routine-model MODEL   Parsed here and read nowhere. The second, cheaper operator a
+                        routine stage would run on is built by main.py's configure_effort,
+                        which this adapter never calls: under --effort-tiers it sets an
+                        EffortPlan and a solo reviewer and nothing else, so every stage
+                        runs on --model. Tiering itself still applies — a routine stage
+                        gets the tier notice in its prompt and the single reviewer rather
+                        than the panel — the model is the part that does not change.
+--deliberation / --no-deliberation
+                        Let a stage stop and pull in a voice panel when it hits a genuine
+                        crux. On at --rigor thorough.
+--max-deliberations N   Cruxes a run may escalate. Default: 3.
+--deliberation-voices VOICE [...]   Seat only these: theorist, empiricist, critic,
+                                    pragmatist.
+--deliberation-models VOICE=MODEL [...]   Model per voice, voice=model or voice=backend:model.
+--ideation-panel / --no-ideation-panel
+                        Widen Stage 02's hypotheses with proposers working from five
+                        distinct lenses. It decides nothing. On at --rigor thorough.
+--ideation-lenses LENS [...]      Seat only these: mechanism, contrarian, adjacent, null,
+                                  regime.
+--ideation-models LENS=MODEL [...]  Model per lens.
+--ideas-per-proposer N  Candidate hypotheses each proposer may return. Default: 2.
+--panel-rounds N        Maximum deliberation rounds for the review panel; later rounds run
+                        only on disagreement. Default: 2.
+--persona PATH          Markdown description of the researcher the panel stands in for,
+                        injected into every panelist.
+
+--max-attempts N        Attempts per stage before it is auto-skipped. Default: 8, higher
+                        than the interactive default because a skipped stage costs score.
+--max-auto-skips N      Stages that may be auto-skipped before aborting. Default: 3.
+--intake                Run the intake stage. Off by default: the benchmark instructions
+                        are already a complete task specification.
+--cross-review {auto,gemini,off}
+                        Independent second opinion on each approval from a different model
+                        family. It can veto an approval and can never override a refusal.
+                        Default: auto, which enables it when a Gemini backend is configured
+                        and stays silent when none is.
+--cross-review-model NAME         Default: gemini-3.1-pro-preview
+                                  (`DEFAULT_CROSS_REVIEW_MODEL`).
 --web-search {auto,gemini,native}
---no-synthesis           Skip the operator-backed report synthesis pass.
---export-only            Re-export the latest run without re-running the pipeline. Use this
-                         to recover deliverables from an interrupted job.
---fake-operator          Smoke-test the adapter without touching a real backend.
+                        Default: auto. See the section above.
+--no-synthesis          Skip the operator-backed report synthesis pass and use only the
+                        deterministic fallback.
+--fake-operator         Smoke-test the adapter. rcb_agent.py threads fake_mode into the
+                        operator, the approval reviewer and each panel it seats. It does
+                        not reach the cross-model reviewer, which is built separately by
+                        resolve_cross_reviewer and has no fake mode: pair it with
+                        --cross-review off for a run that makes no external call.
+--export-only           Skip the pipeline and only re-export the most recent run in the
+                        workspace. Use this to recover deliverables from an interrupted job
+                        — but note that the export prunes images, so it is not a read-only
+                        operation.
 ```
+
+**`--cross-review` is live on this path only.** `main.py` declares and parses the same two
+flags, but `resolve_cross_reviewer` is called from `rcb_agent.py` and nowhere else, so on the
+interactive CLI the flags are accepted and then do nothing. The benchmark adapter is the only
+place the cross-model veto is actually wired to a gate.
+
+That inertness runs both ways, and `--cross-review` is not the only flag it touches: the two
+parsers are mirror images, each declaring something the other honours and it does not —
+`--routine-model` is the one that works on `main.py` and not here. `docs/cli-reference.md`
+diffs the two parsers row by row.
 
 ### Layout inside the workspace
 
 ```
 <workspace>/
 ├── INSTRUCTIONS.md        # written by the harness
+├── _meta.json             # run record; written by the harness, updated by write_run_meta
+├── .autor_export.json     # digest of the report AutoR last exported
 ├── data/                  # read-only input, never modified
 ├── related_work/          # read-only references, never modified
 ├── code/                  # exported
-├── outputs/               # exported
+├── outputs/               # exported; images are pruned from here
+│   └── notes/             # workspace/notes from the run tree
 ├── report/
 │   ├── report.md          # the scored deliverable
-│   └── images/            # PNG figures
+│   └── images/            # PNG figures — the only place an image survives the export
 └── .autor/                # the full AutoR run tree, kept for inspection
     └── <run_id>/
 ```
 
-Everything AutoR needs lives under `.autor/`, so a workspace stays self-contained and a run
-can be inspected or resumed after the fact.
+Everything AutoR needs lives under `.autor/` and two dotfile-sized records at the root, so a
+workspace stays self-contained and a run can be inspected or resumed after the fact.
+`_meta.json` is the one the harness and the leaderboard importer read: a run launched by hand
+has no one else to write it, and without `status: "completed"` plus `task_id` and
+`duration_seconds` the workspace cannot be scored. On `--export-only` the duration is not
+re-measured: `_recorded_duration` keeps a value already on record, or, for a run killed
+before it wrote one, estimates the span of the run tree's file timestamps. Reporting the
+export's own few seconds would put a multi-hour run on the leaderboard at near-zero cost.
 
 ---
 
@@ -398,7 +555,20 @@ python3 tools/score_rcb_run.py \
   --out score.json
 ```
 
-Needs `anthropic`, the bench's `structai`, and `ANTHROPIC_VERTEX_PROJECT_ID`.
+**What it needs depends on the judge, and the default judge needs none of Vertex.**
+
+| | `--judge reference` (the default) | `--judge vertex` |
+|:---|:---|:---|
+| Judge | `gpt-5.1` (`REFERENCE_JUDGE_MODEL`), what the benchmark scores with | `claude-opus-4-5@20251101` (`FALLBACK_JUDGE_MODEL`) |
+| Python package | `openai` | `anthropic` |
+| Credential | a key in `~/api.txt` (`DEFAULT_KEY_FILE`, moved with `--key-file`) | `ANTHROPIC_VERTEX_PROJECT_ID`, or `--project-id`; exits 2 without one |
+| Endpoint | the OpenAI-compatible base URL in `REFERENCE_JUDGE_ENDPOINT`, overridable with `--endpoint` | Vertex, region `global` |
+
+Either judge also needs the ResearchClawBench checkout at `--bench`, since the tool imports
+`evaluation.score` from it and drives the bench's own `score_workspace`; that import is what
+pulls in the bench's `structai`, and the judge object replaces `structai.LLMAgent` afterwards.
+`--model` overrides the model id for whichever judge is selected. Nothing on the default path
+reads a Vertex project, and nothing on either path accepts a key as an argument.
 
 ### The three ways the stock scorer fakes a low score
 
@@ -419,32 +589,44 @@ is not a measurement of the run.
 
 ### The judge is part of the result
 
-The reference judge is `gpt-5.1` (`evaluation/.env.example`), and it is what
-`score_rcb_run.py` uses by default:
+**Score with `gpt-5.1`, and quote the judge next to every total you publish.** That is
+the whole rule, and it is not a style preference:
+
+- **`gpt-5.1` is the reference judge** — it is what ResearchClawBench itself scores with
+  (`evaluation/.env.example`), it is `REFERENCE_JUDGE_MODEL`, and `--judge reference` is
+  the tool's default. Anything else is a local measurement that no published figure can
+  be compared against.
+- **Judge choice is worth roughly sixteen points.** On one identical artifact set, Gemini
+  2.5 Flash scored **37.0** where Claude Opus scored **20.8**. That is not a smaller
+  number, it is an **incomparable** one: the spread is a property of the grader, not of
+  the run, so a total quoted without its judge compares to nothing — including to the
+  same run scored yesterday.
+- **The tool makes this hard to get wrong.** It prints `judge: <model>` before the
+  per-item table, repeats it inside the `TOTAL (judge …)` line, and writes `judge_model`
+  into the result file. Carry that string wherever the number goes.
 
 ```bash
-# Reads the key from ~/api.txt. Never pass a key as an argument — it lands in the
-# shell history and in the process table.
+# The default path: gpt-5.1, key read from ~/api.txt. Never pass a key as an argument —
+# it lands in the shell history and in the process table.
 python3 tools/score_rcb_run.py --workspace <ws> --bench <bench>
 
-# No reference key available:
+# Fallback when no reference key is available. Label the result as Claude-judged; do not
+# put it beside a gpt-5.1 number.
 python3 tools/score_rcb_run.py --workspace <ws> --bench <bench> --judge vertex
 ```
 
 Either judge is a drop-in for `structai.LLMAgent` — `score.py` only ever calls the
-agent as `agent(prompt, image_paths=, return_example=, max_try=)` and expects a dict.
+agent as `agent(prompt, image_paths=, return_example=, max_try=)` and expects a dict —
+so switching judges changes the grader and nothing else about the measurement.
 
 The key is read from a file outside the repository. `DEFAULT_KEY_FILE` is
 `~/api.txt` deliberately: a default inside the tree is one `git add -A` away from a
-leak. Error text is redacted before printing, because an HTTP client's exception can
-carry the request that produced it and this output gets pasted into issues. A test
-scans every tracked file for a key-shaped literal, so a key pasted into a docstring
-or a fixture fails the suite rather than reaching a remote.
-
-On identical artifacts, **Gemini 2.5 Flash scored 37.0 where Claude Opus scored 20.8**.
-A sixteen-point spread is a property of the judge, not of the run, so a number quoted
-without naming its judge compares to nothing. The tool prints the judge on every run
-and writes it into the result file.
+leak. `read_api_key` accepts a bare token, `KEY=token`, or a quoted value, so nobody has
+to print the file to find out its shape, and it exits with instructions rather than a
+traceback when the file is missing. Error text is redacted before printing, because an
+HTTP client's exception can carry the request that produced it and this output gets pasted
+into issues. A test scans every tracked file for a key-shaped literal, so a key pasted
+into a docstring or a fixture fails the suite rather than reaching a remote.
 
 ### What the scale means
 
@@ -559,6 +741,11 @@ read `workspace/reviews/` at all, so a run that argued with itself for six voice
 wrote its report as though the argument had not happened — spending the calls and
 collecting none of the weight they could have earned.
 
+Both files are produced by optional machinery, so a run that seats neither panel has nothing
+to publish here: `deliberations.json` needs `--deliberation` and `idea_pool.json` needs
+`--ideation-panel`, and at the default `--rigor standard` both are off. `--rigor thorough`
+turns both on.
+
 The channel is Stage 07 only, and deliberately thin:
 
 - **An unanswered crux contributes nothing.** A panel that could not be reached is not
@@ -566,8 +753,9 @@ The channel is Stage 07 only, and deliberately thin:
   reasoning that did not happen. (`deliberation.md` covers how the two are told apart.)
 - **A duplicate or adopted candidate is not a road not taken.** Listing a restatement of
   the adopted hypothesis as an alternative overstates how wide the search was.
-- **Counts and field lengths are capped.** Image criteria see only the first 10,000
-  characters and the rubric says "longer is not better" in as many words, so an
+- **Counts and field lengths are capped** — `MAX_CRUXES`, `MAX_REJECTED` and
+  `MAX_FIELD_CHARS` in `src/settled_reasoning.py`. Image criteria see only the first
+  10,000 characters and the rubric says "longer is not better" in as many words, so an
   unbounded transcript costs more than it earns. The preface sends the material to
   Discussion, after the numbers.
 - **A run that argued nothing sends nothing.** An empty heading invites the stage to
@@ -648,11 +836,31 @@ print(r.workspace.resolve())
 "
 
 cd workspaces/Astronomy_000_*
-python3 /abs/path/to/AutoR/rcb_agent.py --fake-operator --no-synthesis --max-auto-skips 9
+python3 /abs/path/to/AutoR/rcb_agent.py --fake-operator --no-synthesis \
+  --cross-review off --max-auto-skips 9
 ```
 
-This exercises the whole path — unattended pipeline, auto-skip recovery, export — without
-spending tokens. Expect exit code 0 and a `report/report.md` assembled by the fallback.
+This exercises the unattended pipeline, the auto-skip recovery and the export without calling
+an execution backend. Expect exit code 0, a `report/report.md`, and a figure published under
+`report/images/`. Do not expect a particular report path: the fake operator writes a report
+into the run tree, so a fake run normally exports `"report_source": "stage"` even while
+auto-skipping stages. Read the source off the final JSON line rather than assuming it.
+
+**`--cross-review off` is not optional if you want a free run.** `--fake-operator` does not
+reach the cross-model reviewer: `rcb_agent.py` builds that one through
+`resolve_cross_reviewer`, whose default `auto` seats a live `GeminiCrossReviewer` whenever
+`resolve_backend` finds a usable Gemini backend — and the Vertex project it will accept
+includes `ANTHROPIC_VERTEX_PROJECT_ID`, so the boxes the web-search section above is written
+for are exactly the ones where a "fake" run makes real calls, one per approval, each capable
+of vetoing it.
+
+`--max-auto-skips 9` lifts the budget above the default of 3, so a fake run whose stages
+exhaust their retries reaches the export instead of aborting part-way; how many it actually
+skips is not fixed, and the export event on stdout carries `auto_skipped_stages`.
+
+The same run works without a bench checkout — any directory with an `INSTRUCTIONS.md` in it
+will do — which is the cheapest way to see what the adapter writes where.
+
 
 ---
 

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -5,8 +5,11 @@ Everything a run produces lives inside one directory, `runs/<run_id>/`, where
 nothing is stored globally, and a run directory can be copied, archived, or
 handed to someone else and remain complete.
 
-This page documents every file in that directory and the schema of every
-machine-readable one.
+This page documents every file **AutoR itself writes** into that directory, and
+the schema of every machine-readable one. It is not a listing of everything you
+will find there: `workspace/` is the agent's own working directory, and a stage
+may put any file it likes under `code/`, `data/`, `results/` or `notes/`. Those
+are inventoried by `artifact_index.json` rather than enumerated here.
 
 ---
 
@@ -16,17 +19,20 @@ machine-readable one.
 runs/<run_id>/
 ├── .claude/skills/             # agent skills, installed from src/skills/ (this is the operator's cwd)
 ├── user_input.txt              # the original research goal, verbatim
-├── memory.md                   # approved cross-stage memory (the only shared context)
+├── memory.md                   # settled stage summaries: the free-text cross-stage memory
 ├── run_config.json             # backend, model, venue, approval mode, sandbox, stage graph
 ├── run_manifest.json           # stage lifecycle state — the machine-readable source of truth
-├── artifact_index.json         # index over workspace/{data,results,figures}
+├── artifact_index.json         # index over workspace/{data,results,figures} and report/images
 ├── intake_context.json         # Stage 00 Q&A, ingested resources, refined goal
+├── obligations.json            # what a reviewer said a later stage still owes (agent gate only)
+├── review_policy.json          # standing rules learned from this run's refusals and rollbacks
+├── report_plan_stamp.json      # AutoR's copy of the report plan's date and digest
 ├── logs.txt                    # human-readable workflow log
 ├── logs_raw.jsonl              # raw backend stream-json events
 ├── prompt_cache/               # the exact prompt sent for every attempt
-├── operator_state/             # per-stage session IDs, attempt state, start markers
+├── operator_state/             # per-stage session IDs, attempt state, start markers, MCP config
 ├── handoff/                    # compressed per-stage handoff summaries
-├── evolution/                  # stage graph route, rubric scores, champions, candidates (--evolve / --stage-graph)
+├── evolution/                  # stage graph route, rubric scores, champions, candidates
 ├── stages/                     # stage summaries: <slug>.tmp.md draft, <slug>.md approved
 ├── notebook/                   # Studio Notebook session and transcript (Studio runs only)
 ├── sessions/                   # Studio trace events per stage (Studio runs only)
@@ -39,15 +45,22 @@ runs/<run_id>/
     ├── writing/                # LaTeX sources, sections/, bibliography, tables (latex mode)
     ├── figures/                # plots and paper figures
     ├── artifacts/              # compiled PDFs, build_log.txt, review JSON, deliverables
-    ├── notes/                  # supporting notes, hypothesis_manifest.json, preregistration.json
+    ├── notes/                  # supporting notes, report_plan.json, hypothesis_manifest.json, preregistration.json
     ├── reviews/                # readiness, critique, dissemination material
-    ├── bootstrap/              # --paper-corpus / --project-root scan output
-    └── profile/                # derived researcher profile
+    ├── bootstrap/              # --project-root scan output
+    └── profile/                # --paper-corpus scan output: derived researcher profile
 ```
 
 The directory shape is created by `ensure_run_layout` and the paths are
 defined once, in `build_run_paths` ([`src/utils.py`](../src/utils.py)). If you
 need a path in code, take it from `RunPaths` rather than joining strings.
+
+Three files sit at the run root rather than under `workspace/` on purpose:
+`obligations.json`, `review_policy.json` and `report_plan_stamp.json` are
+records *about* the run rather than part of its answer, and every stage prompt
+directs the agent at `workspace/` paths. Same reason `evolution/` is out here —
+and, like `evolution/`, it also keeps them out of a benchmark export that
+packages the workspace.
 
 ---
 
@@ -60,13 +73,25 @@ resume; a run without it cannot be resumed.
 
 ### `memory.md`
 
-The **only** context shared across stages. A stage does not see another
-stage's conversation — it sees this file.
+The only *free-text* context shared across stages, and the largest one. A stage
+does not see another stage's conversation — it sees this file. It is not the
+only channel, though: `build_handoff_context` sends the last few stages' trimmed
+summaries, `build_decision_ledger_context` broadcasts every prior `Decision
+Ledger` section separately, and the typed channels in `information_flow.py`
+carry the machine-readable artifacts. What crosses a stage boundary is
+enumerable from `build_prompt` and `CHANNELS`; the sections below cover each
+carrier in turn.
 
-Each approved stage contributes one entry containing its `Objective`,
-`What I Did`, `Key Results`, and `Files Produced` sections. Nothing enters
-`memory.md` before you approve it, which is what makes "approval" mean
-something: an unapproved stage cannot influence the rest of the run.
+Each **settled** stage contributes one entry containing its `Objective`,
+`What I Did`, `Key Results`, and `Files Produced` sections. Settled, not
+approved: `_skip_stage` appends a skipped stage's summary here too, and
+`rebuild_memory_from_manifest` iterates on each entry's `settled` flag rather
+than its `approved` flag when it reconstructs the file after a rollback. That
+is deliberate — a later stage has to know the gap exists — but it means this
+file is not a record of accepted work, and "approval" does not gate what the
+rest of the run sees. Read `approved` in `run_manifest.json` when you want to
+know what was actually accepted. A `--project-root` bootstrap adds entries for
+the stages it declares already done, without any of them being run or reviewed.
 
 Required for resume. Rebuilt from `run_manifest.json` after a rollback.
 
@@ -90,6 +115,7 @@ The settings the run was started with, so a resume reproduces them.
   "evolve_measure": true,
   "archive_steer": false,
   "web_search": "auto",
+  "min_report_figures": 1,
   "created_at": "2026-03-30T10:12:22"
 }
 ```
@@ -110,6 +136,7 @@ The settings the run was started with, so a resume reproduces them.
 | `evolve_rounds` | Improvement rounds per stage; `2` by default, `0` measures without polishing. |
 | `archive_steer` | Whether the cross-run archive may choose this run's topology, as opposed to only recording what it did. `false` by default. |
 | `web_search` | `auto`, `gemini`, or `native`. The mode, not the resolved backend. Absent in runs created before it existed, and read as `auto`. |
+| `min_report_figures` | Distinct rendered figures `workspace/report/images/` must hold before Stage 07 can be approved in `markdown` mode. `MIN_REPORT_FIGURES` = 1 for an ordinary run; `rcb_agent.py` sets `BENCHMARK_MIN_REPORT_FIGURES` = 3. `resolve_min_report_figures` clamps whatever it reads into `[1, MAX_REPORT_FIGURES]`, so a value of `0`, `99` or `"three"` becomes 1, 5 and 1 respectively rather than failing the run. Read as a hard gate by `validate_markdown_report`. |
 | `created_at` | ISO-8601 to the second. Preserved across rewrites. |
 
 A missing or corrupt file falls back to defaults rather than failing the run.
@@ -160,10 +187,21 @@ what rollback rewrites. Written by [`src/manifest.py`](../src/manifest.py).
 ```
 
 **`run_status`** — one of `pending`, `running`, `human_review`, `completed`,
-`failed`, `cancelled`.
+`failed`, `cancelled`, `halted`, `abandoned`.
 
-**Stage `status`** — one of `not_started`, `pending`, `running`,
-`human_review`, `approved`, `skipped`, `completed`, `failed`, `cancelled`.
+The last two are the ones worth knowing about, because both are stops that are
+*not* failures and are *not* completions. `halted` means a budget ran out
+(`--graph-max-steps`, `--graph-max-visits`, or no admissible move) with stages
+still unsettled — a run reported as `completed` there would read as a success
+holding four stages that never ran. `abandoned` means a research round
+concluded `abandon`: the run decided the question could not be answered with
+the resources available, which is a real conclusion and is recorded as one.
+`--final-stage` stopping a run is neither; that is the caller getting what they
+asked for, and it completes.
+
+**Stage `status`** — one of `pending`, `running`, `human_review`, `approved`,
+`skipped`, `failed`, `stale`. `stale` is written by a rollback to every stage
+*after* the one rolled back to; the stage rolled back to returns to `pending`.
 
 **Stage flags:**
 
@@ -197,10 +235,14 @@ Safe to delete: it is rebuilt on the next resume.
 
 ### `artifact_index.json`
 
-An index over `workspace/data/`, `workspace/results/`, and
-`workspace/figures/`, regenerated whenever artifacts change and fed into later
-stages' prompts so a stage can find data without guessing filenames. Written
-by [`src/artifact_index.py`](../src/artifact_index.py).
+An index over `workspace/data/`, `workspace/results/`, `workspace/figures/`
+and — also under the `figures` category — `workspace/report/images/`,
+regenerated whenever artifacts change and fed into later stages' prompts so a
+stage can find data without guessing filenames. `report/images/` is included
+because in markdown mode the report's own figures live beside it rather than in
+`workspace/figures/`, and leaving them out would show Stage 07 an empty figure
+inventory for the figures it had just made. Written by
+[`src/artifact_index.py`](../src/artifact_index.py).
 
 ```json
 {
@@ -225,8 +267,23 @@ by [`src/artifact_index.py`](../src/artifact_index.py).
 }
 ```
 
-`experiment_manifest.json` and any `*.schema.json` sidecar are excluded from
-the index — the manifest is a view of the index, not an entry in it.
+Any `*.schema.json` sidecar is excluded, and so is every path in
+`RECORD_ARTIFACTS`: `results/experiment_manifest.json`,
+`results/hypothesis_outcomes.json`, `notes/hypothesis_manifest.json`,
+`notes/preregistration.json`, `notes/experimental_protocol.json`,
+`notes/report_plan.json`, `notes/research_rounds.json` and
+`notes/round_decision.json`. (Only the two under `results/` are ever in the
+index's scan range; the `notes/` entries do their work in
+`experiment_manifest.json`, which shares the same list.)
+
+These are records *about* the science rather than experimental output. The
+manifest is a view of the index, not an entry in it, and counting the
+preregistration would make a stage that declared its hypotheses look like a
+stage that produced results — measurably: the manifest is rewritten on the way
+*into* every stage from 05 on, so counted as output, a Stage 05 that produced
+literally nothing scored a third of `artifact_breadth` off a file whose own body
+reads `result_artifact_count: 0`. `is_autor_own_record` is the single rule, read
+by both this module and the rubric, so the two cannot drift.
 
 #### Schema metadata
 
@@ -253,7 +310,7 @@ rather than crashing the index.
 | --- | --- |
 | `.json` | `object` with up to 20 sorted `keys`, or `array` with `item_count` and `item_keys` |
 | `.jsonl` | `jsonl` with `row_count` and the union of keys across rows |
-| `.csv`, `.tsv` | column names |
+| `.csv`, `.tsv` | `table` with `columns` (the header row, stripped) and `row_count` |
 | `.yaml`, `.yml` | `yaml_document` |
 | `.parquet` | `parquet_table` |
 | `.npz` / `.npy` | `numpy_archive` / `numpy_array` |
@@ -285,8 +342,156 @@ transcript, the ingested resources, and free-form notes.
 }
 ```
 
-`resource_type` is one of `pdf`, `bib`, `code`, `dataset`, `notes`, `other`;
-`dest_dir` is the workspace subdirectory the resource was copied into.
+`resource_type` is one of `pdf`, `bib`, `code`, `dataset`, `notes`, `tex`,
+`other`, assigned by `classify_resource` from the file suffix (a directory
+holding `.py` or `.ipynb` files is `code`, any other directory is `other`).
+`dest_dir` is the workspace subdirectory the resource was copied into:
+`literature`, `code`, `data`, `notes`, `writing` or `artifacts`.
+
+### `obligations.json`
+
+The obligation ledger: what an *approving* reviewer said a later stage still
+owes. Written by [`src/obligations.py`](../src/obligations.py).
+
+Most stages are approved, and an approval used to discard everything the
+reviewer noticed. A real reviewer approving a literature survey says "fine, but
+you owe me a power analysis at design time" — and then checks. Each obligation
+is injected into the prompts of the stages it targets *and* into the review of
+those stages, so the reviewer that inherits one is asked whether it was met.
+
+```json
+{
+  "version": 1,
+  "obligations": [
+    {
+      "obligation_id": "O001",
+      "text": "State a power analysis justifying the sample size before running the comparison.",
+      "origin_stage": "01_literature_survey",
+      "target_stage": "03_study_design",
+      "status": "open",
+      "deferrals": 0,
+      "discharged_by": null,
+      "discharge_note": ""
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `obligation_id` | `O001`-style, referenced by the reviewer that discharges it. |
+| `text` | The reviewer's condition, verbatim and whitespace-collapsed. Shorter than `MIN_OBLIGATION_CHARS` (20) is dropped: "do better" is not checkable. |
+| `origin_stage` | The stage whose approval attached it. |
+| `target_stage` | The stage on the hook, or `null`. `normalize_stage_slug` accepts `05`, `5`, `05_experimentation` and the display name, because models reach for the display name and silently degrading that to "any later stage" loses the targeting the reviewer intended. A `null` target applies to **every** stage after `origin_stage`. |
+| `status` | `open` or `discharged`. |
+| `deferrals` | How many times a stage it applied to was approved without discharging it. Counted on approval only — a refused stage gets another attempt and has not deferred anything. |
+| `discharged_by` / `discharge_note` | Which stage's review closed it, and why. |
+
+**Only a reviewer discharges an obligation.** The stage that owes it can do the
+work and say so; it cannot mark its own homework. Deferral is allowed and never
+silent: the count is shown to every later reviewer. The set is deduplicated on
+normalized text and capped at `MAX_OBLIGATIONS` (30), so a reviewer restating
+one point cannot inflate the ledger.
+
+Absent unless the run uses the **automated** approval gate — `record_obligations`
+and `discharge_obligations` are reached only from the automated reviewer's
+decision, so a manual human gate never writes this file. See
+[Limits](../README.md#limits): obligations are injected into the solo reviewer's
+prompt only — `_build_review_prompt` carries the ledger and the panel's
+`_build_member_prompt` does not — so a seated review panel never sees them,
+however it was seated.
+
+### `review_policy.json`
+
+The standing rules the run has learned about its own work. Written by
+[`src/review_policy.py`](../src/review_policy.py) whenever a correction is
+demanded or an already-given approval is undone, and injected into every
+subsequent *solo* review prompt. As with obligations, the injection point is
+`_build_review_prompt`; a review panel's seats and chair are prompted elsewhere
+and are not shown the rules.
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "rule_id": "R001",
+      "text": "The design lacks a stated power analysis and the sample size is unjustified.",
+      "origin_stage": "03_study_design",
+      "origin_attempt": 2,
+      "source": "refinement"
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `rule_id` | Stable identifier, referenced in the review prompt and the run log. |
+| `text` | The correction verbatim, as the reviewer worded it — or, for a rollback, the sentence AutoR writes naming the two stages and the reason. Whitespace-collapsed; shorter than `MIN_RULE_CHARS` (25) is dropped. |
+| `origin_stage` / `origin_attempt` | Which review produced the rule. This is what makes the mechanism auditable rather than assertable. A rollback has no attempt to point at and records `0`. |
+| `source` | `refinement` for a demanded correction, `rollback` for an approval that later proved wrong. Rollbacks are rendered first in the prompt. |
+
+Absent until the first correction is recorded. Unlike `obligations.json`, this
+is **not** an automated-reviewer-only file. Two of `record_correction`'s callers
+need a reviewer: `_record_review_correction`, which turns a refusal into a
+`refinement` rule, and the cross-model audit, which records a vetoed approval.
+The rest do not. `_rollback_and_jump` is reached from the operator typing
+`/back <stage>` into the manual gate's feedback prompt, and from choice `2`
+("Roll back to an earlier stage") on the recovery menu an attended run on a tty
+gets when a stage exhausts its retries; the router records one of its own when a
+graph `revisit` re-enters an earlier stage. All three write `source: rollback`
+with text well over `MIN_RULE_CHARS`, so a run on the manual gate with no
+reviewer at all can carry this file. What is never recorded is an approval that
+stood: approvals teach nothing.
+
+Rules are deduplicated on normalized text (casing, punctuation
+and stage numbers collapse) and capped at `MAX_RULES` (40), so a reviewer
+restating one complaint cannot inflate it. A corrupt file is treated as an empty
+policy: the gate falls back to baseline strictness rather than taking the run
+down.
+
+### `report_plan_stamp.json`
+
+AutoR's own copy of the three fields in
+[`workspace/notes/report_plan.json`](#workspacenotesreport_planjson) that the
+agent must not be trusted to write. Written by `stamp_report_plan` in
+[`src/report_plan.py`](../src/report_plan.py).
+
+```json
+{
+  "declared_at": "2026-03-30T13:05:41",
+  "digest": "9c1f0b7e...",
+  "amendments": [
+    {
+      "recorded_at": "2026-03-30T18:44:02",
+      "reason": "round 1: tune both arms on a held-out development split and re-run",
+      "previous_digest": "3ab5c9d1...",
+      "new_digest": "9c1f0b7e..."
+    }
+  ]
+}
+```
+
+The plan itself has to stay in `workspace/notes/`: the agent writes it, amends
+it, and is shown it. But that means the agent also has write access to the
+fields that are supposed to prove *when* it was written, and a stamp kept only
+there is a receipt the payer prints. `recorded_report_plan_stamp` therefore
+reads the previous digest from here, never from the plan file — and the failure
+this catches is the ordinary one, not the hostile one. A stage that regenerates
+the whole plan from its own template, obeying "do not write `declared_at`,
+`digest` or `amendments`", leaves a plan with no header at all. Read from the
+file that is indistinguishable from a first declaration, and `declared_at`
+silently becomes a post-results timestamp with an empty amendment ledger. Read
+from the stamp, it is an amendment, and the plan file is repaired on the spot.
+
+Written when Stage 03 is approved, and again from Stage 06 on for runs that
+reach there without passing a Stage 03 approval (`--resume-run`,
+`--redo-stage`, a `--project-root` bootstrap). Stamping is **idempotent by
+content**: a round that left the plan alone adds no amendment and leaves the
+plan file's bytes alone, so carrying a correct plan through a second round does
+not manufacture a spurious record of having changed it. Absent until a
+`report_plan.json` exists.
 
 ### `logs.txt` and `logs_raw.jsonl`
 
@@ -307,8 +512,16 @@ session trace renders.
 
 - `<slug>.tmp.md` — the current draft, rewritten on each attempt.
 - `<slug>.md` — the approved summary. Only appears after you approve.
+- `<slug>.skip_stub.md` — only when an auto-skipped stage's last draft was
+  *rescued*. A stage that burns its attempt budget unattended is normally
+  replaced by a short stub saying the work was not done; when the final draft
+  passes the same markdown and artifact gates an approval requires, that draft
+  is promoted instead and the stub is kept here rather than thrown away. It is
+  still not an approval — the manifest keeps saying `skipped` — and the skip
+  reason records that a validated draft was preserved and nobody reviewed it.
 
-The required shape of both is the [stage contract](stage-contract.md).
+The required shape of `<slug>.tmp.md` and `<slug>.md` is the
+[stage contract](stage-contract.md).
 
 ### `prompt_cache/`
 
@@ -318,23 +531,63 @@ The exact prompt text sent to the backend, one file per attempt:
 | --- | --- |
 | `<slug>_attempt_NN.prompt.md` | a normal stage attempt |
 | `<slug>_attempt_NN_repair.prompt.md` | a repair pass after a malformed summary |
-| `<slug>_review_attempt_NN.prompt.md` | the automated reviewer in `--full-auto` |
+| `<slug>_route.prompt.md` | the [router](self-improvement.md) asking the agent which move to take |
+| `<slug>_validity_review.prompt.md` | the adversarial reviewer after Stage 05 and Stage 06 |
+| `09_benchmark_report.prompt.md` | the ResearchClawBench report synthesiser (`rcb_agent.py` only) |
 
-Nothing is elided: if you want to know why a stage did what it did, the prompt
-that caused it is on disk. Prompts are passed to the backend by reference
-(`-p @<path>`), so these files are load-bearing during a run, not just a log.
+Every *reviewer-style* call — the solo gate, every panel seat, every crux voice,
+every ideation proposer — goes through `AutomatedReviewer.run_prompt` and lands
+as `<slug>_<label>_attempt_NN.prompt.md`, so the table above is not the whole
+set. Every `label` the code passes, and nothing else:
+
+| `label` | Written by |
+| --- | --- |
+| `review` | the solo automated gate |
+| `panel_<seat>_r<N>` · `panel_chair` | each seat of a [review panel](review-panel.md), per round, and the chair's synthesis |
+| `crux_<voice>` · `crux_brief` · `crux_resolve` | a [crux deliberation](deliberation.md) |
+| `ideate_<lens>` · `ideate_score` | the [ideation panel](ideation-panel.md)'s proposers, one per lens, and its pool scorer |
+| `review_verdict` · `panel_<seat>_verdict` · `panel_chair_verdict` | `parse_with_retry`'s single re-ask, present only when that reviewer's first answer could not be parsed |
+
+The same labels name the per-call records in `operator_state/`. The three
+`*_verdict` files are the useful tell: their presence means a verdict came back
+unreadable and was asked for again.
+
+One prompt is missing from this directory, and it is one that can change what a
+stage did: the cross-model audit's. `CrossReviewer.build_prompt` builds its text
+and hands it straight to the model API, and nothing in
+[`src/cross_reviewer.py`](../src/cross_reviewer.py) writes to `prompt_cache/`,
+`operator_state/` or `logs_raw.jsonl`. When that audit vetoes an approval and
+sends the stage back for another attempt, `logs.txt` records the verdict and
+`review_policy.json` records the rule it produced — but the text that produced
+both is not kept anywhere.
+
+Every prompt that *is* here is the exact text the backend was given, and the run
+reads it from disk rather than from memory. How it reaches the CLI differs by
+backend, which matters if you are
+reproducing a call by hand: the Claude operator passes the path by reference
+(`_build_cli_command` emits `-p @<prompt_path>`), while the Codex operator reads
+the file, rewrites every occurrence of the run root to the temp-directory
+symlink it invokes under (`_rewrite_prompt_for_alias`), and pipes the result on
+stdin against a bare `-`. Under `--operator codex` the prompt file's path is
+never handed to the CLI, and what is on disk is the pre-rewrite text.
 
 ### `operator_state/`
 
 | File | Contents |
 | --- | --- |
 | `<slug>.session_id.txt` | the backend session ID for that stage |
-| `<slug>.session.json` | session bookkeeping |
-| `<slug>.attempt_NN.json` | per-attempt state: command line, mode (`start`/`resume`), prompt path, timestamps |
+| `<slug>.session.json` | `session_id`, plus `broken` / `broken_reason` / `updated_at` when a resume was refused — so the next attempt starts a fresh conversation instead of retrying a dead one |
+| `<slug>.attempt_NN.json` | per-attempt state: `status`, `mode` (`start`/`resume`), session ID, prompt path, the literal `command` argv, `exit_code`, stdout/stderr excerpts, stream metadata, timestamps |
+| `<slug>.<label>_attempt_NN.json` | the same record for a reviewer-style call, under the same labels as the prompt files above |
 | `<slug>.started_at.txt` | the freshness cutoff used by the [artifact gate](stage-contract.md#freshness-checks) |
+| `<slug>.attempt_count.txt` · `<slug>.polish_count.txt` | attempts and improvement rounds this stage has spent, persisted because a stage can be entered more than once (a resume, a rollback, a graph revisit) and the attempt number keeps counting up across all of them |
+| `<slug>.pending_feedback.txt` | opt-in revision feedback injected into the **first** attempt's prompt rather than waiting for attempt 2. Written by the Studio's feedback action, or by any caller that drops one there; absent on a plain CLI run, where behaviour is unchanged |
+| `mcp_config.json` | the `--mcp-config` payload handing the agent an `mcp__autor-search__web_search` tool, written whenever the [MCP search server](configuration.md#web-search-optional) is active. Kept in the run rather than a temp file so a run can say what tools its agent was given, not only what it was told. Claude operator only — the Codex adapter takes no MCP config |
 
-`<slug>.attempt_NN.json` records the literal argv used, which makes a failed
-attempt reproducible by hand.
+`<slug>.attempt_NN.json` records the literal argv used, which is most of what
+you need to reproduce a failed attempt by hand. On the Codex backend it is not
+all of it: the argv ends in a bare `-` and the prompt arrives on stdin, so
+replaying that command means feeding it the prompt file yourself.
 
 ### `handoff/`
 
@@ -342,20 +595,27 @@ One `<slug>.md` per completed stage: a compressed view carrying only
 `Objective`, `Key Results`, `Files Produced`, and the `Decision Ledger`.
 
 At most the four most recent handoffs before the current stage are injected
-into a prompt, and the `Decision Ledger` section is stripped from that
-injection — the ledger is kept on disk for audit, not spent on context. This
-is what keeps long runs from growing their prompts without bound.
+into a prompt, which is what keeps long runs from growing their prompts without
+bound. The `Decision Ledger` section is stripped from *that* injection because
+it travels separately: `build_decision_ledger_context` collects the ledger
+sections from **every** prior handoff into their own channel, broadcast to every
+stage from 02 on. A locked decision binds every stage after it, so trimming it
+to the last four would be the wrong four.
 
 ### `evolution/`
 
-Written only when `--evolve` or a non-linear `--stage-graph` is in use. Outside
-`workspace/` on purpose: this records *how* the run reached its answer, not part of
-the answer, and a benchmark export that swept it up would ship the losing drafts
-alongside the report.
+Present on a default run. The champion ratchet is on unless you pass
+`--no-evolve` (`evolve_measure` defaults to `true`; it costs no backend call),
+and `stage_graph.json` is written on every run including `--stage-graph linear`,
+because the walk is driven by a graph either way.
+
+Outside `workspace/` on purpose: this records *how* the run reached its answer,
+not part of the answer, and a benchmark export that swept it up would ship the
+losing drafts alongside the report.
 
 | Path | Contents |
 | --- | --- |
-| `stage_graph.json` | Every visit: the stage, when it was entered and left, the move chosen out of it, its kind, the stated reason, what AutoR would have chosen, whether the agent chose it, the rubric total at the time, **the targets that were live at the moment of choosing (`offered`) and why the rest were not (`blocked`, target → `guard`/`visits`/`steps`/`pruned`/`concluded`)**, whether the move bypassed the router entirely (`bypassed` — a `/back`, a rollback, or a research-round decision; these are counted but never enter the archive's edge observations, because nothing chose between anything), and the research round this visit closed (`closed_round`). The choice set cannot be reconstructed afterwards: re-evaluating a guard needs the workspace as it was at that moment. |
+| `stage_graph.json` | The walk. Top level: `path`, `route` (the visited slugs joined by `->`), `max_steps`, `max_visits`, `halted_because` and `halted_kind` — the last being what tells `--final-stage` (`pruned`, a completion) apart from a spent budget (`steps`/`visits`, a halt). Each visit in `path`: the stage, when it was entered and left, the move chosen out of it, its kind, the stated reason, what AutoR would have chosen, whether the agent chose it, the rubric total at the time, **the targets that were live at the moment of choosing (`offered`) and why the rest were not (`blocked`, target → `guard`/`visits`/`steps`/`pruned`/`concluded`)**, whether the move bypassed the router entirely (`bypassed` — a `/back`, a rollback, or a research-round decision; these are counted but never enter the archive's edge observations, because nothing chose between anything), and the research round this visit closed (`closed_round`). The choice set cannot be reconstructed afterwards: re-evaluating a guard needs the workspace as it was at that moment. |
 | `improvement_ledger.jsonl` | One row per measured round: stage, attempt, per-criterion scores, delta against the champion, the verdict (`first`, `promoted`, `frontier`, `regressed`, `directed`, `verdict_drift`), whether the draft was reverted, and the verdict digest. |
 | `routing_refusals.jsonl` | Every agent routing choice AutoR refused, why, and which edge it fell back to. |
 | `summary.json` | The settled champion score per stage. This is what the cross-run archive reads. |
@@ -376,18 +636,97 @@ See [Recursive Self-Improvement](self-improvement.md).
 | `figures/` | plots, diagrams, paper figures | Stage 06+ |
 | `report/` | `report.md` and `images/*.png` | Stage 07+ (markdown mode) |
 | `writing/` | `main.tex`, `sections/*.tex`, `.bib`, tables | Stage 07+ (latex mode) |
-| `artifacts/` | compiled PDF, `build_log.txt`, review JSON, packaged deliverables | Stage 07+ |
-| `reviews/` | readiness checklists, threats to validity, critique notes | Stage 08+ |
-| `notes/` | supporting notes, `hypothesis_manifest.json`, `preregistration.json` | — |
-| `bootstrap/` | `--paper-corpus` / `--project-root` scan output | — |
-| `profile/` | derived researcher profile and style notes | — |
+| `artifacts/` | compiled PDF, `build_log.txt`, `self_review.json`, `citation_verification.json`, `claim_provenance.json`, `deliverables_coverage.json`, the format's review JSON, packaged deliverables | Stage 07+ |
+| `reviews/` | readiness checklists, threats to validity, critique notes, the feature ledgers (`scorecard.*`, `effort.json`, `deliberations.json`, `comment_ledger.json`, `panel/`), `validity_review_*.json` / `validity_response_*.json` | Stage 08+ |
+| `notes/` | supporting notes, `report_plan.json`, `hypothesis_manifest.json`, `preregistration.json`, `experimental_protocol.json`, `research_rounds.json` | no directory gate; the individual files are gated from Stage 03 on |
+| `bootstrap/` | the `--project-root` scan, all of it: `project_state.json`, `experiment_inventory.json`, `writing_state.json`, `stage_assessments.json`, `scan_metadata.json`, `bootstrap_summary.md` | — |
+| `profile/` | the `--paper-corpus` scan — derived researcher profile and style notes: `research_profile.json`, `citation_neighborhood.json`, `style_profile.json`, `corpus_manifest.json`, `style_notes.md`, `bootstrap_summary.md` | — |
+
+The two scans do not share a directory. `--project-root` is the only writer of
+`bootstrap/`: `save_project_bootstrap` emits all six files there in one call,
+before the bootstrap stage runs. `--paper-corpus` writes nothing to
+`bootstrap/`; its whole output set goes to `profile/`, and it gets there a
+different way — `src/prompts/bootstrap.md` points the agent at
+`{{WORKSPACE_PROFILE_DIR}}` and asks it for `research_profile.json`,
+`citation_neighborhood.json`, `style_profile.json`, `style_notes.md` and
+`bootstrap_summary.md`, and `missing_bootstrap_profile_artifacts` then refuses
+to approve the bootstrap stage while any entry of `_REQUIRED_PROFILE_FILENAMES`
+is missing from `workspace/profile/`. Those two sets are not the same set:
+`_REQUIRED_PROFILE_FILENAMES` also holds `corpus_manifest.json`, which the
+prompt never mentions and which no live code path writes — `save_bootstrap_result`
+is its only writer and nothing outside the tests calls it. The gate is therefore
+holding the bootstrap stage on a file neither the prompt nor AutoR produces; when
+it refuses, it names the file in the refinement feedback, and that feedback is
+the only place the agent is ever asked for it. `bootstrap_summary.md` is the one
+filename both scans produce, each in its own directory.
+
+The "gated at" column says from which stage `validate_stage_artifacts` starts
+refusing a stage over that directory. Do not read it as one mechanism: only four
+of the rows are directory-level counts, and the rest check named files.
+
+- **Counted.** `data/` from Stage 03, `results/` from 05 and `figures/` from 06
+  fail when `count_in` finds no file carrying one of that category's suffixes
+  (`.json .jsonl .csv .tsv .parquet .yaml .yml` for data, plus `.npz`/`.npy` and
+  minus the YAML pair for results, `.png .pdf .svg .jpg .jpeg` for figures).
+  `reviews/` from 08 fails when the directory holds no file at all, of any
+  kind. Stages 03, 06 and 08 additionally require that at least one such file
+  was written during the current stage execution — the count alone would pass on
+  a file an earlier stage left behind.
+- **Named files, not a count.** `literature/` at Stage 01 is
+  `validate_literature_evidence` over `sources.json` and `claims.json`. A
+  directory holding fifty reading notes and neither of those two fails it, and
+  its errors are about IDs and cross-references, not about how much is there.
+- **Per-file existence, then freshness.** `report/`, `writing/` and `artifacts/`
+  at Stage 07+ are checked file by file rather than counted, and which files
+  depends on the output format: `report.md` and `report_review.json` in markdown
+  mode; `main.tex`, `sections/*.tex`, a bibliography, a compiled PDF,
+  `build_log.txt` and `layout_review.json` in latex mode;
+  `citation_verification.json` and `self_review.json` in both. Do not read that
+  as the whole set — further per-file gates hang off the same Stage 07 branches
+  (`claim_provenance.json` in both formats, `deliverables_coverage.json` in
+  markdown), and the `stage.number >= 7` branches of `validate_stage_artifacts`
+  are where the current list lives. Freshness is narrower still: at Stage 07
+  itself the files named in that branch's `stage7_required_files`, plus the PDF
+  and the section sources in latex mode, must be newer than the stage's start
+  marker. The bibliography is not among them, so one an earlier stage wrote
+  satisfies Stage 07.
+
+`results/` is the one row where both apply: the count, and `experiment_manifest.json`
+by name. Individual files inside a directory carry their own content gates on
+top of all this; those are the section below.
+
+A few more AutoR-written things live under `workspace/` and are not gates:
+
+- `writing/manifest.json`, rebuilt from the artifact index every time the
+  Stage 07 prompt is composed.
+- The `paper_package/` and `release_package/` bundles that Stage 07 (latex mode)
+  and Stage 08 emit into `writing/`, `artifacts/` and `reviews/`.
+- Under `--research-diagram`, a generated method illustration:
+  `report/images/method_overview.png` with a reference injected into `report.md`
+  in markdown mode, or `figures/method_overview.jpg` in latex mode. Skipped with
+  a log line rather than failing when the method section is too short to work
+  from.
+- Under `--fake-operator`, a set of stand-in files (`data/fake_dataset.json`,
+  `notes/autor_intro.md`, `reviews/readiness_review.json` and similar) that
+  exist only to exercise the gates locally. They are not part of a real run.
 
 ---
 
 ## Validated JSON files
 
-These are the files AutoR parses and rejects rather than merely counting. Each
-schema below is what the validator actually requires.
+Most of these AutoR parses and rejects rather than merely counting, and where a
+section names a validator, the schema below is what that validator actually
+requires. **A file's gate is not always a function named after it**, so do not
+read "no validator of its own" as "unchecked": `hypothesis_manifest.json` is
+refused from Stage 05 on by `validate_preregistration`, through the frozen
+preregistration derived from it. Where a file really is unchecked, its own
+section says so — `self_review.json` is gated on existence
+alone, and `deliberation_request.json` is read leniently and never refuses a
+stage. The feature ledgers — `scorecard.json` and
+`scorecard.md`, `effort.json`, `deliberations.json`, `comment_ledger.json`,
+`idea_pool.json` and everything under `panel/` — are written by AutoR and read
+back by AutoR, and have no validator at all; the field tables below describe
+what is written, not a contract anything enforces.
 
 ### `workspace/literature/sources.json`
 
@@ -482,6 +821,12 @@ as support, and what would count as refutation — stated before any experiment
 runs. A hypothesis with no decision rule cannot come out negative, which makes
 "falsifiable" a word rather than a property, and Stage 05 refuses the run.
 
+The gate is `validate_preregistration`, which runs from Stage 05 on and reaches
+this file three ways: it refuses a run that has no `hypothesis_manifest.json` at
+all, it refuses a frozen empirical hypothesis carrying no decision rule, and it
+compares `hypothesis_manifest_digest` of this file against the digest the
+[preregistration](#workspacenotespreregistrationjson) froze.
+
 ### `workspace/notes/research_rounds.json`
 
 Stages 03-06 form a **research round**: design, implement, experiment, analyse.
@@ -490,6 +835,7 @@ round.
 
 ```json
 {
+  "updated_at": "2026-03-30T18:52:10",
   "rounds": [
     {
       "round": 1,
@@ -499,8 +845,10 @@ round.
       "what_changes_next": "Tune both arms on a held-out development split and re-run.",
       "negative_result": false,
       "hypothesis_verdicts": {"H1": "refuted"},
+      "recorded_at": "2026-03-30T18:52:10",
       "acted_on": true,
-      "budget_note": ""
+      "budget_note": "",
+      "reopens_round": 0
     }
   ]
 }
@@ -512,6 +860,10 @@ round.
 | `refine_design` | same hypotheses, next round restarts at Stage 03 |
 | `new_hypothesis` | next round restarts at Stage 02; the preregistration records an amendment |
 | `abandon` | the run stops, and Stage 07 refuses to write up a question the run declared unanswerable |
+
+An abandonment is not permanent, but overruling it has to be said out loud: a
+later round sets `reopens_round: <N>` naming the abandoned round it overrules,
+and until something does, `validate_round_decision` refuses every stage past 06.
 
 There is no `continue`: a round that wants another one has to say what would
 change, because repeating a design without changing what it got wrong produces
@@ -540,8 +892,10 @@ Validated by `validate_round_decision` in
 ### `workspace/notes/preregistration.json`
 
 The hypothesis set, frozen. Written when Stage 04 is approved — design settled,
-code written, nothing measured — and again lazily at the start of Stage 05 for
-runs that arrive by resume, `--redo-stage`, or a `--project-root` bootstrap.
+code written, nothing measured — and again lazily on the way into any stage from
+05 on, for runs that arrive by resume, `--redo-stage`, or a `--project-root`
+bootstrap. `freeze_preregistration` never overwrites, so the second call on a
+run that already froze is a no-op.
 
 ```json
 {
@@ -556,11 +910,13 @@ runs that arrive by resume, `--redo-stage`, or a `--project-root` bootstrap.
 }
 ```
 
-`source_digest` hashes the statements and decision rules in
-`hypothesis_manifest.json`, deliberately ignoring the timestamp and the
-self-declared `status`. From Stage 06 on, a manifest whose digest no longer
-matches — a hypothesis edited after results existed — fails validation unless
-an amendment is on record.
+`source_digest` hashes the id, type, statement and decision rule of every entry
+in `hypothesis_manifest.json`, deliberately ignoring the timestamp and the
+self-declared `status` — rewriting Stage 02 without changing a statement is not
+tampering. From Stage 05 on — the same gate that requires the
+frozen file to exist at all — a manifest whose digest no longer matches, a
+hypothesis edited after results existed, fails validation unless an amendment is
+on record.
 
 Hypotheses may be revised. A rollback to Stage 02 is a legitimate reason, and
 re-running Stage 02 appends an `amendments` entry carrying the reason and the
@@ -600,6 +956,105 @@ any experiment runs, and enforced from Stage 05.
 
 Validated by `validate_experimental_protocol` in
 [`src/experimental_protocol.py`](../src/experimental_protocol.py).
+
+### `workspace/notes/report_plan.json`
+
+Which figures the report will carry, and which claim each one settles — chosen
+at Stage 03, before any result exists. The same discipline as the
+preregistration, applied to what the reader is shown: a figure set assembled at
+the end out of whatever the run happened to produce is evidence chosen after
+seeing it, one level up.
+
+```json
+{
+  "declared_at": "2026-03-30T13:05:41",
+  "digest": "9c1f0b7e...",
+  "no_figures_because": "",
+  "task_outputs": [
+    {"stated": "upper limits on the self-interaction coupling", "covered_by": "figure:1", "why_not": ""},
+    {"stated": "a mass exclusion band", "covered_by": "number:0", "why_not": ""}
+  ],
+  "amendments": [],
+  "figures": [
+    {
+      "slot": 1,
+      "filename": "coupling_limits.png",
+      "supports": ["H1"],
+      "shows": "95% CL coupling limit (GeV^-1) against ULB mass (eV), log-log, with the prior bound overlaid",
+      "if_supported": "our band sits below the prior bound across the whole mass range",
+      "if_refuted": "the two bands overlap and no improvement is visible",
+      "source_artifact": "results/coupling_scan.json",
+      "dropped_because": ""
+    }
+  ],
+  "headline_numbers": [
+    {"quantity": "best-fit coupling upper limit", "unit": "GeV^-1", "source_artifact": "results/coupling_scan.json"}
+  ]
+}
+```
+
+**AutoR owns the header, the agent owns the body.** `declared_at`, `digest` and
+`amendments` are written by `stamp_report_plan` and mirrored to
+[`report_plan_stamp.json`](#report_plan_stampjson); the validators ignore all
+three, because asking a language model for a sha256 is a wish rather than a
+gate. The agent writes `figures`, `headline_numbers`, `task_outputs` and
+`no_figures_because`.
+
+Three gates hang off it, deliberately at three different stages:
+
+| From | What it checks | Function |
+| --- | --- | --- |
+| Stage 03 | Shape — held at the stage that writes it, so a plan-less design is refused while the design can still change | `validate_report_plan` |
+| Stage 06 | Every live slot's and headline number's `source_artifact` resolves to a non-empty file, checked while a stage that could still compute it exists | `validate_report_plan_sources` |
+| Stage 07 (markdown only) | Every planned slot was published under `report/images/` **and** referenced from `report.md`, or dropped on the record | `validate_report_plan_coverage` |
+
+What the shape gate holds, and why each rule is shaped the way it is:
+
+- **Slots are a ranking.** They must be unique and contiguous from 1, so the
+  weakest figure is identifiable now rather than at export. `filename` is a bare
+  filename (it is the join key against the published report) and, in markdown
+  mode, must be `.png`.
+- **Every figure names a claim no other figure carries.** Cite an id from
+  `hypothesis_manifest.json`, or `exploratory:<slug>` for a question the run did
+  not preregister. This is the one rule that pushes the figure count *down*: a
+  run that cannot name a distinct claim for slot 5 has no slot 5. Nothing here
+  ever asks for *more* figures — the only count refusal is "more than
+  `MAX_REPORT_FIGURES`", and only in markdown mode, because that is a ceiling
+  and a gate that restated it as a goal would have turned it into a quota.
+- **`if_supported` must differ from `if_refuted`.** A figure whose two branches
+  are one sentence cannot come out either way, so it carries no claim. Trivially
+  defeated by inserting "not", and that is fine: the guard's job is to make the
+  empty move cost a written sentence and put it where a reviewer reads it.
+- **`source_artifact` is a workspace-relative path under `results/`, `data/` or
+  `outputs/`.** `notes/` is deliberately excluded — a figure computed from a
+  note is a figure computed from prose.
+- **The length floors** (40 characters on `shows`, 20 on each branch and on
+  `dropped_because`) are floors under *a sentence was written*, nothing more.
+  Whether a figure is a good figure is the reviewer's judgement; a gate that
+  tried to measure it would only be measuring length.
+- **A plan with no figures is unusual, not wrong** — three of the forty
+  ResearchClawBench tasks have no image criterion at all. Set
+  `no_figures_because` to the reason instead, in at least 40 characters.
+- **`dropped_because` records a slot abandoned once the results were in.** A
+  slot dropped in the same plan that declares it is refused: five slots with
+  four born dropped reads as a five-slot plan and commits to one.
+- **`headline_numbers` is required and capped at `MAX_HEADLINE_NUMBERS` (8).**
+  Each needs a `quantity`, a `unit` (`dimensionless` and `count` are units; an
+  empty string is not) and a `source_artifact`. A result the prose never puts a
+  number on is a result the reader has to take on trust; a list of everything
+  measured is not a set of headline numbers.
+- **`task_outputs`** answers the task description item by item — `covered_by` is
+  `figure:<slot>`, `number:<index>` (zero-based into `headline_numbers`),
+  `prose`, or `not_attempted` with a `why_not` of at least 20 characters. A
+  deliverable the task named and the report never mentions is the cheapest score
+  there is to lose. An empty `task_outputs` is refused outright.
+
+The Stage 07 gate also flags a lead figure the report first references beyond
+10,000 characters: the benchmark's scorer passes only `report_text[:10000]` when
+grading an image criterion, so the argument for the report's own highest-ranked
+figure would land outside what is read. Only the first slot is held to it.
+
+Written by [`src/report_plan.py`](../src/report_plan.py).
 
 ### `workspace/results/hypothesis_outcomes.json`
 
@@ -651,8 +1106,10 @@ wrong* — reads the run and files specific, checkable objections.
 
 ```json
 {
+  "generated_at": "2026-03-30T19:04:18",
   "reviewed_stage": "05_experimentation",
   "reviewer_failed": false,
+  "note": "",
   "findings": [
     {
       "id": "V1",
@@ -681,14 +1138,28 @@ an argument is a complete answer, and so is `accepted_limitation`. There is no
 `noted`. What is refused is silence, because a finding nobody responded to is
 indistinguishable in the run directory from one nobody raised.
 
-A reviewer that crashed records `reviewer_failed: true`. An empty finding list
-from a failed critique would read as "nothing wrong".
+`category` is one of ten named failure modes — `confound`, `weak_baseline`,
+`insufficient_replication`, `leakage`, `metric_cherry_picking`,
+`effect_within_noise`, `overclaim`, `unsupported_generalization`,
+`missing_ablation`, `irreproducible_procedure`. Naming them beats asking for
+"any problems": an open-ended critique reliably returns prose quality, which is
+not what is dangerous here. `severity` is `critical`, `major` or `minor`.
 
-**When `--review-panel` is on**, the panel's own Methodologist and Reviewer 2
-already cover these categories, so no second critic runs: the concerns still
-standing after the panel's final round *become* the findings, and the next stage
-owes them the same answer. A concern a member withdrew during deliberation was
-answered inside the panel and is not re-raised. What this adds on top of the
+A reviewer that crashed records `reviewer_failed: true`, and `note` carries
+what went wrong. An empty finding list from a failed critique would read as
+"nothing wrong" — though see [Limits](../README.md#limits): the flag is written
+and nothing currently reads it.
+
+**When a review panel left concerns standing**, those concerns *become* the
+findings and no second critic runs: `ValidityReviewer.review` calls
+`findings_from_panel` first and adopts its result whenever it is non-empty,
+because the panel's own Methodologist and Reviewer 2 already cover these
+categories and re-asking would pay for the same questions twice. Only the final
+round counts — a concern a member withdrew during deliberation was answered
+inside the panel and is not re-raised. The switch is the concerns, not the
+seating: a panel that finished unanimous with nothing on the record yields an
+empty list, and the separate adversarial critic then runs as it would with no
+panel at all, at the cost of one more backend call. What this adds on top of the
 panel is the part the panel does not have — an obligation on the **next** stage,
 in its own artifacts, rather than a decision at this one's gate.
 
@@ -712,15 +1183,19 @@ Stage 07's map from each claim in the manuscript to what established it.
 }
 ```
 
-A `confirmatory` claim requires a hypothesis whose verdict is `supported` — the
-run predicted it in advance and the evidence bore it out. Everything else is
-`exploratory`: permitted, often the most interesting part of a run, but it has
-to say so. A post-hoc finding presented as a confirmed prediction is the exact
-failure preregistration exists to prevent.
+`status` is `confirmatory` or `exploratory`, and there is no third value. A
+`confirmatory` claim requires a `hypothesis_id` that was preregistered **and**
+whose verdict is `supported` — the run predicted it in advance and the evidence
+bore it out. Everything else is `exploratory`: permitted, often the most
+interesting part of a run, but it has to say so. A post-hoc finding presented as
+a confirmed prediction is the exact failure preregistration exists to prevent.
 
-Validated by `validate_claim_provenance`.
+Every claim, whichever status, must cite at least one `evidence` path that
+resolves to a file in the run. The whole check is skipped when there is no
+frozen preregistration to compare against.
 
-Written by [`src/hypothesis_manifest.py`](../src/hypothesis_manifest.py).
+Written by Stage 07. Validated by `validate_claim_provenance` in
+[`src/preregistration.py`](../src/preregistration.py).
 
 ### `workspace/artifacts/citation_verification.json`
 
@@ -751,13 +1226,27 @@ The markdown deliverable, and the only Stage 07 output an automated research
 benchmark reads. Required at Stage 07+ in `markdown` mode, and required to be
 *fresh* — written during the Stage 07 execution that is asking for approval.
 
-Content requirements are enforced, not just existence: at least 1,200
-characters, no placeholder text, and at least one figure reference where every
-reference is report-relative, resolves to a real file under
-`workspace/report/`, and uses a format the report viewer can render
-(`.png .jpg .jpeg .gif .webp`). Figures live in `workspace/report/images/` and
-are referenced as `images/<name>.png`, with at most `MAX_REPORT_FIGURES` (5) published —
-a benchmark judge is shown only the first five it finds, in filesystem order.
+Content requirements are enforced, not just existence: at least
+`MIN_REPORT_CHARS` (1,200) characters, no placeholder text, and at least one
+figure reference where every reference is report-relative, resolves to a real
+file under `workspace/report/`, and uses a format the report viewer can render
+(`.png .jpg .jpeg .gif .webp`). A reference that climbs out of `report/` is
+refused even when it resolves on this machine: only `report/` travels to a
+benchmark workspace, so `../figures/x.png` is a link that works here and is
+broken everywhere the report is actually read.
+
+Figures live in `workspace/report/images/` and are referenced as
+`images/<name>.png`. The count of rendered files in that directory — not the
+count of references — is held between two bounds:
+
+- **at least `min_report_figures`**, the [run config](#run_configjson) field.
+  1 for an ordinary run, 3 under `rcb_agent.py`. One figure cannot answer more
+  than one question, and a report that under-illustrates forfeits the criteria
+  it never addresses.
+- **at most `MAX_REPORT_FIGURES` (5)**, because a benchmark judge is shown only
+  the first five it finds, in filesystem order. Filesystem order is not
+  alphabetical, so a sixth figure does not dilute the score, it randomises it —
+  the only way to choose the five is to publish no more than five.
 
 Validated by `validate_markdown_report` in [`src/utils.py`](../src/utils.py).
 
@@ -782,6 +1271,7 @@ each Stage 07 attempt and fed back into the next attempt's prompt.
     "unrenderable_images": 0,
     "non_png_images": 0,
     "unreferenced_images": 1,
+    "unplanned_images": 0,
     "figures_over_budget": 0,
     "total": 2
   },
@@ -799,21 +1289,39 @@ each Stage 07 attempt and fed back into the next attempt's prompt.
 
 Required: non-empty string `overall_status`; boolean `report_available`;
 integer `referenced_image_count`; object `issue_counts`; list `issues`; and
-`priority_fixes` as a list of non-empty strings.
+`priority_fixes` as a list of non-empty strings. AutoR writes `overall_status`
+as `clean` or `needs_attention`.
+
+`unplanned_images` counts figures under `report/images/` that are not slots in
+`report_plan.json` — advisory rather than a refusal, because the plan is
+amendable and a late figure that earns its slot is a legitimate move. Only
+checked once a plan exists.
 
 Validated by `validate_report_review` in
 [`src/writing_manifest.py`](../src/writing_manifest.py).
 
 ### `workspace/artifacts/layout_review.json`
 
-The `latex`-mode triage artifact.
+The `latex`-mode triage artifact, generated after each Stage 07 attempt by
+parsing the LaTeX build log.
 
 ```json
 {
-  "overall_status": "pass",
+  "generated_at": "2026-08-06T02:14:03",
+  "overall_status": "needs_attention",
   "pdf_available": true,
+  "pdf_relative_path": "workspace/writing/main.pdf",
+  "estimated_page_count": 9,
   "build_log_checked": true,
-  "issue_counts": { "overfull_hbox": 3, "missing_figure": 0 },
+  "build_log_relative_path": "workspace/artifacts/build_log.txt",
+  "issue_counts": {
+    "overfull_hboxes": 3,
+    "underfull_hboxes": 0,
+    "undefined_references": 0,
+    "undefined_citations": 1,
+    "missing_file_warnings": 0,
+    "total": 4
+  },
   "issues": [],
   "priority_fixes": ["Trim Section 4 to fit the 9-page limit."]
 }
@@ -821,16 +1329,19 @@ The `latex`-mode triage artifact.
 
 Required: non-empty string `overall_status`; booleans `pdf_available` and
 `build_log_checked`; object `issue_counts`; list `issues`; and
-`priority_fixes` as a list of non-empty strings.
+`priority_fixes` as a list of non-empty strings. AutoR writes `overall_status`
+as `clean` or `needs_attention`.
 
 Validated by `validate_layout_review` in
 [`src/writing_manifest.py`](../src/writing_manifest.py).
 
 ### `workspace/reviews/scorecard.json` and `scorecard.md`
 
-Written when a run finishes with any optional feature enabled. Reads every other ledger and
-says which features earned their cost — `keep`, `drop`, or `unproven` — plus the total extra
-model calls they spent.
+Written at the end of every **completed** run — not a halted or abandoned one,
+which stop before the completion path. Reads every other ledger and says which
+features earned their cost — `keep`, `drop`, or `unproven` — plus the total extra
+model calls they spent. A run with no optional feature enabled still gets the
+files; every feature just reads `not enabled`, and the terminal says nothing.
 
 `unproven` means the measurement could not run, and is deliberately not merged with `drop`. A
 ledger that exists but cannot be parsed is reported as unreadable rather than as a null result.
@@ -839,15 +1350,54 @@ See [Scorecard](scorecard.md).
 
 ### `workspace/reviews/effort.json`
 
-Written under `--effort-tiers`. Which tier each stage ran in, who chose it, why, and both
+Written when effort tiering is on — which is the **default**, since `--rigor`
+defaults to `standard` and `standard` turns `effort_tiers` on. `--rigor fast` or
+an explicit `--no-effort-tiers` is what leaves this file absent.
+
+Which tier each stage ran in, who chose it, why, and both
 directions of mis-spending: `promoted_after_failing` (ran cheap and should not have) and
 `deliberative_but_uncontested` (paid for ceremony nobody used).
 
 See [Effort Tiers](effort-tiers.md).
 
+### `workspace/notes/deliberation_request.json`
+
+Where an executing stage raises a crux. Not written by AutoR — the *agent*
+writes it mid-stage, when it hits a question whose answer is genuinely unclear
+and getting it wrong would invalidate work downstream.
+
+```json
+{
+  "question": "the specific question, answerable and decidable",
+  "why_it_matters": "what breaks downstream if this is wrong",
+  "already_considered": ["what you have already ruled out, and why"],
+  "working_answer": "your best answer right now, so the panel can disagree with it",
+  "help_wanted": "both"
+}
+```
+
+A bare object or a list of them is accepted, because this file is written by a
+model mid-stage and a malformed escalation should cost the escalation rather
+than the stage. Entries whose `question` is under `MIN_QUESTION_CHARS` (25) are
+dropped silently; `help_wanted` outside `perspectives` / `expertise` / `both`
+falls back to `both`. There is no gate — nothing refuses a stage for writing a
+bad one.
+
+**Unlinked once consumed.** `clear_requests` deletes the file as soon as the
+requests are read, so one crux is not deliberated twice. The stage is not
+blocked while the panel sits: it finishes with its working answer, and the
+resolution is handed back on the next pass. Reading it requires an active crux
+panel (`--deliberation`, or `--rigor thorough`/`max`) — with none seated the
+file is never read and never removed. The run-wide budget is
+`DEFAULT_MAX_DELIBERATIONS` (3).
+
+The resolutions land in `workspace/reviews/deliberations.json`. See
+[Raising a Crux](deliberation.md).
+
 ### `workspace/reviews/deliberations.json`
 
-Written when a stage raises a crux under `--deliberation`. Every question escalated, the
+Written when a stage raises a crux and a panel is seated to take it —
+`--deliberation`, or `--rigor thorough`/`max`. Every question escalated, the
 expert brief, each voice's position and self-objection, and the resolution with its falsifier
 and surviving dissent.
 
@@ -858,22 +1408,27 @@ See [Raising a Crux](deliberation.md).
 
 ### `workspace/reviews/comment_ledger.json`
 
-Written when a reviewer anchors its objections to quoted passages. One entry per review round,
-each holding the comments raised and — once the revision arrives — what happened to them.
+Written when a reviewer anchors its objections to quoted passages. `rounds` holds
+one entry per review round — the comments raised and, once the revision arrives,
+its `outcome`. `summary` aggregates across all rounds, and is the part worth
+reading:
 
-| Field | Meaning |
+| `summary` field | Meaning |
 | --- | --- |
+| `rounds` / `comments_raised` | How many anchored rounds ran, and how many comments they raised. |
 | `comments_addressed` | Quoted passages that actually changed. |
 | `comments_left_untouched` | Passages that did not, carried into the next round. |
 | `comments_quoting_absent_text` | Comments whose quote was not in the draft; dropped rather than sent on. |
 | `lines_changed_on_target` / `lines_changed_as_collateral` | Whether the revision stayed local. |
 | `collateral_ratio` | 0.0 for a targeted patch; 0.5 and up means the stage was rewritten, not patched. |
+| `verdict` | One sentence over the above. |
 
 See [Anchored Review Comments](stage-comments.md).
 
 ### `workspace/notes/idea_pool.json`
 
-Written only when `--ideation-panel` is active. The Stage 02 candidate pool, with every
+Written when the ideation panel is seated — `--ideation-panel`, or `--rigor
+thorough`/`max`, which turn it on without a flag. The Stage 02 candidate pool, with every
 proposal, which ones were folded in as restatements, their novelty/feasibility/relevance
 scores, and an `effect` block.
 
@@ -887,29 +1442,86 @@ See [Ideation Panel](ideation-panel.md).
 
 ### `workspace/reviews/panel/`
 
-Written only when `--review-panel` is active. Per gate, `<stage>_attempt_NN.json` and a
+Written when the review panel is seated — `--review-panel`, or `--rigor max`,
+the only level that includes it. Per gate, `<stage>_attempt_NN.json` and a
 readable `.md` hold every position from every round, including dissent that lost and any
 chair override.
 
 Alongside them, `panel_effect.json` accumulates the panel against its own single-pass
-baseline — the chair's round-1 verdict, which is one model, one call, no peer input:
+baseline — the chair's round-1 verdict, which is one model, one call, no peer input. It
+holds `gates`, the per-gate rows, and `summary`, which is where these live:
 
-| Field | Meaning |
+| `summary` field | Meaning |
 | --- | --- |
 | `gates_reviewed` | Gates the panel has judged this run. |
 | `gates_where_the_panel_changed_the_decision` | How often deliberation reached a different decision than the baseline. **If this stays 0, the panel is not earning its cost.** |
 | `gates_where_round_1_disagreed` | How often the seats were not already unanimous. |
 | `chair_overrides` | Approvals converted to refinements by a blocking objection. |
+| `panel_calls` / `single_pass_calls` | The two call counts the ratio below is built from. |
 | `cost_multiple` | Reviewer calls spent per single-pass call. |
 | `verdict` | One plain sentence, written to be unflattering when that is the truth. |
 
 See [Review Panel](review-panel.md) for the pre-registered evidence this measurement exists
 to answer.
 
+### `workspace/artifacts/deliverables_coverage.json`
+
+Did the run answer what the task statement actually demanded? Everything else
+about Stage 07 measures how well the report was *made*; this measures whether it
+answered the question. Required at Stage 07+ in `markdown` mode.
+
+Observed on ResearchClawBench `Astronomy_000`. The task asked for upper limits
+on masses **and self-interaction coupling strengths**; the run produced a
+rigorous mass exclusion band and never reported a coupling limit. Its own rubric
+scored 1.000, and the criterion asking for the coupling constant — half the
+task's weight — scored 25/100. Nothing in the pipeline was comparing the report
+against the ask.
+
+```json
+{
+  "deliverables": [
+    {
+      "task_quote": "derive statistically rigorous upper limits on ULB masses",
+      "addressed": true,
+      "where": "Section 4: Mass Exclusion"
+    },
+    {
+      "task_quote": "and self-interaction coupling strengths",
+      "addressed": false,
+      "reason": "the available spectra do not constrain the coupling at any mass we can probe"
+    }
+  ]
+}
+```
+
+Four checks, all of them things a machine can settle:
+
+- **`task_quote` must be a verbatim span of the task statement** (whitespace
+  collapsed, case-insensitive). Without this, a stage can restate the
+  requirement as something it already did and mark it answered.
+- **Every demanding sentence in the task statement must be spoken to by some
+  quote.** A "demanding sentence" is one of at least 25 characters carrying a
+  verb from `DEMAND_VERBS` (34 of them: `derive`, `compute`, `compare`,
+  `constrain`, `evaluate`, …). Overlap is scored on content words at a 34%
+  threshold rather than exact containment, so a stage may legitimately quote the
+  clause instead of the whole sentence.
+- **`addressed: true` needs a `where` that actually appears in `report.md`.**
+  Deliberately loose — a section title, a figure filename, a heading all count.
+  The point is that the pointer is not fabricated, not that it follows a format.
+- **`addressed: false` needs a `reason`.** Reporting a requirement as unmet is a
+  valid outcome. Omitting it is not.
+
+What the gate deliberately does not do is judge whether the answer is *correct*.
+That is the same line every other AutoR validator holds.
+
+Validated by `validate_deliverables_coverage` in
+[`src/deliverables.py`](../src/deliverables.py), against the verbatim text of
+`user_input.txt`.
+
 ### `workspace/artifacts/self_review.json`
 
-Required to exist at Stage 07+. Its contents are not schema-validated, so its
-shape is up to the writing stage.
+Required to exist at Stage 07+, in both output formats. Its contents are not
+schema-validated, so its shape is up to the writing stage.
 
 ### `workspace/artifacts/build_log.txt`
 
@@ -938,7 +1550,11 @@ it loses the Studio's project groupings; the runs themselves are unaffected.
 ## Practical notes
 
 - **A run directory is self-contained.** Copy or archive `runs/<run_id>/` and
-  you have the whole record.
+  you have the whole record. Two things live outside it and neither is needed to
+  read a run: the Studio's project index at `<repo>/.autor/projects.json`, and
+  the cross-run topology archive at `~/.autor/archive` (`runs.jsonl`,
+  `variants.json`), which records this run's route and fitness so *other* runs
+  can be compared against it. `--archive PATH` moves the latter.
 - **`runs/` is gitignored.** Runs are outputs, not source. Archive them
   yourself if you need them.
 - **`--runs-dir` is resolved relative to the repository root.** Point it at a
@@ -946,37 +1562,3 @@ it loses the Studio's project groupings; the runs themselves are unaffected.
   checkpoints gets big.
 - **Read `logs.txt`, then `logs_raw.jsonl`, then `prompt_cache/`.** That is
   the fastest path from "the output is wrong" to "here is why".
-
-## `review_policy.json`
-
-The standing rules the approval gate has learned during this run. Written by
-[`src/review_policy.py`](../src/review_policy.py) whenever the reviewer demands a
-correction, and injected into every subsequent review prompt.
-
-```json
-{
-  "version": 1,
-  "rules": [
-    {
-      "rule_id": "R001",
-      "text": "The design lacks a stated power analysis and the sample size is unjustified.",
-      "origin_stage": "03_study_design",
-      "origin_attempt": 2,
-      "source": "refinement"
-    }
-  ]
-}
-```
-
-| Field | Meaning |
-| --- | --- |
-| `rule_id` | Stable identifier, referenced in the review prompt and the run log. |
-| `text` | The correction verbatim, as the reviewer worded it. |
-| `origin_stage` / `origin_attempt` | Which review produced the rule. This is what makes the mechanism auditable rather than assertable. |
-| `source` | `refinement` for a demanded correction, `rollback` for an approval that later proved wrong. Rollbacks are rendered first in the prompt. |
-
-Absent until the first correction is recorded. Approvals teach nothing and are not
-recorded. Rules are deduplicated on normalized text (casing, punctuation and stage numbers
-collapse) and the set is capped, so a reviewer restating one complaint cannot inflate it.
-A corrupt file is treated as an empty policy: the gate falls back to baseline strictness
-rather than taking the run down.

--- a/docs/stage-contract.md
+++ b/docs/stage-contract.md
@@ -9,8 +9,26 @@ A stage is only accepted when it satisfies two independent checks:
    Enforced by `validate_stage_artifacts` in [`src/utils.py`](../src/utils.py).
 
 A stage that passes both is shown to you for approval. A stage that fails
-either one is repaired, normalized locally, or re-run — up to
-`MAX_STAGE_ATTEMPTS` (5) attempts, after which AutoR stops and escalates.
+either one is repaired, normalized locally, or re-run — up to `--max-attempts`
+attempts, which defaults to `MAX_STAGE_ATTEMPTS` (5). After that AutoR
+escalates to you.
+
+In an unattended run there is nobody to escalate to, so the stage is
+auto-skipped instead and the walk continues. What lands on disk depends on the
+stage's last draft, and the two outcomes are alternatives, not a pair:
+
+- **The ordinary auto-skip.** `_skip_stage` generates a stub summary and that
+  stub *is* the promoted `stages/<slug>.md`. No `.skip_stub.md` file is written.
+- **A rescued draft.** `_validated_draft_for_skip` re-runs both gates on the
+  stage's last `stages/<slug>.tmp.md`. If that draft passes both, it is promoted
+  as `stages/<slug>.md` instead — real work is not thrown away because the retry
+  budget ran out — and the stub it displaced is kept beside it as
+  `stages/<slug>.skip_stub.md` for the audit trail. That sidecar is the *only*
+  thing that ever writes a `.skip_stub.md`.
+
+Either way the manifest records an auto-skip rather than an approval: nobody
+reviewed the output. Auto-skipping is bounded by `--max-auto-skips` (default 3);
+the run aborts once the budget is spent.
 
 Neither check is a substitute for reading the output. They are a floor, not a
 quality bar: they stop markdown-only theater, they do not certify science.
@@ -47,9 +65,19 @@ stage came from.
 
 ### Title
 
-The first non-empty line must be exactly `# Stage NN: <Display Name>` for that
-stage — for example `# Stage 03: Study Design`. Anything else fails with
-`Stage markdown title must be exactly '...'`.
+Two checks, in order, and they report different things.
+
+The document must *begin* with the literal `# Stage `. This one is a
+`str.startswith` on the raw text rather than on the first non-empty line, so a
+summary that opens with a blank line or a leading space fails with
+`Stage markdown must begin with '# Stage '.` even when its first non-empty line
+is a perfect title.
+
+Only if that passes is the title itself compared: the first non-empty line must
+equal `# Stage NN: <Display Name>` for that stage — for example
+`# Stage 03: Study Design`. A document that starts `# Stage ` and then says
+something else fails with
+`Stage markdown title must be exactly '# Stage NN: <Display Name>'.`
 
 ### No placeholders
 
@@ -128,57 +156,120 @@ so later stages can refer to a specific hypothesis rather than to prose.
 
 ## 2. The artifact gate
 
-Artifact requirements are **cumulative**: a Stage 07 run must still satisfy
-everything Stage 03, 05, and 06 required.
+Artifact requirements are **cumulative**: `validate_stage_artifacts` is a chain
+of `if stage.number >= N` blocks, so a Stage 07 run must still satisfy
+everything Stage 03, 05, and 06 required. Three checks are the exception, and
+the table marks them: the Stage 01 evidence ledger runs at Stage 01 *only*
+(`stage.number == 1`), and the two review-answering checks are called on every
+stage and select their own.
 
-| From stage | Requirement |
-| --- | --- |
-| **01** | `workspace/literature/sources.json` and `workspace/literature/claims.json` exist and cross-reference correctly (see [the evidence ledger](#the-evidence-ledger)). |
-| **03+** | At least one machine-readable file under `workspace/data/` with a suffix in `.json .jsonl .csv .tsv .parquet .yaml .yml`. |
-| **03+** | `workspace/notes/report_plan.json` exists and is a commitment (see [the report plan](#the-report-plan)). |
-| **06+** | Every live slot's and headline number's `source_artifact` resolves to a file that is not empty. |
-| **05+** | At least one result file under `workspace/results/` with a suffix in `.json .jsonl .csv .tsv .parquet .npz .npy`. |
-| **05+** | `workspace/results/experiment_manifest.json` exists and is structurally valid. |
-| **06+** | At least one figure under `workspace/figures/` with a suffix in `.png .pdf .svg .jpg .jpeg`. |
-| **08+** | At least one file under `workspace/reviews/`. |
+| From stage | Requirement | Checked by |
+| --- | --- | --- |
+| **01 only** | `workspace/literature/sources.json` and `workspace/literature/claims.json` exist and cross-reference correctly (see [the evidence ledger](#the-evidence-ledger)). | `validate_literature_evidence` |
+| **03+** | At least one machine-readable file under `workspace/data/` with a suffix in `.json .jsonl .csv .tsv .parquet .yaml .yml`. | `MACHINE_DATA_SUFFIXES` |
+| **03+** | `workspace/notes/report_plan.json` exists and is a commitment (see [the report plan](#the-report-plan)). | `validate_report_plan` |
+| **05+** | At least one result file under `workspace/results/` with a suffix in `.json .jsonl .csv .tsv .parquet .npz .npy`. | `RESULT_SUFFIXES` |
+| **05+** | `workspace/results/experiment_manifest.json` exists and is structurally valid. | `validate_experiment_manifest` |
+| **06+** | Every live slot's and headline number's `source_artifact` resolves to a file that exists and is not empty. | `validate_report_plan_sources` |
+| **06+** | At least one figure under `workspace/figures/` with a suffix in `.png .pdf .svg .jpg .jpeg`. | `FIGURE_SUFFIXES` |
+| **08+** | At least one file under `workspace/reviews/`. | — |
+| **06 and 07 only** | Every finding of the adversarial validity review of the previous stage is answered in `workspace/reviews/`. Stage 06 answers Stage 05, Stage 07 answers Stage 06; every other stage owes nothing, and so does a stage whose review found nothing. | `validate_validity_response` |
+| **06, then 07+** | At Stage 06, `workspace/notes/round_decision.json` names one of the four round decisions. From Stage 07 on, a closed round must exist and must not stand `abandon`ed. | `validate_round_decision` |
 
-Stage 07's requirements depend on the run's `output_format`.
+One Stage 07 requirement is shared by both output formats, because it runs
+before the branch:
+
+| From stage | Requirement | Checked by |
+| --- | --- | --- |
+| **07+** | Every claim in `workspace/artifacts/claim_provenance.json` is `confirmatory` on a `supported` hypothesis or labelled `exploratory`, and cites a file that exists. | `validate_claim_provenance` |
+
+Everything else at Stage 07 depends on the run's `output_format`, and **the two
+branches share very little**. In particular `validate_markdown_report`,
+`validate_report_plan_coverage` and `validate_deliverables_coverage` do **not**
+run on the latex branch.
 
 **`markdown` (the default):**
 
-| From stage | Requirement |
-| --- | --- |
-| **07+** | `workspace/report/report.md` exists and holds at least 1,200 characters. |
-| **07+** | It contains no placeholder text. |
-| **07+** | It references at least one figure, via `![...](...)` or `<img src="...">`. |
-| **07+** | Every figure reference is report-relative — not absolute, not a URL. |
-| **07+** | Every figure reference resolves to a file that exists under `workspace/report/`. |
-| **07+** | Every referenced figure is renderable: `.png .jpg .jpeg .gif .webp`. |
-| **07+** | At least one renderable image under `workspace/report/images/`, and **at most 5**. |
-| **07+** | `workspace/artifacts/citation_verification.json`, structurally valid. |
-| **07+** | `workspace/artifacts/self_review.json`. |
-| **07+** | `workspace/artifacts/report_review.json`, structurally valid. |
-| **07+** | Every slot in `report_plan.json` was published under `report/images/` and referenced from `report.md`, or carries a `dropped_because` of at least 20 characters — and not every slot may be dropped. |
+| From stage | Requirement | Checked by |
+| --- | --- | --- |
+| **07+** | `workspace/report/report.md` exists and holds at least `MIN_REPORT_CHARS` (1,200) characters after stripping. | `validate_markdown_report` |
+| **07+** | It contains no placeholder text. | `validate_markdown_report` |
+| **07+** | It references at least one image, via `![...](...)` or `<img src="...">`. | `validate_markdown_report` |
+| **07+** | Every image reference is report-relative — not absolute, not a URL, and not a path that climbs out of `report/`. | `resolve_report_image` |
+| **07+** | Every image reference resolves to a file that exists under `workspace/report/`. | `validate_markdown_report` |
+| **07+** | Every referenced image is renderable: `.png .jpg .jpeg .gif .webp` (`RENDERABLE_IMAGE_SUFFIXES`). | `validate_markdown_report` |
+| **07+** | The count of **published, renderable images under `workspace/report/images/`** is at least this run's figure floor and at most `MAX_REPORT_FIGURES` (5). | `validate_markdown_report` |
+| **07+** | `workspace/artifacts/deliverables_coverage.json` accounts for what the task statement demanded (see [the deliverables contract](#the-deliverables-contract)). | `validate_deliverables_coverage` |
+| **07+** | `workspace/artifacts/citation_verification.json`, structurally valid. | `validate_citation_verification` |
+| **07+** | `workspace/artifacts/self_review.json`. | — |
+| **07+** | `workspace/artifacts/report_review.json`, structurally valid. | `validate_report_review` |
+| **07+** | Every slot in `report_plan.json` was published under `report/images/` and referenced from `report.md`, or carries a `dropped_because` of at least `MIN_DROP_REASON_CHARS` (20) characters — and not every slot may be dropped. | `validate_report_plan_coverage` |
+| **07+** | The highest-ranked live slot is referenced within the first `JUDGE_VISIBLE_PREFIX_CHARS` (10,000) characters of `report.md`, when the report is longer than that. | `validate_report_plan_coverage` |
+
+#### The figure floor and the figure ceiling are two different numbers
+
+The count check is not "at least one figure". It compares the published images
+against `resolve_min_report_figures(load_run_config(paths).get("min_report_figures"))`,
+which is the run's own recorded floor clamped into `[1, MAX_REPORT_FIGURES]`:
+
+| Run | Floor | Source |
+| --- | --- | --- |
+| An ordinary run | 1 | `MIN_REPORT_FIGURES`, the `default_run_config` value |
+| A ResearchClawBench run | 3 | `BENCHMARK_MIN_REPORT_FIGURES`, passed by `rcb_agent.py` |
+
+There is no `main.py` flag for it: a normal run gets the floor of 1, and the
+raised floor arrives only through the benchmark entry point. The floor is a
+count of *distinct* figures and never a target to pad toward — the ceiling is
+five either way.
 
 The upper bound is not a style preference. A benchmark judge is shown only the first five
 images it finds, in filesystem order, so a sixth figure does not add a sixth chance to be
-credited — it makes it arbitrary which of yours are seen.
+credited — it makes it arbitrary which of yours are seen. It is also why the floor is
+clamped at five: a floor above the ceiling would demand figures nobody is shown.
+
+**Reference-existence is a separate check from the count.** A report can
+reference one figure and still fail the count (three published images required,
+two on disk), and it can publish five images and still fail the reference checks
+(one of them linked as `../figures/x.png`). Both run on every markdown Stage 07.
 
 **`latex`:**
 
-| From stage | Requirement |
-| --- | --- |
-| **07+** | `workspace/writing/main.tex` exists **and** matches the selected venue (see [venue matching](#venue-matching)). |
-| **07+** | A `.bib` file under `workspace/writing/`, or an inline bibliography. |
-| **07+** | At least one `.tex` file under `workspace/writing/sections/`. |
-| **07+** | A compiled PDF under `workspace/writing/` or `workspace/artifacts/`. |
-| **07+** | `workspace/artifacts/build_log.txt`. |
-| **07+** | `workspace/artifacts/citation_verification.json`, structurally valid. |
-| **07+** | `workspace/artifacts/self_review.json`. |
-| **07+** | `workspace/artifacts/layout_review.json`, structurally valid. |
+| From stage | Requirement | Checked by |
+| --- | --- | --- |
+| **07+** | `workspace/writing/main.tex` exists **and** matches the selected venue (see [venue matching](#venue-matching)). | `_looks_like_supported_manuscript` |
+| **07+** | A `.bib` file under `workspace/writing/`, or an inline bibliography. | `_has_inline_bibliography` |
+| **07+** | At least one `.tex` file under `workspace/writing/sections/`. | — |
+| **07+** | A compiled PDF under `workspace/writing/` or `workspace/artifacts/`. | — |
+| **07+** | `workspace/artifacts/build_log.txt`. | — |
+| **07+** | `workspace/artifacts/citation_verification.json`, structurally valid. | `validate_citation_verification` |
+| **07+** | `workspace/artifacts/self_review.json`. | — |
+| **07+** | `workspace/artifacts/layout_review.json`, structurally valid. | `validate_layout_review` |
+
+Nothing on the latex branch reads `report.md`, `report/images/` or
+`deliverables_coverage.json`, and the report plan is checked for *shape* (Stage
+03) and for *sources* (Stage 06) but never for coverage. The layout review is
+what covers that ground for a manuscript, because a LaTeX document places its
+own figures and there is no single directory a coverage check could read.
 
 The schemas of the validated JSON files are in
 [Run Artifacts](run-artifacts.md).
+
+### The validity chain runs from the same function
+
+`validate_stage_artifacts` also hosts the scientific-validity chain — its own
+comment names the split, *"the scientific-validity chain, distinct from the
+artifact gates around it"*. These are not artifact-existence checks, so they are
+listed separately, but they fail a stage exactly the same way.
+
+| From stage | Requirement | Checked by |
+| --- | --- | --- |
+| **05+** | A frozen preregistration exists, holds at least one empirical hypothesis, every one carries a `decision_rule`, and the manifest has not silently changed under it. | `validate_preregistration` |
+| **05+** | An experimental protocol declares a primary metric, planned seeds, and per-baseline `why_competent` and `tuning_budget`. | `validate_experimental_protocol` |
+| **06+** | Exactly one verdict per frozen hypothesis, nothing unpreregistered adjudicated, and every `supported`/`refuted` verdict citing an evidence file that exists. | `validate_hypothesis_outcomes` |
+| **06+** | Each `supported` or `refuted` verdict carries `statistics.n_seeds`, a `dispersion_type` from a fixed vocabulary, and a written justification when a single run settled it (`MIN_SEEDS_FOR_A_VERDICT` is 2). `inconclusive` and `not_tested` are exempt on purpose. | `validate_outcome_statistics` |
+
+The argument for the chain, and where each link is frozen, is in
+[The AutoR Framework](framework.md#33-the-validity-chain).
 
 ### Freshness checks
 
@@ -189,11 +280,21 @@ owns to be at least that new.
 
 | Stage | Must be newly written during this stage |
 | --- | --- |
-| `03_study_design` | at least one file under `workspace/data/` |
-| `06_analysis` | at least one file under `workspace/figures/` |
+| `03_study_design` | at least one file under `workspace/data/` **whose suffix is in `MACHINE_DATA_SUFFIXES`** |
+| `06_analysis` | at least one file under `workspace/figures/` **whose suffix is in `FIGURE_SUFFIXES`** |
 | `07_writing` (markdown) | `report/report.md`, `citation_verification.json`, `self_review.json`, `report_review.json` |
 | `07_writing` (latex) | `main.tex`, `build_log.txt`, `citation_verification.json`, `self_review.json`, `layout_review.json`, a PDF, and at least one `sections/*.tex` |
 | `08_dissemination` | at least one file under `workspace/reviews/` |
+
+The rows are not one rule. The Stage 03 and Stage 06 rows go through
+`_has_recent_files_with_suffixes` against the same suffix sets their existence
+checks use, so writing a file is not the same as satisfying them: a run that
+inherits an older `data/prior.csv` and writes only `data/notes.md` this time is
+refused with *"requires machine-readable data artifacts produced or updated
+during the current stage execution"*, even though a file under `workspace/data/`
+was newly written. The `08_dissemination` row is the one with no suffix filter:
+it iterates `_existing_files(paths.reviews_dir)`, so any newly written file
+there counts.
 
 This is what stops a re-run from being credited with the previous attempt's
 files. Stages that only *consume* an artifact class (for example Stage 05
@@ -202,25 +303,72 @@ reading `workspace/data/`) check existence but not freshness.
 ### The report plan
 
 `workspace/notes/report_plan.json` is where the run commits to its figures —
-at Stage 03, before a result exists that could choose them for it. The
-validator is `src/report_plan.py`.
+at Stage 03, before a result exists that could choose them for it. The module
+is [`src/report_plan.py`](../src/report_plan.py), and it holds the plan at three
+different stages with three different questions:
+
+| Stage | Question | Validator |
+| --- | --- | --- |
+| **03+** | Is the plan a commitment — every field present, every slot distinct? | `validate_report_plan` |
+| **06+** | Does the file each live slot and headline number draws from exist and hold bytes? | `validate_report_plan_sources` |
+| **07+, markdown only** | Was every live slot published and referenced, or dropped on the record? | `validate_report_plan_coverage` |
 
 Each entry in `figures` needs a `slot` (unique, contiguous from 1), a bare
-`filename` with a publishable image suffix, a `supports` list naming the claim
-the figure settles (a `hypothesis_manifest.json` id, or `exploratory:<slug>`),
-a `shows` sentence, an `if_supported` and an `if_refuted` that are not the same
-sentence, and a `source_artifact` under `results/`, `data/` or `outputs/`.
-`headline_numbers` names the quantities the report must state, each with a unit
-and a `source_artifact`. In markdown mode there may be at most
-`MAX_REPORT_FIGURES` slots.
+`filename` whose suffix this run's deliverable publishes (see below), a
+`supports` list naming the claim the figure settles (a
+`hypothesis_manifest.json` id, or `exploratory:<slug>` with a slug of at least
+`MIN_EXPLORATORY_SLUG_CHARS` (3) characters), a `shows` sentence of at least
+`MIN_SHOWS_CHARS` (40) characters, an `if_supported` and an `if_refuted` of at
+least `MIN_BRANCH_CHARS` (20) characters each that are not the same sentence,
+and a `source_artifact` under `results/`, `data/` or `outputs/`. In markdown
+mode there may be at most `MAX_REPORT_FIGURES` slots.
+
+**The plan's suffix rule is narrower than the report's.**
+`_allowed_figure_suffixes` returns exactly `{".png"}`
+(`PREFERRED_REPORT_IMAGE_SUFFIX`) in markdown mode, and only in latex mode does
+it widen to the full `FIGURE_SUFFIXES` set (`.png .pdf .svg .jpg .jpeg`).
+Anything else is refused at Stage 03 with *"whose format is not published by
+this run's deliverable"*. That is not the same set as
+`RENDERABLE_IMAGE_SUFFIXES` (`.png .jpg .jpeg .gif .webp`), which is what Stage
+07 accepts in `report.md`: a `.jpg` already on disk is a legal reference in the
+report, but a plan slot that *declares* `main_result.jpg` never gets that far.
+Plan every markdown figure as `.png`.
+
+Two fields outside `figures` are also required at Stage 03:
+
+- `headline_numbers` — the quantities the report must state, each with a
+  `quantity`, a non-empty `unit` (`dimensionless` and `count` are units) and a
+  `source_artifact`. The list may not be empty, and holds at most
+  `MAX_HEADLINE_NUMBERS` (8) entries.
+- `task_outputs` — every deliverable the task description states, each answered
+  by a `figure:<slot>`, a `number:<index>`, `prose`, or `not_attempted` with a
+  reason of at least 20 characters. A `figure`/`number` target that the plan
+  does not declare is refused.
+
+A plan with **no** figures is allowed but has to say so: `no_figures_because`,
+at least `MIN_SHOWS_CHARS` (40) characters, naming what the prose carries
+instead. Three of the forty ResearchClawBench tasks have no image criterion at
+all, and this field is how such a study declines to *commit* to a figure at
+Stage 03 rather than inventing a slot to satisfy the gate.
+
+**Declining a slot does not exempt the run from publishing figures.** On the
+markdown branch, Stage 07 measures `report/images/` against
+`resolve_min_report_figures`, which clamps into `[1, MAX_REPORT_FIGURES]` and so
+can never yield a floor of 0, and `validate_markdown_report` separately refuses
+a report that references no image at all. A ResearchClawBench run is a markdown
+run whose floor `rcb_agent.py` raises to `BENCHMARK_MIN_REPORT_FIGURES` (3), so
+those image-criterion-free tasks still owe three published figures. An empty
+plan buys a study silence at Stage 03, not an illustration-free report.
 
 Two rules exist to stop the file being satisfied without committing to
 anything:
 
 - **Every slot must carry at least one claim no other slot carries.** This is
-  the only rule here that pushes the figure count *down*; nothing in the module
-  ever asks for more figures, because `MAX_REPORT_FIGURES` is a ceiling and a
-  gate that restated it as a goal would have made it a quota.
+  the only rule here that pushes the figure count *down*, and nothing in
+  `report_plan.py` pushes it up: the published-figure floor is
+  `validate_markdown_report`'s, at Stage 07, not the plan's. `MAX_REPORT_FIGURES`
+  is a ceiling, and a plan gate that restated it as a goal would have made it a
+  quota.
 - **A slot cannot be born dropped.** `dropped_because` is skipped by the Stage
   06 source check and the Stage 07 coverage check, so a slot abandoned in the
   same plan that declares it would owe nothing at all. Dropping is only allowed
@@ -232,6 +380,61 @@ anything:
 `stamp_report_plan` on Stage 03 approval and kept in `report_plan_stamp.json`
 outside `workspace/`. The agent does not write them, and the validators ignore
 them in the file.
+
+### The deliverables contract
+
+Every other gate on this page measures how well the report was *made*.
+`validate_deliverables_coverage` ([`src/deliverables.py`](../src/deliverables.py))
+asks the prior question: did the run answer what it was asked? It is a hard
+Stage 07 gate on the markdown branch, and a report that is rigorous about the
+wrong question fails it.
+
+The stage writes `workspace/artifacts/deliverables_coverage.json`:
+
+```json
+{"deliverables": [
+  {"task_quote": "<verbatim span of the task statement>",
+   "addressed": true,
+   "where": "<section heading or images/figure.png in report.md>"},
+  {"task_quote": "<verbatim span>", "addressed": false,
+   "reason": "<why it could not be answered>"}
+]}
+```
+
+The rules a machine can settle, and does:
+
+- **`task_quote` must be verbatim.** The quote is compared against
+  `user_input.txt` with whitespace collapsed and both sides lower-cased, and
+  nothing else. This is the rule with teeth: without it a stage can restate an
+  inconvenient requirement as something it happened to do and mark that
+  addressed.
+- **`addressed` must be a boolean.** An entry without one is refused before its
+  `where`/`reason` is looked at.
+- **An addressed entry needs a `where` that appears in `report.md`.** The match
+  is deliberately loose — a section title, a figure filename or a heading all
+  count, and the locator is also split on `/`, `,`, `;`, `|` and ` and ` so a
+  fragment of at least six characters can carry it. The point is that the
+  pointer is not fabricated, not that it follows a format.
+- **An unaddressed entry needs a `reason`.** Reporting a requirement as unmet is
+  a valid outcome; omitting it is not.
+- **Every demanding sentence must be covered.** `demanding_sentences()` picks
+  the sentences of the task statement that are at least 25 characters and
+  contain one of the 34 `DEMAND_VERBS` — *derive*, *compute*, *compare*,
+  *constrain*, *reproduce* and the rest. A sentence whose content
+  words (longer than three characters) overlap the union of all quotes by less
+  than 34% is reported as unaccounted for, up to five at a time.
+
+What it does **not** do is judge whether the answer is correct. That is the same
+line every other validator on this page holds.
+
+> **A trap worth knowing.** The file is required unconditionally on the markdown
+> branch, but the only place the agent is ever told to write it is
+> `format_deliverables_for_prompt`, which returns `""` when `demanding_sentences()`
+> finds nothing. A goal phrased without a demand verb — *"I want to know whether
+> X causes Y"* — therefore gets no `# What the Task Asks For` block in any stage
+> prompt, and then hits a Stage 07 refusal for a file it was never asked to
+> write. Phrasing the goal with an explicit verb avoids it; so does writing the
+> file by hand.
 
 ### The evidence ledger
 
@@ -251,15 +454,25 @@ cannot pass Stage 01.
 ### Venue matching
 
 Stage 07's `main.tex` must look like a manuscript for the venue the run was
-started with. AutoR checks for the venue's style package, and accepts an
-explicit override comment near the top of the file:
+started with. `_markers_for_venue` builds the accepted markers from three of the
+venue's registry fields — its key, its `display_name` and its `style_package` —
+each normalized for case, spaces and punctuation, and `main.tex` passes if the
+normalized text contains any one of them. A venue whose `style_package` is empty
+(`nature`, `nature_communications`) is matched on the other two.
+
+An explicit override comment is accepted anywhere in the file, not only at the
+top:
 
 ```tex
 % AutoR venue: iclr_2026
 ```
 
-The failure message names the expected venue key, so a mismatch is
-self-explanatory.
+It has to name the run's own venue. A comment naming some *other* registered
+venue grants nothing: the check falls back to hunting the expected venue's own
+markers in the text, and fails if it finds none. A comment naming a key that is
+not in the registry at all is discarded and treated as if it were absent. The
+failure message names the expected venue key and repeats the comment form, so a
+mismatch is self-explanatory.
 
 ---
 

--- a/docs/tutorial_en.md
+++ b/docs/tutorial_en.md
@@ -2,7 +2,7 @@
 
 > This guide is for first-time AutoR users.
 >
-> The goal is not just to make the command run. The goal is to help you understand how to install AutoR, how to use it correctly, how to supervise each stage so outputs do not stay toy-level, and how to get to a strong final PDF as quickly as possible.
+> The goal is not just to make the command run. The goal is to help you understand how to install AutoR, how to use it correctly, how to supervise each stage so outputs do not stay toy-level, and how to get to a strong final deliverable — a markdown report by default, or a compiled PDF with `--output-format latex` — as quickly as possible.
 
 ## 1. AutoR in One Sentence
 
@@ -26,6 +26,8 @@ So when you use AutoR, the highest-leverage thing is not pressing Enter once. It
 
 If you use that loop well, AutoR becomes much stronger.
 
+> **Want the design instead of the steps?** This guide is the operating manual. [framework.md](framework.md) is the argument: why every gate is a function that reads the filesystem rather than the transcript, why the improvement loop is scored by something it cannot influence, and — stated just as plainly — what has *not* been established. Read it if you want to know why AutoR is shaped the way it is; you do not need it to run your first project.
+
 ---
 
 ## 2. What AutoR Can Do
@@ -33,15 +35,17 @@ If you use that loop well, AutoR becomes much stronger.
 The current mainline is built for these workflows:
 
 - start from a concrete research goal
-- move through a fixed multi-stage research pipeline
+- walk eight research stages that are **nodes in a directed graph**, not steps in a fixed list: the default move is always forward, but a stage that exposes an earlier mistake can send the run back
 - call a real execution backend at every stage
-- write prompts, logs, stage summaries, code, data, figures, writing sources, and PDFs to `runs/<run_id>/`
+- write prompts, logs, stage summaries, code, data, figures, writing sources, reports, and PDFs to `runs/<run_id>/`
 - resume an existing run
 - redo from a specific stage
 - roll back to an earlier stage and invalidate downstream work
+- stop early at a chosen stage (`--final-stage`)
 - start from an existing project repository
 - start from your own prior paper corpus
-- organize Stage 07 writing around a target venue profile
+- produce either a markdown report (the default) or a venue-aware LaTeX package with a compiled PDF (`--output-format latex`)
+- choose how much optional machinery a run uses with one dial (`--rigor`)
 - support literature organization, citation verification, experiment manifests, artifact indexing, and packaging
 
 The current execution backends are:
@@ -59,7 +63,10 @@ Several recent mainline changes matter for real use:
 - The terminal UI is better suited for real runs and recordings: panel body rows keep colored borders, long lines, long paths, and wide characters wrap inside the frame, and Stage 0 plus approval menus support keyboard navigation.
 - The Codex backend now uses the current Codex CLI `--sandbox workspace-write` execution flag, so it should not emit the deprecated Codex CLI `--full-auto` warning. This is separate from AutoR's own `--full-auto` approval mode.
 - If a Codex-backed run needs remote SSH / GPU execution, you can explicitly use `--codex-sandbox danger-full-access`. The default remains the safer `workspace-write`; do not use unrestricted mode by default.
-- AutoR's `--full-auto` still means automated approval: a strict reviewer agent replaces the waiting human gate, while the 9-stage research workflow itself stays unchanged.
+- AutoR's `--full-auto` still means automated approval: a strict reviewer agent replaces the waiting human gate, while the eight-stage research workflow itself stays unchanged. Note that `--full-auto` is a shortcut for `--approval-mode agent` **plus** `--unattended`, so it also stops the run from ever blocking on terminal input, and a stage that burns its whole retry budget is auto-skipped rather than aborting the run (up to `--max-auto-skips`, default 3).
+- The stages are a **graph**, not a list. `--stage-graph` defaults to `adaptive`, where an analysis that exposes a design flaw can route back to Stage 03 instead of writing up around it. `--stage-graph linear` gives the strict 01-through-08 sequence, except that a round which concludes the question cannot be answered still finishes at Stage 06. See [8.1](#81-the-shape-of-the-walk) and [8.2](#82-when-a-late-finding-sends-the-run-back).
+- The optional machinery is behind one dial. `--rigor` picks a level (`fast`, `standard`, `thorough`, `max`) instead of asking you to know four separate switches; `standard` is the default. See [6.5](#65-one-dial-you-should-meet-early---rigor).
+- Stage 07's default deliverable is a markdown report at `workspace/report/report.md` with embedded figures. The submission-style LaTeX package and compiled PDF are still there, behind `--output-format latex`.
 
 ---
 
@@ -73,9 +80,11 @@ Recommended environment:
 | Git | Required | Needed to clone the repository |
 | Node.js 18+ | Strongly recommended | Claude Code officially requires Node 18+, and Codex CLI is also installed via npm |
 | Claude Code or Codex CLI | Required for real runs | You need at least one execution backend |
-| TeX toolchain | Optional but recommended | Helps Stage 07 produce stable compilable PDFs |
+| TeX toolchain | Optional | Only needed for `--output-format latex`, where Stage 07 compiles a PDF |
 | `PyMuPDF` | Optional | Recommended if you use `--paper-corpus` and want PDF text extraction |
-| `google-genai` / `Pillow` / `PyYAML` | Optional | Only needed for `--research-diagram` |
+| `google-genai` / `Pillow` / `PyYAML` | Optional | Needed for `--research-diagram`; `google-genai` is also what `--web-search gemini` and `--cross-review` use |
+
+AutoR's own runtime imports nothing outside the Python standard library, so there is no install step and no requirements file to fight with. Everything in the *Optional* rows above degrades to a recorded "unavailable" rather than a crash.
 
 Platform notes:
 
@@ -184,7 +193,7 @@ Then give it something like this:
 
 ```text
 Please install AutoR in the current directory:
-1. clone https://github.com/AutoX-AI-Labs/AutoR.git
+1. clone https://github.com/tangxiangru/AutoR.git
 2. enter the repo and read the README plus python main.py --help
 3. create a Python virtual environment if needed
 4. install the minimum dependencies required to run the current repo
@@ -204,7 +213,7 @@ Why this is useful:
 If you prefer to do it manually:
 
 ```bash
-git clone https://github.com/AutoX-AI-Labs/AutoR.git
+git clone https://github.com/tangxiangru/AutoR.git
 cd AutoR
 python main.py --help
 ```
@@ -318,6 +327,8 @@ Its purpose is only to check:
 
 Do not mistake a smoke test for a real research run.
 
+One thing a smoke test cannot show you: with `--fake-operator` there is no backend to ask which move to take, so the router always takes the graph's default edge. A fake run therefore walks straight through 01 to 08 and never demonstrates a backward move.
+
 ### 6.4 Optional: Use AutoR Studio in the Browser
 
 If you prefer approving stages, reading the paper, and watching progress from a browser, you can use **AutoR Studio** instead of staying in the terminal the whole time.
@@ -361,6 +372,48 @@ Good rule of thumb:
 - use `python main.py` when you want the most direct, scriptable, backend-flexible workflow
 - use `python studio.py` when you want a more visual approval, review, and demo experience
 
+One more Studio limitation worth knowing before you pick an interface: Studio exposes no stage-graph or routing switches. It drives the same `ResearchManager` the terminal does, so graph routing and backward moves are available there too — but every Studio run gets the defaults (the adaptive graph, `--routing auto`), and there is no browser equivalent of `--stage-graph linear --routing off`.
+
+### 6.5 One Dial You Should Meet Early: `--rigor`
+
+AutoR has a set of optional mechanisms — cheaper prompts for settled stages, a crux panel, an ideation panel, a five-seat review panel. You do not have to learn four switches to use them. One flag picks a level:
+
+| `--rigor` | effort tiers | crux deliberation | ideation panel | review panel |
+| --- | :---: | :---: | :---: | :---: |
+| `fast` | – | – | – | – |
+| `standard` *(the default)* | **on** | – | – | – |
+| `thorough` | **on** | **on** | **on** | – |
+| `max` | **on** | **on** | **on** | **on** |
+
+Each level adds to the one above it, and the table is `_LEVEL_FEATURES` in [../src/rigor.py](../src/rigor.py), which is the single source of truth for it — `python main.py --help` prints the same rows.
+
+What each one is:
+
+- **effort tiers** (`--effort-tiers`) — runs each stage as *routine* or *deliberative* instead of treating them alike. By default `04_implementation`, `05_experimentation` and `08_dissemination` start routine: a leaner prompt, one reviewer, no polish rounds. A routine stage that keeps failing its gate is promoted automatically. This is the only one of the four that makes a run **cheaper**, which is why it is on at the default level.
+- **crux deliberation** (`--deliberation`) — lets a stage stop and pull in a four-voice panel when it hits a genuine crux. Budgeted: `--max-deliberations` defaults to 3.
+- **ideation panel** (`--ideation-panel`) — widens Stage 02 with five proposers working from distinct lenses. It proposes; it decides nothing.
+- **review panel** (`--review-panel`) — replaces the single reviewer with five role-differentiated seats (PI, domain expert, methodologist, reproducibility engineer, adversarial reviewer) that review blind, cross-examine, then have a chair synthesize one decision. `--panel-roles` can reseat it, including an optional sixth `reader` seat.
+
+An explicit switch always beats the level, in both directions:
+
+```bash
+python main.py --rigor thorough --no-ideation-panel --goal "..."
+python main.py --rigor fast --deliberation --goal "..."
+```
+
+**The warning that matters most on this page:**
+
+> `--rigor max` implies `--review-panel`, and `--review-panel` **removes the human from the approval gate**. The panel *is* an approval gate, so there is nobody left to answer a terminal prompt: `resolve_unattended` in [../main.py](../main.py) returns true for `--review-panel` exactly as it does for `--unattended` and `--full-auto`, and `--rigor` is resolved *before* it. A plain `python main.py --rigor max --goal "..."` is therefore an unattended, agent-gated run — the flag that reads like *more review* is the flag that takes away *your* review.
+
+If you want the extra machinery but intend to approve the stages yourself, ask for it without the panel:
+
+```bash
+python main.py --rigor thorough --goal "..."          # deliberation + ideation, human still at the gate
+python main.py --rigor max --no-review-panel --goal "..."   # same effect, stated the other way round
+```
+
+For a new user, `standard` (that is, passing nothing) is the right starting point. Details, and how the levels read back in the run log: [rigor.md](rigor.md).
+
 ---
 
 ## 7. Step Four: Use Explicit Flags When You Need Fixed Configuration
@@ -384,6 +437,8 @@ python main.py \
   --model default \
   --goal "Study whether retrieval-augmented chain-of-thought improves factual QA under a fixed token budget, and produce a submission-style PDF."
 ```
+
+One thing those goals do **not** do: asking for a PDF in the goal text does not produce one. The deliverable is chosen by `--output-format`, which defaults to `markdown`. Add `--output-format latex` if you want the LaTeX package and the compiled PDF.
 
 If your Codex-backed run needs to submit remote GPU jobs through SSH, for example after you have manually verified `ssh gpu-server "hostname && nvidia-smi"`, explicitly relax the Codex sandbox:
 
@@ -424,12 +479,32 @@ python main.py \
   --goal "..."
 ```
 
-Two boundaries matter here:
+Three boundaries matter here:
 
-- `--full-auto` does **not** change the main research pipeline; it only swaps the manual approval gate for a strict reviewer agent
+- `--full-auto` does **not** change the stage graph; it swaps the manual approval gate for a strict reviewer agent
+- it *does* change what happens when a stage fails. `--full-auto` is a shortcut for `--approval-mode agent` plus `--unattended`, and an unattended stage that exhausts `--max-attempts` (default 5) is auto-skipped instead of stopping the run, up to `--max-auto-skips` (default 3). A skipped stage is recorded as skipped, not as approved, but the run keeps going without it
 - for serious research work, the default human-reviewed mode is still the recommended path; `--full-auto` is more useful for unattended sweeps, overnight dry runs, or pipeline pressure tests
 
-### 7.2 Choose the Venue Early
+Three flags put an agent in the approval seat: `--approval-mode agent`, `--full-auto`, and `--review-panel` (including the `--review-panel` that `--rigor max` turns on for you). Each sets `approval_mode` to `agent` and, through `resolve_unattended`, also marks the run unattended.
+
+`--unattended` on its own is the fourth input to `resolve_unattended` but is *not* one of those three. It only says nobody is at the terminal; `approval_mode` stays `manual`, so no reviewer agent is installed and the first approval menu has nobody to answer it — the terminal UI raises `UnattendedInputError` instead of the gate being decided. Removing the human and installing an agent are different things, and only the three flags above do both. If you meant to review the stages yourself, pass none of the four.
+
+### 7.2 A Few More Flags Worth Knowing on a First Real Run
+
+You do not need the full flag list to start, but these come up almost immediately. Every flag, its default, and what is preserved on resume: **[cli-reference.md](cli-reference.md)**.
+
+| Flag | Default | Why a first-time user wants it |
+| --- | --- | --- |
+| `--goal-file PATH` | — | Read the goal from a file instead of `--goal`. A serious goal is usually several paragraphs, and shell quoting stops being fun quickly. Mutually exclusive with `--goal`. |
+| `--output-format {markdown,latex}` | `markdown` | `markdown` writes `workspace/report/report.md` with figures under `workspace/report/images/`. `latex` produces the submission-style package instead: `main.tex`, `sections/*.tex`, a bibliography, and a compiled PDF. Preserved when resuming. |
+| `--final-stage STAGE` | run everything | Stop after this stage instead of running the whole workflow, e.g. `--final-stage 07_writing` when you want the report but not the dissemination package. |
+| `--max-attempts N` | `5` | Attempts per stage before AutoR escalates (or, unattended, auto-skips). Each retry re-runs the stage with the previous attempt's validation errors attached. Raise it for a stubborn stage. |
+| `--stage-timeout SECONDS` | `14400` (4 hours) | Wall-clock ceiling for one stage attempt. Raise it before a heavy Stage 05, not after it times out. |
+| `--web-search {auto,gemini,native}` | `auto` | How the agent searches. `gemini` routes searches through the Gemini API, which is what you need where the backend's own web search is disabled (Claude Code on Vertex AI, for example). `native` leaves the backend's own tool in charge. `auto` uses Gemini when a key is available and falls back to native. |
+| `--fake-operator` | off | A dry run with no backend and no tokens. See [6.3](#63-optional-run-a-smoke-test-first). |
+| `--resume-run ID`, `--redo-stage STAGE`, `--rollback-stage STAGE` | — | Continue, re-run, or invalidate. See [12.1](#121---redo-stage-vs---rollback-stage). |
+
+### 7.3 Choose the Venue Early
 
 If you already know the target writing style, set the venue from the beginning:
 
@@ -451,7 +526,7 @@ python main.py \
   --goal "..."
 ```
 
-Common venue profiles include:
+The registry ships 12 venue keys today:
 
 - `neurips_2025`
 - `neurips_2026`
@@ -466,15 +541,16 @@ Common venue profiles include:
 - `nature_communications`
 - `jmlr`
 
-See the full list in [../templates/registry.yaml](../templates/registry.yaml).
+The authoritative list is [../templates/registry.yaml](../templates/registry.yaml). `resolve_venue_key` accepts a registry key, the display name (`ICLR 2026`), or the style-package name (`iclr2026_conference`), with the comparison ignoring case, spaces, and every other non-alphanumeric character. A value it cannot match to any of those three is **not** quietly replaced by the default: it raises `Unknown venue: <value>`, and because the resolution happens while the CLI is still assembling the run configuration, the process prints `Error: Unknown venue: <value>`, exits 1, and never creates a run directory. (`python main.py --fake-operator --goal x --venue neurips2027` does exactly that.) The silent fallback belongs to `resolve_output_format`, which does return the default for an unrecognized value — not to the venue.
 
 Notes:
 
 - if you do not specify `--venue`, the default is `neurips_2025`
-- AutoR uses the venue profile to shape Stage 07 writing and packaging
+- the venue profile matters most in `--output-format latex`, where Stage 07 is told the venue's type, page limit, citation style, and preferred style package, and the stage gate refuses a `main.tex` it cannot match to the configured venue
+- in the default `markdown` mode the venue key is still recorded in `run_config.json` and shown to the writing stage, but a markdown report has no style package or page budget to hit, so the effect is much smaller
 - this does not mean the repo vendors the complete official submission system for that venue
 
-### 7.3 Strongly Prefer Starting with Resources
+### 7.4 Strongly Prefer Starting with Resources
 
 If you already have papers, BibTeX, data, code, or notes, do not start from a blank slate if you can avoid it.
 
@@ -504,7 +580,9 @@ One more practical detail:
 
 So if you already have a small code repo, a data folder, or a bundle of reading materials, you can ingest the whole thing instead of splitting it manually.
 
-### 7.4 If You Need to Teach AutoR a Specific "Skill"
+With one caveat worth knowing: a directory is classified as a whole, not file by file. A directory containing `.py` or `.ipynb` files is ingested as code into `workspace/code/`; any other directory lands in `workspace/artifacts/`. Individual files are classified by suffix, so PDFs and `.bib` files passed *individually* go to `workspace/literature/`, where the survey stage expects them. If the literature location matters to you, pass the papers as files.
+
+### 7.5 If You Need to Teach AutoR a Specific "Skill"
 
 In real usage, this happens often:
 
@@ -532,7 +610,7 @@ In other words, what you should give AutoR is not a vague instruction. It is a c
 - templates
 - successful cases
 
-### 7.5 When to Provide Those Skill Resources
+### 7.6 When to Provide Those Skill Resources
 
 There are three especially practical ways to do it:
 
@@ -552,7 +630,7 @@ lab_playbooks/
 
 Then include the relevant directory in each run.
 
-### 7.6 Resources Alone Are Not Enough: Put Hard Constraints in the Goal
+### 7.7 Resources Alone Are Not Enough: Put Hard Constraints in the Goal
 
 If some rules are mandatory, do not rely on AutoR to infer them implicitly.
 
@@ -573,7 +651,7 @@ This works well because it explicitly defines:
 - what must not happen
 - what acceptable artifacts look like
 
-### 7.7 Where to Check Whether AutoR Actually Learned It
+### 7.8 Where to Check Whether AutoR Actually Learned It
 
 This kind of skill is best enforced at a few specific stages:
 
@@ -592,7 +670,7 @@ Using `rjob` as an example, by Stage 04 or 05 you should ideally see:
 
 If those are missing, approval is usually premature.
 
-### 7.8 A Practical Refinement Prompt for This Case
+### 7.9 A Practical Refinement Prompt for This Case
 
 If AutoR failed to follow the cluster workflow you gave it, you can use feedback like this:
 
@@ -603,7 +681,7 @@ Create reusable submission scripts and save the submit command, job config, job 
 Local execution is only for smoke tests.
 ```
 
-### 7.9 What Usually Does Not Work
+### 7.10 What Usually Does Not Work
 
 These approaches are usually too weak:
 
@@ -620,9 +698,10 @@ The short version is:
 
 ## 8. How AutoR Runs
 
-The typical pipeline is:
+### 8.1 The Shape of the Walk
 
-0. `00_intake` (optional)
+There are **eight** research stages (`STAGES` in [../src/utils.py](../src/utils.py)):
+
 1. `01_literature_survey`
 2. `02_hypothesis_generation`
 3. `03_study_design`
@@ -632,11 +711,15 @@ The typical pipeline is:
 7. `07_writing`
 8. `08_dissemination`
 
-In practice, that is **1 intake stage + 8 formal research stages = 9 stages**.
+`00_intake` is **not** one of them. It runs once before the walk starts, and it is skipped by `--skip-intake` — and also whenever stdin is not a terminal, because there would be nobody to answer its questions.
+
+Those eight stages are nodes in a directed graph, not entries in a list. The default topology (`--stage-graph adaptive`) has 22 edges: eight that advance, of which six carry a guard; thirteen that go backward; and one conditional terminal that lets a round which concluded the question cannot be answered finish from Stage 06 instead of writing up anyway. `--stage-graph linear` drops the thirteen backward edges and the six forward guards, leaving nine edges: the eight unguarded forward edges (01 → 02 → … → 08, then `08_dissemination → finish`) and — still guarded — that same conditional terminal out of Stage 06. Keeping it is deliberate, and it is load-bearing: `_preempted_by_a_conclusion` makes a live conditional terminal the *only* admissible move at its node, so a linear run whose round records that the question cannot be answered also stops at Stage 06 rather than writing up. `linear` is a strict sequence of *stages*, not a promise that the run will keep going after it has said it cannot.
+
+The forward path is still the normal path, and it is the one this guide walks. What the graph buys you is [8.2](#82-when-a-late-finding-sends-the-run-back).
 
 | Stage | What it does | What you should check |
 | --- | --- | --- |
-| `00_intake` | Aligns the goal, resources, constraints, evaluation direction, and target writing style before formal research begins. | Answer the clarification questions, add hard constraints, and confirm the problem is narrow enough to execute. |
+| `00_intake` *(before the walk)* | Aligns the goal, resources, constraints, evaluation direction, and target writing style before formal research begins. | Answer the clarification questions, add hard constraints, and confirm the problem is narrow enough to execute. |
 | `01_literature_survey` | Organizes related work, task background, benchmarks, baselines, and the real research gap. | Do not accept shallow paper lists; look for structured literature files, comparisons, and evidence ledgers. |
 | `02_hypothesis_generation` | Converts the direction into testable hypotheses and provisional paper claims. | Make sure it converges to a falsifiable main line instead of continuing to brainstorm. |
 | `03_study_design` | Turns the hypothesis into an executable experimental design. | Check datasets, metrics, baselines, ablations, budgets, seeds, failure criteria, and data artifacts. |
@@ -645,6 +728,32 @@ In practice, that is **1 intake stage + 8 formal research stages = 9 stages**.
 | `06_analysis` | Interprets results, creates figures, analyzes failures, and explains mechanisms. | Do not accept metric narration only; require plots, failure cases, ablation interpretation, and boundaries. |
 | `07_writing` | Produces the final deliverable: a markdown report with embedded figures by default, or venue-aware LaTeX sources and a compiled PDF with `--output-format latex`. | Verify that every major claim is backed by experiments, figures, or literature. |
 | `08_dissemination` | Builds review, release, readiness, reproduction, and presentation materials. | Confirm the run can be inspected, reproduced, and shown to others, not just read as a paper. |
+
+### 8.2 When a Late Finding Sends the Run Back
+
+The expensive failure in an automated research run is not a stage that fails loudly. It is a run that reaches Stage 06, discovers the design cannot answer the question, and writes it up anyway because there was nowhere else to go.
+
+So the graph has thirteen backward edges (`REVISIT_EDGES` in [../src/stage_graph.py](../src/stage_graph.py)). Three of them, as examples:
+
+- **06 → 03.** The analysis exposed a design flaw the results cannot repair — a confound, a leak, or a comparison that was never fair. Going back to the study design is cheaper than writing around it.
+- **07 → 06.** Writing it up showed a claim has no analysis behind it, or a figure does not show what the text says it shows. This edge is open only once results exist.
+- **05 → 04.** The experiment could not run, or it ran and produced something the implementation is clearly responsible for.
+
+There are ten more, including 02 → 01 (stating the hypotheses showed the "gap" is not a gap), 06 → 02 (the evidence refutes the hypotheses and points somewhere specific), and 07 → 01 (the finding relates to work the survey missed).
+
+How a move actually gets chosen, and where you sit in it:
+
+1. **AutoR decides which moves are legal**, by evaluating each edge's guard against the files on disk — not against anything the agent claims. The move into Stage 07, for example, stays closed until every preregistered empirical hypothesis has a verdict and at least one figure exists.
+2. **The backend picks among the legal moves and has to state a reason.** With `--routing auto` (the default) it is only asked where more than one move is live, which on a linear graph is never. With `--routing off` it is never asked at all and the walk takes the default edge — with one exception that is not a routing decision: a closed research round's own choice of where to resume (which `--max-rounds 2` or more makes possible) is honoured under every routing mode, provided the edge it names is legal at that stage. An off-menu pick, or one with no stated reason, is refused and replaced by the forward edge.
+3. **The default is always forward.** A refusal, a routing failure, or a run nobody is steering all come out as the plain 01-through-08 pipeline rather than as a stall. A backward move only happens as a deliberate, justified choice, and a revisit whose justification repeats a reason already on the path is refused as a loop.
+4. **You still approve every stage.** The routing decision is made *after* your approval and does not replace it: what the graph chooses is which stage runs next, not whether the finished one was good enough. Every stage the run enters — including one it re-enters — goes through the same approval menu.
+5. **A backward move invalidates the work downstream of it.** AutoR prints a preview of what is about to go stale and marks those stages in `run_manifest.json`, so a later stage cannot quietly keep describing work the revisit is replacing.
+
+Two bounds keep this from becoming an infinite loop: `--graph-max-visits` (default 3) caps how many times one stage may be entered, and `--graph-max-steps` (default 20) caps the whole walk.
+
+If you want none of this, `--stage-graph linear --routing off` gives the strict sequence back — with one exception that neither flag turns off. The conditional terminal out of Stage 06 is present on both topologies, and a live conditional terminal preempts every other move at its node, so a round that ends in abandonment finishes at Stage 06 under `--routing off` as well. Refusing to write up a question the run has just said it cannot settle is a correctness property, not a routing preference.
+
+### 8.3 The Stage Loop and the Approval Menu
 
 The shape of every stage is similar:
 
@@ -687,13 +796,14 @@ when you choose `4` and enter custom feedback, you can also enter control comman
 
 That means:
 
-- the default workflow is still sequential
-- but if you intentionally want to bypass the current stage for now, or return to an earlier stage and rebuild from there, you do not have to abandon the whole run
+- the run's own backward moves ([8.2](#82-when-a-late-finding-sends-the-run-back)) are chosen by AutoR and the backend, from the moves the guards leave open; `/back` is the same capability with your hand on the wheel, and it is not filtered by those guards
+- so if you want to bypass the current stage for now, or return to an earlier stage and rebuild from there, you do not have to abandon the whole run
 
 Notes:
 
 - `/back` is for earlier stages, not for jumping forward
-- if the current stage exhausts the retry limit, AutoR now also shows a recovery menu so you can directly choose to skip the stage or roll back to an earlier one
+- `/back` invalidates the same way a graph revisit does: the target stage becomes pending and everything after it is marked stale
+- if the current stage exhausts the retry limit, AutoR shows a recovery menu so you can directly choose to skip the stage, roll back to an earlier one, or abort
 
 There is also one important detail many users miss:
 
@@ -808,6 +918,10 @@ Approve only when all three are true:
 
 That is very different from "looks good enough."
 
+**One approval is not like the others.** Approving `04_implementation` freezes the hypothesis set: AutoR copies the typed hypotheses into `workspace/notes/preregistration.json`, hashes them, and never overwrites that file. From Stage 05 onward every empirical hypothesis is adjudicated against the frozen set, and changing it later has to arrive as a recorded amendment rather than a quiet edit. Read the hypotheses before you press `5` on Stage 04, not after.
+
+Approving `03_study_design` has a smaller version of the same property: the report plan — which figures the write-up will carry, and which claim each supports — is stamped outside `workspace/` at that moment.
+
 ### 11.4 When to Use `6`
 
 Abort when:
@@ -826,14 +940,23 @@ Do not force a bad run forward.
 | --- | --- |
 | Simplest interactive start | `python main.py` |
 | Start a new run | `python main.py --goal "your research goal"` |
+| Read a long goal from a file | `python main.py --goal-file goal.md` |
 | Use Claude as the backend | `python main.py --operator claude --model sonnet --goal "..."` |
 | Use Codex as the backend | `python main.py --operator codex --model default --goal "..."` |
 | Allow Codex-backed SSH / remote GPU execution | `python main.py --operator codex --codex-sandbox danger-full-access --goal "..."` |
 | Set a target venue | `python main.py --venue neurips_2025 --goal "..."` |
+| Produce a LaTeX package and PDF instead of a markdown report | `python main.py --output-format latex --goal "..."` |
+| Stop once the report is written | `python main.py --final-stage 07_writing --goal "..."` |
 | Start with resources | `python main.py --goal "..." --resources paper.pdf refs.bib data.csv notes.md` |
 | Store runs on another disk | `python main.py --runs-dir /path/to/runs --goal "..."` |
 | Skip intake | `python main.py --skip-intake --goal "..."` |
 | Run a smoke test | `python main.py --fake-operator --goal "Smoke test"` |
+| Turn up the optional machinery, human still at the gate | `python main.py --rigor thorough --goal "..."` |
+| Turn all of it off | `python main.py --rigor fast --goal "..."` |
+| Hand the gate to a reviewer agent | `python main.py --full-auto --goal "..."` |
+| Take the strict 01-through-08 sequence (an abandoned round still finishes at 06) | `python main.py --stage-graph linear --routing off --goal "..."` |
+| Let Stages 03-06 run more than once | `python main.py --max-rounds 2 --goal "..."` |
+| Search the web where the backend's own search is disabled | `python main.py --web-search gemini --goal "..."` |
 | Resume the latest run | `python main.py --resume-run latest` |
 | Resume a specific run | `python main.py --resume-run 20260415_120000` |
 | Redo from a stage | `python main.py --resume-run latest --redo-stage 05` |
@@ -842,6 +965,10 @@ Do not force a bad run forward.
 | Build a researcher profile from prior papers | `python main.py --goal "..." --paper-corpus /path/to/papers` |
 | Generate and insert a method diagram | `python main.py --goal "..." --research-diagram` |
 | Increase per-stage timeout | `python main.py --goal "..." --stage-timeout 28800` |
+| Give a stubborn stage more retries | `python main.py --goal "..." --max-attempts 10` |
+| See what the cross-run archive has learned, then exit | `python main.py --archive-report` |
+
+This is the short list, not the whole surface: `main.py` has 61 flags. For every one of them, its default, and what survives a resume, see **[cli-reference.md](cli-reference.md)**.
 
 ### 12.1 `--redo-stage` vs `--rollback-stage`
 
@@ -896,6 +1023,8 @@ python main.py --resume-run latest --redo-stage 03
 python main.py --resume-run latest --redo-stage 3
 python main.py --resume-run latest --redo-stage 03_study_design
 ```
+
+The same three forms work for `--rollback-stage`, `--final-stage`, and the `/back` control command.
 
 This matters when you resume runs frequently.
 
@@ -963,7 +1092,7 @@ Do not approve if the first pass is missing any of these:
 - real experiments
 - real data files
 - figures
-- PDFs
+- the written deliverable itself (`report.md`, or the PDF in `latex` mode)
 - evidence behind the claims
 - actual files instead of future plans
 
@@ -993,11 +1122,9 @@ Be especially strict about:
 - whether the code actually runs
 - whether the results are really written to disk
 
-### Trick 6: Set `--venue` Early
+### Trick 6: Set `--venue` and `--output-format` Early
 
-If you already know whether you want a conference-style or journal-style draft, set it from the beginning.
-
-That makes Stage 07 more stable.
+If you already know whether you want a conference-style or journal-style draft, set the venue from the beginning. That makes Stage 07 more stable — and if you want the LaTeX package and a compiled PDF rather than the default markdown report, pass `--output-format latex` in the same command. Both are recorded in the run and preserved when you resume, so setting them at the start is cheaper than switching at Stage 07.
 
 ### Trick 6.5: Most New Users Should Not Rush to `--skip-intake`
 
@@ -1067,7 +1194,7 @@ python main.py --goal "..." --stage-timeout 28800
 
 ### Trick 12: `--research-diagram` Is an Enhancement, Not a Requirement
 
-If you want AutoR to generate a method illustration after Stage 07 and insert it into the paper:
+If you want AutoR to generate a method illustration after Stage 07 and insert it into the deliverable — `report.md` in markdown mode, `method.tex` in latex mode:
 
 ```bash
 python main.py --goal "..." --research-diagram
@@ -1120,17 +1247,21 @@ The following files are easy to ignore, but they matter a lot:
 - `workspace/literature/sources.json`
 - `workspace/literature/claims.json`
 - `workspace/notes/hypothesis_manifest.json`
+- `workspace/notes/preregistration.json`
 - `workspace/results/experiment_manifest.json`
+- `workspace/results/hypothesis_outcomes.json`
 - `workspace/artifacts/citation_verification.json`
 
 Roughly speaking:
 
 - `sources.json` / `claims.json`: structured evidence ledgers for literature claims
 - `hypothesis_manifest.json`: typed hypotheses distilled in Stage 02
+- `preregistration.json`: the hypothesis set as it was frozen when you approved Stage 04, before any result existed. It is written once and never overwritten; a later change has to arrive as a recorded amendment
 - `experiment_manifest.json`: a machine-readable experiment bundle for analysis and writing
+- `hypothesis_outcomes.json`: one verdict per preregistered *empirical* hypothesis, each `supported` or `refuted` one citing an evidence file that has to exist. Theoretical propositions and paper claims are frozen alongside them but are not adjudicated here, and a verdict written for one is rejected. This is also what closes or opens the move into Stage 07
 - `citation_verification.json`: structured claim-to-citation coverage checks in Stage 07
 
-If these files are missing, empty, or obviously inconsistent with the PDF, the run is usually not yet solid.
+If these files are missing, empty, or obviously inconsistent with the report, the run is usually not yet solid.
 
 ---
 
@@ -1203,14 +1334,15 @@ Ideally include at least:
 - any existing baseline results
 - your experiment notes
 
-### Step 3: Set the Venue from the Beginning
+### Step 3: Ask for the PDF, and Set the Venue
 
-For example:
+A PDF is not the default deliverable. `--output-format` defaults to `markdown`, which writes a standalone report instead. If you want the submission-style package, say so at the start — the setting is recorded in the run and preserved when you resume:
 
 ```bash
 python main.py \
   --operator claude \
   --model sonnet \
+  --output-format latex \
   --venue neurips_2025 \
   --goal "..."
 ```
@@ -1230,13 +1362,15 @@ Keep asking:
 
 Do not let a compiled PDF fool you.
 
-A strong Stage 07 should include at least:
+In `latex` mode, a strong Stage 07 should include at least:
 
 - LaTeX sources
 - bibliography
 - a compilable PDF
 - citation verification output
 - experiments and figures behind the main claims
+
+In the default `markdown` mode the shape is different but the bar is not: `workspace/report/report.md`, the figures it references actually present under `workspace/report/images/`, citation verification output, and a number behind every claim.
 
 ### Step 6: If Something Earlier Is Wrong, Redo or Roll Back
 
@@ -1262,7 +1396,8 @@ The most useful paths are:
 | --- | --- |
 | `runs/<run_id>/user_input.txt` | your original research goal |
 | `runs/<run_id>/memory.md` | approved cross-stage memory |
-| `runs/<run_id>/run_config.json` | backend, model, venue, and other core run config |
+| `runs/<run_id>/intake_context.json` | the approved intake brief, its resources, and the clarification Q&A |
+| `runs/<run_id>/run_config.json` | backend, model, venue, output format, stage graph, and other core run config |
 | `runs/<run_id>/run_manifest.json` | machine-readable stage lifecycle state |
 | `runs/<run_id>/artifact_index.json` | run-wide structured index for data, results, and figures |
 | `runs/<run_id>/stages/` | the official stage summaries |
@@ -1276,17 +1411,23 @@ The most useful paths are:
 | `runs/<run_id>/workspace/data/` | data |
 | `runs/<run_id>/workspace/results/` | machine-readable results |
 | `runs/<run_id>/workspace/results/experiment_manifest.json` | standardized experiment manifest used downstream |
+| `runs/<run_id>/workspace/results/hypothesis_outcomes.json` | one verdict per preregistered *empirical* hypothesis — `supported`, `refuted`, `inconclusive`, or `not_tested` — with every `supported` or `refuted` one citing an evidence file that exists |
 | `runs/<run_id>/workspace/figures/` | figures |
-| `runs/<run_id>/workspace/writing/` | paper source files |
-| `runs/<run_id>/workspace/artifacts/` | PDFs and packaged outputs |
+| `runs/<run_id>/workspace/report/report.md` | the markdown report, which is the default deliverable |
+| `runs/<run_id>/workspace/report/images/` | the figures embedded in that report |
+| `runs/<run_id>/workspace/writing/` | LaTeX paper sources, in `--output-format latex` runs |
+| `runs/<run_id>/workspace/artifacts/` | PDFs, build logs, and packaged outputs |
 | `runs/<run_id>/workspace/artifacts/citation_verification.json` | citation and claim coverage checks from writing |
 | `runs/<run_id>/workspace/notes/hypothesis_manifest.json` | structured hypotheses from Stage 02 |
+| `runs/<run_id>/workspace/notes/preregistration.json` | the hypothesis set frozen at Stage 04 approval |
+| `runs/<run_id>/workspace/notes/research_rounds.json` | how each Stage 03-06 round closed, and why |
+| `runs/<run_id>/evolution/` | rubric scores, losing drafts, routing refusals — the search, kept out of `workspace/` |
 | `runs/<run_id>/workspace/reviews/` | review / release materials |
 
-If you are looking for the final PDF, check these first:
+If you are looking for the final deliverable, check these first:
 
-- `workspace/artifacts/`
-- `workspace/writing/`
+- `workspace/report/` in the default markdown mode
+- `workspace/artifacts/` and `workspace/writing/` in `--output-format latex` runs
 
 ---
 
@@ -1337,7 +1478,19 @@ AutoR supports both `claude` and `codex`. When you resume a run, it preserves th
 
 In practice, if you switch backends, it is usually safest to combine that with a clear re-entry point such as `--redo-stage`.
 
-### 17.7 What Should I Read Next If I Want to Understand the Project Faster?
+### 17.7 Why Did the Run Go Back to an Earlier Stage?
+
+Because the stages are a graph and something later in the run said an earlier one was wrong. See [8.2](#82-when-a-late-finding-sends-the-run-back).
+
+Where to look for the reason:
+
+- the terminal prints the chosen move and its stated reason at the moment it is taken
+- `run_manifest.json` shows which stages were marked stale, and the reason recorded for it
+- `evolution/routing_refusals.jsonl` records a move the backend asked for and did **not** get
+
+If you never want this, run with `--stage-graph linear --routing off`.
+
+### 17.8 What Should I Read Next If I Want to Understand the Project Faster?
 
 A practical order is:
 
@@ -1345,6 +1498,17 @@ A practical order is:
 2. run one smoke test
 3. run one real experiment with `--resources`
 4. inspect the resulting `runs/<run_id>/` structure
+
+Then, depending on what you want:
+
+| You want | Read |
+| --- | --- |
+| Every flag, its default, and what survives a resume | [cli-reference.md](cli-reference.md) |
+| Why the system is built this way, and what has *not* been established | [framework.md](framework.md) |
+| What each stage must produce before it is allowed to advance | [stage-contract.md](stage-contract.md) |
+| What is in a run directory, file by file | [run-artifacts.md](run-artifacts.md) |
+| The `--rigor` levels in detail | [rigor.md](rigor.md) |
+| A stage that keeps failing its gate | [troubleshooting.md](troubleshooting.md) |
 
 ---
 

--- a/docs/tutorial_zh.md
+++ b/docs/tutorial_zh.md
@@ -2,7 +2,9 @@
 
 > 面向第一次使用 AutoR 的用户。
 >
-> 目标不是“把命令跑起来”而已，而是让你尽快掌握：如何安装、如何正确使用、如何在人类审批环节把结果从 toy 拉到真正可用，最后做出高质量的 PDF 研究产物。
+> 目标不是“把命令跑起来”而已，而是让你尽快掌握：如何安装、如何正确使用、如何在人类审批环节把结果从 toy 拉到真正可用，最后做出高质量的研究产物。
+>
+> 本文只讲怎么用。想先看清整体架构和设计取舍，读 [framework.md](framework.md)；想查某个参数的准确语义、默认值和恢复 run 时会不会被保留，读 [cli-reference.md](cli-reference.md)。
 
 ## 1. 先用一句话理解 AutoR
 
@@ -32,9 +34,9 @@ AutoR 不是一个“把论文一键生成出来”的黑盒，也不是一个�
 
 AutoR 当前主线适合做这些事情：
 
-- 从一个研究目标出发，按固定科研流程推进
+- 从一个研究目标出发，在一张八阶段的有向图里推进研究（默认往前走，必要时可以回溯）
 - 在每个阶段调用底层执行器完成真实工作
-- 把 prompt、日志、阶段总结、代码、数据、图、论文源文件、PDF 都落到 `runs/<run_id>/`
+- 把 prompt、日志、阶段总结、代码、数据、图、报告或论文源文件都落到 `runs/<run_id>/`
 - 支持从已有 run 恢复
 - 支持从某个特定 stage 重做
 - 支持把更早的 stage 回滚，然后让后续阶段全部失效重跑
@@ -42,6 +44,7 @@ AutoR 当前主线适合做这些事情：
 - 支持从你过去的论文语料起步
 - 支持按投稿 venue 组织 Stage 07 的写作输出
 - 支持文献整理、citation verification、实验清单、artifact 索引、发布打包
+- 用 `--rigor` 一个参数决定这次 run 开多少可选机制（见 8.2）
 
 底层执行器目前支持：
 
@@ -58,7 +61,38 @@ AutoR 负责的是更上层的 research loop，而不是重新发明一个新的
 - 终端 UI 更适合真实录屏和长 run：输出框正文行会保持彩色边框，长行、长路径和中文宽字符会自动换行，Stage 0 和审批菜单支持上下键选择。
 - Codex backend 已经改用当前 Codex CLI 的 `--sandbox workspace-write` 执行参数，不再触发 Codex CLI 内部旧 `--full-auto` 参数的 deprecated warning。注意这和 AutoR 自己的 `--full-auto` 审批模式不是一回事。
 - 如果你用 Codex 跑远程 SSH / GPU 实验，可以显式设置 `--codex-sandbox danger-full-access`。默认仍然是更安全的 `workspace-write`，不要把 unrestricted 模式当成默认选择。
-- `--full-auto` 仍然是 AutoR 的自动审批模式：它让一个严格 reviewer agent 替代人工等待，但不改变 9 个 stage 的主体流程。
+- `--full-auto` 仍然是 AutoR 的自动审批模式：它让一个严格 reviewer agent 替代人工等待，但不改变八个研究阶段的主体流程。它等价于 `--approval-mode agent` 加 `--unattended`，也就是整个 run 不会再停下来等任何终端输入。
+- 阶段之间的走法现在由一张有向图决定，默认拓扑是 `adaptive`：分析阶段发现设计有问题，可以直接回到 Stage 03，而不是硬着头皮往下写。细节见 8.1。
+- 默认的最终产物是 `workspace/report/report.md`，不是 PDF。要 LaTeX 源文件加可编译 PDF，显式传 `--output-format latex`。
+
+### 2.2 这份教程写成之后新增的开关
+
+如果你之前用过 AutoR，下面这些参数是后来才加的，第一次用也值得知道有它们存在：
+
+| 参数 | 一句话 |
+| --- | --- |
+| `--rigor {fast,standard,thorough,max}` | 一个档位决定开多少可选机制，默认 `standard`。见 8.2 |
+| `--stage-graph {linear,adaptive}` | 阶段拓扑，默认 `adaptive`（带回溯边）。见 8.1 |
+| `--routing {off,auto,agent}` | 谁来选下一条边，默认 `auto` |
+| `--output-format {markdown,md,latex,tex}` | 最终产物形态，默认 `markdown` |
+| `--final-stage 07` | 只跑到某个阶段就停，接受 `07` 或 `07_writing` |
+| `--max-rounds N` | Stage 03~06 作为一个 round 最多重复几次，默认 1 |
+| `--goal-file path.md` | 目标太长时从文件读，和 `--goal` 互斥 |
+| `--unattended` | 只是禁止等待终端输入，**不会替你装上 reviewer**；用尽重试的 stage 会被自动跳过。真要无人值守，配 `--approval-mode agent`，或者直接用 `--full-auto` |
+| `--max-attempts N` | 单个 stage 的尝试上限，默认 5 |
+| `--review-panel` | 用五席评审团替代单个 reviewer；**会让 run 变成无人值守** |
+| `--panel-models pi=opus skeptic=codex:default` | 给评审团每个席位单独指定模型 |
+| `--persona path.md` | 给评审团一份“你在替谁把关”的说明；只对评审团生效 |
+| `--ideation-panel` | Stage 02 多开五个不同视角的提案者，只提供候选，不做决定 |
+| `--deliberation` | 阶段卡在真正的分歧点时，临时拉一个四人小组把它议清楚 |
+| `--effort-tiers` / `--no-effort-tiers` | 把阶段分成 routine / deliberative，默认已开 |
+| `--evolve` / `--no-evolve` | 每份合格草稿都打分并保留最好的一版，默认已开 |
+| `--archive PATH` / `--archive-report` | 跨 run 记录走过哪些边、收益如何；默认只记录不干预 |
+| `--trial ID --capability X --arm on` / `--trial-report` | 成对 A/B 试验及其统计报告；三个参数必须一起给 |
+| `--web-search {auto,gemini,native}` | 执行器怎么搜网页；`gemini` 用于内置搜索被禁用的部署 |
+| `--cross-review {auto,gemini,off}` | 换一个模型家族复核批准。**注意：目前只有 `rcb_agent.py` 那条路径真的会装上它，`main.py` 上还没接线** |
+
+这张表是提醒，不是参考手册。每个参数的准确语义、默认值、恢复 run 时是否保留，都在 [cli-reference.md](cli-reference.md) 里。
 
 ---
 
@@ -72,9 +106,11 @@ AutoR 负责的是更上层的 research loop，而不是重新发明一个新的
 | Git | 必需 | 用于获取仓库 |
 | Node.js 18+ | 强烈建议 | `Claude Code` 官方要求 Node 18+；`Codex CLI` 也通过 npm 安装 |
 | Claude Code 或 Codex CLI | 必需 | 真正执行研究任务时需要其中之一 |
-| TeX 环境 | 可选但推荐 | Stage 07 更容易稳定产出可编译 PDF |
+| TeX 环境 | 只有 `--output-format latex` 才需要 | 默认 Stage 07 写的是 `workspace/report/report.md`；要 LaTeX 源文件和可编译 PDF 才需要 TeX |
 | `PyMuPDF` | 可选 | 如果你要用 `--paper-corpus` 读取 PDF 内容，推荐安装 |
-| `google-genai` / `Pillow` / `PyYAML` | 可选 | 只有在使用 `--research-diagram` 时才需要 |
+| `google-genai` | 可选 | 不只是画图用：`--research-diagram`、`--web-search gemini` 和 `--cross-review gemini`（这条目前只在 `rcb_agent.py` 上接线，见 2.2）共用这一个 SDK。没装它时 `--web-search gemini` 会直接报 `Error: --web-search gemini cannot work here: ...` 并以退出码 1 结束 |
+| `Pillow` | 可选 | 只有 `--research-diagram` 需要 |
+| `PyYAML` | 可选 | 只有当你把 Gemini key 写进 `configs/diagram_config.yaml` 时才需要（画图、搜索、cross-review 共用同一个 key 读取逻辑）。缺它只会打一条 warning，然后当成“没有配 key” |
 
 平台建议：
 
@@ -181,7 +217,7 @@ claude
 
 ```text
 请在当前目录安装 AutoR：
-1. clone https://github.com/AutoX-AI-Labs/AutoR.git
+1. clone https://github.com/tangxiangru/AutoR.git
 2. 进入仓库，阅读 README 和 python main.py --help
 3. 如有必要，创建 Python 虚拟环境
 4. 安装当前仓库运行所需的最小依赖
@@ -201,7 +237,7 @@ claude
 如果你更喜欢手动操作，也可以直接：
 
 ```bash
-git clone https://github.com/AutoX-AI-Labs/AutoR.git
+git clone https://github.com/tangxiangru/AutoR.git
 cd AutoR
 python main.py --help
 ```
@@ -218,7 +254,9 @@ pip install google-genai pillow pyyaml
 其中：
 
 - `pymupdf` 用于 `--paper-corpus` 的 PDF 文本提取
-- `google-genai pillow pyyaml` 用于 `--research-diagram`
+- `google-genai` 是 `--research-diagram`、`--web-search gemini` 和 `--cross-review gemini` 共用的 SDK，不是画图专属
+- `pillow` 只有 `--research-diagram` 需要
+- `pyyaml` 只在你把 Gemini key 放进 `configs/diagram_config.yaml` 时才需要；改用环境变量 `GOOGLE_API_KEY` / `GEMINI_API_KEY` 就不需要它
 
 ---
 
@@ -389,7 +427,7 @@ python main.py \
 
 这个选项会给 Codex 后端不受 sandbox 限制的本地和远程执行能力。只在你信任当前任务、确认 SSH 命令安全、并且确实需要远程执行时使用。
 
-补充两条很有用的默认行为：
+补充几条很有用的默认行为：
 
 - 新建 run 时，如果你不写 `--operator`，默认使用 `claude`
 - 新建 run 时，如果你不写 `--model`，Claude 默认是 `sonnet`，Codex 默认是 `default`
@@ -417,10 +455,16 @@ python main.py \
   --goal "..."
 ```
 
-这里要明确两点：
+这里要明确四点：
 
 - `--full-auto` **不会改变主体科研流程**，只是把原来等待人工审批的地方，替换成一个严格的 reviewer agent
 - 真正重要、要出高质量成果的研究，仍然推荐默认的人类审批模式；`--full-auto` 更适合夜间 unattended run、批量 dry run、流程压测或长任务巡航
+- **能把 agent 放到审批位置上的参数有 3 个，不是一个**：`--approval-mode agent`、`--full-auto`、`--review-panel`。这三个都会把 `approval_mode` 置成 `agent`，于是 `create_reviewer` 真的造出一个 reviewer 顶替你，run 也随之变成无人值守。其中 `--review-panel` 最容易被误会——它看起来像“评审更严”，实际效果是把人换成了五个 agent。再加一层：`--rigor max` 隐含 `--review-panel`，所以**只写一个 `--rigor max` 也会把一次交互式运行悄悄变成无人值守运行**
+- **`--unattended` 不在这 3 个里面，它是另一件事。** 它只回答“这次 run 允不允许停下来等终端输入”，并不安排任何人来替你答。单独给 `--unattended` 时 `approval_mode` 仍然是 `manual`（启动横幅照旧打印 `Approval mode: manual human gate.`），第一个 stage 结束后审批菜单照样弹出来，然后因为没人可问而报 `Error: AutoR is running unattended and cannot answer an interactive prompt`，退出码 1。要跑通就写 `--full-auto`，或者补齐成 `--unattended --approval-mode agent`
+
+“把人移开”和“让 agent 顶上”是两句不同的话：`--unattended` 只做前者，剩下三个两件都做。
+
+无人值守（`approval_mode` 已经是 `agent`，或显式给了 `--unattended`）模式下还有一个副作用要知道：某个 stage 用尽重试预算之后不会中止整个 run，而是被自动跳过，上限由 `--max-auto-skips` 控制（默认 3）。人工模式下同样的情况会弹出恢复菜单让你选。
 
 ### 7.2 推荐同时指定投稿 venue
 
@@ -613,9 +657,8 @@ Local execution is only for smoke tests.
 
 ## 8. AutoR 会怎么运行
 
-典型流程是：
+正式的研究阶段一共 **八个**：
 
-0. `00_intake`（可选）
 1. `01_literature_survey`
 2. `02_hypothesis_generation`
 3. `03_study_design`
@@ -625,7 +668,9 @@ Local execution is only for smoke tests.
 7. `07_writing`
 8. `08_dissemination`
 
-也就是说，实际是 **1 个 intake + 8 个正式研究阶段 = 9 个 stage**。
+`00_intake` 排在它们前面，但它不是这八个阶段之一，也不是图上的节点：它是正式研究开始前的一次对齐，可以用 `--skip-intake` 跳过。
+
+这八个阶段**不是一条固定顺序的流水线**，而是一张有向图上的节点。默认情况下运行会一路往前走，走出来的路径看上去和流水线一样；但当某个阶段发现更早的工作出了问题时，它可以回到更早的节点。怎么走、谁来选、什么时候不许走，见 8.1。
 
 | Stage | 这一阶段做什么 | 你应该重点检查什么 |
 | --- | --- | --- |
@@ -636,7 +681,7 @@ Local execution is only for smoke tests.
 | `04_implementation` | 写真实代码、配置、数据准备脚本和 sanity check。 | 不要 approve 只有 skeleton 的实现；要看到可运行脚本、命令、配置和日志。 |
 | `05_experimentation` | 按设计运行实验并保存机器可读结果。 | 区分 smoke test 和正式实验；要有 baseline、重复运行、结果文件和失败记录。 |
 | `06_analysis` | 分析结果、画图、做误差分析和机制解释。 | 不要只复述最好指标；要看图表、失败案例、消融解释和结论边界。 |
-| `07_writing` | 生成 venue-aware 的论文源文件、Bib、可编译 PDF 和引用校验。 | 检查每个核心 claim 是否能追溯到实验、图表或文献，不要只看 PDF 是否漂亮。 |
+| `07_writing` | 默认生成 `workspace/report/report.md` 和它引用的图；`--output-format latex` 则生成 venue-aware 的论文源文件、Bib 和可编译 PDF。两种模式都做引用校验。 | 检查每个核心 claim 是否能追溯到实验、图表或文献，不要只看排版是否漂亮。 |
 | `08_dissemination` | 补齐 review、release、readiness、复现和对外交付材料。 | 确认这个 run 能被别人检查、复现、展示，而不是只停在论文。 |
 
 每个 stage 的逻辑都一样：
@@ -645,7 +690,12 @@ Local execution is only for smoke tests.
 2. 底层执行器开始做事
 3. 结果实时显示在终端里
 4. stage 结束后生成结构化 stage summary
-5. 你决定是 refine 还是 approve
+5. AutoR 先做机器校验：stage summary 必须有 7 个规定小节，该落盘的结构化文件必须真的存在、能解析、引用的路径能解析到真实文件。不合格会先尝试修复，再重跑，上限由 `--max-attempts` 控制（默认 5）
+6. 校验通过的草稿会被 rubric 打分，必要时再打磨一两轮，只保留分数最高的那一版（`--no-evolve` 可关掉）
+7. 你决定是 refine 还是 approve
+8. 你批准之后，AutoR 才评估图上每条边能不能走，并决定下一个阶段是哪个（见 8.1）
+
+第 5 步值得单独强调：**这层校验读的是磁盘上的文件，不是 agent 的自述。** 它不看 agent 说自己做了什么，只看 `workspace/` 里到底有什么。所以“阶段总结写得很漂亮但没有文件”这种情况过不了机器校验，根本轮不到你审。
 
 从 `01_literature_survey` 到 `08_dissemination`，审批菜单固定有 6 个动作：
 
@@ -680,25 +730,81 @@ Local execution is only for smoke tests.
 
 这意味着：
 
-- 默认仍然是顺序推进
+- 默认仍然是往前走
 - 但如果你确认当前 stage 先不做、或者需要回到更早阶段重来，不用硬退出整个 run
 
 注意：
 
 - `/back` 是回到更早阶段，不是跳到更晚阶段
+- `/back` 走的是人的通道，不经过 8.1 里那套 guard 和 agent 选边的逻辑：你要求回去就回去
 - 如果当前 stage 已经连续失败到超过重试上限，AutoR 也会弹出恢复菜单，让你直接选择“跳过当前阶段”或“回到更早阶段”
 
 还有一个很值得注意的细节：
 
 每个 stage summary 里不只有结果说明，还会包含一个 `Decision Ledger`。
 
-你可以把它理解为“当前 run 的阶段性决策账本”，里面通常会沉淀：
+你可以把它理解为“当前 run 的阶段性决策账本”，它是 7 个必填小节之一，而且必须同时写出四块内容，缺一块这个 stage 就通不过校验：
 
-- 哪些关键判断已经锁定
-- 还有哪些开放问题
-- 当前阶段为什么这样取舍
+- `Open Questions`：还有哪些开放问题
+- `Locked Decisions`：哪些关键判断已经锁定
+- `Assumptions`：当前阶段建立在哪些假定上
+- `Rejected Alternatives`：哪些方案被否掉了，为什么
 
 这些信息会随着 handoff 一起影响后续阶段，所以它不是装饰性文字，而是研究方向保持稳定的重要机制。
+
+### 8.1 阶段之间怎么走：一张有向图，不是一条流水线
+
+`--stage-graph` 决定拓扑，默认是 `adaptive`：
+
+- 八条前向边（`01→02`…`08→finish`），其中**六条带 guard**——通往 `03`、`04`、`05`、`06`、`07`、`08` 的那六条
+- **十三条回溯边**，例如 `06_analysis → 03_study_design`（分析暴露了设计缺陷）、`07_writing → 05_experimentation`（写作时发现少了一个结果）、`02 → 01`（写假设时发现所谓的空白其实文献里有人做过）
+- 一条条件终止边：一个 round 如果在 Stage 06 判定“这个问题用现有资源答不了”，可以直接结束，而不是硬写一篇论文
+- 合计 22 条边
+
+`--stage-graph linear` 则是 9 条边：同样的八条前向边加那条终止边，回溯边全部去掉，前向边上也不再挂 guard——也就是严格的 01 到 08。前向边不设 guard 是有意的：那里每个节点只有一条边可走，guard 唯一能做的事就是把 run 停住，而它要停的那个条件本来就已经是阶段校验错误，报错信息还更清楚。
+
+三件事值得记住：
+
+**第一，guard 读的是磁盘，不是 agent 的说法。** 通往 `05_experimentation` 的边要求 `workspace/code/` 里真的有可执行文件；通往 `07_writing` 的边要求预注册存在、每条实证假设都有裁定、并且 `workspace/figures/` 里真的有图。条件不满足时，这条边仍然会列在给 agent 看的菜单里，但可用性一栏写的是 `**no** — 原因`，agent 选它会被 refuse 掉。
+
+但要说清楚 guard 到底管到哪一步：**它是路由偏好，不是正确性闸门。** 当一个节点的前向边被 guard 关掉、又没有别人来选边时，`default_move` 仍然会把这条前向边当作 last resort 走下去。实测：把一个已完成 run 的 `workspace/notes/preregistration.json` 删掉之后，`06_analysis` 的 `07_writing` 这条边报 `admissible=False`（“the hypotheses were never frozen”），而 `default_move` 返回的还是 `07_writing`。也就是说，只要 agent 没有主动挑一条回溯边（`--routing off`、没接 backend、或者 agent 的选择被 refuse 掉时都是如此），一个完全不满足 Stage 07 前置条件的 run 照样会进 Stage 07——真正在那里把它拦下来的是这个阶段自己的产物校验（`validate_stage_artifacts`），不是这条边。这样设计是有意的：guard 挡死会让 run 在回溯边之间来回弹到预算耗尽、最后什么都不交，而阶段校验至少会带着证据老老实实报错。
+
+所以 guard 能保证的是“agent 不能主动挑一条自己没资格走的边”，不是“run 绝不会走到那个节点”。
+
+**第二，回溯边不是自动走的，也不是随便走的。** 一条回溯边要成立，先要 guard 允许，再要 agent 明确说出为什么要回去，而且**理由不能和这条路径上已经用过的理由重复**——同一个抱怨走第二遍是死循环，不是迭代。agent 亲自选的边（以及被拒掉的选择）会打印在终端上，所有走过的边都会记进 `evolution/stage_graph.json`。
+
+**第三，默认永远是往前。** 拒绝一次选边、选边失败、或者没人盯着的 run，结果都是继续走前向边，而不是卡住。所以你在实际使用中看到的多数 run，路径就是一条直线。
+
+`--routing` 决定谁来选边：默认 `auto`，只在同一个节点有多条可走的边时才去问 backend；`agent` 是每个节点都问；`off` 永远走图的默认边。
+
+要强调的是：**这一切都发生在你批准这个 stage 之后。** 阶段边界仍然由人把关（除非你用了 8.2 里那些会把人换掉的开关），agent 能决定的只是“下一步去哪个节点”，不是“这个 stage 算不算过”。
+
+### 8.2 `--rigor`：一个参数决定这次 run 开多少可选机制
+
+AutoR 有四个可选机制，过去要分别记四个开关。现在它们收进一个档位参数：
+
+| `--rigor` | effort tiers | crux deliberation | ideation panel | review panel |
+| --- | :---: | :---: | :---: | :---: |
+| `fast` | – | – | – | – |
+| `standard`（默认） | **开** | – | – | – |
+| `thorough` | **开** | **开** | **开** | – |
+| `max` | **开** | **开** | **开** | **开** |
+
+四个机制各自是什么：
+
+- **effort tiers**：把阶段分成 routine 和 deliberative 两档。routine 的阶段拿精简 prompt、单个 reviewer、不提供升级选项。默认判定里 `04_implementation`、`05_experimentation`、`08_dissemination` 是 routine，其余是 deliberative；一个 routine 阶段反复失败会被自动提升。**它是四个里唯一让 run 变便宜的**，所以默认就开着。
+- **crux deliberation**：阶段真的卡在一个分歧点上时，临时拉一个四人小组（theorist / empiricist / critic / pragmatist）把它议清楚。有预算上限，默认一个 run 最多 3 次。
+- **ideation panel**：Stage 02 多开五个不同视角的提案者，去重打分后交给这个阶段挑。它只提供候选，不做决定。
+- **review panel**：五席评审团替代单个 reviewer——先独立评，再匿名交叉质询，最后由主席汇总；有阻断性反对意见时，代码层面不允许主席批准通过。
+
+两条一定要知道的后果：
+
+- **`--rigor max` 会让这次 run 变成无人值守。** 因为它隐含 `--review-panel`，而 `--review-panel` 意味着审批交给 agent。看起来最严的档位，恰恰是把人拿掉的那一档。要人工审批就不要用 `max`。
+- **单独的开关永远压过档位。** `--rigor thorough --no-ideation-panel` 就是字面意思。反过来，`--rigor fast --review-panel` 也成立。
+
+科学有效性那条链——预注册、决策规则、假设裁定、claim 溯源——**不在这个拨盘上**，任何档位（包括 `fast`）都无条件执行。
+
+更细的说明见 [rigor.md](rigor.md)、[effort-tiers.md](effort-tiers.md)、[deliberation.md](deliberation.md)、[ideation-panel.md](ideation-panel.md)、[review-panel.md](review-panel.md)。
 
 ---
 
@@ -725,7 +831,7 @@ Local execution is only for smoke tests.
 - 只写了文字总结，没有真实数据文件
 - 只做了 smoke test，没有做正式实验
 - 只画了图，没有机器可读结果
-- 只写了 PDF，但 claim 没有真实证据支撑
+- 只写了报告，但 claim 没有真实证据支撑
 - 只引用了几篇常见论文，没有真正做 survey
 - 只给出“计划怎么做”，没有真正把文件写出来
 
@@ -835,8 +941,34 @@ AutoR 的强项不是“第一轮就完美”，而是：
 | 从某个 stage 回滚 | `python main.py --resume-run latest --rollback-stage 03` |
 | 扫描已有项目并推荐切入 stage | `python main.py --goal "..." --project-root /path/to/project` |
 | 从你的过往论文语料构建研究者画像 | `python main.py --goal "..." --paper-corpus /path/to/papers` |
-| 生成研究方法图并插入论文 | `python main.py --goal "..." --research-diagram` |
+| 生成研究方法图并插入成品 | `python main.py --goal "..." --research-diagram` |
 | 调大单个 stage 超时上限 | `python main.py --goal "..." --stage-timeout 28800` |
+| 目标太长，从文件读 | `python main.py --goal-file goal.md` |
+| 要 LaTeX 源文件和可编译 PDF | `python main.py --goal "..." --output-format latex` |
+| 只跑到写作阶段就停 | `python main.py --goal "..." --final-stage 07` |
+| 让一个 reviewer agent 代替人工审批 | `python main.py --full-auto --goal "..."` |
+| 执行 agent 和 reviewer 分开 | `python main.py --operator codex --full-auto --review-operator claude --review-model opus --goal "..."` |
+| 调多可选机制的档位 | `python main.py --rigor thorough --goal "..."` |
+| 只加 Stage 02 提案面板 | `python main.py --ideation-panel --goal "..."` |
+| 只加 crux 小组 | `python main.py --deliberation --goal "..."` |
+| 关掉分档，所有阶段都走全套 | `python main.py --no-effort-tiers --goal "..."` |
+| 五席评审团（会让 run 变成无人值守） | `python main.py --review-panel --goal "..."` |
+| 给评审团分配模型 | `python main.py --review-panel --panel-models pi=opus skeptic=codex:default --goal "..."` |
+| 给评审团一份人设 | `python main.py --review-panel --persona persona.md --goal "..."` |
+| 退回严格的 01→08 顺序 | `python main.py --stage-graph linear --goal "..."` |
+| 每个节点都让 agent 选下一步 | `python main.py --routing agent --goal "..."` |
+| 永远走默认边，不问 agent | `python main.py --routing off --goal "..."` |
+| 允许 Stage 03~06 多跑几轮 | `python main.py --max-rounds 2 --goal "..."` |
+| 放宽单个 stage 的尝试次数 | `python main.py --max-attempts 8 --goal "..."` |
+| 无人值守（不等任何终端输入） | `python main.py --unattended --approval-mode agent --goal "..."`（光给 `--unattended` 会在第一个审批菜单处报错退出，见 7.1） |
+| 内置 WebSearch 被禁用时改走 Gemini | `python main.py --web-search gemini --goal "..."`（先 `pip install google-genai` 并配好 key，否则启动就被拒绝） |
+| 关掉打分与择优 | `python main.py --no-evolve --goal "..."` |
+| 看跨 run 归档学到了什么 | `python main.py --archive-report` |
+| 不把这次 run 写进归档 | `python main.py --no-archive --goal "..."` |
+| 把这次 run 标成成对试验的一侧 | `python main.py --trial t1 --capability review_panel --arm on --goal "..."` |
+| 看成对试验的统计结果 | `python main.py --trial-report` |
+
+`--archive-report` 和 `--trial-report` 打印完就退出，不会启动 run。新装的环境里它们是空表——那是当前的真实状态，不是 bug。
 
 ### 12.1 `--redo-stage` 和 `--rollback-stage` 的区别
 
@@ -958,8 +1090,8 @@ python main.py --runs-dir /mnt/large-disk/autor-runs --goal "..."
 - 没有真实实验
 - 没有真实数据文件
 - 没有 figure
-- 没有 PDF
-- PDF 只是形式完成，没有证据支撑
+- 没有最终报告（默认是 `workspace/report/report.md`，latex 模式下是 PDF）
+- 报告只是形式完成，没有证据支撑
 - 只是“计划下一步做什么”
 
 你放水一次，后面往往要多补三次。
@@ -1062,7 +1194,7 @@ python main.py --goal "..." --stage-timeout 28800
 
 ### 技巧 12：`--research-diagram` 是增强项，不是必需项
 
-如果你想在 Stage 07 后自动生成一个方法图并插入论文，可以开启：
+如果你想在 Stage 07 后自动生成一个方法图并插进成品（markdown 模式插进 `report.md`，latex 模式插进 `method.tex`），可以开启：
 
 ```bash
 python main.py --goal "..." --research-diagram
@@ -1094,7 +1226,7 @@ pip install google-genai pillow pyyaml
 
 这些文件非常有用：
 
-- `run_manifest.json`：看每个 stage 当前是 pending、running、approved、stale 还是 dirty
+- `run_manifest.json`：看每个 stage 的 `status` 字段（停在审批菜单前等你处理时，它是 `human_review`），以及 `dirty` 和 `stale` 两个独立的布尔标志——这两个是标志位，不是 `status` 的取值。`status` 到底会写成哪些值，以 `src/manifest.py` 里 `StageManifestEntry` 和那一组 `mark_stage_*_manifest` 函数为准
 - `prompt_cache/`：看这个 stage 当时到底拿到了什么 prompt
 - `operator_state/`：看 session、attempt 和记忆恢复状态
 - `handoff/`：看前面阶段给后面阶段传了什么压缩交接信息
@@ -1188,17 +1320,20 @@ pip install google-genai pillow pyyaml
 - 任何已有 baseline 结果
 - 你的实验想法笔记
 
-### 第三步：开局就指定 venue
+### 第三步：开局就指定 venue，并且明确要 LaTeX
 
-例如：
+**默认的最终产物是 Markdown 报告，不是 PDF。** 要 PDF 就必须显式写 `--output-format latex`：
 
 ```bash
 python main.py \
   --operator claude \
   --model sonnet \
   --venue neurips_2025 \
+  --output-format latex \
   --goal "..."
 ```
+
+`--output-format` 在恢复 run 时会保留，所以开局定下来比中途改省事。
 
 ### 第四步：在 Stage 03~06 非常严格
 
@@ -1215,13 +1350,22 @@ python main.py \
 
 不要被“已经有 PDF”这件事骗过去。
 
-好的 Stage 07 至少应当同时具备：
+在 `--output-format latex` 下，好的 Stage 07 至少应当同时具备：
 
 - LaTeX 源文件
 - Bib
 - 编译成功的 PDF
 - citation verification 输出
 - 关键 claim 对应的实验和图表
+
+在默认的 markdown 模式下，对应的是：
+
+- `workspace/report/report.md`，而且它至少引用了一张图，每个图片引用都用 `report.md` 的相对路径（推荐 `images/xxx.png`）解析到 `workspace/report/` 下真实存在的文件
+- 每个结论都带数字，而不是只有形容词
+- citation verification 输出
+- 关键 claim 对应的实验和图表
+
+还有一层机器保证值得知道：从 Stage 07 起，`workspace/artifacts/claim_provenance.json` 里的每条 claim 要么是挂在某条 `supported` 预注册假设上的 `confirmatory`，要么被显式标成 `exploratory`，而且都要引到真实存在的文件。做不到，这个阶段过不了校验。
 
 ### 第六步：如果前面某一步不对，果断 redo 或 rollback
 
@@ -1261,17 +1405,22 @@ runs/<run_id>/
 | `runs/<run_id>/workspace/data/` | 数据 |
 | `runs/<run_id>/workspace/results/` | 机器可读结果 |
 | `runs/<run_id>/workspace/results/experiment_manifest.json` | 标准化实验清单，后续分析和写作都会用到 |
+| `runs/<run_id>/workspace/results/hypothesis_outcomes.json` | Stage 06 对每条冻结假设的裁定，以及裁定所引的证据文件 |
 | `runs/<run_id>/workspace/figures/` | 图 |
-| `runs/<run_id>/workspace/writing/` | 论文源文件 |
+| `runs/<run_id>/workspace/report/report.md` | **默认模式下的最终报告** |
+| `runs/<run_id>/workspace/report/images/` | 报告引用的图片 |
+| `runs/<run_id>/workspace/writing/` | 论文源文件（`--output-format latex`） |
 | `runs/<run_id>/workspace/artifacts/` | PDF 和打包产物 |
 | `runs/<run_id>/workspace/artifacts/citation_verification.json` | 写作阶段的引用与 claim 覆盖校验结果 |
 | `runs/<run_id>/workspace/notes/hypothesis_manifest.json` | 假设阶段提炼出的结构化假设清单 |
+| `runs/<run_id>/workspace/notes/preregistration.json` | Stage 04 批准时冻结下来的预注册，之后不再被覆盖 |
 | `runs/<run_id>/workspace/reviews/` | review / release 材料 |
+| `runs/<run_id>/evolution/` | 每一版候选草稿、它们的分数、冠军版本和改进账本；**在 `workspace/` 之外**，导出成果时不会被一起带走 |
 
-如果你想找最终 PDF，优先看：
+如果你想找最终产物：
 
-- `workspace/artifacts/`
-- `workspace/writing/`
+- 默认（markdown）模式：`workspace/report/report.md`
+- `--output-format latex`：`workspace/artifacts/` 和 `workspace/writing/`
 
 ---
 
@@ -1330,6 +1479,15 @@ AutoR 当前支持 `claude` 和 `codex`。恢复 run 时默认会保留之前的
 2. 再跑一次 smoke test
 3. 再开一个带 `--resources` 的真实 run
 4. 最后再去看 `runs/<run_id>/` 里的真实产物结构
+
+想继续往深处走：
+
+- [framework.md](framework.md)：这个系统在赌什么、六条设计承诺、控制回路怎么跑、以及作者自己列出的“还没有被证明的部分”
+- [cli-reference.md](cli-reference.md)：每个参数的默认值、恢复 run 时是否保留、退出码
+- [architecture.md](architecture.md)：模块地图
+- [stage-contract.md](stage-contract.md)：一个 stage 必须写出什么才算合格
+- [run-artifacts.md](run-artifacts.md)：`runs/<run_id>/` 里每个文件的含义
+- [troubleshooting.md](troubleshooting.md)：跑不通的时候先看这里
 
 ---
 


### PR DESCRIPTION
#179 rebuilt `README.md` and added `docs/framework.md`, and explicitly scoped the rest of the set out: the two tutorials were pre-graph documents, and four reference pages claimed a completeness they did not have. This is that half.

## Method, because it is the part worth copying

Each page was repaired against the code, then read back by a **different** agent whose only job was to falsify it. That pass earned its cost immediately:

| Round | Confirmed false statements |
| --- | ---: |
| 1 | **38** across six pages |
| 2 | **23** — *including ones round 1's repair introduced* |
| 3 | **2** blocking, 0 CI-mechanical failures |

Round 2's findings are the interesting ones. One is recorded as *"False, and it was introduced by the rewrite (it is in the diff against HEAD)"*; another as *"the fixing agent re-vouched for it while rewriting this very row."* So the failure mode is not ignorance, it is **confident elaboration**.

Round 3 was given that lesson explicitly, plus the instruction that produced most of the convergence: **prefer deleting a false completeness claim to completing it.** "The full ladder is in `validate_stage_artifacts`" does not rot; a hand-copied list does.

## The two tutorials

The largest change. They described a fixed **nine-stage sequential pipeline** — there are eight stages, the default topology is `adaptive`, and thirteen backward edges exist. Between them they mentioned **none** of `--rigor`, `--review-panel`, `--ideation-panel`, `--deliberation`, `--effort-tiers`, `--stage-graph`, `--routing`, `--evolve`, `--archive`, `--trial`, `--final-stage`, `--max-rounds`, `--cross-review`, `--web-search`, `--goal-file`, `--unattended`, `--max-attempts`, `--persona`, `--panel-models`. They also assumed a LaTeX PDF deliverable throughout, when markdown has been the default for some time.

`tutorial_zh.md` stays in Chinese.

## The two round-3 blocking items were both false "only"s

- **`run-artifacts.md`** called `memory.md` "the **only** context shared across stages" — which three later sections of the same page contradict. `build_handoff_context` and `build_decision_ledger_context` are separate carriers, and the typed channels carry the rest.
- **`configuration.md`** said setup "needs no `pip install`" and scoped the exception to three optional paths. There is a fourth: `--paper-corpus` imports `fitz` (PyMuPDF) in `_extract_pdf_text`, and unlike the other three it degrades **silently** — every PDF becomes a one-line placeholder in the researcher profile that seeds later stages.

## `framework.md` had had no adversarial pass at all

Three lenses found seven blocking defects. **Four were not documentation errors** — they were the document describing the code as I would like it to be:

| Claimed | Actual |
| --- | --- |
| "drift rejection removes the *possibility*" of the loop changing its answer | `_revert` copies the champion stage summary back and touches nothing else. A rejected round that rewrote `hypothesis_outcomes.json` leaves it rewritten, and the promoted summary and the outcomes file disagree. |
| "a revision a **human** asked for is exempt" | The exemption is any attempt with `is_polish_round=False`, which the manager sets for a *reviewer's* decision too — its own comment reads "a human or reviewer decision". Unattended, that reviewer is a model. |
| "close the router edge into writing until all of that holds" | The guard takes the move off the agent's menu; `default_move` takes a guard-blocked advance as a last resort anyway. The refusal that stops an unadjudicated Stage 07 is `validate_stage_artifacts`. |
| "a dropped hypothesis cannot be silently deleted" | Deleting `preregistration.json` makes `_build_stage_prompt` re-freeze from the current manifest with `amendments: []`; `_amend_preregistration` early-returns when the file is gone. Both files are under the agent's own `workspace/notes/`. |

All four now appear as limits in §7 rather than as properties in §2 and §5. The fifth defect — the scorecard reading four of five ledgers — was a real bug, fixed separately in #188.

## Testing

`python -m unittest discover -s tests -p "test_*.py"` — **2026 pass**, 1 skip. No `file.py:NNN` citation anywhere; every spelled-out count checked against its symbol by `tests/test_doc_counts.py`.

## Residual risk, stated rather than implied

Three rounds converged; they did not exhaust. Round 3's sign-off recorded non-blocking imprecision it deliberately did not spend a fourth round on — for example `tutorial_en.md` saying adjudication starts at Stage 05 when `validate_hypothesis_outcomes` is the Stage 06 block, and several headings still leading with "PDF" where the body now says markdown. These are wrong in emphasis rather than in substance, and the next pass over these files should start there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)