### PR TITLE
A mention is not an execution, and a fake operator is not contention

### DIFF
--- a/tests/test_rcb_trial_driver.py
+++ b/tests/test_rcb_trial_driver.py
@@ -1114,3 +1114,112 @@ class StallTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ForeignRunDetectionTests(unittest.TestCase):
+    """A mention is not an execution, and a fake operator is not contention.
+
+    Both of these refused a real trial on a live box. The driver stands down for ten
+    minutes per refusal, so a detector that fires on the wrong thing does not merely
+    add noise -- on a machine where anyone is running the test suite, or where anyone
+    types a one-liner to check whether a run is up, the trial never starts at all.
+
+    This is the same shape as the quota classifier matching the bare substring "429":
+    a detector matching a broader pattern than the thing it protects against.
+    """
+
+    def setUp(self) -> None:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "rcb_trial_tool", Path(__file__).resolve().parent.parent / "tools" / "rcb_trial.py"
+        )
+        self.tool = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(self.tool)
+
+    def test_a_real_benchmark_run_is_a_run(self) -> None:
+        argv = ["python3", "/home/u/AutoR/rcb_agent.py", "--workspace", "/w", "--model", "opus"]
+        self.assertTrue(self.tool.is_backed_run(argv))
+
+    def test_a_real_goal_run_is_a_run(self) -> None:
+        argv = ["python", "main.py", "--goal-file", "/tmp/g.txt", "--full-auto", "--model", "opus"]
+        self.assertTrue(self.tool.is_backed_run(argv))
+
+    def test_a_fake_operator_run_contends_for_nothing(self) -> None:
+        # What the test suite runs, constantly. It makes no backend call.
+        argv = ["python", "main.py", "--fake-operator", "--full-auto", "--goal", "coverage"]
+        self.assertFalse(self.tool.is_backed_run(argv))
+
+    def test_a_fake_operator_benchmark_run_contends_for_nothing_either(self) -> None:
+        argv = ["python3", "/home/u/AutoR/rcb_agent.py", "--fake-operator", "--no-synthesis"]
+        self.assertFalse(self.tool.is_backed_run(argv))
+
+    def test_a_shell_that_merely_names_the_script_is_not_a_run(self) -> None:
+        # The exact false positive: a diagnostic one-liner asking whether a run is up.
+        argv = ["/bin/bash", "-c", 'pgrep -af "rcb_agent.py" | head -3']
+        self.assertFalse(self.tool.is_backed_run(argv))
+
+    def test_a_grep_for_the_script_is_not_a_run(self) -> None:
+        argv = ["grep", "-rn", "rcb_agent.py", "/home/u/AutoR"]
+        self.assertFalse(self.tool.is_backed_run(argv))
+
+    def test_a_non_python_binary_is_not_a_run(self) -> None:
+        # The script name is a bare argument to grep too. Requiring an interpreter at
+        # argv[0] is what separates reading the file from running it. A shebang
+        # execution is unaffected: the kernel rewrites argv to put python first.
+        self.assertFalse(self.tool.is_backed_run(["/usr/bin/rcb_agent.py"]))
+        self.assertFalse(self.tool.is_backed_run(["vim", "rcb_agent.py"]))
+        self.assertTrue(self.tool.is_backed_run(["/usr/bin/python3.11", "rcb_agent.py", "-w", "/w"]))
+
+    def test_main_py_without_a_goal_is_not_a_run(self) -> None:
+        # `main.py --trial-report` reads artifacts and calls nothing.
+        self.assertFalse(self.tool.is_backed_run(["python", "main.py", "--trial-report"]))
+
+    def test_an_empty_argv_is_not_a_run(self) -> None:
+        # Kernel threads have an empty cmdline.
+        self.assertFalse(self.tool.is_backed_run([]))
+
+    def test_process_argv_splits_on_nul_rather_than_joining(self) -> None:
+        argv = self.tool.process_argv(os.getpid())
+        self.assertGreater(len(argv), 1)
+        self.assertNotIn(" ", argv[0])
+
+    def test_process_argv_on_a_dead_pid_is_empty_not_an_error(self) -> None:
+        self.assertEqual(self.tool.process_argv(999999), [])
+
+    def test_foreign_runs_reads_real_proc_and_separates_mention_from_execution(self) -> None:
+        """The producer, not just the predicate.
+
+        Every other test here calls ``is_backed_run`` with a hand-built argv, which
+        leaves ``foreign_runs`` free to go on substring-matching the joined command
+        line -- the very thing that refused a live trial. This spawns three real
+        processes and asks the scanner what it sees.
+        """
+        import subprocess
+        import tempfile
+        import time
+
+        with tempfile.TemporaryDirectory() as tmp:
+            script = Path(tmp) / "rcb_agent.py"
+            script.write_text("import time; time.sleep(30)\n", encoding="utf-8")
+            real = subprocess.Popen([sys.executable, str(script), "--workspace", tmp])
+            faked = subprocess.Popen(
+                [sys.executable, str(script), "--fake-operator", "--workspace", tmp]
+            )
+            mention = subprocess.Popen(["sleep", "30"] if False else
+                                       ["/bin/sh", "-c", "sleep 30 # rcb_agent.py --workspace x"])
+            try:
+                deadline = time.time() + 10
+                while time.time() < deadline:
+                    listed = self.tool.foreign_runs()
+                    if any(str(real.pid) == line.split()[0] for line in listed):
+                        break
+                    time.sleep(0.2)
+                pids = {line.split()[0] for line in listed}
+                self.assertIn(str(real.pid), pids, f"a real run must be seen: {listed}")
+                self.assertNotIn(str(faked.pid), pids, f"a fake operator contends for nothing: {listed}")
+                self.assertNotIn(str(mention.pid), pids, f"a mention is not an execution: {listed}")
+            finally:
+                for proc in (real, faked, mention):
+                    proc.kill()
+                    proc.wait()

