### PR TITLE
Give the scorer the draw count its own numbers need

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,7 +19,7 @@ it](#how-the-agent-reaches-it)), and `docs/ui-design/generate_progress_docx.py`
 regenerates one design document and needs `python-docx`.
 
 Every flag on those six is named below: `main.py`'s 61, `studio.py`'s 5,
-`tools/web_search.py`'s 4 and `tools/score_rcb_run.py`'s 8 each get their own
+`tools/web_search.py`'s 4 and `tools/score_rcb_run.py`'s 9 each get their own
 table row, and `rcb_agent.py`'s 37 are covered as the six that are its own plus
 the 31 it shares with `main.py`, every one of the 31 spelled out by name.
 `tools/archive_sample_complexity.py` has none.
@@ -699,7 +699,7 @@ to print a total while any call failed.
 ```
 python tools/score_rcb_run.py --workspace PATH --bench PATH
                               [--judge {reference,vertex}] [--model MODEL]
-                              [--key-file PATH] [--endpoint URL]
+                              [--draws N] [--key-file PATH] [--endpoint URL]
                               [--project-id ID] [--out PATH]
 ```
 
@@ -709,6 +709,7 @@ python tools/score_rcb_run.py --workspace PATH --bench PATH
 | `--bench PATH` | **required** | A checkout of ResearchClawBench. It is prepended to `sys.path` so `evaluation.score` can be imported; the scoring logic is the bench's, not this repo's. |
 | `--judge {reference,vertex}` | `reference` | Which judge scores the run. See below — this is the single most consequential flag on the tool. |
 | `--model MODEL` | `gpt-5.1` under `reference` (`REFERENCE_JUDGE_MODEL`), `claude-opus-4-5@20251101` under `vertex` (`FALLBACK_JUDGE_MODEL`) | Override the judge model id. Whatever it resolves to is printed twice — the `judge:` header line and the `TOTAL (judge …)` line — and recorded as `judge_model` in the `--out` JSON. The per-item lines carry no judge. |
+| `--draws N` | `1` | Score the same artifacts N times and report the mean, the per-draw totals and the spread. The judge is stochastic — see below. At `1` the dispersion prints as **unmeasured**, never as `0.0`: a zero there would be a precision claim inferred from the one sample size that cannot support it, and it flatters, because a fabricated `±0.0` makes any delta look real. Costs one full pass per draw; `judge_calls` accumulates. |
 | `--key-file PATH` | `~/api.txt` (`DEFAULT_KEY_FILE`) | File holding the reference judge's key. Outside any repository on purpose: a default inside the tree is one `git add -A` away from a leak. There is deliberately no flag that takes the key itself — it would land in the shell history and in the process table. The file may be a bare token, `KEY=token`, or a quoted value. |
 | `--endpoint URL` | `REFERENCE_JUDGE_ENDPOINT` | The OpenAI-compatible base URL the reference judge is served from. Only read under `--judge reference`. |
 | `--project-id ID` | `$ANTHROPIC_VERTEX_PROJECT_ID`, else empty | Vertex project for `--judge vertex`. Empty and unset exits `2` with `Set ANTHROPIC_VERTEX_PROJECT_ID or pass --project-id.` |
@@ -728,6 +729,29 @@ inside the `TOTAL (judge …)` line so the number cannot be copied out without i
 and stores `judge_model` in the `--out` JSON. (The module docstring claims the
 judge is on *every* line of output; it is not — the per-item rows, the
 `workspace:` line and the `items judged:` line carry none.)
+
+### `--draws` is the other half of the same caution
+
+`--judge` is about *which* judge. `--draws` is about the same judge twice.
+
+Eight draws of `gpt-5.1` over one artifact set held fixed — same workspace, same
+`report.md`, same five figures, nothing changed between draws — scored 41.4, 42.8,
+45.5, 47.1, 49.1, 49.6, 49.8 and 49.9: **spread 8.5**, sd 3.4, around a mean of
+46.9. The variance is worst where it costs most; the item weighted 0.5 spanned 32
+to 55, which is 11.5 points of the total by itself.
+
+So a single-draw total on a single task carries roughly ±4 points of pure sampling
+noise, and **a one-task A/B below about eight points is uninterpretable** — including
+a before-and-after on the same task, which is the shape a harness change most tempts
+you into. One such comparison read 46.0 against 42.8 and looked like a small
+regression; 46.0 sits at the 3/8 percentile of the unchanged artifact's own
+distribution.
+
+The full table is in
+[ResearchClawBench → How wide the judge's sampling range actually is](researchclawbench.md#how-wide-the-judges-sampling-range-actually-is).
+Note that 8.5 holds the artifacts fixed: AutoR's own run-to-run variance is
+additional and still unmeasured, so the floor for a real A/B is higher than that,
+not equal to it.
 `--judge vertex` exists for when no reference key is available;
 its numbers are internally consistent and are **not** comparable to a published
 figure.

--- a/tests/test_score_rcb_run.py
+++ b/tests/test_score_rcb_run.py
@@ -482,3 +482,88 @@ class ReferenceJudgeTest(unittest.TestCase):
     def test_the_endpoint_is_not_treated_as_a_secret(self) -> None:
         """An endpoint in source is fine; a key is not. Keep them distinguishable."""
         self.assertTrue(self.tool.REFERENCE_JUDGE_ENDPOINT.startswith("https://"))
+
+
+class DrawAggregationTest(unittest.TestCase):
+    """The judge is stochastic and a one-draw total does not say so.
+
+    Eight draws over one unchanged artifact set -- same workspace, same report, same
+    figures -- spanned 8.5 points (41.4 to 49.9, sd 3.4), and the heaviest checklist
+    item alone spanned 23. That is enough to make a single-task before/after below
+    about eight points meaningless, and I nearly reported one: 46.0 against 42.8, where
+    46.0 sits at the 3/8 percentile of the *unchanged* artifact's own distribution.
+
+    So the tests worth having here are not about the mean. They are about the tool
+    refusing to imply a precision it has not got.
+    """
+
+    def setUp(self) -> None:
+        self.tool = _load()
+
+    @staticmethod
+    def _drawn(total: float, scores: list[float]) -> dict:
+        return {
+            "total_score": total,
+            "judge_model": "gpt-5.1",
+            "judge_calls": len(scores),
+            "judge_failures": [],
+            "items": [{"type": "text", "weight": 0.5, "content": f"c{i}", "score": s}
+                      for i, s in enumerate(scores)],
+        }
+
+    def test_the_mean_is_over_every_draw(self) -> None:
+        merged = self.tool.aggregate_draws(
+            [self._drawn(40.0, [40, 40]), self._drawn(50.0, [60, 40])]
+        )
+        self.assertEqual(merged["total_score"], 45.0)
+        self.assertEqual(merged["total_scores"], [40.0, 50.0])
+        self.assertEqual(merged["draws"], 2)
+        self.assertEqual(merged["items"][0]["score"], 50.0)
+        self.assertEqual(merged["items"][0]["scores"], [40.0, 60.0])
+
+    def test_one_draw_reports_its_dispersion_as_unmeasured_not_as_zero(self) -> None:
+        """The whole point. A zero here reads as "the judge is deterministic".
+
+        It would be inferred from the one sample size that cannot show it, and it is
+        the direction that flatters: a fabricated +/-0.0 makes any delta look
+        significant. `rcb_trial` refuses the same shape one layer up.
+        """
+        merged = self.tool.aggregate_draws([self._drawn(40.0, [40, 40])])
+
+        self.assertIsNone(merged["total_spread"])
+        self.assertIsNone(merged["items"][0]["spread"])
+        self.assertIn("unmeasured", self.tool.format_spread(merged["total_spread"], 1))
+        self.assertNotIn("0.0", self.tool.format_spread(merged["total_spread"], 1))
+
+    def test_the_spread_is_reported_once_there_is_one(self) -> None:
+        merged = self.tool.aggregate_draws(
+            [self._drawn(41.4, [40]), self._drawn(49.9, [60]), self._drawn(45.5, [50])]
+        )
+        self.assertAlmostEqual(merged["total_spread"], 8.5, places=6)
+        self.assertIn("8.5", self.tool.format_spread(merged["total_spread"], 3))
+        self.assertIn("3 draws", self.tool.format_spread(merged["total_spread"], 3))
+
+    def test_judge_calls_accumulate_across_draws(self) -> None:
+        """Cost is per draw, and a reader comparing two totals needs to see that."""
+        merged = self.tool.aggregate_draws(
+            [self._drawn(40.0, [40, 40]), self._drawn(50.0, [60, 40])]
+        )
+        self.assertEqual(merged["judge_calls"], 4)
+
+    def test_the_draw_count_travels_with_the_total(self) -> None:
+        """A total whose sampling is unstated cannot be compared with another one.
+
+        Same argument as the judge model, which this tool already prints for the same
+        reason -- and the two are the same failure at different scales.
+        """
+        text = TOOL.read_text(encoding="utf-8")
+        self.assertIn("TOTAL (judge {result['judge_model']}, {draw_count} draw", text)
+
+    def test_the_default_is_one_draw_so_behaviour_is_unchanged(self) -> None:
+        merged = self.tool.aggregate_draws([self._drawn(42.8, [42.8])])
+        self.assertEqual(merged["draws"], 1)
+        self.assertEqual(merged["total_score"], 42.8)
+
+    def test_aggregating_nothing_raises_rather_than_reporting_zero(self) -> None:
+        with self.assertRaises(ValueError):
+            self.tool.aggregate_draws([])

--- a/tools/score_rcb_run.py
+++ b/tools/score_rcb_run.py
@@ -421,6 +421,60 @@ def write_result(out: Path, result: dict) -> None:
     os.replace(tmp, out)
 
 
+def aggregate_draws(results: list[dict]) -> dict:
+    """Fold N independent judge passes over the same artifacts into one result.
+
+    Averaging is the easy half. The half that matters is refusing to state an
+    uncertainty a single draw has not earned: with one draw the spread is
+    ``None`` and every printed form says *unmeasured*, never ``0.0``. A zero
+    there would be the most expensive kind of wrong -- it reads as "this judge
+    is deterministic" from the exact evidence that cannot show it, and
+    ``rcb_trial`` already refuses the same shape one layer up ("fewer draws must
+    not produce a smaller stated uncertainty").
+
+    Measured on one artifact set held fixed, eight ``gpt-5.1`` draws spanned 8.5
+    points; see docs/researchclawbench.md. That is why this exists.
+    """
+    if not results:
+        raise ValueError("aggregate_draws needs at least one result")
+
+    merged = dict(results[-1])
+    totals = [float(r.get("total_score", 0.0)) for r in results]
+    merged["draws"] = len(results)
+    merged["total_scores"] = totals
+    merged["total_score"] = sum(totals) / len(totals)
+    merged["judge_calls"] = sum(int(r.get("judge_calls", 0)) for r in results)
+    merged["judge_failures"] = [f for r in results for f in r.get("judge_failures", [])]
+    merged["total_spread"] = (max(totals) - min(totals)) if len(totals) > 1 else None
+
+    # Per item, keyed on position: `score` returns the checklist in a fixed order and
+    # every draw scores the same checklist, so a positional join is exact here. A join
+    # on `content` would look safer and would silently drop an item whose text the
+    # bench revision changed between draws -- but the draws are one process over one
+    # checkout, so that cannot happen, and a dropped item is worse than a wrong one.
+    per_item: list[dict] = []
+    for index, item in enumerate(merged.get("items", [])):
+        scores = [
+            float(r["items"][index].get("score", 0.0))
+            for r in results
+            if index < len(r.get("items", []))
+        ]
+        entry = dict(item)
+        entry["scores"] = scores
+        entry["score"] = sum(scores) / len(scores) if scores else 0.0
+        entry["spread"] = (max(scores) - min(scores)) if len(scores) > 1 else None
+        per_item.append(entry)
+    merged["items"] = per_item
+    return merged
+
+
+def format_spread(spread: float | None, draws: int) -> str:
+    """One phrasing for every place a dispersion is printed, including its absence."""
+    if spread is None:
+        return f"unmeasured ({draws} draw)"
+    return f"spread {spread:.1f} over {draws} draws"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     parser.add_argument("--workspace", required=True, type=Path)
@@ -449,6 +503,19 @@ def main() -> int:
     parser.add_argument(
         "--project-id", default=os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
     )
+    parser.add_argument(
+        "--draws",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Score the same artifacts N times and report the mean. The judge is "
+            "stochastic: eight draws over one unchanged artifact set spanned 8.5 "
+            "points, so a one-draw total on a single task carries about +/-4 points "
+            "of sampling noise and a one-task A/B below ~8 points is uninterpretable. "
+            "Default 1, which reports its dispersion as unmeasured rather than as zero."
+        ),
+    )
     parser.add_argument("--out", type=Path, default=None)
     args = parser.parse_args()
 
@@ -466,14 +533,29 @@ def main() -> int:
             model=args.model or FALLBACK_JUDGE_MODEL, project_id=args.project_id
         )
 
