### PR TITLE
Let a run say which code produced it

### DIFF
--- a/src/rcb.py
+++ b/src/rcb.py
@@ -60,6 +60,7 @@ from .utils import (
     StageSpec,
     approved_stage_summaries,
     build_run_paths,
+    code_version,
     extract_fenced_task,
     extract_markdown_image_targets,
     read_text,
@@ -193,6 +194,12 @@ def write_run_meta(
             "agent_name": meta.get("agent_name") or agent_name,
             "duration_seconds": duration_seconds,
             "model": model,
+            # Which AutoR produced this. `_meta.json` is the file the scorer and the
+            # leaderboard importer read, so it is the one place a published number can
+            # carry the code behind it. Written last-wins rather than preserved like
+            # `agent_cmd`: a re-export runs new code over an old workspace, and saying so
+            # is the point.
+            "code_version": code_version(),
         }
     )
     if extra:

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,6 +9,60 @@ from typing import Any, Mapping, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE_REGISTRY_PATH = REPO_ROOT / "templates" / "registry.yaml"
+
+#: What `code_version()` reports when it cannot tell. Never an empty string: a field that is
+#: sometimes absent and sometimes blank is one a reader has to guess about.
+UNKNOWN_CODE_VERSION = "unknown"
+
+_code_version_cache: str | None = None
+
+
+def code_version() -> str:
+    """The commit this run's code came from, with ``+dirty`` when the tree is modified.
+
+    A run could not say what produced it. ``run_manifest.json`` has the run id, timestamps,
+    status and stages; ``_meta.json`` has the model and the duration; neither has a version
+    of any kind. That is fine until the checkout moves, and on a shared clone it moves
+    constantly: during one 12-run benchmark batch this repository advanced twelve commits
+    under the running processes, so the first six runs and the last six did not use the same
+    code and nothing on disk recorded which was which. The provenance had to be reconstructed
+    by hand from shell history, which is not evidence.
+
+    ``+dirty`` matters as much as the sha. A run from a modified tree is not reproducible
+    from its commit, and a bare sha would claim it is.
+
+    Best-effort by construction: a tarball with no ``.git``, a missing git binary and a
+    non-repository all report :data:`UNKNOWN_CODE_VERSION` rather than failing a run over
+    metadata. Cached because it cannot change within a process and every run start would
+    otherwise pay for two subprocesses.
+    """
+    global _code_version_cache
+    if _code_version_cache is not None:
+        return _code_version_cache
+
+    import subprocess
+
+    def _git(*args: str) -> str | None:
+        try:
+            done = subprocess.run(
+                ["git", "-C", str(REPO_ROOT), *args],
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return done.stdout.strip() if done.returncode == 0 else None
+
+    sha = _git("rev-parse", "HEAD")
+    if not sha:
+        _code_version_cache = UNKNOWN_CODE_VERSION
+        return _code_version_cache
+
+    # `--porcelain` is empty exactly when the tree matches the commit. A failure to *ask*
+    # is not a clean tree, so it is reported as unknown rather than assumed either way.
+    status = _git("status", "--porcelain")
+    suffix = "" if status == "" else ("+dirty" if status else "+unknown")
+    _code_version_cache = sha[:12] + suffix
+    return _code_version_cache
 DEFAULT_VENUE = "neurips_2025"
 MAX_STAGE_ATTEMPTS = 5
 DEFAULT_CODEX_SANDBOX = "workspace-write"
@@ -481,6 +535,10 @@ def default_run_config() -> dict[str, Any]:
         **normalize_walk_settings({}),
         "web_search": DEFAULT_WEB_SEARCH_MODE,
         "min_report_figures": MIN_REPORT_FIGURES,
+        # A run whose config could not be read cannot claim a version either. This is the
+        # code reading it, not the code that produced it, and the two differ exactly when
+        # the question is being asked.
+        "code_version": UNKNOWN_CODE_VERSION,
     }
 
 
