### PR TITLE
Take the length gradient out of `commitment`, so the prompt's prohibition is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ included.
 Every valid stage draft is measured against a rigour rubric read off disk — do the paths it names
 resolve, do the numbers it reports appear in a results file, did it produce artifacts during *this*
 execution, is the decision ledger four different things rather than one sentence four times. Eight
-weighted criteria, `RUBRIC_VERSION = "2"`:
+weighted criteria, `RUBRIC_VERSION = "4"`:
 
 | Criterion | Weight | From | What it measures |
 | --- | ---: | :---: | --- |

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -163,8 +163,10 @@ exists to prevent, reached by a route the design did not consider. Declining to 
 fabrication is not the same as declining to *pay* for it. `_cap_quantification_by_fidelity` now caps
 the first criterion at the second wherever both apply, which makes the middle row 0.0; the cap is
 recorded in `observed` so a stage can still tell which half to fix, and Stage 04 is exempt because
-fidelity does not apply before there are results. `RUBRIC_VERSION` is `3`, so no score from before
-the change is ranked against one after it.
+fidelity does not apply before there are results. `RUBRIC_VERSION` is `4` — it went to 3 when
+that cap landed and to 4 when the length gradient came out of `commitment` — and the archive
+ranks no score from before a bump against one after it, so each bump is a clean break rather
+than a silent drift.
 
 1,842 tests passed before the fix and none of them failed after it: the hole was in a composition
 nothing asserted over. The four tests added with it are mutation-checked — they fail when the cap is

--- a/src/rubric.py
+++ b/src/rubric.py
@@ -72,7 +72,7 @@ from .utils import (
 #: :func:`_cap_quantification_by_fidelity`. Every stage draft scored before the cap
 #: over-credits any Key Results section carrying unverifiable numbers, which is why
 #: this is a version bump and not a patch.
-RUBRIC_VERSION = "3"
+RUBRIC_VERSION = "4"
 
 #: The keys the rubric refuses to read out of an adjudication artifact.
 #:
@@ -727,19 +727,72 @@ def _score_traceability(markdown: str) -> CriterionScore:
     )
 
 
+#: A sentence that describes work rather than surrounding it: it carries a quantity, or
+#: it names a path. Used as the denominator of :func:`_score_commitment` in place of a
+#: word count — see that function for why the word count had to go.
+_WORK_BEARING_PATH = re.compile(r"`[^`]*[/.][^`]*`")
+
+#: Work-bearing sentences per unit of hedge allowance. Calibrated, not chosen: on the
+#: four stage summaries of the first real backend run, ``work / 4`` reproduces the old
+#: ``words / 200`` to within a factor of one (8.05 against 9.50, 16.75 against 15.50,
+#: 15.74 against 14.75), so a genuinely dense report keeps the allowance it had. Stage
+#: 04 comes out twice as generous, which is the right direction: it earned it in short
+#: lines naming files.
+_SENTENCES_PER_ALLOWANCE = 4.0
+
+
+def _work_bearing_sentences(body: str) -> int:
+    """Sentences that say what was done, as opposed to sentences that are present."""
+    return sum(
+        1
+        for sentence in re.split(r"(?<=[.!?])\s+|\n", body)
+        if sentence.strip()
+        and (
+            _QUANTITY_PATTERN.search(sentence)
+            or _NAMED_QUANTITY_PATTERN.search(sentence)
+            or _WORK_BEARING_PATH.search(sentence)
+        )
+    )
+
+
 def _score_commitment(markdown: str) -> CriterionScore:
-    """Density of intention over report, in the sections describing work done."""
+    """Density of intention over report, in the sections describing work done.
+
+    Density over *work*, not over words, and the difference is the whole point.
+
+    The allowance used to be ``words / 200``, which put a length gradient inside a
+    criterion the improvement prompt promises has none — ``src/evolution.py`` tells the
+    agent, every polish round, that "every criterion here is a ratio or a count over
+    artifacts on disk; prose cannot move any of them". Measured before this change, on
+    one hedge held fixed while clean prose was added around it: 149 words scored 0.8000,
+    677 scored 0.9409, 2,789 scored 0.9857. That is +0.0253 on a Stage 01 total against
+    a ``DEFAULT_MIN_GAIN`` of 0.02, so `EvolutionController.consider` recorded a round
+    that added nothing but words as ``promoted``, "New champion". The prohibition was
+    written down and the gradient rewarded breaking it.
+
+    Counting work-bearing sentences instead closes it for prose specifically: padding
+    adds sentences that carry no quantity and name no path, so it moves the numerator
+    and the denominator not at all. Buying allowance now requires writing quantities
+    that were not measured, which is a different move, is what ``quantification`` and
+    ``numeric_fidelity`` are for, and leaves a trace in the report rather than in its
+    length.
+    """
     weight = CRITERIA_BY_KEY["commitment"].weight
     body = "\n".join(
         extract_markdown_section(markdown, heading) or ""
         for heading in ("What I Did", "Key Results")
     )
