### PR TITLE
Reach the cross-model veto from `main.py`, and refuse it behind a fake operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -950,9 +950,19 @@ code that would have to change.
   reviewer's prompt. Under `--review-panel`, no seat is shown the accumulated rules and no seat is
   asked whether an inherited obligation was met — and because neither the seat nor the chair prompt
   asks for `carry_forward`, a panel run essentially never creates an obligation either.
-- **The cross-model veto is unreachable from `main.py`.** `--cross-review` is declared and parsed
-  there, but `resolve_cross_reviewer` is called only from `rcb_agent.py`. The feature is live on the
-  benchmark path only.
+- **The cross-model veto now reaches both front ends, but no test runs it against a real model, it
+  does not survive a resume, and it never sees a human approval.** `main.py` seats it through
+  `create_cross_reviewer`, which both `ResearchManager` constructions call — and which refuses the
+  auditor outright under `--fake-operator`, as `ResearchManager.__init__` then does again for any
+  caller. That refusal is not a nicety: `--cross-review` defaults to `auto`,
+  `VERTEX_PROJECT_ENV_VARS` includes `ANTHROPIC_VERTEX_PROJECT_ID`, and
+  `tests/test_fake_pipeline_end_to_end.py` approves every stage twice, so without it the suite would
+  buy a Gemini call per approval on any developer box and let a live model veto a scripted draft. The
+  price is that the audit is only ever exercised against a stubbed verdict. The mode is also absent
+  from the keys `load_run_config` reads, so unlike `--web-search` a resumed run re-decides it from
+  whatever credentials are in the environment that day; and `_collect_review_decision` returns before
+  `_apply_cross_review` whenever no automated reviewer is seated, so under a manual gate the reviewer
+  is built and nothing consults it.
 - **The validity chain is bypassable in unattended mode, and past the skip budget it is bypassed
   deliberately.** A stage that burns its attempts against the gate is auto-skipped, up to
   `--max-auto-skips` (default 3). Past that, `_route_to_deliverable` routes to the writing stage

--- a/main.py
+++ b/main.py
@@ -922,6 +922,30 @@ def create_ideation_panel(args, *, backend_name: str, model: str, ui: TerminalUI
     )
 
 
+def create_cross_reviewer(args, *, ui: TerminalUI):
+    """Seat the cross-model veto, or None when this run must not make that call.
+
+    A fake operator is refused the auditor before `resolve_cross_reviewer` is reached,
+    not after. `--fake-operator` exists to walk the whole stage graph with no model
+    behind it, and `--cross-review` defaults to `auto`, which seats a live
+    `GeminiCrossReviewer` whenever `resolve_backend` finds a usable project — including
+    the `ANTHROPIC_VERTEX_PROJECT_ID` a Claude Code host already exports. Without this
+    branch, wiring the veto here would turn every fake run into one real Gemini call per
+    approval, and hand a live model the power to send a scripted draft back for
+    refinement. `ResearchManager` refuses the same pairing again, for callers that build
+    it directly.
+    """
+    if args.fake_operator:
+        if args.cross_review != "off":
+            ui.show_status(
+                "Cross-model review is off for this run: --fake-operator makes no backend "
+                "call, and a live auditor could veto a scripted draft.",
+                level="info",
+            )
+        return None
+    return resolve_cross_reviewer(args.cross_review, args.cross_review_model)
+
+
 def main() -> int:
     args = parse_args()
     repo_root = Path(__file__).resolve().parent
@@ -1055,6 +1079,7 @@ def main() -> int:
             archive_steer=bool(walk["archive_steer"]),
             archive=archive if walk["archive_steer"] else None,
             web_search_mode=web_search_mode,
