### PR TITLE
Refuse a trial plan whose every arm would be discarded, before it is launched

### DIFF
--- a/src/rcb_trial.py
+++ b/src/rcb_trial.py
@@ -1138,7 +1138,42 @@ class TrialPlan:
             raise ValueError("the two arms carry the same label; the difference would be zero")
         if not plan.tasks:
             raise ValueError("a plan with no tasks cannot become a measurement")
+        for side in ("control", "treatment"):
+            _refuse_a_label_that_is_not_the_revision(side, getattr(plan, side))
         return plan
+
+
+def _refuse_a_label_that_is_not_the_revision(side: str, spec: ArmSpec) -> None:
+    """Fail at freeze time on the mismatch ``revision_matches_arm`` would fail on later.
+
+    ``ArmSpec`` carries the commit twice. ``sha`` is what the worktree is checked out
+    to; ``label`` is what :func:`_revision_matches_arm` compares the recorded revision
+    against, because ``RunRecord`` has no revision field and the label is the only
+    carrier. Two fields, one fact, and only one of them is read by the gate.
+
+    So a plan reading ``{"label": "off", "sha": "621566b"}`` — the obvious way to
+    write an on/off trial, and the way the flag-shaped CLI trains you to think — is
+    accepted, launched, and then has **every single arm refused** by
+    ``revision_matches_arm`` after the runs are already spent. Measured on the dry-run
+    path: twelve runs, twelve refusals, zero pairs, and a report whose exclusion lines
+    name the clause but not the cause.
+
+    The relation checked here is exactly the one the clause will apply, so a plan that
+    passes freeze cannot fail admission on this ground. A trial costs days; this costs
+    a string comparison, and it happens before the first launch.
+    """
+    label, sha = spec.label.strip(), spec.sha.strip()
+    if not label:
+        raise ValueError(f"the {side} arm has no label; `revision_matches_arm` would refuse every run")
+    if not sha:
+        raise ValueError(f"the {side} arm has no sha; there is nothing to check the worktree out to")
+    if not (label.startswith(sha) or sha.startswith(label)):
+        raise ValueError(
+            f"the {side} arm is labelled `{label}` but runs at `{sha}`. The arm label is what "
+            "`revision_matches_arm` compares the run's recorded revision against, so every run "
+            "of this arm would be launched, scored, and then discarded. Label the arm with its "
+            "commit."
+        )
 
 
 def arm_order(plan: TrialPlan) -> tuple[tuple[str, str], ...]:

