### PR TITLE
Run the rubric against a real backend, and refuse the trial that cannot mean anything

### DIFF
--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -589,24 +589,87 @@ off rather than a matter of taste.
 
 **Not measured.** Whether any of this makes research better.
 
-- **The cross-run archive has zero real runs.** Every number it can produce today
-  comes from synthetic records in the test suite. `--archive-report` on a fresh
-  install prints an empty table, and that is the honest state: the estimator, the
-  believability gate and the promotion rule are all implemented and none of them has
-  ever been fed a real observation.
-- **The paired-trial mechanism has never completed a trial.** Six pairs were
-  attempted on 2026-08-11 — the same goal twice, `--evolve-rounds 0` against `2`,
-  strictly one run at a time with backoff. The result was 46 attempts and **zero
-  recorded runs**, every one failing on Vertex quota (`RESOURCE_EXHAUSTED` for
-  `anthropic-claude-sonnet-4-5`, 218 errors). A rate-limited run auto-skips its
-  stages, and a skipped stage is never scored, so nothing reached the archive. The
-  blocker is infrastructure, not the mechanism — but the mechanism is unproven on
-  real data either way.
+- **The cross-run archive holds one real run.** As of 2026-08-11 there is exactly
+  one record with `provenance: live` in it, written by the smoke run described below.
+  Every *statistic* it can produce still comes from synthetic records: one
+  observation is not a contrast, `--archive-report` still prints an empty payoff
+  table, and the estimator, the believability gate and the promotion rule remain
+  untested against real data.
+- **The paired-trial mechanism has still never completed a trial**, but the reason
+  changed twice on 2026-08-11 and the second reason is the interesting one.
+
+  The first attempt — six pairs, `--evolve-rounds 0` against `2`, strictly one run at
+  a time — produced 46 attempts and zero recorded runs, all refused by Vertex quota
+  (`RESOURCE_EXHAUSTED` for `anthropic-claude-sonnet-4-5`, 218 errors). **That
+  blocker is gone.** The quota pools are per base model and AutoR defaults into the
+  exhausted one; `--model opus --review-model opus` moves the operator *and* the
+  reviewer, and a two-hour run through Stage 04 then recorded **zero**
+  `RESOURCE_EXHAUSTED`. `--model` alone is not enough — the reviewer and every panel
+  read `--review-model` independently and would die on the old pool while the stages
+  sailed on.
+
+  The second reason is a design fault in the trial, not in the infrastructure, and it
+  is why the twelve queued runs were cancelled rather than launched. See
+  [what may not be trialled](#what-may-not-be-trialled).
+
+**Measured on a real backend for the first time (2026-08-11).** One `--model opus`
+run, the goal a retrieval-augmented-generation leakage question, taken to Stage 04:
+
+| Stage | First measured draft | After the ratchet |
+| --- | --- | --- |
+| 01_literature_survey | **1.0000** | — (nothing to improve) |
+| 02_hypothesis_generation | **1.0000** | — |
+| 03_study_design | 0.9231 | 1.0000 (+0.0769, one round) |
+| 04_implementation | 0.9296 | 1.0000 (+0.0702, one round) |
+
+Two things follow, and both change how a number in this document should be read.
+
+**The rubric has no resolution at Stages 01 and 02 against a competent backend.**
+Every criterion scored exactly 1.0 — 8/8 referenced paths resolving, 4/4 decision
+ledger buckets distinct, 0 forward-looking phrases in 1,611 words — and the
+improvement ledger records `rounds_spent: 0`, because the controller found no
+headroom to spend. The composition figure quoted above for stages 01–02, 0.973, is a
+property of the `--fake-operator` *script*, not of the rubric: a real run scores
+1.000 there. This makes the early-stopping hole `comparability_basis` exists to close
+worse than the table implies. Stopping early is not worth "nearly eight times what a
+promotion needs"; on a real run it buys a perfect score.
+
+**A trial cut at `--final-stage 02` therefore cannot resolve anything.** Both arms
+would score 1.0, every within-pair difference would be 0, and the report would say
+"no effect" when it means "no instrument". Resolution starts at Stage 03, where
+`artifact_breadth` enters, and the first two stages cost about 35 minutes each on
+opus before reaching it.
 
 So when this document says a capability *is* better, it is describing an argument.
-When it says a capability *measures* better, it means the rubric, on a scripted run.
-Nothing here yet says a capability produced better research, and the paired trial is
-the thing that would.
+When it says a capability *measures* better, it means the rubric, and now on one real
+run rather than only a scripted one. Nothing here yet says a capability produced
+better research, and the paired trial is the thing that would.
+
+### What may not be trialled
+
+The capability queued for the first trial was the champion ratchet itself,
+`--evolve-rounds 0` against `2`, scored on the rubric. That trial is circular, and
+`src/trials.py` now refuses to report it.
+
+`EvolutionController.consider` promotes a polish round when `delta >= min_gain` and
+reverts it otherwise. The kept draft is `argmax` over drafts on `score.total` — which
+is precisely the number the trial report prints. So the treatment arm is the maximum
+of several draws from the distribution the control arm draws from once, and it cannot
+lose: a generator of random drafts would produce the same positive mean difference.
+The table above shows it happening, twice, at +0.0769 and +0.0702.
+
+This is a stronger objection than the Goodhart one. There the worry is that a
+capability raises the proxy without improving the work. Here the capability does not
+have to touch the work at all — the arithmetic settles it before the first token is
+generated.
+
+The test is whether the run **reads the rubric in order to decide what to keep**.
+`--effort-tiers`, the review panel, deliberation, the ideation panel and the stage
+graph do not; they change what gets written and the rubric scores it at arm's length.
+Those are trialable against a rubric outcome. The ratchet and the Pareto frontier are
+not, and are listed in `SELECTS_ON_THE_OUTCOME`. To trial them, the outcome has to be
+something the ratchet cannot see: a held-out judge, a benchmark score, or a human
+reading the draft.
 
 ---
 

--- a/src/trials.py
+++ b/src/trials.py
@@ -36,6 +36,15 @@ raises ``artifact_breadth`` whether or not the research is better. A win
 concentrated in one criterion is a flag, not a result, and the only way to see it
 is to print the vector next to the scalar.
 
+**It does not report a capability that selects on the outcome measure.** The
+champion ratchet keeps whichever polish round scored highest and reverts the rest —
+``argmax`` over drafts on ``score.total``, which is the number this module reports.
+Trialling it against ``--evolve-rounds 0`` therefore cannot lose: the treatment arm is
+the maximum of several draws from the same distribution the control arm draws once
+from, and a generator of random drafts would show the same "effect". The mean
+difference would be real, positive, and evidence of nothing. See
+:data:`SELECTS_ON_THE_OUTCOME`.
+
 **It does not call an unattainable result "not significant".** An exact two-sided
 paired sign-flip test over *n* pairs cannot go below ``2 / 2**n``: three pairs
 bottom out at 0.25, five at 0.0625, six at 0.031. Below six pairs no result can
@@ -73,6 +82,29 @@ from .archive import RunRecord
 #: Pairs below this cannot reach p < 0.05 at any effect size, because an exact
 #: two-sided sign-flip test over *n* pairs bottoms out at ``2 / 2**n``.
 MIN_PAIRS_FOR_SIGNIFICANCE = 6
+
+#: Capabilities whose mechanism is selection on the rubric total, which is the
+#: outcome this module reports. A paired trial of one of these measures
+#: ``max(N draws) >= 1 draw`` and nothing else.
+#:
+#: Found the hard way. The first paired trial anyone tried to run here was the
+#: champion ratchet, ``--evolve-rounds 0`` against ``2``, and twelve real runs were
+#: queued before the circularity was noticed. `EvolutionController.consider` promotes
+#: a round when ``delta >= min_gain`` and reverts it otherwise, so the arm with rounds
+#: is the running maximum over drafts, scored on exactly the total the report prints.
+#:
+#: This is not the same objection as the Goodhart one two paragraphs up. There the
+#: worry is that a capability raises the proxy without improving the work. Here the
+#: capability does not have to touch the work at all: the arithmetic guarantees the
+#: win before the first token is generated.
+#:
+#: A capability belongs here if the run *reads the rubric* in order to decide what to
+#: keep. `--effort-tiers`, the review panel, deliberation, the ideation panel and the
+#: stage graph do not — they change what gets written, and the rubric then scores it
+#: at arm's length. Those are trialable. These are not.
+SELECTS_ON_THE_OUTCOME: frozenset[str] = frozenset(
+    {"polish_rounds", "evolve_rounds", "evolution", "champion_ratchet", "pareto_frontier"}
+)
 
 #: Above this, the exact enumeration is replaced by the same arithmetic on a
 #: sampled basis. 2**18 is a quarter of a million sign assignments, which is
@@ -246,6 +278,17 @@ class TrialResult:
     def underpowered(self) -> bool:
         return self.n < MIN_PAIRS_FOR_SIGNIFICANCE
 
+    @property
+    def circular(self) -> bool:
+        """The capability selects on the number this report prints.
+
+        Reported instead of the p-value, not beside it. A reader who sees
+        "+0.0736, p = 0.031" takes the number; a caveat under it does not undo
+        that, and the number here is an artifact of the arithmetic rather than a
+        measurement of anything.
+        """
+        return self.capability in SELECTS_ON_THE_OUTCOME
+
     def criterion_differences(self) -> dict[str, float]:
         """Mean per-criterion difference across pairs, worst first.
 
@@ -357,8 +400,23 @@ def format_trial_report(result: TrialResult, *, unit: str = "rubric points") -> 
     0–100 points, that line printed "+24.6000 rubric points", which is a lie about the
     instrument in the one place a reader takes the number from.
     """
+    header = f"## `{result.capability}`  —  `{result.treatment_arm}` against `{result.control_arm}`"
+    if result.circular:
+        return "\n".join([
+            header,
+            "",
+            f"- pairs: **{result.n}**",
+            "- **refused: this capability selects on the outcome measure.** The champion "
+            "ratchet keeps the highest-scoring draft and reverts the rest, so the treatment "
+            "arm is the maximum of several draws on exactly the total reported here. It "
+            "cannot lose, a random draft generator would show the same effect, and a "
+            "positive mean difference would be arithmetic rather than evidence.",
+            "- To trial it, score the arms on something the ratchet does not read — a held-out "
+            "judge, a benchmark, or a human read of the draft.",
+        ])
+
     lines = [
-        f"## `{result.capability}`  —  `{result.treatment_arm}` against `{result.control_arm}`",
+        header,
         "",
         f"- pairs: **{result.n}**"
         + (f" ({len(result.excluded)} excluded)" if result.excluded else ""),

--- a/tests/test_trials_circularity.py
+++ b/tests/test_trials_circularity.py
@@ -1,0 +1,127 @@
+"""A capability that selects on the outcome measure may not be trialled against it.
+
+The first paired trial anyone tried to run in this repo was the champion ratchet:
+`--evolve-rounds 0` against `2`, scored on the rubric. Twelve real runs were queued
+before the circularity surfaced.
+
+`EvolutionController.consider` promotes a polish round when `delta >= min_gain` and
+reverts it otherwise, so the arm with rounds is `argmax` over drafts on
+`score.total` — the same total `format_trial_report` prints. The treatment arm is
+the maximum of several draws from the distribution the control arm draws from once.
+It cannot lose. A generator of random drafts would show the same effect, and on a
+real run it did: Stage 03 went 0.9231 to 1.0000 and Stage 04 0.9296 to 1.0000, both
+in a single round.
+
+The refusal replaces the report rather than annotating it. A reader shown
+"+0.0736, p = 0.031" takes the number, and a caveat underneath does not undo that.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.trials import (
+    SELECTS_ON_THE_OUTCOME,
+    Pair,
+    TrialResult,
+    format_trial_report,
+)
+from src.archive import RunRecord
+
+
+def record(run_id: str, *, arm: str, fitness: float) -> RunRecord:
+    return RunRecord(
+        run_id=run_id,
+        variant_id="baseline",
+        rubric_version="2",
+        edges={},
+        stage_fitness={"03_study_design": fitness, "04_implementation": fitness},
+        topology="adaptive",
+        provenance="live",
+        route="",
+        steps=2,
+        revisits=0,
+        agent_directed=0,
+        bypassed=0,
+        recorded_at="2026-08-11T00:00:00",
+        trial_id=run_id,
+        capability="polish_rounds",
+        arm=arm,
+    )
+
+
+def result_for(capability: str, *, pairs: int = 6) -> TrialResult:
+    made = []
+    for index in range(pairs):
+        control = record(f"t{index}", arm="off", fitness=0.93)
+        treatment = record(f"t{index}", arm="on", fitness=1.00)
+        made.append(Pair(f"t{index}", control, treatment))
+    return TrialResult(
+        capability=capability,
+        control_arm="off",
+        treatment_arm="on",
+        pairs=tuple(made),
+    )
+
+
+class ACircularTrialIsRefusedTests(unittest.TestCase):
+    def test_the_ratchet_is_named_as_selecting_on_the_outcome(self) -> None:
+        self.assertIn("polish_rounds", SELECTS_ON_THE_OUTCOME)
+        self.assertIn("pareto_frontier", SELECTS_ON_THE_OUTCOME)
+
+    def test_the_report_refuses_instead_of_reporting(self) -> None:
+        rendered = format_trial_report(result_for("polish_rounds"))
+        self.assertIn("selects on the outcome measure", rendered)
+
+    def test_the_refusal_replaces_the_number_rather_than_annotating_it(self) -> None:
+        """The whole point. A caveat under a p-value is not a refusal."""
+        rendered = format_trial_report(result_for("polish_rounds"))
+        # The report *lines*, not the words. The refusal prose says "a positive mean
+        # difference would be arithmetic rather than evidence", which is the point
+        # being made rather than the number being reported.
+        self.assertNotIn("- mean difference: **", rendered)
+        self.assertNotIn("- exact two-sided p: **", rendered)
+        self.assertNotIn("Concentration:", rendered)
+
+    def test_the_refusal_says_what_would_make_it_trialable(self) -> None:
+        rendered = format_trial_report(result_for("polish_rounds"))
+        self.assertIn("does not read", rendered)
+
+    def test_a_capability_that_does_not_read_the_rubric_still_reports(self) -> None:
+        """The guard must not swallow the capabilities that *can* be trialled.
+
+        `--effort-tiers` changes which model writes a stage. It never reads the
+        rubric to decide what to keep, so the rubric scores its output at arm's
+        length and a paired difference means something.
+        """
+        rendered = format_trial_report(result_for("effort_tiers"))
+        self.assertNotIn("selects on the outcome measure", rendered)
+        self.assertIn("- mean difference: **", rendered)
+        self.assertIn("- exact two-sided p: **", rendered)
+
+    def test_the_circular_flag_tracks_the_constant(self) -> None:
+        self.assertTrue(result_for("polish_rounds").circular)
+        self.assertFalse(result_for("effort_tiers").circular)
+
+
+class TheRatchetReallyIsArgmaxOnTheReportedTotalTests(unittest.TestCase):
+    """The premise of the refusal, asserted against the code rather than assumed.
+
+    If `consider` ever stopped selecting on `total` — if it became, say, a fixed
+    number of rounds with the last one kept — the refusal would be wrong and this
+    test is what should notice.
+    """
+
+    def test_a_losing_polish_round_is_reverted(self) -> None:
+        import inspect
+
+        from src.evolution import EvolutionController
+
+        source = inspect.getsource(EvolutionController.consider)
+        self.assertIn("delta >= self.config.min_gain", source)
+        self.assertIn("_revert", source)
+        self.assertIn("regressed", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two findings from getting the first live run into the archive. The second cancelled twelve queued runs before they started.

## 1. The quota blocker is gone

The Vertex pools are **per base model**, and AutoR defaults into the exhausted one. The first paired-trial attempt produced 46 attempts and zero recorded runs, all `RESOURCE_EXHAUSTED` on `anthropic-claude-sonnet-4-5`. With `--model opus --review-model opus`, a two-hour run through Stage 04 recorded **zero**.

`--model` alone is not enough — the reviewer and every panel read `--review-model` independently, so a run rescued onto opus has its stages sail on while every panel dies on the old pool.

The archive now holds its first `provenance: live` record.

## 2. The rubric has no resolution at Stages 01–02

One real opus run, goal a retrieval-augmented-generation leakage question, taken to Stage 04:

| Stage | First measured draft | After the ratchet |
| --- | --- | --- |
| `01_literature_survey` | **1.0000** | — nothing to improve |
| `02_hypothesis_generation` | **1.0000** | — |
| `03_study_design` | 0.9231 | 1.0000 (+0.0769, one round) |
| `04_implementation` | 0.9296 | 1.0000 (+0.0702, one round) |

Every criterion at 1.0 for the first two stages — *8/8 referenced paths resolve*, *4/4 decision-ledger buckets carry distinct content*, *0 forward-looking phrases across 1,611 words* — and the improvement ledger records `rounds_spent: 0`, because the controller found no headroom.

So the trial cut I had queued, `--final-stage 02`, could not have resolved anything: both arms 1.0, every within-pair difference 0, and a report saying "no effect" when it means "no instrument". That is the thing `src/trials.py` refuses to do everywhere else.

**It also corrects a reading.** The composition figure for stages 01–02, 0.973, is a property of the `--fake-operator` *script*, not of the rubric. A real run scores 1.000 there — which makes the early-stopping hole `comparability_basis` exists to close **worse** than the table implies. Stopping early is not worth "nearly eight times what a promotion needs"; it buys a perfect score.

## 3. The trial itself was circular

The capability queued first was the champion ratchet, `--evolve-rounds 0` against `2`, scored on the rubric.

`EvolutionController.consider` promotes a polish round when `delta >= min_gain` and reverts it otherwise. The kept draft is **`argmax` over drafts on `score.total`** — precisely the number `format_trial_report` prints. The treatment arm is the maximum of several draws from the distribution the control arm draws from once. It cannot lose; a generator of random drafts would show the same effect. The table above *is* that effect, twice.

This is stronger than the Goodhart objection already in the module. There the worry is that a capability raises the proxy without improving the work. Here the capability does not have to touch the work at all — the arithmetic settles it before the first token is generated.

### The guard

`SELECTS_ON_THE_OUTCOME` names the capabilities whose mechanism reads the rubric in order to decide what to keep. `format_trial_report` **replaces** the report for those, rather than annotating it:

```
## `polish_rounds`  —  `on` against `off`

- pairs: **6**
- **refused: this capability selects on the outcome measure.** …
- To trial it, score the arms on something the ratchet does not read — a held-out
  judge, a benchmark, or a human read of the draft.
```

Replacing rather than annotating is the point: a reader shown "+0.0736, p = 0.031" takes the number, and a caveat underneath does not undo that.

Effort tiers, the review panel, deliberation, the ideation panel and the stage graph do **not** read the rubric — they change what gets written and the rubric scores it at arm's length. Those stay trialable, and a test asserts the guard does not swallow them.

## Testing

2054 pass. Five mutations kill the new guard: dropping the refusal branch, emptying the constant, and three on the report contents. One test checks the *premise* against `EvolutionController.consider` rather than assuming it — if the ratchet ever stops selecting on `total`, the refusal becomes wrong and that test is what notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)