### PR TITLE
Measure the judge's sampling range instead of naming it

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,16 @@ spread of 16.2; on another, Opus scored 52.6 where gpt-5.1 scored 46.0, a spread
 carrying the wrong judge is not a smaller number, it is an incomparable one. Quote the judge with
 every total.
 
+**Fixing the judge does not fix the number.** Eight draws of `gpt-5.1` over one identical artifact
+set — same workspace, same report, same five figures, nothing changed between draws — scored
+41.4, 42.8, 45.5, 47.1, 49.1, 49.6, 49.8 and 49.9: a spread of **8.5 points** around a mean of 46.9,
+sd 3.4. The variance is worst where it costs most, on the heaviest checklist item: that one is
+weighted 0.5 and spanned 32 to 55 across the eight, 11.5 points of the total by itself. So a
+single-draw score on a single task carries roughly ±4 points of pure sampling noise, and **any
+one-task A/B comparison below about eight points is uninterpretable** — including a
+before-and-after on the same task, which is the shape a harness change most tempts you into. Average
+draws, or compare across tasks, or say nothing.
+
 ### Where AutoR lands, on all forty tasks
 
 One attempt per task, Claude Opus executing and reviewing, judged by `gpt-5.1`. The three

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -989,6 +989,39 @@ judge's sampling range and there are **zero** observations of AutoR's own run-to
 variance. And a refusal removes a pair, not an arm — refusals are not random with
 respect to arm, so a lopsided refusal ledger is itself the result.
 
+### How wide the judge's sampling range actually is
+
+The paragraph above says replicate scoring measures the judge's sampling range without
+saying how wide it is. Measured, on `Astronomy_000`, with `gpt-5.1` and **nothing changed
+between draws** — same workspace, same `report.md`, same five published figures:
+
+| draw | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|:---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `[0]` text, w=0.2 | 45 | 55 | 55 | 55 | 40 | 45 | 45 | 40 |
+| `[1]` image, w=0.3 | 46 | 46 | 52 | 48 | 48 | 55 | 52 | 47 |
+| `[2]` text, w=0.5 | 40 | 50 | 45 | 32 | 55 | 40 | 45 | 55 |
+| **total** | 42.8 | 49.8 | 49.1 | 41.4 | 49.9 | 45.5 | 47.1 | 49.6 |
+
+Mean 46.9, median 48.1, sd 3.4, **spread 8.5**. The variance is worst where it is most
+expensive: item `[2]` carries half the weight and spanned 32 to 55, which is 11.5 points of
+the total on its own.
+
+Three consequences, and the third is the one that bites:
+
+1. A single-draw score on a single task carries roughly **±4 points** of sampling noise.
+2. Any one-task A/B below about eight points is uninterpretable. An earlier before-and-after
+   on this task read 46.0 against 42.8 and looked like a small regression; 46.0 sits at the
+   3/8 percentile of the *unchanged* artifact's own distribution, so it was noise. The 9.6 →
+   46.0 jump from the export repairs is 36 points and survives this comfortably — the point is
+   not that nothing is measurable, it is where the floor sits.
+3. This is judge variance with the artifacts held fixed. AutoR's own run-to-run variance is
+   **additional and still unmeasured**, so the floor for a full A/B is higher than 8.5, not
+   equal to it.
+
+Eight draws of one task is a small sample and the number is a floor rather than an estimate.
+It is enough to say that a one-draw per-arm trial cannot resolve a small effect, which is what
+the `stage_fitness` key's draw count exists to refuse.
+
 ### Dry run
 
 ```bash


### PR DESCRIPTION
`docs/researchclawbench.md` says replicate scoring *"measures the judge's sampling range"* and never says how wide it is.

It is **8.5 points**.

## The measurement

Eight draws of `gpt-5.1` over one identical artifact set — same workspace, same `report.md`, same five published figures, **nothing changed between draws**:

| draw | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|:---|---:|---:|---:|---:|---:|---:|---:|---:|
| `[0]` text, w=0.2 | 45 | 55 | 55 | 55 | 40 | 45 | 45 | 40 |
| `[1]` image, w=0.3 | 46 | 46 | 52 | 48 | 48 | 55 | 52 | 47 |
| `[2]` text, w=0.5 | 40 | 50 | 45 | 32 | 55 | 40 | 45 | 55 |
| **total** | 42.8 | 49.8 | 49.1 | 41.4 | 49.9 | 45.5 | 47.1 | 49.6 |

Mean 46.9, median 48.1, sd 3.4, spread **8.5**. The variance is worst where it is most expensive: item `[2]` carries half the weight and spanned 32 to 55 — 11.5 points of the total on its own.

## Why it matters more than the width suggests

**A single-draw score on a single task carries roughly ±4 points of pure sampling noise**, so a one-task A/B below about eight points says nothing.

That is not hypothetical. I had a before-and-after on this exact task reading 46.0 against 42.8 and was about to report a small regression from today's fixes. 46.0 sits at the **3/8 percentile of the unchanged artifact's own distribution**. It was noise, and the shape that produced it — same task, one draw each side, small delta — is exactly the shape a harness change tempts you into.

The earlier 9.6 → 46.0 jump from the export repairs is 36 points and survives this comfortably. The point is where the floor sits, not that nothing is measurable.

**And this is judge variance with the artifacts held fixed.** AutoR's own run-to-run variance is additional and still unmeasured, so the floor for a real A/B is *higher* than 8.5, not equal to it. That is the thing the `stage_fitness` key's draw count already exists to refuse — now with a number behind it.

## Scope

Eight draws of one task is a small sample, and 8.5 is a floor rather than an estimate. The text says so. It is enough to establish that a one-draw-per-arm trial cannot resolve a small effect, which is the claim the paired-trial machinery depends on.

Also added as a short paragraph to the README's Benchmarks section, next to the existing judge-*choice* note — same axis of caution, different mechanism: that one is about which judge, this one is about the same judge twice.

## Testing

Docs only. `tests/test_doc_counts.py` and `tests/test_score_rcb_run.py` pass; no line-number citations, no key-shaped literals, all counts checked against their symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)