### PR TITLE
Record whether the adversarial pass ran, and act on the answer

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -54,7 +54,11 @@ from .experiment_manifest import format_experiment_manifest_for_prompt, write_ex
 from .hypothesis_manifest import write_hypothesis_manifest
 from .information_flow import CHANNELS, ChannelContext, render_inbound
 from .prompt_fragments import compose_stage_template
-from .validity_review import ValidityReviewer, format_findings_for_prompt
+from .validity_review import (
+    ValidityReviewer,
+    ValidityReviewOutcome,
+    format_findings_for_prompt,
+)
 from .research_rounds import (
     ROUND_CLOSING_STAGE_NUMBER,
     RoundIntent,
@@ -289,6 +293,13 @@ class ResearchManager:
         # loop, not to save money, so callers with time to spend should raise it.
         self.max_stage_attempts = max_stage_attempts
         self.auto_skipped_stages: list[str] = []
+        #: Which stages the adversarial pass never actually judged, and how it ended:
+        #: stage slug -> `crashed` or `unreadable`. Kept on the harness rather than read
+        #: back out of `workspace/reviews/`, because that directory is writable by the
+        #: stage the next gate constrains — a stage that cleared its own
+        #: `reviewer_failed` would be clearing the disclosure that its result went
+        #: unattacked. A stage re-reviewed after a revisit drops out of here again.
+        self.validity_reviews_not_completed: dict[str, str] = {}
         self.web_search_context = web_search_context
         self.min_report_figures = min_report_figures
         # The *mode* is recorded in run_config so a resume reconciles it the way it does
@@ -637,6 +648,13 @@ class ResearchManager:
     def _complete_run(self, paths: RunPaths, state: "GraphState | None" = None) -> bool:
         route = format_route(state) if state is not None else ""
 
+        # Written on every way out, not only the clean one: a halted or abandoned run
+        # still publishes the stage files whose validity reviews never ran, and "no
+        # findings" means the same misleading thing in all three.
+        disclosure = self.validity_disclosure()
+        if disclosure:
+            append_log_entry(paths.logs, "validity_review_not_completed", disclosure)
+
         # A run that concluded it cannot answer its question reached the end of the
         # graph legitimately, and it did not produce what it set out to produce.
         # `completed` and `cancelled` are both wrong, and `cancelled` is the worse
@@ -714,7 +732,11 @@ class ResearchManager:
         if route and self.stage_graph.name != "linear":
             self.ui.show_status(f"Route taken: {route}", level="info")
         self._report_optional_machinery(paths)
-        self._print("All stages approved. Run complete.")
+        # The disclosure rides on this line rather than beside it, because "All stages
+        # approved" is the sentence it qualifies.
+        self._print(
+            "All stages approved. Run complete." + (f"\n{disclosure}" if disclosure else "")
+        )
         return True
 
     def _graph_entry_stage(self, paths: RunPaths, start_stage: StageSpec | None) -> StageSpec | None:
@@ -3667,6 +3689,14 @@ class ResearchManager:
         stage did its work, and an agent asked to do both jobs at once reliably
         does the easier one. This has no authority to approve or reject — the
         next stage simply has to answer what it raises.
+
+        It is also where a pass that did not complete is caught, and the choice of
+        *here* is the point. The alternative site is ``validate_validity_response``,
+        which feeds Stage 06's retry loop — and a Stage 06 agent cannot re-run Stage
+        05's reviewer, so a backend hiccup refused there would spend the stage's whole
+        attempt budget on a repair it has no way to make, then auto-skip. Vertex 429s
+        are ordinary. This method holds the operator, so it is the one party in the run
+        that can simply ask again.
         """
         from .validity_review import REVIEWED_STAGE_NUMBERS
 
@@ -3675,20 +3705,46 @@ class ResearchManager:
         self.ui.show_status(
             f"Adversarial validity review of {stage.stage_title}...", level="info"
         )
-        try:
-            findings = ValidityReviewer(self.operator, ui=self.ui).review(
-                paths=paths, stage=stage, stage_markdown=stage_markdown
+        reviewer = ValidityReviewer(self.operator, ui=self.ui)
+        outcome = self._attempt_validity_review(paths, stage, stage_markdown, reviewer, attempt_no=1)
+        if outcome.degraded:
+            # Exactly once. A second failure is evidence about the backend, not about
+            # this prompt, and a third call would buy the same empty list at the same
+            # price. What the re-ask does buy back is the routine case: a single 429 or
+            # a truncated stream, where the stage really is one call from being judged.
+            self.ui.show_status(
+                f"The adversarial pass did not complete ({outcome.completion}); asking once "
+                "more before the run records this stage as unattacked.",
+                level="warn",
             )
-        except Exception as exc:  # noqa: BLE001 - a failed critique must not lose the stage
+            outcome = self._attempt_validity_review(
+                paths, stage, stage_markdown, reviewer, attempt_no=2
+            )
+
+        if outcome.degraded:
+            # A revisit can bring the stage back through here, so this is a set-and-clear
+            # record rather than an append-only one: the disclosure has to describe the
+            # last pass, not every pass.
+            self.validity_reviews_not_completed[stage.slug] = outcome.completion
             append_log_entry(
                 paths.logs,
-                f"{stage.slug} validity_review_failed",
-                f"The adversarial validity review did not run: {exc}",
+                f"{stage.slug} validity_review_not_completed",
+                (
+                    f"The adversarial pass did not complete on either attempt "
+                    f"({outcome.completion}), so this stage was never attacked. Its empty "
+                    "finding list is AutoR's, not a reviewer's, and the run discloses it "
+                    "rather than reading it as a clean result."
+                ),
             )
             self.ui.show_status(
-                "Validity review did not run; the stage stands unchallenged.", level="warn"
+                f"Validity review did not complete ({outcome.completion}) on either attempt "
+                f"for {stage.stage_title}; the stage stands unchallenged and the run says so.",
+                level="warn",
             )
             return
+
+        self.validity_reviews_not_completed.pop(stage.slug, None)
+        findings = outcome.findings
         append_log_entry(
             paths.logs,
             f"{stage.slug} validity_review",
@@ -3707,6 +3763,58 @@ class ResearchManager:
                 "The next stage must answer each one.",
                 level="warn",
             )
+
+    def _attempt_validity_review(
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        stage_markdown: str,
+        reviewer: ValidityReviewer,
+        *,
+        attempt_no: int,
+    ) -> ValidityReviewOutcome:
+        """One pass, with a raised exception reported as a completion rather than as nothing.
+
+        The ``except`` used to return, which left the caller with no outcome at all and
+        the run with no record — the same shape as the bug this method now catches, one
+        level up.
+        """
+        from .validity_review import CRASHED
+
+        try:
+            return reviewer.review(
+                paths=paths,
+                stage=stage,
+                stage_markdown=stage_markdown,
+                attempt_no=attempt_no,
+            )
+        except Exception as exc:  # noqa: BLE001 - a failed critique must not lose the stage
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} validity_review_failed",
+                f"The adversarial validity review did not run (attempt {attempt_no}): {exc}",
+            )
+            return ValidityReviewOutcome(CRASHED, [])
+
+    def validity_disclosure(self) -> str:
+        """The run's banner line when a stage was approved but never attacked.
+
+        Without it the run's closing output says "All stages approved", every artifact
+        under `workspace/reviews/` says zero findings, and both are true. Together they
+        read as "nothing was found wrong", which is a claim the run cannot make about a
+        stage no reviewer reached. Empty when every pass completed, so a healthy run
+        prints nothing extra.
+        """
+        if not self.validity_reviews_not_completed:
+            return ""
+        named = ", ".join(
+            f"{slug} ({completion})"
+            for slug, completion in sorted(self.validity_reviews_not_completed.items())
+        )
+        return (
+            f"Adversarial validity review did not complete for {named}. Those stages carry no "
+            "findings because none were produced, not because none were found."
+        )
 
     def _freeze_preregistration(self, paths: RunPaths) -> None:
         """Fix the hypothesis set before any result exists.

--- a/src/validity_review.py
+++ b/src/validity_review.py
@@ -65,6 +65,38 @@ SEVERITIES = ("critical", "major", "minor")
 #: particular there is no "noted".
 RESPONSE_STATUSES = ("addressed", "rebutted", "accepted_limitation")
 
+#: How the adversarial pass ended, in the approval gate's vocabulary rather than a
+#: second one of this module's own.
+#:
+#: :mod:`src.approval_agent` already separates "the backend never ran"
+#: (``CRASHED_REASON``) from "it answered and the answer could not be read"
+#: (``UNREADABLE_REASON``), and exposes a single predicate,
+#: ``AutomatedReviewer.is_degraded_verdict``, for everything downstream. Both events
+#: happen to this pass too, so it reuses the split. The third member of that
+#: vocabulary, ``UNSUPPORTED_REASON``, has no counterpart here: it names a decision
+#: token outside the gate's vocabulary, and this reviewer casts no vote — an
+#: unrecognised ``category`` is coerced to ``overclaim`` rather than voiding the
+#: finding, because losing a real objection to a taxonomy mismatch is the worse error.
+COMPLETED = "completed"
+CRASHED = "crashed"
+UNREADABLE = "unreadable"
+
+#: The completions under which the stage was not attacked at all. ``reviewer_failed``
+#: in the written artifact is derived from this, so the field docs/run-artifacts.md
+#: documents keeps answering exactly the question it answered before.
+DEGRADED_COMPLETIONS = (CRASHED, UNREADABLE)
+
+
+def is_degraded_completion(completion: str) -> bool:
+    """Whether the empty finding list is AutoR's, rather than the reviewer's.
+
+    The counterpart of ``AutomatedReviewer.is_degraded_verdict``, asking the same
+    question of a pass that produces no verdict: did a reviewer look and find nothing,
+    or did no reviewer look. Those are the same value — ``[]`` — everywhere downstream,
+    and only this tells them apart.
+    """
+    return completion in DEGRADED_COMPLETIONS
+
 
 def _now() -> str:
     return datetime.now().isoformat(timespec="seconds")
@@ -112,6 +144,25 @@ class ValidityFinding:
             "why_it_matters": self.why_it_matters,
             "what_would_settle_it": self.what_would_settle_it,
         }