-    words = max(len(body.split()), 1)
+    words = len(body.split())
+    working = _work_bearing_sentences(body)
     hedges = sum(len(re.findall(pattern, body, flags=re.IGNORECASE)) for pattern in _HEDGE_PATTERNS)
-    # One hedge per 200 words is ordinary scientific caution. Six is a plan.
-    allowance = max(words / 200.0, 1.0)
+    # One hedge per four sentences of described work is ordinary scientific caution.
+    # Six is a plan.
+    allowance = max(working / _SENTENCES_PER_ALLOWANCE, 1.0)
     score = _clamp(1.0 - (hedges / (allowance * 5.0)))
-    observed = f"{hedges} forward-looking phrase(s) across {words} words of What I Did / Key Results"
+    observed = (
+        f"{hedges} forward-looking phrase(s) against {working} sentence(s) carrying a "
+        f"quantity or a path, in {words} words of What I Did / Key Results"
+    )
     shortfall = (
         ""
         if score >= 1.0

--- a/tests/test_doc_counts.py
+++ b/tests/test_doc_counts.py
@@ -104,6 +104,30 @@ class CountsInProseMatchTheSymbolTests(unittest.TestCase):
                         )
         self.assertEqual(wrong, [], "\n".join(wrong))
 
+    def test_the_rubric_version_in_the_docs_is_the_live_one(self) -> None:
+        """A bump splits the archive in two; a doc still naming the old one is a lie.
+
+        Both places were already wrong when this was added — `README.md` said `"2"`
+        and `docs/framework.md` said `3` while the code said `3` and `4` respectively.
+        The version is quoted precisely because a reader needs to know which scores
+        are comparable, which is the one thing a stale copy destroys.
+        """
+        from src.rubric import RUBRIC_VERSION
+
+        for name in ("README.md", "docs/framework.md"):
+            text = (REPO / name).read_text(encoding="utf-8")
+            # Only the two canonical forms in which a doc states the *live* version.
+            # A sentence recounting which bump was which ("it went to 3 when...") is
+            # history and must stay readable, so it is deliberately not matched.
+            pattern = r'`RUBRIC_VERSION(?:` is `| = ")(\d+)'
+            quoted = set(re.findall(pattern, text))
+            self.assertTrue(quoted, f"{name} stopped naming RUBRIC_VERSION")
+            self.assertEqual(
+                quoted,
+                {RUBRIC_VERSION},
+                f"{name} quotes RUBRIC_VERSION {sorted(quoted)}, the code says {RUBRIC_VERSION}",
+            )
+
     def test_the_criteria_count_is_stated_correctly(self) -> None:
         text = (REPO / "docs/self-improvement.md").read_text(encoding="utf-8")
         self.assertIn(f"{spelled(len(CRITERIA)).capitalize()} criteria", text)