+    if args.draws < 1:
+        print("--draws must be at least 1.", file=sys.stderr)
+        return 2
+
+    # Every draw is scored, even after one refuses. A refusal is "this total is not a
+    # measurement", and the per-item table from the remaining draws is what tells you
+    # whether the failure was one flaky call or the whole judge -- which is the first
+    # question anyone asks. Refusing early would throw that away to save a minute.
     refused: ScoringRefused | None = None
-    try:
-        result = score(args.workspace, args.bench, judge=judge)
-    except ScoringRefused as exc:
-        refused, result = exc, exc.result
-    if "error" in result:
-        print(f"scoring failed: {result['error']}", file=sys.stderr)
-        return 1
+    draws: list[dict] = []
+    for draw_no in range(1, args.draws + 1):
+        if args.draws > 1:
+            print(f"draw {draw_no}/{args.draws} ...", file=sys.stderr)
+        try:
+            drawn = score(args.workspace, args.bench, judge=judge)
+        except ScoringRefused as exc:
+            refused, drawn = refused or exc, exc.result
+        if "error" in drawn:
+            print(f"scoring failed: {drawn['error']}", file=sys.stderr)
+            return 1
+        draws.append(drawn)
+
+    result = aggregate_draws(draws)
 
     # `score_workspace` returns this under "items". Reading "results" left the
     # per-item table empty and printed "items judged: 0" beside a real total --