+
+
+@dataclass(frozen=True)
+class ValidityReviewOutcome:
+    """What the pass produced, and whether it ran at all.
+
+    :meth:`ValidityReviewer.review` used to return the findings alone. That makes "a
+    reviewer attacked the stage and found nothing" and "no reviewer ever returned" the
+    same value, and the value is ``[]`` — which every reader downstream, the next
+    stage's gate included, takes as nothing owed. The completion is carried beside the
+    findings so a caller cannot read one without being handed the other.
+    """
+
+    completion: str
+    findings: list[ValidityFinding]
+
+    @property
+    def degraded(self) -> bool:
+        return is_degraded_completion(self.completion)
 
 
 def load_findings(paths: RunPaths, stage_slug: str) -> list[ValidityFinding]:
@@ -317,9 +368,26 @@ class ValidityReviewer:
     def fake_mode(self) -> bool:
         return bool(getattr(self._operator, "fake_mode", False))
 
-    def review(self, *, paths: RunPaths, stage: StageSpec, stage_markdown: str) -> list[ValidityFinding]:
+    def review(
+        self,
+        *,
+        paths: RunPaths,
+        stage: StageSpec,
+        stage_markdown: str,
+        attempt_no: int = 1,
+    ) -> ValidityReviewOutcome:
+        """Attack the stage once, and say how the attempt ended.
+
+        ``attempt_no`` only reaches the operator's own logging, so a re-ask is
+        distinguishable in ``logs/raw`` from the call that provoked it. Deciding
+        *whether* to re-ask is the manager's: it owns the operator and the budget, and
+        this returns the fact it needs rather than acting on it.
+        """
         if stage.number not in REVIEWED_STAGE_NUMBERS:
-            return []
+            # Nothing to complete: before 05 there is no result to be wrong about. The
+            # empty list here is an absence of subject matter, not an absent judgement,
+            # so it must not read as degraded.
+            return ValidityReviewOutcome(COMPLETED, [])
 
         # If a panel already deliberated over this stage, its surviving concerns
         # are the findings. Running a second critic would ask the Methodologist's
@@ -329,7 +397,7 @@ class ValidityReviewer:
             self._write_review(
                 paths, stage, from_panel, note="carried from the review panel's final round"
             )
-            return from_panel
+            return ValidityReviewOutcome(COMPLETED, from_panel)
 
         if self.fake_mode:
             findings = [
@@ -346,7 +414,7 @@ class ValidityReviewer:
                 )
             ]
             self._write_review(paths, stage, findings, note="fake-operator mode")
-            return findings
+            return ValidityReviewOutcome(COMPLETED, findings)
 
         prompt_path = paths.prompt_cache_dir / f"{stage.slug}_validity_review.prompt.md"
         write_text(prompt_path, self._build_prompt(paths=paths, stage=stage, stage_markdown=stage_markdown))
@@ -364,6 +432,7 @@ class ValidityReviewer:
                     "command": command,
                     "prompt_path": str(prompt_path),
                     "session_id": session_id,
+                    "attempt_no": attempt_no,
                 }
             },
         )
@@ -371,7 +440,7 @@ class ValidityReviewer:
             command=command,
             cwd=invocation_cwd,
             stage=stage,
-            attempt_no=1,
+            attempt_no=attempt_no,
             paths=paths,
             mode="validity_review",
             stdin_text=stdin_text,
@@ -384,13 +453,32 @@ class ValidityReviewer:
                 stage,
                 [],
                 note=f"the validity reviewer failed with exit code {exit_code} and raised nothing",
-                failed=True,
+                completion=CRASHED,
             )
-            return []
+            return ValidityReviewOutcome(CRASHED, [])
 
-        findings = self._parse(stdout_text)
+        payload = self._extract_json(stdout_text)
+        if payload is None:
+            # Not "it returned nothing": there is no findings object at all. Emptiness
+            # cannot be the test, because `{"findings": []}` is a clean review and the
+            # prompt above says in as many words that raising nothing is legitimate.
+            # The absence of the object the prompt asked for can be, and it is the same
+            # event the approval gate calls unreadable.
+            self._write_review(
+                paths,
+                stage,
+                [],
+                note=(
+                    f"the validity reviewer returned {len(stdout_text)} characters carrying no "
+                    "findings object, so this stage has no judgement rather than a clean one"
+                ),
+                completion=UNREADABLE,
+            )
+            return ValidityReviewOutcome(UNREADABLE, [])
+
+        findings = self._findings_from(payload)
         self._write_review(paths, stage, findings)