+            cross_reviewer=create_cross_reviewer(args, ui=ui),
         )
         manager.ideation_panel = create_ideation_panel(
             args, backend_name=review_operator, model=review_model, ui=ui
@@ -1143,6 +1168,7 @@ def main() -> int:
         archive_steer=bool(walk["archive_steer"]),
         archive=archive if walk["archive_steer"] else None,
         web_search_mode=web_search_mode,
+        cross_reviewer=create_cross_reviewer(args, ui=ui),
     )
 
     manager.ideation_panel = create_ideation_panel(

--- a/src/manager.py
+++ b/src/manager.py
@@ -300,7 +300,17 @@ class ResearchManager:
         self.artifact_roots = artifact_roots or []
         # A veto-only second opinion from a different model family. Never overrides a
         # refusal, so enabling it can only make the gate stricter.
-        self.cross_reviewer = cross_reviewer
+        #
+        # Refused outright behind a fake operator, and refused here rather than only at
+        # the front ends so it holds for every caller — `main.py`, `rcb_agent.py` and a
+        # manager built directly. A fake operator emits the same scripted draft whatever
+        # it is asked, so there is nothing an auditor could find in it, while
+        # `--cross-review` defaults to `auto` and seats a live `GeminiCrossReviewer`
+        # wherever `resolve_backend` finds a project. The pairing therefore buys one real
+        # call per approval and, worse, lets a live model's veto send a scripted stage
+        # back — a non-deterministic outcome inside `test_fake_pipeline_end_to_end`, which
+        # asserts that every stage was approved on its first attempt.
+        self.cross_reviewer = None if getattr(operator, "fake_mode", False) else cross_reviewer
         # Where a stage's machine-readable output may legitimately land outside the run
         # tree. The benchmark's read-only data/ is excluded on purpose: it is always
         # populated, so counting it would make the stage-03 gate vacuous.

--- a/tests/test_cli_flags_are_read.py
+++ b/tests/test_cli_flags_are_read.py
@@ -24,19 +24,15 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 
 #: Flags this repository knowingly parses and does not act on, each with the reason.
-#: Deliberately exact rather than a prefix match: adding a third entry has to be a decision
-#: somebody wrote down, not a line that quietly grew.
+#: Deliberately exact rather than a prefix match: adding an entry has to be a decision
+#: somebody wrote down, not a line that quietly grew. Both sets are empty today —
+#: `--cross-review` and `--cross-review-model` were the last two, exempted on `main.py`
+#: because wiring them would have added a Gemini call to every approval on any machine
+#: with a project in the environment. `create_cross_reviewer` makes that a decision
+#: instead of a side effect: it refuses the auditor behind `--fake-operator`, so the
+#: flags are now read on both front ends and neither needs an exemption.
 KNOWN_UNWIRED: dict[str, set[str]] = {
-    "main.py": {
-        # `resolve_cross_reviewer` is imported here and called only from `rcb_agent.py`, so
-        # neither `ResearchManager(...)` construction in this file passes `cross_reviewer=`.
-        # The cross-model veto is therefore live on the benchmark path alone. Recorded as a
-        # limitation in README.md rather than fixed, because wiring it would add a Gemini
-        # call to every approval on any machine with a key in the environment, which is a
-        # default worth choosing deliberately rather than inheriting from a bug fix.
-        "--cross-review",
-        "--cross-review-model",
-    },
+    "main.py": set(),
     "rcb_agent.py": set(),
 }
 

--- a/tests/test_cross_review_reaches_main.py
+++ b/tests/test_cross_review_reaches_main.py
@@ -1,0 +1,313 @@
+"""The cross-model veto has to be reachable from the interactive CLI, and unreachable
+from a fake run.
+
+`--cross-review` was declared and parsed in `main.py` and read by no line in it: the only
+production caller of `resolve_cross_reviewer` was `rcb_agent.py`, so the veto was live on
+the benchmark path alone and every interactive run silently had a single-opinion approval
+gate. `tests/test_cli_flags_are_read.py` carried both flags as a written-down exemption.
+
+Wiring them is half the change. The other half is a refusal, because the two flags
+interact badly with the one path CI walks end to end. `--cross-review` defaults to `auto`,
+which seats a live `GeminiCrossReviewer` whenever `resolve_backend` finds a usable project
+— and it accepts `ANTHROPIC_VERTEX_PROJECT_ID`, which a Claude Code host already exports.
+`tests/test_fake_pipeline_end_to_end.py` runs `main.py --fake-operator --full-auto` twice,
+eight approved stages each. Wired naively, that is a real Gemini call per approval on a
+machine that was supposed to make none, and a live model holding a veto over a scripted
+draft — a random red in `test_every_stage_is_approved_and_none_is_skipped`.
+
+So the guard is tested in three places, because it has to hold in three: the front end
+must not construct the auditor, every `ResearchManager` construction in `main.py` must
+pass the argument at all, and the manager must refuse the pairing for callers that build
+it directly.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import main as autor_main
+from src.cross_reviewer import GeminiCrossReviewer
+from src.manager import ResearchManager
+from src.terminal_ui import TerminalUI
+from src.web_search import SearchBackend
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+BACKEND = SearchBackend(kind="vertex", model="gemini-x", project="p", location="global")
+
+
+class _Stop(BaseException):
+    """Abort main() at the manager construction; running the pipeline is not the point."""
+
+
+class MainSeatsTheCrossReviewerTest(unittest.TestCase):
+    """Drive the real `main()` and read the argument the manager was handed."""
+
+    def _construct(self, extra: list[str], *, backend: SearchBackend | None = BACKEND) -> dict:
+        captured: dict = {}
+
+        def record(**kwargs):
+            captured.update(kwargs)
+            raise _Stop
+
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = [
+                "main.py",
+                "--goal", "cross-review wiring",
+                "--full-auto",
+                "--web-search", "native",
+                "--runs-dir", str(Path(tmp) / "runs"),
+                "--archive", str(Path(tmp) / "archive"),
+                *extra,
+            ]
+            with patch("main.ResearchManager", side_effect=record), \
+                 patch("src.cross_reviewer.resolve_backend", return_value=backend), \
+                 patch("src.terminal_ui.TerminalUI.show_banner"), \
+                 patch("src.terminal_ui.TerminalUI.show_status"), \
+                 patch.object(sys, "argv", argv):
+                with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                    try:
+                        autor_main.main()
+                    except _Stop:
+                        pass
+
+        self.assertIn("cross_reviewer", captured, "main() built a manager without the argument")
+        return captured
+
+    def test_a_live_run_hands_the_manager_a_cross_reviewer(self) -> None:
+        captured = self._construct([])
+        self.assertIsInstance(captured["cross_reviewer"], GeminiCrossReviewer)
+
+    def test_the_model_flag_reaches_the_reviewer_it_names(self) -> None:
+        """Wiring only the mode would leave `--cross-review-model` parsed and dropped."""
+        captured = self._construct(["--cross-review-model", "gemini-not-the-default"])
+        self.assertEqual(captured["cross_reviewer"].requested_model, "gemini-not-the-default")
+
+    def test_off_means_off(self) -> None:
+        self.assertIsNone(self._construct(["--cross-review", "off"])["cross_reviewer"])
+
+    def test_auto_stays_silent_where_no_backend_is_configured(self) -> None:
+        self.assertIsNone(self._construct([], backend=None)["cross_reviewer"])
+
+    def test_gemini_seats_one_even_without_a_backend(self) -> None:
+        """`gemini` is an explicit request, so it reports `unavailable` rather than
+        vanishing: an audit that could not run must not be mistaken for one that passed."""
+        captured = self._construct(["--cross-review", "gemini"], backend=None)
+        self.assertIsInstance(captured["cross_reviewer"], GeminiCrossReviewer)
+
+
+class _Args:
+    """The three attributes `create_cross_reviewer` reads, and nothing else."""
+
+    def __init__(self, *, fake_operator: bool, cross_review: str, cross_review_model=None) -> None:
+        self.fake_operator = fake_operator
+        self.cross_review = cross_review
+        self.cross_review_model = cross_review_model
+
+
+class AFakeRunNeverConstructsAnAuditorTest(unittest.TestCase):
+    """`--fake-operator` must not reach `resolve_cross_reviewer` at all.
+
+    Not "the reviewer it builds is never called" — never built, so the credential probe
+    and every downstream call are refused before the cost is spent.
+    """
+
+    def _construct(self, extra: list[str]) -> tuple[dict, object]:
+        captured: dict = {}
+
+        def record(**kwargs):
+            captured.update(kwargs)
+            raise _Stop
+
+        with tempfile.TemporaryDirectory() as tmp:
+            argv = [
+                "main.py",
+                "--goal", "fake run",
+                "--full-auto",
+                "--fake-operator",
+                "--web-search", "native",
+                "--runs-dir", str(Path(tmp) / "runs"),
+                "--archive", str(Path(tmp) / "archive"),
+                *extra,
+            ]
+            with patch("main.ResearchManager", side_effect=record), \
+                 patch("main.resolve_cross_reviewer") as resolver, \
+                 patch("src.cross_reviewer.resolve_backend", return_value=BACKEND), \
+                 patch("src.terminal_ui.TerminalUI.show_banner"), \
+                 patch("src.terminal_ui.TerminalUI.show_status"), \
+                 patch.object(sys, "argv", argv):
+                with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                    try:
+                        autor_main.main()
+                    except _Stop:
+                        pass
+
+        self.assertIn("cross_reviewer", captured, "main() built a manager without the argument")
+        return captured, resolver
+
+    def test_the_resolver_is_never_reached_under_a_fake_operator(self) -> None:
+        captured, resolver = self._construct([])
+        resolver.assert_not_called()
+        self.assertIsNone(captured["cross_reviewer"])
+
+    def test_an_explicit_gemini_request_is_refused_too(self) -> None:
+        """The default is not what makes this safe; the fake operator is."""
+        captured, resolver = self._construct(["--cross-review", "gemini"])
+        resolver.assert_not_called()
+        self.assertIsNone(captured["cross_reviewer"])
+
+    def test_the_run_says_out_loud_that_the_audit_is_off(self) -> None:
+        """A gate that silently is not there is the failure this repo keeps finding."""
+        said: list[str] = []
+        ui = TerminalUI(output_stream=io.StringIO(), interactive=False)
+        with patch.object(TerminalUI, "show_status", lambda self, text, level="info": said.append(text)):
+            reviewer = autor_main.create_cross_reviewer(
+                _Args(fake_operator=True, cross_review="auto"), ui=ui
+            )
+        self.assertIsNone(reviewer)
+        self.assertTrue(
+            any("Cross-model review is off" in line for line in said),
+            f"nothing announced the disabled audit: {said}",
+        )
+
+    def test_it_does_not_announce_a_gate_the_user_already_turned_off(self) -> None:
+        said: list[str] = []
+        ui = TerminalUI(output_stream=io.StringIO(), interactive=False)
+        with patch.object(TerminalUI, "show_status", lambda self, text, level="info": said.append(text)):
+            autor_main.create_cross_reviewer(
+                _Args(fake_operator=True, cross_review="off"), ui=ui
+            )
+        self.assertEqual(said, [])
+
+
+class EveryManagerConstructionIsWiredTest(unittest.TestCase):
+    """`main.py` builds a manager twice — the fresh run and `--resume-run`.
+
+    Wiring one and not the other is the exact shape of divergence this repo has already
+    paid for between its two front ends, and it would be invisible: a resumed run would
+    just quietly have a single-opinion gate. Read off the syntax tree rather than a
+    regex, so a reformatted call site still counts.
+    """
+
+    def _constructions(self) -> list[ast.Call]:
+        tree = ast.parse((REPO_ROOT / "main.py").read_text(encoding="utf-8"))
+        return [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "ResearchManager"
+        ]
+
+    def test_both_of_them_pass_a_cross_reviewer(self) -> None:
+        calls = self._constructions()
+        self.assertGreaterEqual(len(calls), 2, "the scan lost sight of main.py's manager constructions")
+        for call in calls:
+            with self.subTest(line=call.lineno):
+                self.assertIn(
+                    "cross_reviewer",
+                    {kw.arg for kw in call.keywords},
+                    f"main.py line {call.lineno} builds a manager with no cross_reviewer argument",
+                )
+
+    def test_they_all_go_through_the_guarded_factory(self) -> None:
+        """Calling `resolve_cross_reviewer` directly at a call site would skip the fake
+        refusal, which lives in `create_cross_reviewer` and nowhere else in this file."""
+        for call in self._constructions():
+            keyword = next(kw for kw in call.keywords if kw.arg == "cross_reviewer")
+            with self.subTest(line=call.lineno):
+                self.assertIsInstance(keyword.value, ast.Call)
+                self.assertEqual(keyword.value.func.id, "create_cross_reviewer")
+
+
+class _FakeOperator:
+    model = "fake"
+    backend_name = "claude"
+    fake_mode = True
+
+
+class _LiveOperator:
+    model = "opus"
+    backend_name = "claude"
+
+
+class TheManagerRefusesTheAuditorBehindAFakeOperatorTest(unittest.TestCase):
+    """The backstop, held where every caller passes: `ResearchManager.__init__`.
+
+    `rcb_agent.py` builds its auditor unconditionally, and a test or a tool can build a
+    manager without going through either front end. The refusal sits beside the one that
+    zeroes evolution rounds for the same reason and on the same evidence: a fake operator
+    emits the same scripted draft whatever it is asked, so there is nothing to audit.
+    """
+
+    def _manager(self, operator, reviewer) -> ResearchManager:
+        with tempfile.TemporaryDirectory() as tmp:
+            return ResearchManager(
+                project_root=REPO_ROOT,
+                runs_dir=Path(tmp),
+                operator=operator,
+                ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+                cross_reviewer=reviewer,
+            )
+
+    def test_a_fake_operator_drops_the_auditor(self) -> None:
+        manager = self._manager(_FakeOperator(), GeminiCrossReviewer())
+        self.assertIsNone(manager.cross_reviewer)
+
+    def test_a_real_operator_keeps_it(self) -> None:
+        """Guards against the refusal being written as an unconditional drop."""
+        reviewer = GeminiCrossReviewer()
+        self.assertIs(self._manager(_LiveOperator(), reviewer).cross_reviewer, reviewer)
+
+    def test_an_operator_that_does_not_declare_fake_mode_keeps_it(self) -> None:
+        """`OperatorProtocol` does not require the attribute; absence is not fakeness."""
+
+        class _Bare:
+            model = "x"
+            backend_name = "claude"
+
+        reviewer = GeminiCrossReviewer()
+        self.assertIs(self._manager(_Bare(), reviewer).cross_reviewer, reviewer)
+
+    def test_a_live_veto_cannot_send_a_scripted_stage_back(self) -> None:
+        """The consequence, not just the attribute: this is the random red."""
+        from src.approval_agent import ReviewDecision
+        from src.cross_reviewer import CrossVerdict
+        from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+
+        reviewer = GeminiCrossReviewer()
+        reviewer.audit = lambda **kwargs: CrossVerdict(  # type: ignore[assignment]
+            agrees=False, reason="x" * 80, model="gemini-x"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = build_run_paths(Path(tmp) / "run_0001")
+            ensure_run_layout(paths)
+            write_text(paths.user_input, "goal")
+            manager = ResearchManager(
+                project_root=REPO_ROOT,
+                runs_dir=paths.run_root.parent,
+                operator=_FakeOperator(),
+                ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+                cross_reviewer=reviewer,
+            )
+            self.assertIsNone(
+                manager._apply_cross_review(
+                    paths=paths,
+                    stage=STAGES[0],
+                    attempt_no=1,
+                    decision=ReviewDecision(choice="5", decision_token="t", reason="approved"),
+                    stage_markdown="# Stage 01: Literature Survey\n",
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`--cross-review` was declared and parsed in `main.py` and called from nowhere: `resolve_cross_reviewer` had one caller, `rcb_agent.py`. The README's Limits section already admitted it — the feature was live on the benchmark path only.

## The wiring

`create_cross_reviewer` seats it, and both `ResearchManager` constructions in `main.py` call it.

## The fake-operator refusal is the load-bearing part

Not a nicety. `--cross-review` defaults to `auto`; `VERTEX_PROJECT_ENV_VARS` includes `ANTHROPIC_VERTEX_PROJECT_ID`, which a Claude Code host already exports; and `tests/test_fake_pipeline_end_to_end.py` approves every stage twice. Wiring the veto without a guard would therefore have bought **one real Gemini call per approval on any developer box**, and handed a live model the power to send a scripted draft back for refinement — a non-deterministic outcome inside a test that asserts every stage was approved on its first attempt.

Refused in two places on purpose: at the front end, and again in `ResearchManager.__init__` so it holds for a manager built directly. Verified the second guard is not inert — `ClaudeOperator(fake_mode=True).fake_mode` is `True` and the real one is `False`.

## Two residual limits, found while wiring and written down rather than papered over

- The mode is **absent from the keys `load_run_config` reads**, so unlike `--web-search` a resumed run re-decides it from whatever credentials are in the environment that day.
- `_collect_review_decision` returns before `_apply_cross_review` whenever no automated reviewer is seated, so **under a manual gate the reviewer is built and nothing consults it**.

Both are in the README bullet, which now describes what the feature does and does not reach instead of claiming it is unreachable.

The price of the fake-operator refusal is stated too: the audit is only ever exercised against a stubbed verdict.

## Testing

2122 pass. Mutations run independently of the author's report:

| Mutation | Tests that die |
| --- | --- |
| make the `ResearchManager` guard inert | 2 |
| drop the `main.py` front-end guard | 3 |
| unwire it again (the original defect) | 1 failure + 1 error |

🤖 Generated with [Claude Code](https://claude.com/claude-code)