@@ -484,9 +566,12 @@ def main() -> int:
     print(f"workspace: {args.workspace}")
     print()
     for item in items:
+        spread = item.get("spread")
+        dispersion = f"  [{format_spread(spread, result['draws'])}]" if result["draws"] > 1 else ""
         print(
             f"  [{item.get('type','?'):>5}] w={item.get('weight',0):<5} "
-            f"score={item.get('score',0):>3}  {str(item.get('content',''))[:70]}"
+            f"score={item.get('score',0):>5.1f}{dispersion}  "
+            f"{str(item.get('content',''))[:70]}"
         )
 
     # The check that matters. A judge failure reads as a zero, so a total quoted
@@ -502,7 +587,21 @@ def main() -> int:
         return 1
 
     print()
-    print(f"TOTAL (judge {result['judge_model']}): {result.get('total_score', 0):.1f}")
+    draw_count = result["draws"]
+    # The draw count rides with the total, always, for the same reason the judge model
+    # does: a number whose sampling is unstated cannot be compared with another one.
+    print(
+        f"TOTAL (judge {result['judge_model']}, {draw_count} draw"
+        f"{'s' if draw_count != 1 else ''}): {result.get('total_score', 0):.1f}"
+    )
+    print(f"  dispersion: {format_spread(result.get('total_spread'), draw_count)}")
+    if draw_count > 1:
+        print("  draws: " + ", ".join(f"{t:.1f}" for t in result.get("total_scores", [])))
+    else:
+        print(
+            "  one draw on one task carries about +/-4 points of judge sampling noise; "
+            "pass --draws to bound it."
+        )
     print(f"items judged: {len(items)}   judge calls: {result.get('judge_calls', 0)}")
 
     if args.out:


### PR DESCRIPTION
## Why

`src/rcb_trial.py` reasons carefully about how many judge draws a total averages — it keys `stage_fitness` on the count, refuses to pair arms whose counts differ, and states outright that *"fewer draws must not produce a smaller stated uncertainty."*

The tool anyone actually runs by hand scored once and printed a bare total.

That gap is not theoretical. Eight draws of `gpt-5.1` over one artifact set **held fixed** — same workspace, same `report.md`, same five figures, nothing changed between draws — scored 41.4, 42.8, 45.5, 47.1, 49.1, 49.6, 49.8, 49.9. Spread **8.5**, sd 3.4. The item weighted 0.5 alone spanned 32 to 55.

I had a before-and-after on that task reading 46.0 against 42.8 and was one step from reporting that today's fixes cost three points. **46.0 sits at the 3/8 percentile of the unchanged artifact's own distribution.**

## What this adds

`--draws N` scores the same artifacts N times and reports the mean, the per-draw totals and the spread. `judge_calls` accumulates so the cost stays visible. Default `1`, so existing behaviour is unchanged.

```
TOTAL (judge gpt-5.1, 3 draws): 49.0
  dispersion: spread 4.4 over 3 draws
  draws: 46.1, 50.5, 50.3
items judged: 3   judge calls: 18
```