--- a/tests/test_rcb_trial_plan_labels.py
+++ b/tests/test_rcb_trial_plan_labels.py
@@ -1,0 +1,117 @@
+"""A plan that every arm would fail admission on must not freeze.
+
+`ArmSpec` carries the commit twice. `sha` is what the worktree gets checked out to and
+what reaches the run command; `label` is what `_revision_matches_arm` compares the
+recorded revision against, because `RunRecord` has no revision field and the label is
+the only carrier. Two fields, one fact, and the gate reads the one not called `sha`.
+
+So this plan is the obvious way to write an on/off trial:
+
+    "control":   {"label": "off", "sha": "621566b", ...},
+    "treatment": {"label": "on",  "sha": "47f3fbf", ...}
+
+and it froze, launched, and had **every arm refused** by `revision_matches_arm` after
+the runs were spent. Measured on the dry-run path before this guard existed: twelve
+runs, twelve refusals, zero pairs. The exclusion lines in the report name the clause,
+not the cause, so the reader sees `revision_matches_arm` twelve times and no
+indication that the plan was the problem.
+
+A real trial costs days of serialized live runs. The check costs a string comparison
+and runs before the first launch.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.rcb_trial import ArmEvidence, RunEnvironment, TrialPlan, _revision_matches_arm
+
+
+def plan_payload(*, control_label: str, treatment_label: str) -> dict:
+    return {
+        "capability": "whatever",
+        "bench": "/bench",
+        "tasks": ["Astronomy_000"],
+        "control": {"label": control_label, "sha": "621566b", "worktree": "/w/control"},
+        "treatment": {"label": treatment_label, "sha": "47f3fbf", "worktree": "/w/treatment"},
+    }
+
+
+class AMislabelledArmIsRefusedAtFreezeTests(unittest.TestCase):
+    def test_the_on_off_labelling_is_refused(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            TrialPlan.from_dict(plan_payload(control_label="off", treatment_label="on"))
+        self.assertIn("621566b", str(caught.exception))
+
+    def test_the_refusal_says_what_would_have_happened(self) -> None:
+        """Naming the clause is not enough; the reader has to know the cost."""
+        with self.assertRaises(ValueError) as caught:
+            TrialPlan.from_dict(plan_payload(control_label="off", treatment_label="on"))
+        message = str(caught.exception)
+        self.assertIn("revision_matches_arm", message)
+        self.assertIn("discarded", message)
+
+    def test_a_label_that_is_the_commit_freezes(self) -> None:
+        plan = TrialPlan.from_dict(
+            plan_payload(control_label="621566b", treatment_label="47f3fbf")
+        )
+        self.assertEqual(plan.control.label, "621566b")
+
+    def test_a_short_label_against_a_full_sha_freezes(self) -> None:
+        """The prefix relation both ways, matching what the clause allows."""
+        payload = plan_payload(control_label="621566b", treatment_label="47f3fbf")
+        payload["control"]["sha"] = "621566b" + "0" * 33
+        self.assertEqual(TrialPlan.from_dict(payload).control.label, "621566b")
+
+    def test_an_empty_label_is_refused(self) -> None:
+        with self.assertRaises(ValueError):
+            TrialPlan.from_dict(plan_payload(control_label="", treatment_label="47f3fbf"))
+
+    def test_an_empty_sha_is_refused(self) -> None:
+        payload = plan_payload(control_label="621566b", treatment_label="47f3fbf")
+        payload["treatment"]["sha"] = ""
+        with self.assertRaises(ValueError):
+            TrialPlan.from_dict(payload)
+
+
+class TheFreezeCheckMatchesTheAdmissionClauseTests(unittest.TestCase):
+    """The guard is only worth anything if it applies the clause's own relation.
+
+    A freeze check that were stricter would refuse plans that would in fact have run;
+    one that were looser would let through the twelve-refusals case it exists to stop.
+    Both are asserted against `_revision_matches_arm` itself rather than against a
+    restatement of it.
+    """
+
+    def evidence(self, *, arm: str, revision: str) -> ArmEvidence:
+        return ArmEvidence(
+            task_id="Astronomy_000",
+            arm=arm,
+            run_id="r1",
+            workspace="/w",
+            env=RunEnvironment(),
+            items=(),
+            published_total=0.0,
+            facts={
+                "revision_at_launch": revision,
+                "revision_at_finish": revision,
+                "worktree_dirty": False,
+            },
+        )
+
+    def test_a_label_the_freeze_accepts_is_one_the_clause_accepts(self) -> None:
+        TrialPlan.from_dict(plan_payload(control_label="621566b", treatment_label="47f3fbf"))
+        self.assertTrue(
+            _revision_matches_arm(self.evidence(arm="621566b", revision="621566b8e1"))
+        )
+
+    def test_a_label_the_freeze_refuses_is_one_the_clause_refuses(self) -> None:
+        with self.assertRaises(ValueError):
+            TrialPlan.from_dict(plan_payload(control_label="off", treatment_label="on"))
+        self.assertFalse(
+            _revision_matches_arm(self.evidence(arm="off", revision="621566b8e1"))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Found by driving `tools/rcb_trial.py` end to end on its dry-run path for the first time.

## The defect

`ArmSpec` carries the commit twice:

- `sha` — what the worktree is checked out to, and what reaches the run command as `--sha`.
- `label` — what `_revision_matches_arm` compares the run's recorded revision against, *because* `RunRecord` has no revision field and the label is the only carrier.

Two fields, one fact, and the admission clause reads the one that isn't called `sha`.

So this plan is accepted — and it is the obvious way to write an on/off trial, the way the flag-shaped CLI trains you to think:

```json
"control":   {"label": "off", "sha": "621566b", "worktree": "..."},
"treatment": {"label": "on",  "sha": "47f3fbf", "worktree": "..."}
```

It freezes. It launches. Every arm is then refused by `revision_matches_arm` **after the runs are spent**.

Measured on the dry-run path:

```
- pairs: **0** (6 excluded)
  - excluded `Astronomy_000`: the control arm `off` was refused (revision_matches_arm);
                              the treatment arm `on` was refused (revision_matches_arm)
  … 6 tasks, 12 arms, 12 refusals
```

Change nothing but the two labels to the commits they run at, on the same plan:

```
- pairs: **6**
- mean difference: **-0.3333** RCB points (0-100 total scale)
- exact two-sided p: **0.2500** (floor at n=6: 0.0312)
```

The report's exclusion lines name the clause, not the cause. A reader sees `revision_matches_arm` twelve times and nothing that points at the plan.

## Why it is worth a guard rather than a docstring

The module's own header lists four operational facts it is bent around, all of the form *this failure costs days and is invisible while it happens*. This is a fifth. A real trial is 6+ pairs of serialized live runs — the durations recorded in that same header are 3,426 / 57,011 / 50,536 / 11,360 seconds — against a paid external judge. The mistake is silent until the report, and the report blames a clause.

`TrialPlan.from_dict` now applies the clause's own relation at freeze time:

```
the control arm is labelled `off` but runs at `621566b`. The arm label is what
`revision_matches_arm` compares the run's recorded revision against, so every run of
this arm would be launched, scored, and then discarded. Label the arm with its commit.
```

A plan that freezes cannot fail admission on this ground.

## Testing

2085 pass. The new tests assert the guard against `_revision_matches_arm` itself rather than a restatement, in **both** directions — a freeze check that were stricter would refuse plans that would in fact have run, and one that were looser would let the twelve-refusals case through. Two mutations kill them: removing the call (5 fail), loosening the relation to accept anything (3 fail).

## Context

This came out of establishing that a real paired trial is now executable here for the first time: the gpt-5.1 reference judge answers (HTTP 200), the Vertex opus pool is healthy (a two-hour run recorded zero `RESOURCE_EXHAUSTED` where sonnet gave 218 in 46 attempts), and this driver works end to end. A plan for capability `pr175_scale_and_settled_reasoning` was frozen on 2026-08-11 and never run; at 3 tasks it is also below `MIN_PAIRS_FOR_SIGNIFICANCE`, so it could not have cleared 0.05 at any effect size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)