@@ -520,6 +578,9 @@ def initialize_run_config(
         **normalize_walk_settings(walk or {}),
         "web_search": normalize_web_search_mode(web_search),
         "min_report_figures": resolve_min_report_figures(min_report_figures),
+        # Stamped at run start, not read back at resume: it records the code this run began
+        # under, which is the question a later reader is asking.
+        "code_version": code_version(),
         "created_at": datetime.now().isoformat(timespec="seconds"),
     }
     write_text(paths.run_config, json.dumps(config, indent=2, ensure_ascii=False))
@@ -567,6 +628,16 @@ def load_run_config(paths: RunPaths) -> dict[str, Any]:
         **normalize_walk_settings(payload),
         "web_search": normalize_web_search_mode(payload.get("web_search")),
         "min_report_figures": resolve_min_report_figures(payload.get("min_report_figures")),
+        # Read back verbatim, never recomputed. This field answers "which code started this
+        # run", and recomputing it on load would answer "which code is reading it" -- the
+        # same string on the day the run happens and a different one every day after, which
+        # is precisely when a reader is asking. A config written before the field existed
+        # says so rather than borrowing today's commit.
+        "code_version": (
+            payload["code_version"].strip()
+            if isinstance(payload.get("code_version"), str) and payload["code_version"].strip()
+            else UNKNOWN_CODE_VERSION
+        ),
     }
     created_at = payload.get("created_at")
     if isinstance(created_at, str) and created_at.strip():
@@ -594,6 +665,15 @@ def save_run_config(paths: RunPaths, config: dict[str, Any]) -> None:
         **normalize_walk_settings(config),
         "web_search": normalize_web_search_mode(config.get("web_search")),
         "min_report_figures": resolve_min_report_figures(config.get("min_report_figures")),
+        # Carried through, not recomputed, for the same reason `created_at` below is: this
+        # says which code *started* the run. A resume runs newer code over an older run, and
+        # stamping today's commit here would quietly rewrite the run's history to claim it
+        # always ran on it. A config with nothing recorded says so.
+        "code_version": (
+            config["code_version"].strip()
+            if isinstance(config.get("code_version"), str) and config["code_version"].strip()
+            else UNKNOWN_CODE_VERSION
+        ),
     }
     created_at = config.get("created_at")
     if isinstance(created_at, str) and created_at.strip():