--- a/tests/test_rubric_has_no_length_gradient.py
+++ b/tests/test_rubric_has_no_length_gradient.py
@@ -1,0 +1,149 @@
+"""Prose may not move a criterion, because the improvement prompt promises it cannot.
+
+`src/evolution.py` tells the agent, in every polish round:
+
+    Do not lengthen a section to raise a score. Every criterion here is a ratio or a
+    count over artifacts on disk; prose cannot move any of them.
+
+That was false for `commitment`, whose hedge allowance was `words / 200`. Holding one
+forward-looking phrase fixed and adding clean prose around it, measured on main before
+this change:
+
+    149 words   -> 0.8000
+    677 words   -> 0.9409
+    2,789 words -> 0.9857
+
++0.1857 on the criterion is +0.0253 on a Stage 01 total, against a `DEFAULT_MIN_GAIN`
+of 0.02. So `EvolutionController.consider` recorded a round that added nothing but
+words as `promoted`, "New champion". The rule was written down in the prompt and the
+gradient paid for breaking it.
+
+This module holds the prohibition itself rather than one formula: the assertion is
+that adding contentless prose does not raise the criterion, and does not raise the
+stage total past the threshold the ratchet promotes on. Any future denominator that
+reintroduces a length term fails here.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.archive import DEFAULT_MIN_GAIN
+from src.rubric import CRITERIA, CRITERIA_BY_KEY, _score_commitment
+
+WORK = (
+    "Ran the deduplication pass over the retrieval corpus and recorded 8/8 source paths. "
+    "Counted 412 overlapping passages and wrote them to `workspace/data/overlap.json`. "
+)
+HEDGE = "We will investigate the remaining discrepancy in a follow-up pass. "
+#: Grammatical, on topic, and says nothing that could be checked against a file.
+FILLER = (
+    "The corpus is an important object of study and the question is a longstanding one. "
+    "Careful attention was paid throughout, and the approach follows established practice. "
+)
+
+
+def draft(body: str) -> str:
+    return f"## What I Did\n\n{body}\n\n## Key Results\n\nAll counts above are from the run.\n"
+
+
+def stage_01_weight_pool() -> float:
+    return sum(
+        criterion.weight
+        for criterion in CRITERIA
+        if (criterion.min_stage or 1) <= 1 and (criterion.max_stage or 99) >= 1
+    )
+
+
+class PaddingDoesNotPayTests(unittest.TestCase):
+    def test_filler_does_not_raise_the_criterion(self) -> None:
+        lean = _score_commitment(draft(WORK * 6 + HEDGE)).score
+        padded = _score_commitment(draft(WORK * 6 + HEDGE + FILLER * 30)).score
+        self.assertEqual(lean, padded)
+
+    def test_filler_does_not_buy_a_promotion(self) -> None:
+        """The number that matters is the stage total the ratchet compares.
+
+        A criterion moving a little is harmless; a criterion moving enough to clear
+        `DEFAULT_MIN_GAIN` on the weighted total is a champion recorded for padding.
+        """
+        lean = _score_commitment(draft(WORK * 6 + HEDGE)).score
+        padded = _score_commitment(draft(WORK * 6 + HEDGE + FILLER * 30)).score
+        weight = CRITERIA_BY_KEY["commitment"].weight
+        moved = (padded - lean) * weight / stage_01_weight_pool()
+        self.assertLess(moved, DEFAULT_MIN_GAIN)
+
+    def test_the_gradient_is_absent_at_every_length_tried(self) -> None:
+        """Not just the endpoints: no monotone climb hiding between them."""
+        scores = {
+            _score_commitment(draft(WORK * 6 + HEDGE + FILLER * n)).score
+            for n in (0, 1, 4, 10, 30, 60)
+        }
+        self.assertEqual(len(scores), 1, f"length moved the score: {sorted(scores)}")
+
+
+class WorkIsStillRewardedAndPlansAreStillPunishedTests(unittest.TestCase):
+    def test_a_report_that_is_mostly_plan_scores_badly(self) -> None:
+        score = _score_commitment(draft("Set up the environment. " + HEDGE * 4)).score
+        self.assertLess(score, 0.35)
+
+    def test_a_long_work_dense_report_keeps_its_allowance(self) -> None:
+        """Ordinary scientific caution in a report full of results is not a plan.
+
+        The old comment — "One hedge per 200 words is ordinary scientific caution" —
+        had the right intent and the wrong denominator. Three hedges across eighty
+        sentences of measured work must not read as a plan. Under the old rule the
+        same draft scored 0.4545, because it was punished for the words the work
+        needed.
+        """
+        score = _score_commitment(draft(WORK * 40 + HEDGE * 3)).score
+        self.assertGreater(score, 0.95)
+
+    def test_the_same_hedges_cost_more_in_a_thinner_report(self) -> None:
+        """Density, not a flat per-hedge fine. The criterion is a ratio or it is nothing."""
+        dense = _score_commitment(draft(WORK * 40 + HEDGE * 3)).score
+        thin = _score_commitment(draft(WORK * 4 + HEDGE * 3)).score
+        self.assertGreater(dense, thin)
+
+    def test_hedges_still_cost_something(self) -> None:
+        clean = _score_commitment(draft(WORK * 6)).score
+        hedged = _score_commitment(draft(WORK * 6 + HEDGE * 3)).score
+        self.assertEqual(clean, 1.0)
+        self.assertLess(hedged, clean)
+
+    def test_the_observed_string_names_the_denominator(self) -> None:
+        """A reader has to be able to see why, or the shortfall is unactionable."""
+        observed = _score_commitment(draft(WORK * 6 + HEDGE)).observed
+        self.assertIn("sentence(s) carrying a quantity or a path", observed)
+
+
+class TheProhibitionInThePromptIsTrueTests(unittest.TestCase):
+    """The prompt makes a promise about every criterion. Hold it to that.
+
+    Asserting the sentence is present would pass while the sentence was false, which
+    is how this survived: `tests/test_evolution.py` already checks the string is
+    rendered. This checks the claim.
+    """
+
+    def test_no_criterion_scored_from_markdown_alone_has_a_length_gradient(self) -> None:
+        from src.rubric import _score_quantification, _score_traceability
+
+        for name, scorer in (
+            ("commitment", _score_commitment),
+            ("quantification", _score_quantification),
+            ("traceability", _score_traceability),
+        ):
+            lean = draft(WORK * 6 + HEDGE)
+            padded = draft(WORK * 6 + HEDGE + FILLER * 30)
+            with self.subTest(criterion=name):
+                before = scorer(lean)
+                after = scorer(padded)
+                self.assertLessEqual(
+                    getattr(after, "score", after),
+                    getattr(before, "score", before) + 1e-9,
+                    f"{name} rose on filler alone",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every polish round, `src/evolution.py` tells the agent:

> Do not lengthen a section to raise a score. Every criterion here is a ratio or a count over artifacts on disk; **prose cannot move any of them.**

That was false.

## The gradient

`commitment`'s hedge allowance was `words / 200`, so words with no hedges in them bought the penalty back. One forward-looking phrase held fixed, clean prose added around it, measured on main at `07ecb0a`:

| Words in *What I Did* / *Key Results* | `commitment` |
| ---: | ---: |
| 149 | 0.8000 |
| 677 | 0.9409 |
| 2,789 | **0.9857** |

+0.1857 on the criterion is **+0.0253** on a Stage 01 weighted total, against a `DEFAULT_MIN_GAIN` of **0.02**. So `EvolutionController.consider` records a round that added nothing but words as `promoted`, *"New champion"*. The prohibition was written into the prompt and the gradient paid for breaking it.

And it contaminates the only outcome variable there is: `stage_fitness` is what the archive ranks, what `src/trials.py` takes within-pair differences of, and what `offered_payoffs` divides. A length term inside it makes every one of those a measurement of something else.

## The fix, calibrated rather than chosen

The allowance is now **sentences that carry a quantity or name a path**, over four. On the four stage summaries of the first real backend run, `work / 4` reproduces the old `words / 200` to within a factor of one:

| Stage | words/200 | work/4 |
| --- | ---: | ---: |
| 01_literature_survey | 8.05 | 9.50 |
| 02_hypothesis_generation | 16.75 | 15.50 |
| 03_study_design | 15.74 | 14.75 |
| 04_implementation | 16.52 | 30.00 |

A genuinely dense report keeps the allowance it had. Stage 04 comes out twice as generous, which is the right direction — it earned it in short lines naming files.

After:

```
lean                     0.9333   1 phrase against 12 sentences carrying a quantity or a path, in 149 words
+ 900 words of filler    0.9333   1 phrase against 12 sentences carrying a quantity or a path, in 929 words
stage-01 total moved by padding: +0.0000
```

Padding moves neither numerator nor denominator. Buying allowance now requires writing quantities that were not measured — a different move, one `quantification` and `numeric_fidelity` exist for, and one that leaves its trace in the report rather than in its length.

The criterion still does its job: a report that is mostly plan scores **0.2000**, three hedges among eighty work-bearing sentences scores **0.9750**, and the same three hedges in a thin report score lower. Density, not a flat fine.

## The version bump, and why now

`RUBRIC_VERSION` 3 → 4. Every estimator in `src/archive.py` filters on it, so a bump splits the archive into two incomparable halves. The archive holds **exactly one** `provenance: live` record today, so this costs one observation. The same bump in a month costs however many have accumulated. This is the cheapest moment it will ever have.

## Docs

`README.md` said `RUBRIC_VERSION = "2"` and `docs/framework.md` said `3`, while the code said `3`. Both now say `4`, and `tests/test_doc_counts.py` pins them to the live symbol. The version is quoted in the docs precisely because a reader needs to know which scores are comparable — the one thing a stale copy destroys. A sentence recounting the history ("it went to 3 when that cap landed") stays readable and is deliberately not matched.

## Testing

2107 pass. Three mutations kill the new tests:

| Mutation | Tests that die |
| --- | --- |
| restore `words / 200` | 5 |
| flat `1 - 0.15 × hedges` instead of a density | 3 |
| make the criterion inert at 1.0 | 3 |

One test asserts the *claim* the prompt makes rather than that the sentence is present. `tests/test_evolution.py` already checks that string renders — which is exactly how a false promise stayed green.

## Provenance

Found by a six-lens sweep with per-candidate adversarial refutation (30 candidates, 17 survived). Its numbers for this item did not reproduce — it quoted `DEFAULT_MIN_GAIN` as 0.005 where main says 0.02 — so everything above was re-measured here. The conclusion survives at 0.02; it just takes more padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)