### PR TITLE
Key the circularity refusal on (capability, outcome), so an honest trial of the ratchet is possible

### DIFF
--- a/src/rcb_trial.py
+++ b/src/rcb_trial.py
@@ -10,8 +10,20 @@ wants; the claim is that the external benchmark score moves.
 This module is a **producer**, not a second statistics module. :class:`src.trials.Pair`
 is the only reader of those two dicts anywhere in the tree, and nothing above it names
 a stage slug or a rubric key. So swapping the outcome measure is swapping what fills
-them, and every one of the refusals in :mod:`src.trials` keeps working on the new
-numbers without being touched.
+them, and the refusals in :mod:`src.trials` — the composition gate, the decomposition,
+the p-value floor — keep working on the new numbers without being touched.
+
+One of them did have to be told, and the exception is the point rather than a caveat.
+The circularity refusal is a statement about a mechanism *and* a measure: the champion
+ratchet cannot lose a trial scored on the rubric it optimises, and it can lose one
+scored here, where the judge runs after the workspace is finished against a checklist
+no stage was shown. Keyed on the capability alone it refused the ratchet on this path
+too — printing "score the arms on a held-out judge or a benchmark" over a report
+produced by exactly that. So :func:`collect_rcb_pairs` declares
+:data:`src.trials.RCB_TOTAL` as the measure that filled the dicts, and the refusal is
+read against it. The declaration lives here, in the producer that knows what the
+numbers are, and not on :class:`TrialPlan`: a trial that could name its own exemption
+would be granting it to itself.
 
 **The mapping, and why each half is shaped the way it is.**
 
