### PR TITLE
Put the routing decisions to the agent that were being taken for it

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -778,6 +778,7 @@ class ResearchManager:
             score_total=score.total if score is not None else None,
             offered=decision.offered,
             blocked=decision.blocked,
+            refusal=decision.refusal,
         )
         if decision.agent_directed or decision.refusal:
             self.ui.show_status(format_decision(decision), level="info")

--- a/src/router.py
+++ b/src/router.py
@@ -187,7 +187,28 @@ class StageRouter:
                 offered=offered, blocked=blocked_kinds,
             )
 
-        should_ask = self.mode == "agent" or (self.mode == "auto" and len(live) > 1)
+        # `auto` means "ask where the answer can differ". `len(live) > 1` was the wrong
+        # way to say that, and it skipped the one decision this graph exists to put to
+        # an agent.
+        #
+        # A blocked edge is not in `live`. So at a node whose forward guard is unmet and
+        # whose backward edge is open — Stage 02, 03 and 04 on any run that has not yet
+        # produced design artifacts, runnable code or results — `live` holds exactly the
+        # repair move, `len(live) == 1`, and the router is skipped. `default_move` then
+        # advances forward anyway as a `last_resort`, with the precondition still unmet,
+        # and the agent is never told that the edge which would satisfy it was open.
+        #
+        # Measured over the 50 archived ResearchClawBench routes: 133 visits, one
+        # revisit, and 41 of 50 runs halting at or before Stage 03 — the stages where
+        # this is the shape of every node.
+        #
+        # "Push on with the precondition unmet, or go back and satisfy it" is a research
+        # judgement, it is the reason the thirteen backward edges exist, and it is
+        # exactly what the module docstring promises an agent gets shown. Ask for it.
+        a_repair_is_open = default.last_resort and bool(live)
+        should_ask = self.mode == "agent" or (
+            self.mode == "auto" and (len(live) > 1 or a_repair_is_open)
+        )
         if not should_ask or self.operator is None or self.fake_mode:
             return RoutingDecision(
                 default.target,
@@ -443,6 +464,21 @@ def _default_reason(default: Move, moves: list[Move]) -> str:
     observation.
     """
     if default.last_resort:
+        # Two different events, and recording them as one put a false claim on the
+        # route. `default_move` never goes backward by design, so it last-resorts
+        # forward whether or not a backward edge was open — and at Stages 02-04 one
+        # usually is. The archive learns from these reasons; "nowhere left to go back
+        # to" written over a live repair edge is a mislabelled observation about the
+        # topology, in the direction that makes the topology look inert.
+        open_moves = [move.target for move in moves if move.admissible]
+        if open_moves:
+            return (
+                "No forward move is open, so the run advances with the precondition unmet: "
+                f"{default.guard.reason}. It was not sent back to "
+                f"{', '.join(f'`{target}`' for target in open_moves)}, which "
+                f"{'was' if len(open_moves) == 1 else 'were'} open — the default never goes "
+                "backward, and nothing chose one."
+            )
         return (
             f"No move out of this stage is open and there is nowhere left to go back to, so the "
             f"run advances with the precondition unmet: {default.guard.reason}"

--- a/src/router.py
+++ b/src/router.py
@@ -345,6 +345,53 @@ class StageRouter:
         # `target` is what identifies a routing move, the way `decision` identifies a review
         # verdict: the backend is an agent whose stdout is a transcript, and the object it
         # merely quoted from a file must not outrank the one it chose.
+        payload = extract_json_payload(stdout_text, verdict_key="target")
+        if payload is not None:
+            return payload
+
+        # Every failure of the ask degrades *forward*: `choose` falls through to
+        # `_refuse`, which takes the default, and the default is a forward move by
+        # construction. So a dropped brace is scored as "advance" — a routing decision
+        # lost to formatting, indistinguishable in the archive from one the agent made.
+        # The reviewer gate has re-asked for years; this had one attempt.
+        append_log_entry(
+            paths.logs,
+            f"{stage.slug} route_unparsed",
+            "No object carrying `target` in the routing response; re-asking once.\n"
+            f"tail: {stdout_text[-2000:]}",
+        )
+        return self._reask(paths=paths, stage=stage, previous=stdout_text)
+
+    def _reask(self, *, paths: RunPaths, stage: StageSpec, previous: str) -> dict[str, Any] | None:
+        """One more attempt, asking only for the object."""
+        prompt_path = paths.prompt_cache_dir / f"{stage.slug}_route.retry.prompt.md"
+        write_text(
+            prompt_path,
+            "# Routing answer, second attempt\n\n"
+            "Your previous answer could not be parsed. Return the routing object and "
+            "nothing else — no explanation, no code fence, no text after it.\n\n"
+            '{"target":"<stage slug>","reason":"<one or two sentences>"}\n\n'
+            "## What you replied\n\n"
+            f"{previous[-4000:]}\n",
+        )
+        try:
+            command, cwd, stdin_text = self.operator._prepare_invocation(  # noqa: SLF001
+                prompt_path, str(uuid.uuid4()), paths=paths, resume=False
+            )
+            exit_code, stdout_text, _stderr, _observed, _meta = self.operator._run_streaming_command(  # noqa: SLF001
+                command=command,
+                cwd=cwd,
+                stage=stage,
+                attempt_no=0,
+                paths=paths,
+                mode="route_retry",
+                stdin_text=stdin_text,
+            )
+        except Exception as exc:  # noqa: BLE001 - a routing failure must not end the run
+            append_log_entry(paths.logs, f"{stage.slug} route_error", str(exc))
+            return None
+        if exit_code != 0:
+            return None
         return extract_json_payload(stdout_text, verdict_key="target")
 
     def _archive_evidence(self, source: str, targets: list[str]) -> str:
@@ -429,6 +476,12 @@ class StageRouter:
         if evidence:
             sections += ["", evidence]
 
+        # Only offer `finish` where a finish edge exists. Inviting it everywhere cost a
+        # real decision: at Stage 07 the agent answered `finish`, 07 has no finish edge,
+        # the router refused an off-menu target and fell through to the default — which
+        # at 07 happens to be backward. That fallback is the single `revisit` recorded in
+        # the whole 133-visit archive, and it was not a routing decision at all.
+        can_finish = any(move.edge.kind == "finish" for move in moves)
         sections += [
             "",
             "## Original goal",
@@ -441,16 +494,21 @@ class StageRouter:
             "",
             "## Answer",
             "",
-            "Return JSON only, with no prose outside the object:",
+            "Return JSON only, with no prose outside the object. Emit it as your final "
+            "message and emit nothing after it.",
             "",
-            '{"target":"<stage slug or finish>","reason":"<one or two sentences>"}',
+            f'{{"target":"{"<stage slug or finish>" if can_finish else "<stage slug>"}",'
+            '"reason":"<one or two sentences>"}',
             "",
             "- `target` must be one of the available moves above, spelled exactly as shown.",
             "- `reason` must say what in *this stage's results* makes that the right move. "
             "\"Continue the workflow\" is not a reason; \"H2 is inconclusive because only one "
             "seed was run\" is.",
-            "- Choose `finish` only if the run has produced what it set out to produce.",
         ]
+        if can_finish:
+            sections.append(
+                "- Choose `finish` only if the run has produced what it set out to produce."
+            )
         return "\n".join(sections)
 
 
@@ -533,6 +591,7 @@ def routing_summary(paths: RunPaths) -> dict[str, Any]:
     agent_directed = 0
     revisits = 0
     bypassed = 0
+    refused = 0
     for visit in payload.get("path", []):
         if not isinstance(visit, dict):
             continue
@@ -544,14 +603,30 @@ def routing_summary(paths: RunPaths) -> dict[str, Any]:
         if visit.get("bypassed"):
             bypassed += 1
             continue
-        decisions.append(
-            {
-                "source": source,
-                "chose": target,
-                "offered": [str(item) for item in visit.get("offered", []) if str(item)],
-                "agent_directed": bool(visit.get("agent_directed")),
-            }
-        )
+        # A refused route is a real traversal and not a real decision, and the two
+        # halves go to different places.
+        #
+        # The edge *was* taken, with its guards evaluated and the graph's own default
+        # chosen, so it stays in `edges` — unlike a bypass, where no guard was
+        # evaluated at all. What did not happen is a choice: the router was asked, an
+        # answer came back, and it was lost as unreadable or off-menu. Recorded in
+        # `decisions`, that reads to `src.decisions` as "an alternative was offered and
+        # declined", which is the one thing it was built to keep out. In the archived
+        # corpus 23 of the 27 visits where anything was on offer were refusals, so the
+        # estimator's picture of every forward edge was built almost entirely out of
+        # answers nobody read.
+        was_refused = bool(visit.get("refusal"))
+        if was_refused:
+            refused += 1
+        if not was_refused:
+            decisions.append(
+                {
+                    "source": source,
+                    "chose": target,
+                    "offered": [str(item) for item in visit.get("offered", []) if str(item)],
+                    "agent_directed": bool(visit.get("agent_directed")),
+                }
+            )
         edges[f"{source}->{target}"] = edges.get(f"{source}->{target}", 0) + 1
         if visit.get("agent_directed"):
             agent_directed += 1
@@ -562,6 +637,7 @@ def routing_summary(paths: RunPaths) -> dict[str, Any]:
         "agent_directed": agent_directed,
         "revisits": revisits,
         "bypassed": bypassed,
+        "refused": refused,
         "route": payload.get("route", ""),
     }
 

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -497,6 +497,13 @@ class Visit:
     #: and an estimator that counted them as decisions where nothing else was on
     #: offer would be reading an operator's intervention as evidence about an edge.
     bypassed: bool = False
+    #: Why the router's answer was not used, when it was not. A refused route is not a
+    #: routing observation: the run took the default because the answer was lost or
+    #: off-menu, not because anything preferred it. Recorded rather than inferred,
+    #: because `agent_directed=False` alone cannot tell "nobody was asked" from
+    #: "somebody answered and it did not survive" — and in the archived corpus 23 of
+    #: the 27 visits where anything was on offer were the second kind.
+    refusal: str = ""
     #: The research round this visit closed, if it closed one. Zero otherwise.
     #: What makes the abandonment guard a statement about this traversal rather than
     #: about the run's whole history.
@@ -529,6 +536,7 @@ class Visit:
             "offered": list(self.offered),
             "blocked": dict(self.blocked),
             "bypassed": self.bypassed,
+            "refusal": self.refusal,
             "closed_round": self.closed_round,
         }
 
@@ -553,6 +561,7 @@ class Visit:
                 str(k): str(v) for k, v in (payload.get("blocked") or {}).items() if str(k)
             },
             bypassed=bool(payload.get("bypassed")),
+            refusal=str(payload.get("refusal") or ""),
             closed_round=int(payload.get("closed_round") or 0),
         )
 
@@ -582,11 +591,18 @@ class GraphState:
         return sum(1 for visit in self.path if visit.stage == slug)
 
     def revisit_reasons(self, slug: str) -> list[str]:
-        """Why the run entered ``slug`` before, normalised for comparison."""
+        """Why the run went *back* to ``slug`` before, normalised for comparison.
+
+        Backward moves only. The pool exists so `repeats_a_previous_reason` can refuse
+        a revisit that has already been tried, and an *advance* into a stage is not a
+        previous attempt at that repair — it is the run arriving there in the first
+        place. Pooling both put the machine-written forward rationales, which are
+        identical every run, in the way of a first backward move to the same node.
+        """
         return [
             " ".join(visit.reason.lower().split())
             for visit in self.path
-            if visit.chose == slug and visit.reason
+            if visit.chose == slug and visit.reason and visit.kind == "revisit"
         ]
 
     def to_dict(self) -> dict[str, Any]:
@@ -760,6 +776,37 @@ class StageGraph:
             if final_stage is not None and edge.target != FINISH:
                 target_stage = stage_for_slug(edge.target)
                 if target_stage is not None and target_stage.number > final_stage.number:
+                    if edge.kind == "advance":
+                        # Reaching the stage the caller asked for is a *completion*, and
+                        # the graph already has an edge kind for that. Recorded as a
+                        # pruned advance it was neither: with no live forward move
+                        # `default_move` returns None, `StageRouter.choose` takes its
+                        # "nothing is open" halt, and the live backward edges at that
+                        # node are discarded without anyone being asked.
+                        #
+                        # That is not a corner case. `--final-stage 07_writing` is the
+                        # ResearchClawBench default, so every benchmark run ended by
+                        # throwing away the one decision worth most at Stage 07 —
+                        # whether the write-up contains a claim the analysis does not
+                        # support, which is the 07 -> 06 edge.
+                        results.append(
+                            Move(
+                                replace(
+                                    edge,
+                                    target=FINISH,
+                                    kind="finish",
+                                    guard="always",
+                                    rationale=(
+                                        f"`{final_stage.slug}` is the last stage this run was "
+                                        "asked for, and it is done."
+                                    ),
+                                ),
+                                GuardResult(True, "the requested final stage is complete"),
+                                "",
+                                "",
+                            )
+                        )
+                        continue
                     results.append(
                         Move(
                             edge,
@@ -967,6 +1014,7 @@ def leave(
     offered: "Sequence[str]" = (),
     blocked: Mapping[str, str] | None = None,
     bypassed: bool = False,
+    refusal: str = "",
 ) -> None:
     if not state.path:
         return
@@ -981,6 +1029,7 @@ def leave(
     visit.offered = tuple(offered)
     visit.blocked = dict(blocked or {})
     visit.bypassed = bypassed
+    visit.refusal = refusal
     save_graph_state(paths, state)
 
 

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -324,7 +324,14 @@ class GraphWalkTests(unittest.TestCase):
 
         paths = self.only_run()
         self.assertEqual(load_run_manifest(paths.run_manifest).run_status, "completed")
-        self.assertEqual(load_graph_state(paths).halted_kind, "pruned")
+        # No halt kind at all, which is what this test's name has always said it is.
+        # Reaching the requested final stage now takes a live `finish` edge rather than
+        # leaving the node with no forward move; `halted_kind` describes a walk that
+        # stopped because it could not continue, and this one stopped because it was
+        # done. The distinction the docstring draws is preserved and sharpened.
+        state = load_graph_state(paths)
+        self.assertEqual(state.halted_kind, "")
+        self.assertEqual(state.path[-1].chose, FINISH)
 
     def test_resuming_an_abandoned_run_does_not_relabel_it_completed(self) -> None:
         """A refused resume ran no walk, and `_complete_run` read the walk.

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -363,6 +363,42 @@ class RouterTests(unittest.TestCase):
         self.assertEqual(len(operator.prompts), 1)
         self.assertTrue(decision.agent_directed)
 
+    def test_the_requested_final_stage_asks_instead_of_halting(self) -> None:
+        """`--final-stage 07_writing` is the ResearchClawBench default.
+
+        The advance past the requested final stage used to be recorded as a *pruned*
+        move, which left the node with no live forward move at all: `default_move`
+        returned None, `choose` took its "nothing is open" halt, and the live backward
+        edges at Stage 07 were discarded with nobody asked. So every benchmark run
+        ended by throwing away the decision worth most at that node — whether the
+        write-up carries a claim the analysis does not support.
+        """
+        stage_07 = next(stage for stage in STAGES if stage.number == 7)
+        operator = FakeRoutingOperator(json.dumps({"target": FINISH, "reason": "Everything asked for is written."}))
+        decision = StageRouter(operator, mode="auto").choose(
+            paths=self.paths,
+            stage=stage_07,
+            graph=self.graph,
+            state=GraphState(),
+            final_stage=stage_07,
+        )
+        self.assertEqual(len(operator.prompts), 1)
+        self.assertEqual(decision.target, FINISH)
+        self.assertIn(FINISH, decision.offered)
+        self.assertGreater(len(decision.offered), 1, msg="the backward edges were discarded again")
+
+    def test_the_final_stage_default_is_still_finish_and_never_backward(self) -> None:
+        """The property the pruning was introduced for, kept."""
+        stage_07 = next(stage for stage in STAGES if stage.number == 7)
+        decision = StageRouter(None, mode="off").choose(
+            paths=self.paths,
+            stage=stage_07,
+            graph=self.graph,
+            state=GraphState(),
+            final_stage=stage_07,
+        )
+        self.assertEqual(decision.target, FINISH)
+
     def test_a_node_with_one_edge_and_no_repair_is_still_not_asked(self) -> None:
         """The saving that makes `auto` a safe default has to survive the change."""
         stage_01 = next(stage for stage in STAGES if stage.number == 1)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -342,6 +342,56 @@ class RouterTests(unittest.TestCase):
         )
         self.assertEqual(len(operator.prompts), 1)
 
