### PR TITLE
Spend the five judge slots by the plan's ranking, not the alphabet

### DIFF
--- a/src/rcb.py
+++ b/src/rcb.py
@@ -50,6 +50,7 @@ from pathlib import Path
 from typing import Any, TextIO
 
 from .intake import ResourceEntry, classify_resource
+from .report_plan import load_report_plan
 from .utils import (
     DEFAULT_OUTPUT_FORMAT,
     MAX_REPORT_FIGURES,
@@ -526,6 +527,27 @@ def _figure_candidates(
     return candidates
 
 
+def _planned_rank(paths: RunPaths) -> dict[str, int]:
+    """Filename -> slot, from the run's own report plan. Empty when there is no plan.
+
+    Case-folded because the plan names a file the writing stage intends to produce and the
+    file on disk is whatever the code that made it chose to call it; a plan that loses to a
+    capital letter would be worse than no plan.
+
+    A dropped slot is skipped rather than ranked last. `dropped_because` records a figure
+    the run decided against, and reinstating it behind the survivors would quietly undo
+    that decision at export time.
+    """
+    plan = load_report_plan(paths)
+    if plan is None:
+        return {}
+    return {
+        figure.filename.casefold(): figure.slot
+        for figure in plan.figures
+        if figure.filename and not figure.dropped_because
+    }
+
+
 def collect_figures(paths: RunPaths, workspace: Path, report_text: str = "") -> list[str]:
     """Publish at most :data:`MAX_REPORT_FIGURES` figures into ``report/images/``.
 
@@ -574,7 +596,23 @@ def collect_figures(paths: RunPaths, workspace: Path, report_text: str = "") -> 
     # a synthesized or fallback report, which is assembled from this list in the first place.
     selected = list(referenced)
     if not selected:
-        for name, _source in candidates:
+        # Nothing in the report says which figures matter, so the run's own report plan is
+        # asked instead. Without it the order here is `_figure_candidates`' order, which
+        # resolves to filename order -- and the slots are contested: one benchmark run
+        # reached this branch holding 426 candidate PNGs, so five of them were published on
+        # the judge's ~61% of the weight because their names sorted first. The plan already
+        # ranks the figures by the claim each settles, was written before any of this, and
+        # is the only ranking in the run that means anything. Unplanned figures keep their
+        # existing order behind the planned ones rather than being dropped: a run whose plan
+        # is thin must still publish something.
+        ranked = _planned_rank(paths)
+        # Sentinel above every real slot, not `len(ranked)`: a two-slot plan would otherwise
+        # rank its own second figure equal to every unplanned one, and the stable sort would
+        # hand the tie to whichever filename came first -- losing a planned figure to the
+        # alphabet inside the fix meant to stop exactly that.
+        unplanned = max(ranked.values(), default=0) + 1
+        ordered = sorted(candidates, key=lambda item: ranked.get(item[0].casefold(), unplanned))
+        for name, _source in ordered:
             if len(selected) >= MAX_REPORT_FIGURES:
                 break
             selected.append(name)

--- a/tests/test_figure_slots_follow_the_plan.py
+++ b/tests/test_figure_slots_follow_the_plan.py
@@ -1,0 +1,146 @@
+"""Which five figures reach the judge, when the report names none of them.
+
+ResearchClawBench shows the judge at most five images and scores ~61% of the benchmark's
+weight against them. When the report references its figures, `collect_figures` publishes
+those and this branch never runs. When it references none -- a synthesized or assembled
+report -- the slots were filled in `_figure_candidates` order, which resolves to filename
+order. One benchmark run reached that branch holding 426 candidate PNGs, so five were
+published because their names sorted first.
+
+The run already ranks its figures: `report_plan.json` commits each slot to a filename and
+the claim it settles, written before any of the results existed. It is the only ranking in
+the run that means anything, and the export ignored it.
+
+Rare, and worth fixing anyway: measured over 40 scored runs the unreferenced branch decided
+the slots exactly once. Choosing five of 426 by filename is wrong at any frequency, and the
+fix cannot make a run worse -- with no plan the order is unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.rcb import collect_figures, ensure_workspace_layout
+from src.utils import MAX_REPORT_FIGURES, build_run_paths, ensure_run_layout
+
+
+PNG = bytes.fromhex(
+    "89504e470d0a1a0a0000000d494844520000000100000001080600000"
+    "01f15c4890000000a49444154789c6360000002000100ffff0300000600"
+    "0557bfabd40000000049454e44ae426082"
+)
+
+
+class PlannedRankTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self.paths = build_run_paths(root / "run_0001")
+        ensure_run_layout(self.paths)
+        self.workspace = root / "ws"
+        ensure_workspace_layout(self.workspace)
+
+    def _figures(self, *names: str) -> None:
+        self.paths.figures_dir.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            (self.paths.figures_dir / name).write_bytes(PNG)
+
+    def _plan(self, *filenames: str, dropped: tuple[str, ...] = ()) -> None:
+        figures = [
+            {
+                "slot": index,
+                "filename": name,
+                "supports": [f"H{index}"],
+                "shows": f"claim {index}",
+                "if_supported": "a",
+                "if_refuted": "b",
+                "source_artifact": f"outputs/{index}.json",
+                "dropped_because": "superseded" if name in dropped else "",
+            }
+            for index, name in enumerate(filenames, start=1)
+        ]
+        self.paths.report_plan.parent.mkdir(parents=True, exist_ok=True)
+        self.paths.report_plan.write_text(
+            json.dumps({"declared_at": "2026-08-11T00:00:00", "digest": "d",
+                        "no_figures_because": "", "task_outputs": [], "figures": figures}),
+            encoding="utf-8",
+        )
+
+    def _publish(self) -> list[str]:
+        return collect_figures(self.paths, self.workspace, report_text="")
+
+    def test_the_plans_top_five_win_over_the_alphabet(self) -> None:
+        """The exact failure: a main-result figure whose name sorts last is dropped."""
+        self._figures("a.png", "b.png", "c.png", "d.png", "e.png", "f.png", "zz_main_result.png")
+        self._plan("zz_main_result.png", "f.png", "e.png", "d.png", "c.png")
+        # collect_figures returns a sorted listing of what it published, so membership is
+        # the assertion: the ranking decides which five survive, not what order they appear in.
+        self.assertEqual(
+            set(self._publish()), {"zz_main_result.png", "f.png", "e.png", "d.png", "c.png"}
+        )
+
+    def test_the_planned_figure_is_not_pruned_off_disk(self) -> None:
+        """Losing the slot also deleted the file: the prune enforces the budget on disk."""
+        self._figures("a.png", "b.png", "c.png", "d.png", "e.png", "f.png", "zz_main_result.png")
+        self._plan("zz_main_result.png", "f.png", "e.png", "d.png", "c.png")
+        self._publish()
+        self.assertTrue((self.workspace / "report" / "images" / "zz_main_result.png").exists())
+
+    def test_a_run_with_no_plan_is_unchanged(self) -> None:
+        """The fix cannot make a run worse than it was."""
+        self._figures("a.png", "b.png", "c.png", "d.png", "e.png", "f.png")
+        self.assertEqual(self._publish(), ["a.png", "b.png", "c.png", "d.png", "e.png"])
+
+    def test_an_unreadable_plan_is_unchanged(self) -> None:
+        self._figures("a.png", "b.png", "c.png", "d.png", "e.png", "f.png")
+        self.paths.report_plan.parent.mkdir(parents=True, exist_ok=True)
+        self.paths.report_plan.write_text("{not json", encoding="utf-8")
+        self.assertEqual(self._publish(), ["a.png", "b.png", "c.png", "d.png", "e.png"])
+
+    def test_unplanned_figures_fill_the_slots_a_thin_plan_leaves(self) -> None:
+        """A run whose plan names two figures must still publish five."""
+        self._figures("a.png", "b.png", "c.png", "d.png", "e.png", "zz_main.png")
+        self._plan("zz_main.png", "e.png")
+        published = self._publish()
+        self.assertEqual(len(published), MAX_REPORT_FIGURES)
+        # Both planned figures survive; the remaining three slots go to unplanned ones. The
+        # sentinel has to sit above every real slot or the plan's *last* figure ties with
+        # the unplanned pool and loses the tie to the alphabet.
+        self.assertIn("zz_main.png", published)
+        self.assertIn("e.png", published)
+
+    def test_a_dropped_slot_is_not_reinstated_at_export(self) -> None:
+        """`dropped_because` records a decision; ranking it last would quietly undo it."""
+        self._figures("a.png", "b.png", "c.png", "d.png", "e.png", "zz_dropped.png")
+        self._plan("zz_dropped.png", "e.png", dropped=("zz_dropped.png",))
+        published = self._publish()
+        self.assertIn("e.png", published)
+        self.assertNotIn("zz_dropped.png", published)
+
+    def test_the_plan_wins_on_a_case_mismatch(self) -> None:
+        """The plan names an intended file; the code that drew it chose the real name."""
+        self._figures("a.png", "b.png", "c.png", "d.png", "e.png", "Zz_Main_Result.png")
+        self._plan("zz_main_result.PNG", "e.png")
+        self.assertIn("Zz_Main_Result.png", self._publish())
+
+    def test_a_plan_naming_files_that_do_not_exist_changes_nothing(self) -> None:
+        self._figures("a.png", "b.png", "c.png", "d.png", "e.png", "f.png")
+        self._plan("never_drawn.png", "also_missing.png")
+        self.assertEqual(self._publish(), ["a.png", "b.png", "c.png", "d.png", "e.png"])
+
+    def test_a_referenced_report_still_outranks_the_plan(self) -> None:
+        """The report saying which figures it argues with is better evidence than a plan."""
+        self._figures("a.png", "b.png", "c.png", "d.png", "e.png", "zz_main.png")
+        self._plan("zz_main.png", "e.png")
+        published = collect_figures(
+            self.paths, self.workspace, report_text="![one](images/b.png)\n![two](images/c.png)"
+        )
+        self.assertEqual(published, ["b.png", "c.png"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

ResearchClawBench shows its judge **at most five images** and scores ~61% of the benchmark's weight against them. When the report references its figures, `collect_figures` publishes those. When it references none — a synthesized or assembled report — the slots were filled in `_figure_candidates` order, which resolves to **filename order**.

Reproduced on the pinned tree:

```
figures on disk    : a b c d e f zz_main_result
published to judge : a b c d e
zz_main_result published? -> False
still on disk?            -> False     # the prune deletes it too
```

One benchmark run reached that branch holding **426 candidate PNGs**.

## The fix

The run already ranks its figures. `report_plan.json` commits each slot to a filename and the claim that figure settles, written before any of the results existed. It is the only ranking in the run that means anything, and the export ignored it. The unreferenced fill now orders candidates by slot; unplanned figures keep their existing order behind the planned ones, so a thin plan still publishes five.

**Deliberately narrow:**
- A **referenced report still wins** — the report saying which figures it argues with is better evidence than a plan written before the results.
- **No plan, or an unreadable one → behaviour is byte-identical.** This cannot make any run worse.
- A slot carrying `dropped_because` is **skipped, not ranked last**: that field records a decision the run made, and reinstating the figure at export would quietly undo it.

## Two bugs the tests caught, both mine

1. The sentinel for unplanned figures was `len(ranked)`, which **ties with a real slot**. A two-slot plan ranked its own second figure equal to every unplanned one and lost the tie to the alphabet — inside the fix meant to stop exactly that.
2. `collect_figures` returns a *sorted* listing of what it published, so three tests asserted an ordering the function never promised.

## Honest about size

Measured over 40 scored runs, the unreferenced branch decided the slots on **exactly one task** (Astronomy_001, 426 candidates, scored 34.8). This is a rare fix, **not the big lever**.

It ships because choosing five of 426 figures by filename is wrong at any frequency and the fix is fifteen lines. The big lever is elsewhere and measured separately: of the 154 checklist items, 76 (49.2% of weight) are experiments **runnable inside the workspace**, and they currently earn 9.24 of a possible 22.14. Two tasks scored ~0 with the judge writing *"the report explicitly states that no ECAT model was assembled, no LHS design was drawn, and no mechanism simulations were run"* — the run audited the data and declined to run the experiment. That is the next PR, not this one.

## Tests

9 new tests in `tests/test_figure_slots_follow_the_plan.py`. Full suite **2063 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)