### PR TITLE
Show the approval gate the whole task it is judging against

### DIFF
--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -18,6 +18,7 @@ from .utils import (
     StageSpec,
     append_jsonl,
     extract_stream_text_fragments,
+    goal_excerpt,
     read_text,
     truncate_text,
     write_text,
@@ -62,6 +63,18 @@ DECISION_TO_CHOICE = {
 UNREADABLE_REASON = "Automated reviewer did not return valid JSON."
 UNSUPPORTED_REASON = "Automated reviewer returned an unsupported decision token."
 CRASHED_REASON = "Automated reviewer failed to run."
+
+#: How much of the research task the approval gate is shown.
+#:
+#: The reviewer decides whether a stage did its job, and the only statement of what that
+#: job is comes from here. It used to read the first 3,000 characters of the goal --
+#: head-truncated, and on a benchmark run the goal opens with AutoR's own header and
+#: workspace contract. Measured over the 40 ResearchClawBench tasks, the gate had never
+#: once seen a whole task: 0 of 39 complete, median 50% visible. What falls off the end is
+#: the task's own list of required outputs and data files, so "materially complete for its
+#: current milestone" was judged against half a question. The longest task is 8,540
+#: characters; 10,000 fits every one of them with room for a longer task to arrive.
+GOAL_EXCERPT_CHARS = 10_000
 
 #: The last thing the reviewer reads, and the reason it is last.
 #:
@@ -581,7 +594,12 @@ class AutomatedReviewer:
             f"2. {suggestions[1]}\n"
             f"3. {suggestions[2]}\n\n"
             "# Original Goal\n\n"
-            f"{self._read_excerpt(paths.user_input, max_chars=3000)}\n\n"
+            # `goal_excerpt`, not `_read_excerpt`: it returns the *task* where one is fenced
+            # and truncates from the tail, so an overlong task loses its closing notes rather
+            # than its subject. The router, the deliberation panel and the validity reviewer
+            # were moved onto it; the approval gate -- the one reader whose whole job is
+            # deciding whether the task was done -- was left behind.
+            f"{goal_excerpt(read_text(paths.user_input), max_chars=GOAL_EXCERPT_CHARS)}\n\n"
             "# Approved Memory\n\n"
             f"{self._read_excerpt(paths.memory, max_chars=12000)}\n\n"
             "# Current Stage Summary\n\n"

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -39,11 +39,20 @@ from typing import Any
 from .approval_agent import (
     CRASHED_REASON,
     DECISION_TO_CHOICE,
+    GOAL_EXCERPT_CHARS,
     AutomatedReviewer,
     ReviewDecision,
 )
 from .terminal_ui import TerminalUI
-from .utils import RunPaths, StageSpec, append_log_entry, read_text, truncate_text, write_text
+from .utils import (
+    RunPaths,
+    StageSpec,
+    append_log_entry,
+    goal_excerpt,
+    read_text,
+    truncate_text,
+    write_text,
+)
 
 
 #: Choices that leave the stage unapproved. Used to decide whether a panel actually converged.
@@ -1129,7 +1138,9 @@ class ReviewPanel:
             f"- experiment manifest: `{paths.experiment_manifest.resolve()}`\n"
             f"- workspace root: `{paths.workspace_root.resolve()}`\n\n"
             "# Original Goal\n\n"
-            f"{excerpt(paths.user_input, 3000)}\n\n"
+            # Same reader, same fix as the solo reviewer: a seat cannot judge whether a
+            # stage did the task on half the task.
+            f"{goal_excerpt(read_text(paths.user_input), max_chars=GOAL_EXCERPT_CHARS)}\n\n"
             "# Approved Memory\n\n"
             f"{excerpt(paths.memory, 10000)}\n\n"
             "# Current Stage Summary\n\n"

--- a/tests/test_reviewer_sees_the_task.py
+++ b/tests/test_reviewer_sees_the_task.py
@@ -1,0 +1,115 @@
+"""The approval gate has to be able to read the task it is judging against.
+
+The reviewer's job is deciding whether a stage did its job, and the only statement of what
+that job is comes from the goal block. It read the first 3,000 characters, head-truncated,
+and on a benchmark run the goal opens with AutoR's own header and workspace contract.
+
+Measured over the 40 ResearchClawBench tasks: the gate had never once seen a whole task --
+0 of 39 complete, median 50% visible, longest task 8,540 characters. What falls off the end
+is the task's own list of required outputs and data files, so "materially complete for its
+current milestone" was judged against half a question.
+
+`goal_excerpt` already fixes this and three other readers already use it: the router, the
+deliberation panel and the adversarial validity reviewer were all moved onto it. The
+approval gate -- the one reader whose entire job is deciding whether the task was done --
+was left behind.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.approval_agent import GOAL_EXCERPT_CHARS, AutomatedReviewer
+from src.utils import (
+    TASK_BEGIN_MARKER,
+    TASK_END_MARKER,
+    StageSpec,
+    build_run_paths,
+    ensure_run_layout,
+    write_text,
+)
+
+
+STAGE = StageSpec(1, "01_literature_survey", "Literature Survey")
+
+#: The shape of a benchmark goal: AutoR's own preamble, the fenced task, then more of
+#: AutoR's own contract after it.
+PREAMBLE = "# Benchmark Run: ResearchClawBench\n\n" + ("AutoR preamble prose. " * 40)
+TRAILER = "\n\n## Benchmark Workspace Contract\n\n" + ("AutoR contract prose. " * 400)
+
+
+def build_goal(task: str) -> str:
+    return f"{PREAMBLE}\n\n## Research Task\n{TASK_BEGIN_MARKER}\n{task}\n{TASK_END_MARKER}{TRAILER}"
+
+
+class ReviewerGoalBlockTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.memory, "# Memory\n")
+        self.reviewer = AutomatedReviewer("claude", model="opus", unattended=True)
+
+    def _prompt(self, task: str) -> str:
+        write_text(self.paths.user_input, build_goal(task))
+        return self.reviewer._build_review_prompt(  # noqa: SLF001
+            paths=self.paths, stage=STAGE, attempt_no=1,
+            stage_markdown="# Stage 01\n\n## Key Results\n\nSomething.",
+            suggestions=["a", "b", "c"],
+        )
+
+    def test_the_whole_task_reaches_the_reviewer(self) -> None:
+        """A 5,400-character task is the median; it used to be cut in half."""
+        task = ("### Task Description\n" + ("Body sentence. " * 300)
+                + "\n\nOutput: correctly derived Hartree-Fock Hamiltonians.\n")
+        self.assertGreater(len(task), 3000)
+        self.assertIn("Output: correctly derived Hartree-Fock Hamiltonians.", self._prompt(task))
+
+    def test_the_longest_real_task_fits(self) -> None:
+        """The longest of the 40 benchmark tasks is 8,540 characters."""
+        task = ("x" * 8540) + "\nOutput: the deliverable.\n"
+        self.assertIn("Output: the deliverable.", self._prompt(task))
+
+    def test_autors_own_preamble_does_not_spend_the_budget(self) -> None:
+        """The goal opens with AutoR's header; a head-truncation reads that first."""
+        prompt = self._prompt("### Task Description\n" + ("Body sentence. " * 300))
+        self.assertNotIn("AutoR preamble prose.", prompt)
+        self.assertNotIn("AutoR contract prose.", prompt)
+
+    def test_an_overlong_task_loses_its_tail_not_its_subject(self) -> None:
+        task = "SUBJECT: reproduce the study.\n" + ("filler. " * 4000) + "\nCLOSING NOTE\n"
+        self.assertGreater(len(task), GOAL_EXCERPT_CHARS)
+        prompt = self._prompt(task)
+        self.assertIn("SUBJECT: reproduce the study.", prompt)
+        self.assertNotIn("CLOSING NOTE", prompt)
+
+    def test_an_unfenced_goal_still_works(self) -> None:
+        """An ordinary interactive run has no fence and must be unaffected."""
+        write_text(self.paths.user_input, "Study whether X causes Y.")
+        prompt = self.reviewer._build_review_prompt(  # noqa: SLF001
+            paths=self.paths, stage=STAGE, attempt_no=1,
+            stage_markdown="# Stage 01\n", suggestions=["a", "b", "c"],
+        )
+        self.assertIn("Study whether X causes Y.", prompt)
+
+    def test_the_budget_covers_every_benchmark_task(self) -> None:
+        """Stated rather than assumed: 10,000 against a measured maximum of 8,540."""
+        self.assertGreaterEqual(GOAL_EXCERPT_CHARS, 8540)
+
+
+class PanelSeatsSeeItTooTest(unittest.TestCase):
+    """A seat cannot judge whether a stage did the task on half the task either."""
+
+    def test_the_panel_uses_the_same_reader(self) -> None:
+        source = (Path(__file__).resolve().parent.parent / "src" / "review_panel.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("goal_excerpt(read_text(paths.user_input)", source)
+        self.assertNotIn("excerpt(paths.user_input, 3000)", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

The reviewer decides whether a stage did its job. The only statement of what that job is comes from the goal block — and it read the **first 3,000 characters of the goal, head-truncated**. On a benchmark run the goal opens with AutoR's own header and workspace contract, so part of that budget was never the task at all.

Measured over the 40 ResearchClawBench tasks:

| | |
|---|---|
| gate saw the **whole** task | **0 / 39** |
| median fraction visible | **50%** |
| task lengths | 4,616 – 8,540 chars |

What falls off the end is the task's own list of required outputs and data files. So the policy line *"approve only if this stage is materially complete for its current milestone"* was judged against half a question — and against a half that systematically excluded the deliverables.

This is the mechanism behind runs the external judge described as *"the report explicitly states that no ECAT model was assembled, no LHS design was drawn, and no mechanism simulations were run"* while AutoR's own rubric scored them **1.00 on all eight criteria**. The gate had no anchor to check them against.

## The fix

`goal_excerpt` already exists for exactly this, and three other readers already use it — the router, the deliberation panel and the adversarial validity reviewer were all moved onto it when the same defect was found in them. It returns the fenced task where there is one, and truncates from the **tail**, so an overlong task loses its closing notes rather than its subject.

The approval gate — the one reader whose entire job is deciding whether the task was done — was left behind. So was the review panel's per-seat prompt, which carried its own copy of the same line.

Budget is 10,000 against a measured maximum of 8,540, and a test asserts that relationship rather than leaving the number to be rediscovered.

## Honest about what this buys

This is a prompt-input fix and **its effect is not measurable from here**. It makes the gate able to check something it could not see; whether it then does is a question only a run answers. It ships on the narrower ground that a gate holding a stage to a requirement it was never shown is wrong on its face.

## Two things I tried first and dropped

Both were measured before building, and both failed their own test:

1. **Cross-check deliverable locators against the report plan.** Would have fired on **1 of 12** runs — Information_001, the *best* run at 26.0. A new refusal that mostly hits healthy runs, on the mechanism that produced 197-byte reports, is a bad trade.
2. **Score deliverables by artifact-citation fraction.** Correlation with the external judge: **+0.01** over 5 scored runs. No signal.

Recorded because the next person to look at AutoR's rubric will have the same two ideas.

## A note on the smoke check

An import-only check passed while `GOAL_EXCERPT_CHARS` was unimported in `review_panel.py` — the `NameError` lives in a function body. 33 panel tests caught it. The habit that needs correcting is the smoke check, not the import.

## Tests

7 new tests in `tests/test_reviewer_sees_the_task.py`, covering the median task, the longest real task, AutoR's preamble not spending the budget, tail-truncation of an overlong task, the unfenced interactive case, and the panel sharing the reader. Full suite **2070 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)