+    def test_auto_asks_when_the_forward_guard_is_unmet_and_a_repair_edge_is_open(self) -> None:
+        """The decision the graph exists for, and `auto` used to skip exactly it.
+
+        A blocked edge is not in `live`. At a node whose forward guard fails and whose
+        backward edge is open, `live` holds only the repair, so `len(live) > 1` was
+        false and the router was never consulted — `default_move` then advanced across
+        the failing guard as a `last_resort` and the agent never learned that the edge
+        which would satisfy it was open. Measured over the 50 archived ResearchClawBench
+        routes: 133 visits, one revisit.
+        """
+        operator = FakeRoutingOperator(
+            json.dumps({"target": "05_experimentation", "reason": "No hypothesis carries a verdict yet."})
+        )
+        decision = StageRouter(operator, mode="auto").choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+        )
+        default = self.graph.default_move(self.paths, STAGE_06.slug, GraphState())
+        self.assertTrue(default.last_resort, msg="fixture no longer reproduces the unmet-guard case")
+        self.assertEqual(len(operator.prompts), 1)
+        self.assertTrue(decision.agent_directed)
+
+    def test_a_node_with_one_edge_and_no_repair_is_still_not_asked(self) -> None:
+        """The saving that makes `auto` a safe default has to survive the change."""
+        stage_01 = next(stage for stage in STAGES if stage.number == 1)
+        operator = FakeRoutingOperator(json.dumps({"target": "02_hypothesis_generation", "reason": "x"}))
+        StageRouter(operator, mode="auto").choose(
+            paths=self.paths, stage=stage_01, graph=self.graph, state=GraphState()
+        )
+        self.assertEqual(operator.prompts, [])
+
+    def test_off_still_never_asks_however_stuck_the_run_is(self) -> None:
+        operator = FakeRoutingOperator(json.dumps({"target": "05_experimentation", "reason": "x"}))
+        decision = StageRouter(operator, mode="off").choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+        )
+        self.assertEqual(operator.prompts, [])
+        self.assertFalse(decision.agent_directed)
+
+    def test_the_route_does_not_claim_there_was_nowhere_to_go_back_to(self) -> None:
+        """`default_move` never goes backward, so it last-resorts forward whether or not
+        a backward edge was open. Recording both as "nowhere left to go back to" writes a
+        false claim about the topology onto the route the archive learns from."""
+        decision = StageRouter(None, mode="off").choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState()
+        )
+        self.assertNotIn("nowhere left to go back to", decision.reason)
+        self.assertIn("open", decision.reason)
+        self.assertIn("05_experimentation", decision.reason)
+        self.assertIn("the default never goes backward", decision.reason)
+
     def test_an_unknown_mode_is_refused_at_construction(self) -> None:
         with self.assertRaises(ValueError):
             StageRouter(None, mode="vibes")