--- a/tests/test_code_version.py
+++ b/tests/test_code_version.py
@@ -1,0 +1,168 @@
+"""A run has to be able to say which code produced it.
+
+`run_manifest.json` had the run id, timestamps, status and stages. `_meta.json` had the
+model and the duration. Neither had a version of any kind, which is fine until the checkout
+moves -- and on a shared clone it moves constantly. During one 12-run ResearchClawBench
+batch this repository advanced twelve commits under the running processes, so the first six
+runs and the last six did not use the same code and nothing on disk recorded which was
+which. The provenance had to be reconstructed by hand from shell history.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import src.utils as utils
+from src.rcb import write_run_meta
+from src.utils import (
+    UNKNOWN_CODE_VERSION,
+    build_run_paths,
+    code_version,
+    ensure_run_layout,
+    initialize_run_config,
+    load_run_config,
+)
+
+
+class CodeVersionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        utils._code_version_cache = None
+        self.addCleanup(setattr, utils, "_code_version_cache", None)
+
+    def test_it_reports_a_commit_in_this_repository(self) -> None:
+        version = code_version()
+        self.assertNotEqual(version, UNKNOWN_CODE_VERSION)
+        self.assertRegex(version, r"^[0-9a-f]{12}(\+(dirty|unknown))?$")
+
+    def test_it_is_never_blank(self) -> None:
+        """A field that is sometimes absent and sometimes empty is one readers guess about."""
+        self.assertTrue(code_version().strip())
+
+    def test_a_modified_tree_says_so(self) -> None:
+        """A run from a dirty tree is not reproducible from its sha, and must not claim to be."""
+        with mock.patch("subprocess.run") as run:
+            run.side_effect = [
+                mock.Mock(returncode=0, stdout="abcdef0123456789\n"),
+                mock.Mock(returncode=0, stdout=" M src/utils.py\n"),
+            ]
+            self.assertEqual(code_version(), "abcdef012345+dirty")
+
+    def test_a_clean_tree_carries_no_suffix(self) -> None:
+        with mock.patch("subprocess.run") as run:
+            run.side_effect = [
+                mock.Mock(returncode=0, stdout="abcdef0123456789\n"),
+                mock.Mock(returncode=0, stdout=""),
+            ]
+            self.assertEqual(code_version(), "abcdef012345")
+
+    def test_a_status_that_could_not_be_read_is_not_reported_as_clean(self) -> None:
+        """Failing to ask whether the tree is dirty is not the same as it being clean."""
+        with mock.patch("subprocess.run") as run:
+            run.side_effect = [
+                mock.Mock(returncode=0, stdout="abcdef0123456789\n"),
+                mock.Mock(returncode=128, stdout=""),
+            ]
+            self.assertEqual(code_version(), "abcdef012345+unknown")
+
+    def test_a_checkout_with_no_git_is_unknown_rather_than_an_error(self) -> None:
+        """A tarball install must not fail a run over metadata."""
+        with mock.patch("subprocess.run", side_effect=FileNotFoundError("git")):
+            self.assertEqual(code_version(), UNKNOWN_CODE_VERSION)
+
+    def test_a_non_repository_is_unknown(self) -> None:
+        with mock.patch("subprocess.run", return_value=mock.Mock(returncode=128, stdout="")):
+            self.assertEqual(code_version(), UNKNOWN_CODE_VERSION)
+
+    def test_a_hung_git_does_not_hang_the_run(self) -> None:
+        with mock.patch("subprocess.run", side_effect=subprocess.TimeoutExpired("git", 10)):
+            self.assertEqual(code_version(), UNKNOWN_CODE_VERSION)
+
+    def test_it_is_computed_once_per_process(self) -> None:
+        """Every run start would otherwise pay for two subprocesses."""
+        with mock.patch("subprocess.run") as run:
+            run.side_effect = [
+                mock.Mock(returncode=0, stdout="abcdef0123456789\n"),
+                mock.Mock(returncode=0, stdout=""),
+            ]
+            first = code_version()
+        self.assertEqual(code_version(), first)
+
+
+class StampedOnTheRunTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def test_the_run_config_records_it(self) -> None:
+        paths = build_run_paths(self.root / "run_0001")
+        ensure_run_layout(paths)
+        config = initialize_run_config(paths, model="opus", venue=None)
+        self.assertEqual(config["code_version"], code_version())
+        self.assertEqual(load_run_config(paths)["code_version"], code_version())
+
+    def test_the_benchmark_metadata_records_it(self) -> None:
+        """`_meta.json` is what the scorer and the leaderboard importer read."""
+        workspace = self.root / "Physics_000_20260811_120000"
+        workspace.mkdir()
+        write_run_meta(
+            workspace, task_id="Physics_000", run_id="Physics_000_20260811_120000",
+            status="completed", duration_seconds=42, model="opus",
+        )
+        meta = json.loads((workspace / "_meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta["code_version"], code_version())
+
+    def test_a_config_predating_the_field_is_unknown_not_todays_commit(self) -> None:
+        """Recomputing on load would answer "which code is reading this", not "which ran"."""
+        paths = build_run_paths(self.root / "run_0002")
+        ensure_run_layout(paths)
+        initialize_run_config(paths, model="opus", venue=None)
+        payload = json.loads(paths.run_config.read_text(encoding="utf-8"))
+        payload.pop("code_version")
+        paths.run_config.write_text(json.dumps(payload), encoding="utf-8")
+        self.assertEqual(load_run_config(paths)["code_version"], UNKNOWN_CODE_VERSION)
+
+    def test_a_recorded_version_is_read_back_verbatim(self) -> None:
+        paths = build_run_paths(self.root / "run_0003")
+        ensure_run_layout(paths)
+        initialize_run_config(paths, model="opus", venue=None)
+        payload = json.loads(paths.run_config.read_text(encoding="utf-8"))
+        payload["code_version"] = "0000deadbeef+dirty"
+        paths.run_config.write_text(json.dumps(payload), encoding="utf-8")
+        self.assertEqual(load_run_config(paths)["code_version"], "0000deadbeef+dirty")
+
+    def test_a_resume_does_not_rewrite_which_code_started_the_run(self) -> None:
+        """save_run_config dropped the field, so a resume lost it -- caught by an existing test."""
+        from src.utils import save_run_config
+
+        paths = build_run_paths(self.root / "run_0004")
+        ensure_run_layout(paths)
+        initialize_run_config(paths, model="opus", venue=None)
+        config = load_run_config(paths)
+        config["code_version"] = "0000deadbeef"
+        save_run_config(paths, config)
+        self.assertEqual(load_run_config(paths)["code_version"], "0000deadbeef")
+
+    def test_a_re_export_records_the_code_that_re_exported(self) -> None:
+        """Unlike `agent_cmd`, this is last-wins: new code over an old workspace is the news."""
+        workspace = self.root / "Physics_000_20260811_120000"
+        workspace.mkdir()
+        (workspace / "_meta.json").write_text(
+            json.dumps({"agent_cmd": "autor", "code_version": "0000deadbeef"}), encoding="utf-8"
+        )
+        write_run_meta(
+            workspace, task_id="Physics_000", run_id="Physics_000_20260811_120000",
+            status="completed", duration_seconds=42, model="opus",
+        )
+        meta = json.loads((workspace / "_meta.json").read_text(encoding="utf-8"))
+        self.assertEqual(meta["code_version"], code_version())
+        self.assertEqual(meta["agent_cmd"], "autor")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The gap

`run_manifest.json` has the run id, timestamps, status and stages. `_meta.json` has the model and the duration. **Neither has a version of any kind.**

That is fine until the checkout moves, and on a shared clone it moves constantly. During today's 12-run ResearchClawBench batch this repository advanced **twelve commits** under the running processes. Python binds its modules at process start, so the six runs in flight were pinned to the commit they began on while the six still queued would import whatever was in the clone when their slot freed. Nothing on disk recorded which was which — the provenance had to be reconstructed by hand from shell history, which is not evidence.

A published benchmark number that cannot name its code is a number nobody can reproduce.

## The fix

`code_version()` reports the commit, with `+dirty` when the tree is modified. Stamped into `run_config.json` and into `_meta.json` — the file `evaluation.score` and the leaderboard importer read, so a published number can carry the code behind it.

The suffix carries as much as the sha: a run from a modified tree is **not** reproducible from its commit, and a bare sha would claim it is. A `git status` that could not be read reports `+unknown` rather than being assumed clean.

Best-effort by construction — a tarball with no `.git`, a missing git binary, a non-repository and a hung git all report `unknown` rather than failing a run over metadata. Cached, because it cannot change within a process and every run start would otherwise pay for two subprocesses.

## Read back verbatim, never recomputed

The field answers *"which code started this run"*. Recomputing it on load would answer *"which code is reading it"* — the same string on the day of the run and a different one every day after, which is exactly when someone is asking. A config written before the field existed says `unknown` rather than borrowing today's commit.

`_meta.json` is the one deliberate exception and is last-wins: a re-export runs new code over an old workspace, and saying so is the point.

## What the suite caught

`save_run_config` dropped the field. That was caught by an existing test whose docstring is the whole argument:

> *A field the writer drops is a field the resume cannot reconcile.*

A resume runs newer code over an older run, so it now carries the recorded value through rather than restamping — restamping would quietly rewrite the run's history to claim it always ran on today's commit.

## Tests

15 new tests in `tests/test_code_version.py`, covering dirty/clean/unreadable status, all four unavailable-git paths, the cache, both stamped files, the resume, and the pre-field config. Full suite **2041 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)