@@ -73,6 +85,7 @@ from .archive import RunRecord
 from .information_flow import CHANNELS
 from .rubric import RUBRIC_VERSION
 from .trials import (
+    RCB_TOTAL,
     TrialResult,
     collect_pairs,
     format_trial_report,
@@ -636,6 +649,11 @@ def collect_rcb_pairs(
     from an arm that was never launched. Three treatment deaths against zero control
     deaths is this trial's result whenever it happens, and it cannot be the one thing the
     ledger structurally cannot see.
+
+    The ``outcome=RCB_TOTAL`` below is what makes a champion-ratchet trial reportable on
+    this path. It is not an exemption the caller can ask for: the argument is fixed
+    here, in the function that builds the records, and ``TrialResult`` refuses any
+    measure that is not in ``trials.DECLARED_OUTCOMES``.
     """
     admitted: dict[tuple[str, str], ArmEvidence] = {}
     refusals: list[Refusal] = []
@@ -663,6 +681,7 @@ def collect_rcb_pairs(
         capability=capability,
         control_arm=control_arm,
         treatment_arm=treatment_arm,
+        outcome=RCB_TOTAL,
     )
 
     named: dict[str, list[str]] = {}
@@ -814,7 +833,7 @@ def format_rcb_trial_report(
     plan_digest: str = "",
     judge_model: str = "",
     planned_judge_model: str = "",
-    unit: str = "RCB points (0-100 total scale)",
+    unit: str | None = None,
 ) -> str:
     """The whole rendering: provenance, ledger, statistics, decomposition, dose.
 
@@ -823,6 +842,11 @@ def format_rcb_trial_report(
     it is not the number underneath. The p-value sits at the bottom under the floor it
     cannot beat, because at three pairs the floor is 0.25 and the conclusion has to be
     carried by the decomposition and by which channel each task can see.
+
+    ``unit`` was the benchmark's scale written out a second time, one function away
+    from the outcome that already names it. ``None`` now means "read it off
+    ``result.outcome``", so the scale on the mean-difference line and the instrument
+    printed above it cannot come apart.
     """
     result = trial.result
     lines: list[str] = [

--- a/src/trials.py
+++ b/src/trials.py
@@ -342,6 +342,16 @@ class TrialResult:
         rather than like an exemption. ``dataclasses.replace`` re-runs this, so the
         rewrite in ``rcb_trial.collect_rcb_pairs`` cannot slip one past it either.
         """
+        if not isinstance(self.outcome, Outcome):
+            # A bare string is the natural mistake — `outcome="rubric"` reads like a
+            # keyword argument and today raises `AttributeError: 'str' object has no
+            # attribute 'key'` three frames away from the call. Refuse it here with the
+            # registry in the message, because the whole point of this check is that an
+            # outcome nobody declared exempts every capability from the refusal.
+            raise TypeError(
+                f"outcome must be a declared `Outcome`, not {type(self.outcome).__name__}. "
+                f"Pass one of {sorted(DECLARED_OUTCOMES)} from `src.trials`."
+            )
         declared = DECLARED_OUTCOMES.get(self.outcome.key)
         if declared is None:
             raise ValueError(

--- a/src/trials.py
+++ b/src/trials.py
@@ -45,6 +45,18 @@ from, and a generator of random drafts would show the same "effect". The mean
 difference would be real, positive, and evidence of nothing. See
 :data:`SELECTS_ON_THE_OUTCOME`.
 
+That refusal is keyed on the *pair* — capability and outcome — rather than on the
+capability alone, because ``argmax`` on ``score.total`` guarantees the win only while
+``score.total`` is what gets printed. The same ratchet scored against an external
+judge is a sound trial, and it is the one ``docs/self-improvement.md`` asks for under
+"What may not be trialled": *to trial them, the outcome has to be something the
+ratchet cannot see*. :mod:`src.rcb_trial` is that outcome — a benchmark judge run
+after the workspace is finished, against a checklist no stage was shown — so a trial
+declares which measure filled its ``stage_fitness`` and the refusal reads the
+capability against *that*. The declared measures are :data:`DECLARED_OUTCOMES`, and a
+:class:`TrialResult` carrying anything else is refused at construction: a call site
+that could invent an outcome could exempt itself from the refusal by naming one.
+
 **It does not call an unattainable result "not significant".** An exact two-sided
 paired sign-flip test over *n* pairs cannot go below ``2 / 2**n``: three pairs
 bottom out at 0.25, five at 0.0625, six at 0.031. Below six pairs no result can
@@ -83,9 +95,11 @@ from .archive import RunRecord
 #: two-sided sign-flip test over *n* pairs bottoms out at ``2 / 2**n``.
 MIN_PAIRS_FOR_SIGNIFICANCE = 6
 
-#: Capabilities whose mechanism is selection on the rubric total, which is the
-#: outcome this module reports. A paired trial of one of these measures
-#: ``max(N draws) >= 1 draw`` and nothing else.
+#: Capabilities whose mechanism is selection on the rubric total. A paired trial of
+#: one of these *against the rubric* measures ``max(N draws) >= 1 draw`` and nothing
+#: else. Scored against a measure the run cannot read, the same capability is
+#: trialable — which is why this set is a property of :data:`RUBRIC_TOTAL` and not of
+#: the module.
 #:
 #: Found the hard way. The first paired trial anyone tried to run here was the
 #: champion ratchet, ``--evolve-rounds 0`` against ``2``, and twelve real runs were
@@ -105,6 +119,86 @@ MIN_PAIRS_FOR_SIGNIFICANCE = 6
 SELECTS_ON_THE_OUTCOME: frozenset[str] = frozenset(
     {"polish_rounds", "evolve_rounds", "evolution", "champion_ratchet", "pareto_frontier"}
 )
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """The measure a trial's difference is a difference *in*.
+
+    Three fields because the report needs three different things from it and each was
+    previously a literal somewhere else: ``unit`` names the scale on the
+    mean-difference line, ``measured_by`` names the instrument for a reader deciding
+    whether the number is comparable to anything, and ``selected_on_by`` is what the
+    circularity refusal reads. Keeping them on one object is what makes the refusal
+    keyed on the pair rather than on the capability: an outcome the run can read
+    during the run carries the capabilities that read it, and an outcome computed
+    after the workspace is finished carries none.
+    """
+
+    #: Stable identifier, printed in the report so a reader can tell two trials of one
+    #: capability apart when they were scored against different things.
+    key: str
+    #: The scale the mean difference is in. ``format_trial_report`` prints it.
+    unit: str
+    #: What computes the number, in a clause. Not the same claim as ``unit``: a 0–100
+    #: total says nothing about who assigned it, and who assigned it is the whole of
+    #: whether the ratchet could have optimised against it.
+    measured_by: str
+    #: Capabilities whose mechanism is ``argmax`` on *this* number. Empty is the
+    #: ordinary case and the honest one for any measure produced after the run ends.
+    selected_on_by: frozenset[str] = frozenset()
+
+    def selects(self, capability: str) -> bool:
+        return capability in self.selected_on_by
+
+
+#: AutoR grading its own drafts, during the run, while it is still choosing between
+#: them. The default for every caller that does not say otherwise, because it is what
+#: :class:`src.archive.RunRecord` holds and it is the measure that can be gamed from
+#: inside.
+RUBRIC_TOTAL = Outcome(
+    key="rubric_total",
+    unit="rubric points",
+    measured_by="AutoR's own rubric, scored during the run",
+    selected_on_by=SELECTS_ON_THE_OUTCOME,
+)
+
+#: ResearchClawBench, filled by :mod:`src.rcb_trial`. ``selected_on_by`` is empty and
+#: that is a claim, not an omission: the score is produced by a judge that runs after
+#: the workspace is finished, against a checklist no stage was shown, so no mechanism
+#: inside a run can keep a draft *because* it scores well here. A capability that read
+#: a benchmark score in-loop to decide what to keep would belong in this set, and the
+#: refusal would then fire on this outcome exactly as it does on the rubric.
+RCB_TOTAL = Outcome(
+    key="rcb_total",
+    unit="RCB points (0-100 total scale)",
+    measured_by="ResearchClawBench's judge, after the run, against a checklist no stage was shown",
+    selected_on_by=frozenset(),
+)
+
+#: Every measure a trial may declare, by key. A registry and not a free-form string
+#: for the same reason ``stage_graph.GUARDS`` is one: the failure mode of an outcome
+#: nothing recognises is silence. ``circular`` would read an empty ``selected_on_by``,
+#: the ratchet would report ``+0.0736, p = 0.031``, and the escape would be one
+#: keyword argument at one call site. Adding a measure means adding it here, where the
+#: claim that nothing selects on it is written down next to it.
+DECLARED_OUTCOMES: Mapping[str, Outcome] = {
+    outcome.key: outcome for outcome in (RUBRIC_TOTAL, RCB_TOTAL)
+}
+
+
+def outcomes_free_of(capability: str) -> tuple[Outcome, ...]:
+    """Declared measures this capability's mechanism cannot select on.
+
+    What a refusal owes the reader. "Score it on something the ratchet does not read"
+    is advice; this is the list, derived from the same registry the refusal fires off,
+    so a measure added to the registry appears in the refusal without anyone
+    remembering to update the prose.
+    """
+    return tuple(
+        outcome for outcome in DECLARED_OUTCOMES.values() if not outcome.selects(capability)
+    )
+
 
 #: Above this, the exact enumeration is replaced by the same arithmetic on a
 #: sampled basis. 2**18 is a quarter of a million sign assignments, which is
@@ -227,9 +321,42 @@ class TrialResult:
     control_arm: str
     treatment_arm: str
     pairs: tuple[Pair, ...]
+    #: What filled ``stage_fitness``. Defaults to :data:`RUBRIC_TOTAL`, which is what
+    #: an archived :class:`src.archive.RunRecord` carries, so every caller that does
+    #: not produce its own measure keeps the behaviour it had. A producer that fills
+    #: the two dicts from somewhere else declares it here, and ``circular`` is then
+    #: read against the measure that was actually used.
+    outcome: Outcome = RUBRIC_TOTAL
     #: Pairs found but not usable, with the reason. Reported rather than dropped:
     #: an analysis over four of nine pairs is a different claim from one over nine.
     excluded: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        """Refuse an outcome that is not in the registry, at construction.
+
+        The same shape as ``Edge.__post_init__`` refusing an unregistered guard, for
+        the same reason: the failure is silent in the direction that publishes. An
+        outcome nobody declared has an empty ``selected_on_by``, so it makes
+        ``circular`` false for every capability — inventing one at the call site is
+        how a circular trial gets reported, and it would look like a keyword argument
+        rather than like an exemption. ``dataclasses.replace`` re-runs this, so the
+        rewrite in ``rcb_trial.collect_rcb_pairs`` cannot slip one past it either.
+        """
+        declared = DECLARED_OUTCOMES.get(self.outcome.key)
+        if declared is None:
+            raise ValueError(
+                f"outcome {self.outcome.key!r} is not declared. Add it to "
+                "`DECLARED_OUTCOMES` with the capabilities that select on it, next to "
+                "the argument that nothing does. An undeclared measure exempts every "
+                "capability from the circularity refusal and reads as a spelling."
+            )
+        if declared != self.outcome:
+            raise ValueError(
+                f"outcome {self.outcome.key!r} does not match the declared one: "
+                f"selected_on_by={sorted(self.outcome.selected_on_by)} against "
+                f"{sorted(declared.selected_on_by)}. A trial may choose which declared "
+                "measure it was scored on; it may not restate what selects on it."
+            )
 
     @property
     def n(self) -> int:
@@ -286,8 +413,15 @@ class TrialResult:
         "+0.0736, p = 0.031" takes the number; a caveat under it does not undo
         that, and the number here is an artifact of the arithmetic rather than a
         measurement of anything.
+
+        Read against :attr:`outcome` and not against the module. "Selects on the
+        outcome" is a relation between a mechanism and a measure, and the mechanism
+        that cannot lose a rubric-scored trial can lose one scored by a judge it never
+        sees. Keying on the capability alone refused a sound trial — the ratchet
+        against ResearchClawBench — with a message telling the reader to run exactly
+        that trial.
         """
-        return self.capability in SELECTS_ON_THE_OUTCOME
+        return self.outcome.selects(self.capability)
 
     def criterion_differences(self) -> dict[str, float]:
         """Mean per-criterion difference across pairs, worst first.
@@ -343,8 +477,17 @@ def collect_pairs(
     capability: str,
     control_arm: str,
     treatment_arm: str,
+    outcome: Outcome = RUBRIC_TOTAL,
 ) -> TrialResult:
-    """Group tagged runs into pairs and say why any were dropped."""
+    """Group tagged runs into pairs and say why any were dropped.
+
+    ``outcome`` is what filled ``stage_fitness`` on these records, and the caller is
+    the only one who knows: this function reads two dicts of floats and cannot tell a
+    rubric mean from a benchmark total. It defaults to the rubric because the archive
+    holds nothing else, and a producer that fills the dicts from another instrument
+    passes its own — :func:`src.rcb_trial.collect_rcb_pairs` passes
+    :data:`RCB_TOTAL`. Only a measure in :data:`DECLARED_OUTCOMES` is accepted.
+    """
     by_trial: dict[str, dict[str, RunRecord]] = {}
     for record in records:
         if not record.trial_id or record.capability != capability:
@@ -376,6 +519,7 @@ def collect_pairs(
         control_arm=control_arm,
         treatment_arm=treatment_arm,
         pairs=tuple(pairs),
+        outcome=outcome,
         excluded=tuple(excluded),
     )
 
@@ -389,30 +533,56 @@ def declared_trials(records: Iterable[RunRecord]) -> dict[str, set[str]]:
     return found
 
 
-def format_trial_report(result: TrialResult, *, unit: str = "rubric points") -> str:
+def format_trial_report(result: TrialResult, *, unit: str | None = None) -> str:
     """Render a trial. ``unit`` names what the mean difference is measured in.
 
     A rendering concern, so it lives here and not on :class:`TrialResult`, which is a
-    record about the statistics. The default keeps every existing caller byte-identical.
-    It exists because the arithmetic in this module is scale-free — ``sign_flip_p`` is
-    invariant to it, ``concentration`` is a ratio — and the only thing that was not was
-    the literal string on the mean-difference line. Handed a ResearchClawBench total in
-    0–100 points, that line printed "+24.6000 rubric points", which is a lie about the
-    instrument in the one place a reader takes the number from.
+    record about the statistics. It exists because the arithmetic in this module is
+    scale-free — ``sign_flip_p`` is invariant to it, ``concentration`` is a ratio — and
+    the only thing that was not was the literal string on the mean-difference line.
+    Handed a ResearchClawBench total in 0–100 points, that line printed "+24.6000 rubric
+    points", which is a lie about the instrument in the one place a reader takes the
+    number from.
+
+    Now an *override* of ``result.outcome.unit`` rather than a default of its own. The
+    scale is a property of the measure, so a caller that declared the measure has
+    already said it, and two callers saying it separately is one string that can drift
+    into disagreeing with the outcome printed two lines above it. ``None`` means "the
+    outcome's"; a string still wins, for a caller rendering the same result on a
+    rescaled axis.
     """
+    unit = result.outcome.unit if unit is None else unit
     header = f"## `{result.capability}`  —  `{result.treatment_arm}` against `{result.control_arm}`"
+    # Printed on both branches, and above the number on the reporting branch. Which
+    # instrument produced the difference decides whether the refusal below applies, so
+    # a reader who disagrees with the verdict needs it before the verdict, not in a
+    # footnote after it.
+    measure = f"- outcome: `{result.outcome.key}` — {result.outcome.measured_by}"
     if result.circular:
+        # No need to drop the measure just refused: it selects on this capability, which
+        # is why we are here, so `outcomes_free_of` has already left it out.
+        escapes = outcomes_free_of(result.capability)
         return "\n".join([
             header,
             "",
             f"- pairs: **{result.n}**",
-            "- **refused: this capability selects on the outcome measure.** The champion "
-            "ratchet keeps the highest-scoring draft and reverts the rest, so the treatment "
-            "arm is the maximum of several draws on exactly the total reported here. It "
-            "cannot lose, a random draft generator would show the same effect, and a "
-            "positive mean difference would be arithmetic rather than evidence.",
+            measure,
+            f"- **refused: `{result.capability}` selects on the outcome measure "
+            f"`{result.outcome.key}`.** The champion ratchet keeps the highest-scoring "
+            "draft and reverts the rest, so the treatment arm is the maximum of several "
+            "draws on exactly the total reported here. It cannot lose, a random draft "
+            "generator would show the same effect, and a positive mean difference would be "
+            "arithmetic rather than evidence.",
             "- To trial it, score the arms on something the ratchet does not read — a held-out "
-            "judge, a benchmark, or a human read of the draft.",
+            "judge, a benchmark, or a human read of the draft. "
+            + (
+                "Declared here: "
+                + ", ".join(f"`{outcome.key}` ({outcome.measured_by})" for outcome in escapes)
+                + "."
+                if escapes
+                else "No other measure is declared, so there is nothing to rerun this against "
+                "until one is."
+            ),
         ])
 
     lines = [
@@ -420,6 +590,7 @@ def format_trial_report(result: TrialResult, *, unit: str = "rubric points") -> 
         "",
         f"- pairs: **{result.n}**"
         + (f" ({len(result.excluded)} excluded)" if result.excluded else ""),
+        measure,
         f"- mean difference: **{result.mean_difference:+.4f}** {unit}",
         f"- won {result.wins}, lost {result.losses}, tied {result.ties}",
     ]
@@ -466,7 +637,13 @@ def format_trial_report(result: TrialResult, *, unit: str = "rubric points") -> 
 
 
 def format_all_trials(records: Sequence[RunRecord], *, arms: Mapping[str, tuple[str, str]] | None = None) -> str:
-    """Every declared trial in the archive, or a note that there are none."""
+    """Every declared trial in the archive, or a note that there are none.
+
+    No ``outcome`` parameter, and that is the refusal rather than an omission. These
+    records came out of :class:`src.archive.Archive`, where ``stage_fitness`` is
+    AutoR's own rubric by construction, so the measure is not the caller's to choose
+    here and the ratchet stays refused on this path whatever a flag says.
+    """
     declared = declared_trials(records)
     if not declared:
         return (

--- a/tests/test_rcb_trial.py
+++ b/tests/test_rcb_trial.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from src.rcb_trial import (
     ADMISSION_CLAUSES,
+    RCB_TOTAL,
     SETTLED_REASONING_HEADING,
     ArmEvidence,
     ArmSpec,
@@ -230,6 +231,66 @@ class SeamTests(unittest.TestCase):
             body = (REPO_ROOT / name).read_text(encoding="utf-8")
             for forbidden in ("Archive(", "record_run", "runs.jsonl"):
                 self.assertNotIn(forbidden, body, f"{name} can reach the archive via {forbidden}")
+
+
+class TheMeasureIsDeclaredHereTests(unittest.TestCase):
+    """This module is the only thing that knows what filled `stage_fitness`.
+
+    `collect_pairs` reads two dicts of floats and cannot tell a rubric mean from a
+    judge's total, so the measure has to be declared by the producer — and the
+    circularity refusal, which is a statement about a mechanism *and* a measure, then
+    reads the capability against the one that was actually used.
+    """
+
+    def test_the_trial_declares_the_benchmark_as_its_measure(self) -> None:
+        control = arm(scores=(40, 30, 20))
+        treatment = arm(label="47f3fbf", scores=(60, 30, 20))
+        self.assertEqual(trial(control, treatment).result.outcome, RCB_TOTAL)
+
+    def test_the_champion_ratchet_is_reportable_against_the_judge(self) -> None:
+        """The whole point of the seam, and what the keyed-on-the-string refusal broke.
+
+        `EvolutionController.consider` is `argmax` on AutoR's own `score.total`. The
+        judge here runs after the workspace is finished, against a checklist no stage
+        was shown, so the ratchet cannot have optimised against it and the arm with
+        rounds can lose. Refused, this trial printed "score the arms on a held-out
+        judge, or a benchmark" over a report produced by exactly that.
+        """
+        finished = collect_rcb_pairs(
+            [arm(scores=(40, 30, 20)), arm(label="47f3fbf", scores=(60, 30, 20))],
+            capability="polish_rounds",
+            control_arm="621566b",
+            treatment_arm="47f3fbf",
+            planned_pairs=1,
+        )
+        self.assertFalse(finished.result.circular)
+
+        rendered = format_rcb_trial_report(finished)
+        self.assertIn("- mean difference: **+10.0000**", rendered)
+        self.assertNotIn("selects on the outcome measure", rendered)
+
+    def test_the_measure_is_fixed_here_rather_than_asked_for(self) -> None:
+        """An exemption a caller can request is an exemption a caller can grant itself.
+
+        Two ways it could have been made requestable, both refused: a parameter on this
+        function, and a field on `TrialPlan` — which would also have changed
+        `TrialPlan.digest` and invalidated the plan frozen before the first launch.
+        """
+        import dataclasses
+        import inspect
+
+        self.assertNotIn("outcome", inspect.signature(collect_rcb_pairs).parameters)
+        self.assertNotIn("selects_on", {f.name for f in dataclasses.fields(TrialPlan)})
+
+    def test_the_report_takes_its_scale_from_the_measure(self) -> None:
+        """The benchmark's scale used to be written out here as well as on the outcome.
+        One string, two encodings, and the copy printed beside the number is the one a
+        reader takes it from."""
+        control = arm(scores=(40, 30, 20))
+        treatment = arm(label="47f3fbf", scores=(60, 30, 20))
+        rendered = format_rcb_trial_report(trial(control, treatment))
+        self.assertIn(f"- mean difference: **+10.0000** {RCB_TOTAL.unit}", rendered)
+        self.assertIn(f"- outcome: `rcb_total` — {RCB_TOTAL.measured_by}", rendered)
 
 
 class EnvironmentTests(unittest.TestCase):

--- a/tests/test_trials.py
+++ b/tests/test_trials.py
@@ -14,6 +14,8 @@ from src.archive import RunRecord, TrialTag
 from src.rubric import RUBRIC_VERSION
 from src.trials import (
     MIN_PAIRS_FOR_SIGNIFICANCE,
+    RCB_TOTAL,
+    RUBRIC_TOTAL,
     Pair,
     collect_pairs,
     format_all_trials,
@@ -309,6 +311,40 @@ class RenderingContractTests(unittest.TestCase):
         rendered = format_trial_report(result, unit="RCB points (0-100 total scale)")
         self.assertIn("+0.1000** RCB points (0-100 total scale)", rendered)
         self.assertNotIn("rubric points", rendered)
+
+    def test_the_unit_comes_off_the_outcome_when_the_caller_says_nothing(self) -> None:
+        """The scale belongs to the measure, and a caller that declared the measure has
+        already said it. Two callers saying it separately is one string with two
+        encodings, and the one that drifts is the one printed beside the number."""
+        result = self.collect(paired(3, 0.5, 0.6), outcome=RCB_TOTAL)
+        rendered = format_trial_report(result)
+        self.assertIn(f"+0.1000** {RCB_TOTAL.unit}", rendered)
+        self.assertNotIn("rubric points", rendered)
+
+    def test_the_report_names_the_instrument_and_not_only_the_scale(self) -> None:
+        """"0-100 points" says nothing about who assigned them, and who assigned them
+        is the whole of whether the number could have been optimised against. The same
+        arithmetic over two measures now renders two different claims, so the measure
+        is printed above the number rather than left to the unit."""
+        rubric = format_trial_report(self.collect(paired(3, 0.5, 0.6)))
+        benchmark = format_trial_report(self.collect(paired(3, 0.5, 0.6), outcome=RCB_TOTAL))
+        self.assertIn(f"- outcome: `rubric_total` — {RUBRIC_TOTAL.measured_by}", rubric)
+        self.assertIn(f"- outcome: `rcb_total` — {RCB_TOTAL.measured_by}", benchmark)
+
+    def test_the_archive_wide_report_cannot_be_handed_another_measure(self) -> None:
+        """`format_all_trials` reads `Archive.runs()`, where `stage_fitness` is AutoR's
+        own rubric by construction. No `outcome` parameter, so the path that renders
+        every trial in the archive keeps refusing the ratchet whatever a caller wants."""
+        import inspect
+
+        self.assertNotIn("outcome", inspect.signature(format_all_trials).parameters)
+        records = [
+            run("g1", "off", stages=flat(0.5), capability="polish_rounds"),
+            run("g1", "on", stages=flat(0.9), capability="polish_rounds"),
+        ]
+        rendered = format_all_trials(records)
+        self.assertIn("selects on the outcome measure `rubric_total`", rendered)
+        self.assertNotIn("- mean difference: **", rendered)
 
     def test_the_decomposition_table_says_how_many_pairs_each_row_is_over(self) -> None:
         """A criterion seen in one pair of three renders exactly like a mean over three.

--- a/tests/test_trials_circularity.py
+++ b/tests/test_trials_circularity.py
@@ -14,6 +14,16 @@ in a single round.
 
 The refusal replaces the report rather than annotating it. A reader shown
 "+0.0736, p = 0.031" takes the number, and a caveat underneath does not undo that.
+
+**"Selects on" is a relation, so the refusal is keyed on the pair.** The half of these
+tests below the first class is there because the refusal used to read the capability
+alone, and a relation reduced to one of its arguments over-refuses on the other. The
+same ratchet scored by a judge that runs after the workspace is finished is a sound
+trial — the one `docs/self-improvement.md` asks for by name — and the report refused
+it while printing "score the arms on a held-out judge or a benchmark", which is what
+had just been done. Which measures exist is `DECLARED_OUTCOMES`; which capabilities
+read each is on the measure; and a trial that could name a measure of its own would be
+writing its own exemption, so an undeclared one is refused at construction.
 """
 
 from __future__ import annotations
@@ -21,10 +31,15 @@ from __future__ import annotations
 import unittest
 
 from src.trials import (
+    DECLARED_OUTCOMES,
+    RCB_TOTAL,
+    RUBRIC_TOTAL,
     SELECTS_ON_THE_OUTCOME,
+    Outcome,
     Pair,
     TrialResult,
     format_trial_report,
+    outcomes_free_of,
 )
 from src.archive import RunRecord
 
@@ -50,7 +65,9 @@ def record(run_id: str, *, arm: str, fitness: float) -> RunRecord:
     )
 
 
-def result_for(capability: str, *, pairs: int = 6) -> TrialResult:
+def result_for(
+    capability: str, *, pairs: int = 6, outcome: Outcome = RUBRIC_TOTAL
+) -> TrialResult:
     made = []
     for index in range(pairs):
         control = record(f"t{index}", arm="off", fitness=0.93)
@@ -61,6 +78,7 @@ def result_for(capability: str, *, pairs: int = 6) -> TrialResult:
         control_arm="off",
         treatment_arm="on",
         pairs=tuple(made),
+        outcome=outcome,
     )
 
 
@@ -102,6 +120,125 @@ class ACircularTrialIsRefusedTests(unittest.TestCase):
     def test_the_circular_flag_tracks_the_constant(self) -> None:
         self.assertTrue(result_for("polish_rounds").circular)
         self.assertFalse(result_for("effort_tiers").circular)
+
+    def test_the_rubric_outcome_carries_the_module_constant(self) -> None:
+        """One rule, not two. `SELECTS_ON_THE_OUTCOME` is named by
+        `docs/self-improvement.md` and by three docstrings; the refusal now reads
+        `RUBRIC_TOTAL.selected_on_by`. If those two ever hold different sets, the doc
+        describes a gate that is not the one running."""
+        self.assertEqual(RUBRIC_TOTAL.selected_on_by, SELECTS_ON_THE_OUTCOME)
+
+
+class TheRefusalIsKeyedOnTheMeasureTests(unittest.TestCase):
+    """The same capability, two measures, two answers — and only one of them refused."""
+
+    def test_the_ratchet_is_reportable_against_a_measure_it_cannot_read(self) -> None:
+        """The over-refusal this class exists for.
+
+        `argmax` on `score.total` guarantees the win only while `score.total` is what
+        gets printed. Scored by ResearchClawBench's judge — run after the workspace is
+        finished, against a checklist no stage was shown — the ratchet can lose, so the
+        difference is a measurement and the report has to produce one.
+        """
+        result = result_for("polish_rounds", outcome=RCB_TOTAL)
+        self.assertFalse(result.circular)
+
+        rendered = format_trial_report(result)
+        self.assertNotIn("refused", rendered)
+        self.assertIn("- mean difference: **", rendered)
+        self.assertIn("- exact two-sided p: **", rendered)
+
+    def test_the_same_capability_on_the_rubric_is_still_refused(self) -> None:
+        """The other half of the pair, asserted beside it: widening the gate for one
+        measure must not open it for the measure the mechanism does read."""
+        self.assertTrue(result_for("polish_rounds", outcome=RUBRIC_TOTAL).circular)
+        self.assertIn(
+            "selects on the outcome measure",
+            format_trial_report(result_for("polish_rounds", outcome=RUBRIC_TOTAL)),
+        )
+
+    def test_the_report_names_the_measure_the_number_came_from(self) -> None:
+        """Two trials of one capability now have two possible readings, and the only
+        thing that separates them is which instrument filled `stage_fitness`. It is
+        printed above the number on both branches rather than inferred from the unit,
+        which names a scale and not who assigned it."""
+        self.assertIn(
+            "- outcome: `rcb_total` — " + RCB_TOTAL.measured_by,
+            format_trial_report(result_for("effort_tiers", outcome=RCB_TOTAL)),
+        )
+        self.assertIn(
+            "- outcome: `rubric_total` — " + RUBRIC_TOTAL.measured_by,
+            format_trial_report(result_for("polish_rounds")),
+        )
+
+    def test_the_refusal_lists_the_declared_measures_that_escape_it(self) -> None:
+        """"Score it on something the ratchet does not read" is advice; the list is
+        the answer. Derived from the registry the refusal itself fires off, so a
+        measure added there appears here without anyone editing prose."""
+        self.assertEqual([item.key for item in outcomes_free_of("polish_rounds")], ["rcb_total"])
+        self.assertEqual(
+            sorted(item.key for item in outcomes_free_of("effort_tiers")),
+            sorted(DECLARED_OUTCOMES),
+        )
+
+        rendered = format_trial_report(result_for("polish_rounds"))
+        self.assertIn("Declared here: `rcb_total`", rendered)
+        # The measure it was just refused on is never in the list, and that needs no
+        # filtering at the call site: it is in the list of measures that select on this
+        # capability, which is the whole reason this branch ran.
+        self.assertNotIn("`rubric_total` (", rendered)
+
+
+class AnOutcomeIsDeclaredNotInventedTests(unittest.TestCase):
+    """The exemption has to cost an edit to the registry, not a keyword argument.
+
+    An outcome carries the capabilities that select on it, so an outcome nobody
+    declared carries none and makes `circular` false for everything. That failure is
+    silent in the direction that publishes: the report renders, the p-value is real
+    arithmetic, and the only trace is a string in a call.
+    """
+
+    def test_an_undeclared_measure_is_refused_at_construction(self) -> None:
+        invented = Outcome(
+            key="held_out_judge",
+            unit="points",
+            measured_by="a judge nobody has written",
+        )
+        with self.assertRaises(ValueError) as caught:
+            result_for("polish_rounds", outcome=invented)
+        self.assertIn("not declared", str(caught.exception))
+        self.assertIn("DECLARED_OUTCOMES", str(caught.exception))
+
+    def test_a_declared_key_may_not_be_restated_with_a_softer_selector_set(self) -> None:
+        """The subtler forgery, and the reason equality is checked and not just the key.
+
+        `Outcome` is a value type, so a caller can rebuild `rubric_total` with an empty
+        `selected_on_by` and hand it in. The key matches, the report header reads
+        identically, and the ratchet's rubric-scored trial publishes a p-value.
+        """
+        softened = Outcome(
+            key="rubric_total",
+            unit=RUBRIC_TOTAL.unit,
+            measured_by=RUBRIC_TOTAL.measured_by,
+            selected_on_by=frozenset(),
+        )
+        self.assertFalse(softened.selects("polish_rounds"))
+        with self.assertRaises(ValueError) as caught:
+            result_for("polish_rounds", outcome=softened)
+        self.assertIn("may not restate what selects on it", str(caught.exception))
+
+    def test_the_check_survives_a_dataclasses_replace(self) -> None:
+        """`rcb_trial.collect_rcb_pairs` rewrites the result with `replace` after
+        pairing, which is the one construction path that does not go through
+        `collect_pairs`. `__post_init__` runs there too, and this is what says so."""
+        import dataclasses
+
+        result = result_for("polish_rounds", outcome=RCB_TOTAL)
+        with self.assertRaises(ValueError):
+            dataclasses.replace(
+                result,
+                outcome=Outcome(key="rcb_total", unit="x", measured_by="y"),
+            )
 
 
 class TheRatchetReallyIsArgmaxOnTheReportedTotalTests(unittest.TestCase):

--- a/tests/test_trials_circularity.py
+++ b/tests/test_trials_circularity.py
@@ -260,5 +260,30 @@ class TheRatchetReallyIsArgmaxOnTheReportedTotalTests(unittest.TestCase):
         self.assertIn("regressed", source)
 
 
+class ABareStringOutcomeIsRefusedTests(unittest.TestCase):
+    """`outcome="rubric"` is the natural mistake and used to fail three frames away.
+
+    It matters more than an ordinary type slip: the registry check exists because an
+    outcome nobody declared has an empty `selected_on_by` and therefore exempts every
+    capability from the circularity refusal. A `TypeError` from deep inside
+    `__post_init__` reads as a bug in the module rather than as a rejected exemption.
+    """
+
+    def test_a_string_is_refused_with_the_registry_in_the_message(self) -> None:
+        from src.trials import DECLARED_OUTCOMES
+
+        with self.assertRaises(TypeError) as caught:
+            TrialResult(
+                capability="polish_rounds",
+                control_arm="off",
+                treatment_arm="on",
+                pairs=(),
+                outcome="rubric",
+            )
+        message = str(caught.exception)
+        for key in DECLARED_OUTCOMES:
+            self.assertIn(key, message)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
PR #193 made `format_trial_report` refuse any capability whose mechanism is `argmax` on the rubric total — correct, because the champion ratchet cannot lose a trial scored on the number it optimises.

But the refusal matched a capability **string**. The same capability scored against an *external* outcome — ResearchClawBench's gpt-5.1 judge, mapped into `stage_fitness` by `src/rcb_trial.py` precisely so the ratchet cannot see it — is a sound trial, and #193 would have refused it. The guard was blocking the one measurement it exists to make possible.

## Now

`Outcome` is a declared value, `DECLARED_OUTCOMES` is the registry, and `circular` is read against **that outcome** rather than against the module:

```
capability=polish_rounds  outcome=rubric_total  circular=True
  -> refused: `polish_rounds` selects on the outcome measure `rubric_total`.

capability=polish_rounds  outcome=rcb_total     circular=False
  -> mean difference: +0.0000 RCB points (0-100 total scale)
```

The champion ratchet is untrialable against its own rubric and trialable against the benchmark, which is the true statement about it. `unit=` survives as an override of a value now derived from the outcome, so both live callers keep working and the RCB report labels its own scale.

## Two exemptions refused rather than added

- **No `TrialPlan.selects_on` field.** It is a self-granted exemption, and it would change the plan digest — invalidating the already-frozen plan at `/rmeng_data/robtang/rcb-trial-175/plan.json`. A test now asserts the field does not exist, so the constraint is a guard rather than a note.
- **An undeclared outcome is refused at construction**, the same shape as `Edge.__post_init__` refusing an unregistered guard, and for the same reason: an outcome nobody declared has an empty `selected_on_by`, so it makes `circular` false for every capability. Inventing one at the call site is how a circular trial gets reported, and it would look like a keyword argument rather than like an exemption. `dataclasses.replace` re-runs the check, so the rewrite in `rcb_trial.collect_rcb_pairs` cannot slip one past it.

Review of the branch added one more: `outcome="rubric"` — the natural mistake — raised `AttributeError` three frames away. It is now a `TypeError` naming the registry, because an obscure crash inside the guard reads as a bug in the module rather than as a rejected exemption, and the natural next move is to work around it.

## Testing

2193 pass. Mutations, run independently of the author's report:

| Mutation | Tests that die |
| --- | --- |
| ignore the outcome, key on capability alone (#193's behaviour) | 1 |
| `circular` always true — refuse everything | 3 |
| make the bare-string check inert | 1 error |

🤖 Generated with [Claude Code](https://claude.com/claude-code)