--- a/tests/test_stage_graph.py
+++ b/tests/test_stage_graph.py
@@ -275,9 +275,16 @@ class AdaptiveTopologyTests(unittest.TestCase):
         moves = self.graph.moves(
             self.paths, "07_writing", GraphState(), final_stage=stage_07
         )
-        pruned = next(move for move in moves if move.target == "08_dissemination")
-        self.assertFalse(pruned.admissible)
-        self.assertEqual(pruned.blocked_kind, "pruned")
+        self.assertNotIn("08_dissemination", [move.target for move in moves])
+        # Reaching the stage the caller asked for is a completion, so the advance past
+        # it is rendered as the finish edge it amounts to rather than as a dead one.
+        # Recorded as a pruned advance the node had no live forward move at all,
+        # `default_move` returned None, and `StageRouter.choose` halted without asking
+        # — discarding the live backward edges at 07, which is the node where "is any
+        # written claim unsupported by the analysis?" gets decided.
+        finish = next(move for move in moves if move.target == FINISH)
+        self.assertTrue(finish.admissible)
+        self.assertEqual(finish.edge.kind, "finish")
 
     def test_final_stage_ends_the_walk_instead_of_sending_it_backwards(self) -> None:
         """The bug that dropping the edge caused, at every final stage.
@@ -295,10 +302,13 @@ class AdaptiveTopologyTests(unittest.TestCase):
         for number in (5, 6, 7):
             final = next(stage for stage in STAGES if stage.number == number)
             with self.subTest(final_stage=final.slug):
-                self.assertIsNone(
-                    self.graph.default_move(
-                        self.paths, final.slug, GraphState(), final_stage=final
-                    ),
+                default = self.graph.default_move(
+                    self.paths, final.slug, GraphState(), final_stage=final
+                )
+                self.assertIsNotNone(default, msg=f"--final-stage {final.slug} halted")
+                self.assertEqual(
+                    default.target,
+                    FINISH,
                     msg=f"--final-stage {final.slug} did not end the walk",
                 )
 


### PR DESCRIPTION
Follow-on from the measurement in [`docs/framework.md`](docs/framework.md) §6.6: across the
50 archived ResearchClawBench routes the graph took **one** backward edge in 133 visits and
the agent decided **4** of them.

First, the honest correction — **most of that was not the graph, and it is already fixed.**
The batch now in flight, at #181 and still *before* this PR, shows:

| | pre-repair batch | in flight, at #181 |
|:---|---:|---:|
| visits offering more than one move | 20% | 58% |
| visits the agent, not the default, decided | 3% | **58%** |

#180 and #181 did that by letting runs live long enough to produce the artifacts that open
a forward guard, and the residual gap was a verdict parser fixed in #176 — 22 of the 27
archived asks were answers the backend really gave and the unkeyed extractor could not read.
The archived `4 of 27` is a parser census, not a fact about topology.

What is left is three places where a decision that exists is still not put to anyone.

## 1. The stage the run was asked to end on halts instead of asking

`--final-stage 07_writing` is the ResearchClawBench default. The advance past the requested
final stage was recorded as a **pruned** move, which leaves the node with no live forward
move: `default_move` returns None, `choose` takes its "nothing is open" halt, and the live
backward edges at 07 are discarded unasked. Reproduced directly — `default_move` is None
while `01_literature_survey` is live, and on a real run `06_analysis` and `05_experimentation`
are too.

Every benchmark run therefore ended by throwing away the decision worth most at that node:
**does the write-up carry a claim the analysis does not support?**

Reaching the requested final stage is a *completion*, and the graph already has an edge kind
for it. The pruned advance is now the `finish` edge it amounts to — the walk still ends by
default, still never reverses, and the agent is asked whether to finish or go back.

## 2. `auto` skipped the case it exists for

    should_ask = self.mode == "agent" or (self.mode == "auto" and len(live) > 1)

A blocked edge is not in `live`. At a node whose forward guard is unmet and whose backward
edge is open, `live` holds exactly the repair, `len(live) == 1`, the router is skipped, and
`default_move` advances anyway as a `last_resort` — without the agent being told the edge
that would satisfy the precondition was open. On a fresh run that is 02, 03 and 04; nodes
consulting the router go **3/8 → 7/8**.

`_default_reason` is corrected alongside: it wrote "there is nowhere left to go back to"
whether or not anything was open, because `default_move` never goes backward by design. The
archive learns from these reasons, and that one was false in the direction that makes the
topology look inert.

## 3. Two records that were lying to the estimator

- **`Visit.refusal`.** A refused route is a real traversal and not a real decision. It stays
  in `edges` — guards were evaluated, the default was taken — but is out of `decisions`,
  where it read as "an alternative was offered and declined". 23 of the 27 archived
  multi-choice visits were refusals, so the estimator's picture of every forward edge was
  built almost entirely out of answers nobody read.
- **`revisit_reasons` pools backward moves only.** It collected every visit that *entered* a
  stage, so the machine-written forward rationales — identical on every run — sat in the way
  of a first backward move to the same node.

Plus: the prompt no longer offers `finish` where no finish edge exists. That invitation
produced the corpus's only recorded `revisit` — the agent answered `finish` at 07, the target
was off-menu, and the fallback happened to be backward. And `_ask` re-asks once on an
unparseable answer, because every failure of the ask degrades *forward*.

## What this does not claim

None of it makes the agent go backward, and it should not. A graph that is asked and still
advances every time is a valid, reportable outcome; a graph that is never asked is not.
Whether the answers change is for the re-run to say.

2032 tests green; 9 new, none of which passed before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)