-        return findings
+        return ValidityReviewOutcome(COMPLETED, findings)
 
     def _write_review(
         self,
@@ -399,12 +487,17 @@ class ValidityReviewer:
         findings: list[ValidityFinding],
         *,
         note: str = "",
-        failed: bool = False,
+        completion: str = COMPLETED,
     ) -> None:
         payload = {
             "generated_at": _now(),
             "reviewed_stage": stage.slug,
-            "reviewer_failed": failed,
+            # Derived rather than stored beside the completion, and deliberately the
+            # only shape of it that reaches disk. The authoritative record is the
+            # manager's, because `workspace/reviews/` is writable by the very stage the
+            # next gate constrains; what is written here is the artifact field
+            # docs/run-artifacts.md already documents, unchanged.
+            "reviewer_failed": is_degraded_completion(completion),
             "note": note,
             "findings": [item.to_dict() for item in findings],
         }
@@ -417,6 +510,15 @@ class ValidityReviewer:
         payload = self._extract_json(raw)
         if not isinstance(payload, dict):
             return []
+        return self._findings_from(payload)
+
+    def _findings_from(self, payload: dict) -> list[ValidityFinding]:
+        """The findings in an object that has already been recovered from a transcript.
+
+        Split from :meth:`_parse` because :meth:`review` has to know *which* of the two
+        empty results it got — no object, or an object with an empty list — and a
+        function that swallows the distinction cannot tell it.
+        """
         findings: list[ValidityFinding] = []
         for index, entry in enumerate(payload.get("findings", []), start=1):
             if not isinstance(entry, dict):

--- a/tests/test_validity_completion.py
+++ b/tests/test_validity_completion.py
@@ -224,6 +224,38 @@ class ManagerReAsksOnceTest(CompletionTestCase):
         self.assertIn("validity_review_failed", read_text(self.paths.logs))
 
 
+class TheDisclosureReachesTheEndOfTheRunTest(CompletionTestCase):
+    """The record has to reach a reader, which is the defect this module exists to fix.
+
+    Everything above asserts the *state*: `validity_reviews_not_completed` is populated
+    and `validity_disclosure()` renders. None of it asserts the state is delivered.
+    Measured before this class existed: replacing the call at the end of
+    `_complete_run` with `disclosure = None` left the entire suite — 2,146 tests —
+    green. A record with no reader is the exact shape of the `reviewer_failed` flag
+    this branch is removing, reintroduced one layer up.
+    """
+
+    def test_the_run_banner_names_a_stage_that_was_never_attacked(self) -> None:
+        manager = self.manager(ScriptedOperator((1, "")))
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+        self.assertEqual(manager.validity_reviews_not_completed, {STAGE_05.slug: CRASHED})
+
+        manager._complete_run(self.paths)  # noqa: SLF001
+
+        log = read_text(self.paths.logs)
+        self.assertIn("validity_review_not_completed", log)
+        self.assertIn(STAGE_05.slug, log.split("validity_review_not_completed", 1)[1][:400])
+
+    def test_a_healthy_run_closes_without_the_banner(self) -> None:
+        """Empty when every pass completed, or the line stops meaning anything."""
+        manager = self.manager(ScriptedOperator((0, CLEAN_REVIEW)))
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        manager._complete_run(self.paths)  # noqa: SLF001
+
+        self.assertNotIn("validity_review_not_completed", read_text(self.paths.logs))
+
+
 class ManagerRecordsCompletionTest(CompletionTestCase):
     def test_two_failures_are_recorded_against_the_stage(self) -> None:
         manager = self.manager(ScriptedOperator((1, "")))