--- a/tools/rcb_trial.py
+++ b/tools/rcb_trial.py
@@ -150,6 +150,22 @@ def process_cmdline(pid: int) -> str:
     return raw.replace(b"\0", b" ").decode("utf-8", "replace")
 
 
+def process_argv(pid: int) -> list[str]:
+    """The real argument vector, not the joined string.
+
+    ``/proc/pid/cmdline`` is NUL-separated, and joining it before matching is what
+    turns *mentioning* a script into *running* one. A shell running
+    ``grep rcb_agent.py`` -- or the diagnostic one-liner someone types to check
+    whether a run is up -- has ``rcb_agent.py`` in its joined command line and is
+    not a run.
+    """
+    try:
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return []
+    return [part.decode("utf-8", "replace") for part in raw.split(b"\0") if part]
+
+
 def lock_is_live(payload: Mapping[str, Any], *, marker: str = "rcb_trial.py") -> bool:
     """Three conditions, all required. Any one alone gives a false answer.
 
@@ -250,6 +266,46 @@ def autor_pids() -> frozenset[int]:
     return frozenset(found)
 
 
+#: Scripts whose execution is a run competing for the same per-base-model quota.
+_RUN_SCRIPTS = ("rcb_agent.py", "main.py")
+
+
+def is_backed_run(argv: Sequence[str]) -> bool:
+    """True only for a process that will actually call a model.
+
+    Two false positives cost a live trial ten minutes each, and on a busy box they
+    cost it forever:
+
+    * **A mention is not an execution.** The first version joined ``cmdline`` and
+      substring-matched it, so a shell scanning ``/proc`` for ``rcb_agent.py``
+      refused the driver by existing. The script has to be an *argument*, and after
+      the interpreter -- ``argv[0]`` is the python binary.
+    * **A fake operator makes no backend calls at all.** ``--fake-operator`` is what
+      the test suite runs, constantly, and a driver that stands down for the unit
+      tests never starts on a machine anybody is developing on. It contends for
+      nothing, so it is not contention.
+    """
+    if not argv or "--fake-operator" in argv:
+        return False
+    # argv[0] must be the interpreter. Without this, ``grep -rn rcb_agent.py .``
+    # reads as a run: the script name is a bare argument there too. A shebang
+    # execution still shows the interpreter first -- the kernel rewrites argv --
+    # so requiring it costs nothing real.
+    binary = argv[0].rsplit("/", 1)[-1]
+    if not binary.startswith("python"):
+        return False
+    script_args = argv[1:]
+    for arg in script_args:
+        if arg.startswith("-"):
+            continue
+        name = arg.rsplit("/", 1)[-1]
+        if name == "rcb_agent.py":
+            return True
+        if name == "main.py":
+            return any(a == "--goal" or a.startswith("--goal") for a in script_args)
+    return False
+
+
 def foreign_runs() -> list[str]:
     """Any AutoR process that is not ours. Refuse to start alongside one."""
     found: list[str] = []
@@ -259,9 +315,9 @@ def foreign_runs() -> list[str]:
         pid = int(entry.name)
         if pid == os.getpid():
             continue
-        line = process_cmdline(pid)
-        if "rcb_agent.py" in line or ("main.py" in line and "--goal" in line):
-            found.append(f"{pid} {line.strip()[:110]}")
+        argv = process_argv(pid)
+        if is_backed_run(argv):
+            found.append(f"{pid} {' '.join(argv).strip()[:110]}")
     return found
 
 


### PR DESCRIPTION
The foreign-run guard from [#183](https://github.com/tangxiangru/AutoR/pull/183) refused a real trial on its **first live attempt**, twice, and both refusals were wrong:

```
REFUSING TO START. AutoR is already running here:
  230462 python main.py --fake-operator --full-auto --goal End-to-end fake pipeline coverage
  230581 /bin/bash -c ... rcb_agent.py ...
```

**Neither is a run.**

The first is the **test suite**. `--fake-operator` makes no backend call, so it contends for nothing — and on any machine where somebody is running tests, the driver would have stood down forever.

The second is a shell that merely **names** the script: the diagnostic one-liner you type to ask whether a run is up. The guard joined `/proc/pid/cmdline` into a string and substring-matched it, so **asking the question answered it wrong.**

## Same disease as the "429" bug

#183's worst finding was a quota classifier matching the bare substring `"429"` against logs full of chi² values and grep line numbers. This is that again, one function over: a detector matching a broader pattern than the thing it protects against.

It is worse here in one way. A refusal costs ten minutes of backoff and then re-checks, so a detector that fires on the wrong thing does not merely add noise — **it prevents the trial from ever starting.**

## The rule

`process_argv` reads the NUL-separated vector instead of joining it. `is_backed_run` then requires all of:

| Requirement | Rejects |
|:---|:---|
| a python interpreter at `argv[0]` | `grep -rn rcb_agent.py .`, `vim rcb_agent.py` |
| the script as an argument after it | `bash -c '… # rcb_agent.py'` |
| no `--fake-operator` | the test suite, the smoke test |
| for `main.py`, a `--goal` | `main.py --trial-report` |

A shebang execution is unaffected — the kernel rewrites `argv` to put the interpreter first, so requiring it costs nothing real.

## Verification

2,007 tests, 12 new.

| Mutant | Killed |
|:---|:---|
| `--fake-operator` no longer excused *(the live blocker)* | 2 |
| interpreter check dropped — `grep` reads as a run | 2 |
| `main.py` no longer needs a `--goal` | 1 |
| back to joined-string substring matching | **survived → 1** |

That last row is the finding worth naming. Every test I had written called `is_backed_run` with a hand-built argv, which left `foreign_runs` — the actual producer, and the thing that refused the trial — free to go on substring-matching. It took a test that spawns three real processes (a run, a fake-operator run, and a shell that names the script) and asks the scanner what it sees. **The predicate was covered; the caller was not.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)