## The part worth arguing about

**What a single draw prints.**

```
TOTAL (judge gpt-5.1, 1 draw): 46.0
  dispersion: unmeasured (1 draw)
  one draw on one task carries about +/-4 points of judge sampling noise; pass --draws to bound it.
```

`unmeasured`, never `0.0`. A zero there would be a precision claim inferred from the one sample size that cannot support it, and it fails in the **flattering** direction — a fabricated `±0.0` makes any delta look real. That is the same refusal `rcb_trial` already makes one layer up, now made where the number is produced rather than only where it is compared.

The draw count also rides *inside* the `TOTAL` line, for exactly the reason the judge model already does: a number whose sampling is unstated cannot be compared with another one. Those are the same failure at different scales.

Every draw is scored even after one refuses, because *"was that one flaky call or the whole judge"* is the first question a refusal raises, and the remaining draws are what answer it.

## Tests

Seven. The load-bearing one is `test_one_draw_reports_its_dispersion_as_unmeasured_not_as_zero`; the rest cover the mean, the spread, call accumulation, empty input, and that the default is still a single draw.

## Verified against the real judge

`--draws 1` → 46.0, dispersion unmeasured. `--draws 3` → 49.0, spread 4.4 over 46.1 / 50.5 / 50.3.

## Docs

`docs/cli-reference.md` gains the flag, its own subsection contrasting it with `--judge` (*which* judge vs. the same judge twice), and a corrected flag count — that page asserts how many flags each command has, so adding one moves a claim.

## Not in scope

`src/rcb_trial.py` has its own scoring path and does not shell out to this tool, so nothing is rewired there. Sourcing the trial's `draws` field from this flag is the natural follow-up.

## Testing

`python -m unittest discover -s tests -p "test_*.py"` — **2077 pass**, 1 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)