--- a/tests/test_validity_completion.py
+++ b/tests/test_validity_completion.py
@@ -1,0 +1,325 @@
+"""Did the adversarial pass run, and does anything act on the answer.
+
+`_write_review(..., failed=True)` recorded `reviewer_failed: true` and no production
+code read it, so a reviewer that never returned and a reviewer that attacked the stage
+and found nothing were the same input to every reader downstream: an empty finding list,
+nothing owed, gate open. These tests pin the three things that had to change together —
+the pass reports how it ended, the manager re-asks once when it did not complete, and a
+run that never got a judgement says so instead of printing "All stages approved".
+
+The completion is deliberately *not* read back out of `workspace/reviews/`. That
+directory is writable by the stage the next gate constrains, so the last test here
+tampers with the artifact and checks the harness ignores it.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.manager import ResearchManager
+from src.terminal_ui import TerminalUI
+from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
+from src.validity_review import (
+    COMPLETED,
+    CRASHED,
+    DEGRADED_COMPLETIONS,
+    UNREADABLE,
+    ValidityReviewer,
+    is_degraded_completion,
+    validate_validity_response,
+    validity_review_path,
+)
+
+
+STAGE_05 = next(stage for stage in STAGES if stage.number == 5)
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+
+CLEAN_REVIEW = '{"findings": []}'
+ONE_FINDING = json.dumps(
+    {
+        "findings": [
+            {
+                "id": "V1",
+                "category": "confound",
+                "severity": "critical",
+                "finding": "Both arms were tuned on the split that reports the headline number.",
+                "why_it_matters": "The gap may be selection.",
+                "what_would_settle_it": "Re-tune on a development split.",
+            }
+        ]
+    }
+)
+
+
+class ScriptedOperator:
+    """An operator that returns a scripted (exit code, stdout) per call.
+
+    Enough of the private surface `ValidityReviewer` reaches into, and no more: the
+    reviewer calls `_prepare_invocation` and `_run_streaming_command` directly, the way
+    the approval gate does.
+    """
+
+    model = "stub-model"
+    backend_name = "claude"
+    fake_mode = False
+
+    def __init__(self, *turns: tuple[int, str]) -> None:
+        self._turns = list(turns)
+        #: (attempt_no, mode) per call, so a test can count re-asks rather than infer them.
+        self.calls: list[tuple[int, str]] = []
+
+    def _prepare_invocation(self, prompt_path, session_id, *, paths, resume):
+        return (["stub", str(prompt_path)], str(paths.run_root), "")
+
+    def _run_streaming_command(
+        self, *, command, cwd, stage, attempt_no, paths, mode, stdin_text
+    ):
+        self.calls.append((attempt_no, mode))
+        exit_code, stdout = self._turns[min(len(self.calls) - 1, len(self._turns) - 1)]
+        return exit_code, stdout, "", [], {}
+
+
+class ExplodingOperator(ScriptedOperator):
+    def _run_streaming_command(self, **kwargs):
+        self.calls.append((kwargs["attempt_no"], kwargs["mode"]))
+        raise RuntimeError("vertex 429")
+
+
+class CompletionTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.paths = build_run_paths(self.root / "runs" / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.memory, "# Memory\n\n## Approved Stage Summaries\n\n_None yet._\n")
+
+    def review(self, *turns: tuple[int, str]):
+        operator = ScriptedOperator(*turns)
+        outcome = ValidityReviewer(operator).review(
+            paths=self.paths, stage=STAGE_05, stage_markdown="# Stage 05"
+        )
+        return operator, outcome
+
+    def written(self) -> dict:
+        return json.loads(validity_review_path(self.paths, STAGE_05.slug).read_text(encoding="utf-8"))
+
+    def manager(self, operator) -> ResearchManager:
+        return ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=self.root / "runs",
+            operator=operator,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+
+
+class CompletionVocabularyTest(CompletionTestCase):
+    """Three values, borrowed from the approval gate, not a new five-value enum."""
+
+    def test_there_are_exactly_two_ways_to_not_complete(self) -> None:
+        self.assertEqual(DEGRADED_COMPLETIONS, (CRASHED, UNREADABLE))
+
+    def test_completed_is_not_degraded(self) -> None:
+        self.assertFalse(is_degraded_completion(COMPLETED))
+        self.assertTrue(all(is_degraded_completion(value) for value in DEGRADED_COMPLETIONS))
+
+    def test_the_whole_vocabulary_is_three_values(self) -> None:
+        self.assertEqual(len({COMPLETED, *DEGRADED_COMPLETIONS}), 3)
+
+
+class CompletionIsReportedTest(CompletionTestCase):
+    def test_a_nonzero_exit_is_crashed(self) -> None:
+        _operator, outcome = self.review((1, ""))
+        self.assertEqual(outcome.completion, CRASHED)
+        self.assertTrue(outcome.degraded)
+
+    def test_an_answer_with_no_findings_object_is_unreadable(self) -> None:
+        """The reviewer talked, at length, and never produced the object it was asked for."""
+        _operator, outcome = self.review((0, "I read the protocol and it all looks reasonable."))
+        self.assertEqual(outcome.completion, UNREADABLE)
+        self.assertTrue(outcome.degraded)
+
+    def test_a_transcript_carrying_some_other_json_is_still_unreadable(self) -> None:
+        """`extract_json_payload` is keyed on `findings`, so a quoted data file is not a review."""
+        _operator, outcome = self.review((0, 'I read `{"accuracy": 0.91, "seeds": 3}` and stopped.'))
+        self.assertEqual(outcome.completion, UNREADABLE)
+
+    def test_zero_findings_is_a_clean_review_not_a_broken_one(self) -> None:
+        """The prompt says raising nothing is legitimate, so emptiness cannot be the test."""
+        _operator, outcome = self.review((0, CLEAN_REVIEW))
+        self.assertEqual(outcome.completion, COMPLETED)
+        self.assertFalse(outcome.degraded)
+        self.assertEqual(outcome.findings, [])
+
+    def test_a_real_finding_is_a_clean_review(self) -> None:
+        _operator, outcome = self.review((0, ONE_FINDING))
+        self.assertEqual(outcome.completion, COMPLETED)
+        self.assertEqual([item.identifier for item in outcome.findings], ["V1"])
+
+    def test_reviewer_failed_is_still_written_and_still_derived(self) -> None:
+        """docs/run-artifacts.md documents this field; it keeps meaning what it said."""
+        self.review((1, ""))
+        self.assertTrue(self.written()["reviewer_failed"])
+        self.review((0, CLEAN_REVIEW))
+        self.assertFalse(self.written()["reviewer_failed"])
+
+    def test_an_unreadable_pass_says_so_in_the_note_rather_than_claiming_nothing_wrong(self) -> None:
+        self.review((0, "narration, no object"))
+        note = self.written()["note"]
+        self.assertIn("no findings object", note)
+        self.assertEqual(self.written()["findings"], [])
+
+
+class ManagerReAsksOnceTest(CompletionTestCase):
+    def test_a_crashed_pass_is_re_asked(self) -> None:
+        operator = ScriptedOperator((1, ""), (0, ONE_FINDING))
+        manager = self.manager(operator)
+
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        self.assertEqual([attempt for attempt, _mode in operator.calls], [1, 2])
+        self.assertEqual(manager.validity_reviews_not_completed, {})
+        self.assertEqual(manager.validity_disclosure(), "")
+
+    def test_a_clean_pass_is_not_re_asked(self) -> None:
+        operator = ScriptedOperator((0, CLEAN_REVIEW))
+        manager = self.manager(operator)
+
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        self.assertEqual(len(operator.calls), 1)
+        self.assertEqual(manager.validity_reviews_not_completed, {})
+
+    def test_the_re_ask_happens_exactly_once(self) -> None:
+        """A second failure is evidence about the backend, not about this prompt."""
+        operator = ScriptedOperator((1, ""))
+        manager = self.manager(operator)
+
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        self.assertEqual(len(operator.calls), 2)
+
+    def test_an_unreadable_pass_is_re_asked_too(self) -> None:
+        operator = ScriptedOperator((0, "no object here"), (0, ONE_FINDING))
+        manager = self.manager(operator)
+
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        self.assertEqual(len(operator.calls), 2)
+        self.assertEqual(manager.validity_reviews_not_completed, {})
+
+    def test_a_raised_exception_is_a_completion_rather_than_a_silent_return(self) -> None:
+        """The `except` used to return, leaving the caller no outcome and the run no record."""
+        operator = ExplodingOperator((0, ONE_FINDING))
+        manager = self.manager(operator)
+
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        self.assertEqual(manager.validity_reviews_not_completed, {STAGE_05.slug: CRASHED})
+        self.assertIn("validity_review_failed", read_text(self.paths.logs))
+
+
+class ManagerRecordsCompletionTest(CompletionTestCase):
+    def test_two_failures_are_recorded_against_the_stage(self) -> None:
+        manager = self.manager(ScriptedOperator((1, "")))
+
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        self.assertEqual(manager.validity_reviews_not_completed, {STAGE_05.slug: CRASHED})
+        self.assertIn("validity_review_not_completed", read_text(self.paths.logs))
+
+    def test_the_two_failure_modes_are_told_apart_in_the_record(self) -> None:
+        manager = self.manager(ScriptedOperator((0, "narration only")))
+
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        self.assertEqual(manager.validity_reviews_not_completed, {STAGE_05.slug: UNREADABLE})
+
+    def test_a_later_clean_pass_clears_the_record(self) -> None:
+        """Thirteen backward edges: a revisited stage can be attacked on the second visit."""
+        manager = self.manager(ScriptedOperator((1, "")))
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+        self.assertTrue(manager.validity_reviews_not_completed)
+
+        manager.operator = ScriptedOperator((0, ONE_FINDING))
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        self.assertEqual(manager.validity_reviews_not_completed, {})
+        self.assertEqual(manager.validity_disclosure(), "")
+
+    def test_the_record_is_the_harness_not_the_artifact(self) -> None:
+        """`workspace/reviews/` is writable by the stage the next gate constrains."""
+        manager = self.manager(ScriptedOperator((1, "")))
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        tampered = self.written()
+        tampered["reviewer_failed"] = False
+        tampered["note"] = ""
+        write_text(validity_review_path(self.paths, STAGE_05.slug), json.dumps(tampered))
+
+        self.assertEqual(manager.validity_reviews_not_completed, {STAGE_05.slug: CRASHED})
+        self.assertIn(STAGE_05.slug, manager.validity_disclosure())
+
+
+class DisclosureBannerTest(CompletionTestCase):
+    def test_a_healthy_run_adds_nothing(self) -> None:
+        manager = self.manager(ScriptedOperator((0, CLEAN_REVIEW)))
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+        self.assertEqual(manager.validity_disclosure(), "")
+
+    def test_the_banner_names_the_stage_and_how_the_pass_ended(self) -> None:
+        manager = self.manager(ScriptedOperator((0, "narration only")))
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        banner = manager.validity_disclosure()
+        self.assertIn(STAGE_05.slug, banner)
+        self.assertIn(UNREADABLE, banner)
+        self.assertIn("not because none were found", banner)
+
+    def test_a_completed_run_prints_the_banner_beside_all_stages_approved(self) -> None:
+        """Both sentences are true separately; alone the first one reads as a clean bill."""
+        stream = io.StringIO()
+        manager = self.manager(ScriptedOperator((1, "")))
+        manager.ui = TerminalUI(output_stream=stream, interactive=False)
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        manager._complete_run(self.paths)  # noqa: SLF001
+
+        printed = stream.getvalue()
+        self.assertIn("All stages approved", printed)
+        self.assertIn("did not complete", printed)
+        self.assertIn("validity_review_not_completed", read_text(self.paths.logs))
+
+    def test_a_completed_run_with_every_pass_intact_prints_only_the_usual_line(self) -> None:
+        stream = io.StringIO()
+        manager = self.manager(ScriptedOperator((0, CLEAN_REVIEW)))
+        manager.ui = TerminalUI(output_stream=stream, interactive=False)
+        manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+
+        manager._complete_run(self.paths)  # noqa: SLF001
+
+        self.assertIn("All stages approved", stream.getvalue())
+        self.assertNotIn("did not complete", stream.getvalue())
+
+
+class TheGateIsNotWhereThisLivesTest(CompletionTestCase):
+    def test_stage_06_is_not_blocked_by_a_crashed_stage_05_review(self) -> None:
+        """Deliberate. The validator feeds Stage 06's retry loop, and a Stage 06 agent
+        cannot re-run Stage 05's reviewer — refusing there would spend the attempt
+        budget on a repair the stage has no way to make, then auto-skip. The manager
+        holds the operator, so the re-ask is the manager's and the gate stays open.
+        """
+        self.manager(ScriptedOperator((1, "")))._run_validity_review(  # noqa: SLF001
+            self.paths, STAGE_05, "# Stage 05"
+        )
+        self.assertTrue(self.written()["reviewer_failed"])
+        self.assertEqual(validate_validity_response(self.paths, STAGE_06), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validity_review.py
+++ b/tests/test_validity_review.py
@@ -15,6 +15,7 @@ import unittest
 from pathlib import Path
 
 from src.validity_review import (
+    CRASHED,
     REVIEWED_STAGE_NUMBERS,
     RESPONSE_STATUSES,
     ValidityFinding,
@@ -196,16 +197,20 @@ class ReviewerTest(ValidityTestCase):
     def test_the_fake_reviewer_writes_a_real_finding(self) -> None:
         """Fake mode has to exercise the loop, or the loop is untested end to end."""
         reviewer = ValidityReviewer(_FakeOperator())
-        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="# Stage 05")
+        outcome = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="# Stage 05")
 
-        self.assertEqual(len(findings), 1)
+        self.assertEqual(len(outcome.findings), 1)
+        self.assertFalse(outcome.degraded)
         self.assertTrue(validity_review_path(self.paths, STAGE_05.slug).exists())
         self.assertEqual(load_findings(self.paths, STAGE_05.slug)[0].severity, "critical")
 
     def test_stages_with_no_result_to_attack_are_skipped(self) -> None:
         reviewer = ValidityReviewer(_FakeOperator())
         stage_03 = next(stage for stage in STAGES if stage.number == 3)
-        self.assertEqual(reviewer.review(paths=self.paths, stage=stage_03, stage_markdown="x"), [])
+        outcome = reviewer.review(paths=self.paths, stage=stage_03, stage_markdown="x")
+        self.assertEqual(outcome.findings, [])
+        # No result to attack is an absent subject, not an absent judgement.
+        self.assertFalse(outcome.degraded)
         self.assertFalse(validity_review_path(self.paths, stage_03.slug).exists())
 
     def test_a_malformed_finding_is_dropped_rather_than_half_parsed(self) -> None:
@@ -279,7 +284,7 @@ class ReviewerFailureTest(ValidityTestCase):
         """An empty findings list from a crashed critique reads as "nothing wrong"."""
         reviewer = ValidityReviewer(_FakeOperator())
         reviewer._write_review(  # noqa: SLF001
-            self.paths, STAGE_05, [], note="exit code 1", failed=True
+            self.paths, STAGE_05, [], note="exit code 1", completion=CRASHED
         )
         payload = json.loads(validity_review_path(self.paths, STAGE_05.slug).read_text(encoding="utf-8"))
         self.assertTrue(payload["reviewer_failed"])
@@ -321,7 +326,9 @@ class PanelBridgeTest(ValidityTestCase):
         self._panel_file([self._verdict("Both arms were tuned on the reporting split.", blocking=True)])
         reviewer = ValidityReviewer(_FakeOperator())
 
-        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="# Stage 05")
+        findings = reviewer.review(
+            paths=self.paths, stage=STAGE_05, stage_markdown="# Stage 05"
+        ).findings
 
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0].severity, "critical")
@@ -330,7 +337,7 @@ class PanelBridgeTest(ValidityTestCase):
     def test_a_nonblocking_concern_is_major_rather_than_critical(self) -> None:
         self._panel_file([self._verdict("Only three seeds were run.")])
         reviewer = ValidityReviewer(_FakeOperator())
-        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x")
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x").findings
         self.assertEqual(findings[0].severity, "major")
 
     def test_only_the_final_round_counts(self) -> None:
@@ -340,20 +347,20 @@ class PanelBridgeTest(ValidityTestCase):
             [self._verdict("Still standing.")],
         )
         reviewer = ValidityReviewer(_FakeOperator())
-        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x")
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x").findings
         self.assertEqual([item.finding for item in findings], ["Still standing."])
 
     def test_a_failed_panel_member_contributes_nothing(self) -> None:
         self._panel_file([self._verdict("Never actually produced.", failed=True)])
         reviewer = ValidityReviewer(_FakeOperator())
-        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x")
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x").findings
         # Falls through to the standalone critic rather than reporting a clean panel.
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0].category, "insufficient_replication")
 
     def test_with_no_panel_the_standalone_critic_runs(self) -> None:
         reviewer = ValidityReviewer(_FakeOperator())
-        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x")
+        findings = reviewer.review(paths=self.paths, stage=STAGE_05, stage_markdown="x").findings
         self.assertEqual(findings[0].category, "insufficient_replication")
 
     def test_panel_findings_are_owed_the_same_answer(self) -> None:


### PR DESCRIPTION
`_write_review(..., failed=True)` recorded `reviewer_failed: true` and **no production code read it**. Zero findings and a reviewer that never returned were the same input to `validate_validity_response`: nothing owed, gate open. A stage could be approved having never been attacked, and every artifact under `workspace/reviews/` would honestly say zero findings.

## Three decisions, each of which the obvious implementation gets wrong

**No new enum.** Aligned with the three-way split `src/approval_agent.py` already ships — `COMPLETED` / `CRASHED` / `UNREADABLE`. Two other reviewers in this tree had already made this call; this is consistency, not a new mechanism.

**Emptiness is not the unreadable test.** `{"findings": []}` is a *legitimate clean review* — the prompt says in as many words that raising nothing is a valid outcome. The test is `extract_json_payload(raw, verdict_key="findings") is None`: the absence of the object the prompt asked for, which is the same event the approval gate already calls unreadable. Verified: `{"findings": []}` → `{'findings': []}`, prose → `None`, empty → `None`.

**Enforced in the manager, not in `validate_validity_response`.** The validator feeds Stage 06's retry loop, and a Stage 06 agent cannot re-run Stage 05's adversarial pass. Enforcing there would convert a backend hiccup into a burned attempt budget and an auto-skip. Vertex 429s are routine on this box, so that is not a theoretical risk. `_run_validity_review` holds the operator and re-asks **once** — exactly once, because a second failure is evidence about the backend rather than about the prompt.

`src/utils.py` is untouched, which is the check that the enforcement point did not drift.

**The completion record is held by the harness.** The operator runs with `bypassPermissions` at `cwd=run_root`, and `workspace/reviews/` is writable by the party the gate constrains — an agent that cannot answer a review could write `"outcome": "completed"` more cheaply than it could write a waiver. The record lives in manager runtime and is disclosed in the run's own closing log. `reviewer_failed` is still derived from it, so `docs/run-artifacts.md` stays true.

## Review of this branch found the same defect one layer up

Every test asserted the *state*. None asserted it was **delivered**. Replacing the call at the end of `_complete_run` with `disclosure = None` left the entire suite green at 2,146 tests — a record written, correct, and read by nothing, which is the exact shape of the `reviewer_failed` flag being removed. Two tests added: a crashed pass must name its stage in the closing log, and a clean run must close without the line at all, because a banner that always fires carries no information.

## Testing

2148 pass. Mutations, run independently of the author's report:

| Mutation | Tests that die |
| --- | --- |
| emptiness as the unreadable test (the trap above) | 5 |
| a crashed reviewer recorded as completed | 7 |
| `disclosure = None` at the end of the run | 1 *(0 before the added tests)* |
| disclose on a clean run too | 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)