### PR TITLE
Carry the graph's blocked-edge record into the run's own census

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -115,7 +115,9 @@ from .stage_graph import (
     FINISH as GRAPH_FINISH,
     GraphState,
     StageGraph,
+    block_census,
     enter as graph_enter,
+    format_block_census,
     format_route,
     leave as graph_leave,
     load_graph_state,
@@ -647,6 +649,7 @@ class ResearchManager:
 
     def _complete_run(self, paths: RunPaths, state: "GraphState | None" = None) -> bool:
         route = format_route(state) if state is not None else ""
+        self._record_block_census(paths, state)
 
         # Written on every way out, not only the clean one: a halted or abandoned run
         # still publishes the stage files whose validity reviews never ran, and "no
@@ -738,6 +741,37 @@ class ResearchManager:
             "All stages approved. Run complete." + (f"\n{disclosure}" if disclosure else "")
         )
         return True
+
+    def _record_block_census(self, paths: RunPaths, state: "GraphState | None") -> None:
+        """Write down which edges this walk was offered and what shut the rest.
+
+        The route already says where the run went. What it never said is what else
+        was on the menu, and what was closed and by which kind of block — the guards
+        that did the closing are evaluated against a workspace the later stages have
+        since overwritten, so the walk's own record is the only copy. `Visit` kept
+        it and every reader after the run dropped it, which left a graph-structured
+        run reporting exactly what a linear one would: the path, and nothing about
+        the graph.
+
+        Written at the top of `_complete_run`, so it covers all three ways a walk
+        ends there — completed, halted, abandoned — rather than only the one that
+        reaches the bottom. A run stopped by a budget is the case where "what was
+        still open" is worth the most, and it is the branch that returns first.
+
+        Nothing when no walk ran. A resume with nothing to resume must not report
+        the previous walk's census as this invocation's.
+        """
+        if state is None or not state.path:
+            return
+        census = block_census(state.path)
+        append_log_entry(paths.logs, "route_census", format_block_census(census))
+        if census.blocks and self.stage_graph.name != "linear":
+            tally = ", ".join(f"{kind} {count}" for kind, count in census.kinds.items())
+            self.ui.show_status(
+                f"Graph census: {len(census.offered)} edge(s) offered, "
+                f"{census.blocks} block(s) ({tally}).",
+                level="info",
+            )
 
     def _graph_entry_stage(self, paths: RunPaths, start_stage: StageSpec | None) -> StageSpec | None:
         """Where the walk starts: the requested stage, or the first unsettled one.

--- a/src/router.py
+++ b/src/router.py
@@ -38,7 +38,7 @@ from typing import Any
 
 from .approval_agent import extract_json_payload
 from .rubric import StageScore, format_score_for_prompt
-from .stage_graph import FINISH, GraphState, Move, StageGraph
+from .stage_graph import FINISH, GraphState, Move, StageGraph, block_census
 from .utils import (
     RunPaths,
     StageSpec,
@@ -579,10 +579,20 @@ def routing_summary(paths: RunPaths) -> dict[str, Any]:
 
     They are counted, not silently dropped. A summary that quietly discards moves
     reports a route shorter than the one the run walked.
+
+    **`census` is the other half of the walk.** `edges` and `decisions` are about
+    moves the run *made*; every visit also records which edges were live and which
+    were shut and by what (:attr:`src.stage_graph.Visit.blocked`), and this function
+    read neither. So a finished run could say where it went and could not say what
+    it was ever offered — the exploration happened and left no record of its own
+    shape. :func:`src.stage_graph.block_census` sums it per edge. A bypassed visit
+    contributes no offer and no block, for the same reason it contributes no edge:
+    nothing was evaluated.
     """
     payload = _load_json(paths.evolution_dir / "stage_graph.json")
     if not isinstance(payload, dict):
         return {}
+    census = block_census(GraphState.from_dict(payload).path)
     edges: dict[str, int] = {}
     # The same walk, kept per decision rather than summed per edge. `edges` cannot
     # distinguish "declined" from "never offered", and those are different
@@ -633,6 +643,7 @@ def routing_summary(paths: RunPaths) -> dict[str, Any]:
     return {
         "edges": edges,
         "decisions": decisions,
+        "census": census.to_dict(),
         "steps": len(payload.get("path", [])),
         "agent_directed": agent_directed,
         "revisits": revisits,

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -38,7 +38,9 @@ The path is recorded in ``evolution/stage_graph.json`` — every visit, the move
 of it, whether the agent's choice matched what AutoR would have picked, and the
 rubric total at the time. :mod:`src.archive` reads those across runs to learn
 which edges actually pay, which is what lets the topology improve rather than just
-exist.
+exist. :func:`block_census` sums the same record the other way, per edge rather
+than per visit, so a finished run can say which moves it was ever offered and what
+shut the rest — the walk, and not only the path through it.
 """
 
 from __future__ import annotations
@@ -713,6 +715,29 @@ class Move:
     #: Taken because nothing else was available, with its guard still failing.
     last_resort: bool = False
 
+    def __post_init__(self) -> None:
+        # The same refusal `Edge` makes about its kind, for the same reason. The two
+        # fields are one fact written twice — `admissible` reads the sentence,
+        # `block_census` reads the kind — and a `Move` carrying one without the other
+        # makes them disagree: a move with a kind and no sentence is *admissible* and
+        # counted as blocked, a move with a sentence and no kind is refused and
+        # counted nowhere. Refused at construction, so the census's arithmetic is a
+        # property of the type rather than of how carefully each call site was
+        # written.
+        if bool(self.blocked_because) != bool(self.blocked_kind):
+            raise ValueError(
+                f"Move {self.edge.source}->{self.edge.target} was given "
+                f"blocked_because={self.blocked_because!r} and "
+                f"blocked_kind={self.blocked_kind!r}; a block needs both or neither."
+            )
+        if self.blocked_kind and self.blocked_kind not in BLOCK_KINDS:
+            raise ValueError(
+                f"Move {self.edge.source}->{self.edge.target} is blocked as "
+                f"{self.blocked_kind!r}, which is not one of {', '.join(BLOCK_KINDS)}. "
+                "A kind nothing declares would be counted under a heading no reader "
+                "can interpret."
+            )
+
     @property
     def replay_cost(self) -> int:
         """Stages this move discards and has to redo. 0 for a forward move."""
@@ -1045,6 +1070,144 @@ def leave(
     visit.bypassed = bypassed
     visit.refusal = refusal
     save_graph_state(paths, state)
+
+
+# ----------------------------------------------------------------------------
+# What the walk explored
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BlockCensus:
+    """Per edge, what this walk was offered and what shut the rest.
+
+    The route says which edges the run *took*. It cannot say which were on the menu
+    and passed over, nor which were unavailable and why — and for a run whose claim
+    is that it explored a graph rather than continued a list, those are the two
+    halves that make the claim checkable. Each visit records both
+    (:attr:`Visit.offered`, :attr:`Visit.blocked`); this is the sum over the walk.
+
+    Counted per edge, ``source->target``, for the same reason the archive counts
+    traversals that way: the same target reached from two nodes is two different
+    moves. One node can hold two edges to one target — measured with
+    ``--final-stage 06``, where the pruned advance out of Stage 06 is replaced by a
+    live ``finish`` while the abandonment terminal at the same node stays
+    guard-blocked — so an edge key may appear in both :attr:`offered` and
+    :attr:`blocked` for a single visit. Recorded as it happened rather than
+    reconciled: the node did offer a finish and did have one shut.
+    """
+
+    #: Visits the census read. The denominator for everything else here.
+    visits: int
+    #: ``source->target`` -> visits at which that edge was live.
+    offered: dict[str, int]
+    #: ``source->target`` -> block kind -> visits at which it was shut for that
+    #: reason. The kinds are :data:`BLOCK_KINDS` and nothing else: :class:`Move`
+    #: refuses an undeclared one at construction, so this vocabulary is closed
+    #: rather than merely intended.
+    blocked: dict[str, dict[str, int]]
+    #: Visits that recorded no choice set at all — an operator's jump, a visit the
+    #: run was interrupted in before it left, or a ``stage_graph.json`` written
+    #: before the fields existed. Not a visit at which nothing was blocked: nothing
+    #: was *evaluated*. Carried as a number because a census that quietly drops the
+    #: visits it could not read describes a graph that offered less than it did.
+    unobserved: int
+    #: Visits an operator's move carried out of, from :attr:`Visit.bypassed`.
+    #: Usually also ``unobserved`` — a jump arrives with the move already made and
+    #: no guard evaluated — but not always: a resume starting somewhere other than
+    #: where the last visit was heading flags a visit the router had already closed
+    #: with a full choice set. Two counters rather than one, so that visit's offers
+    #: are not read as an operator's, and the jumps are not read as offers nobody
+    #: took.
+    bypassed: int
+
+    @property
+    def kinds(self) -> dict[str, int]:
+        """Blocks per kind over the whole walk.
+
+        Derived from :attr:`blocked` rather than tallied beside it. Two counts of
+        one thing drift, and "how often did a budget stop this run" has to be the
+        same number as the sum of the budget column under it.
+        """
+        totals: dict[str, int] = {}
+        for per_kind in self.blocked.values():
+            for kind, count in per_kind.items():
+                totals[kind] = totals.get(kind, 0) + count
+        return dict(sorted(totals.items()))
+
+    @property
+    def blocks(self) -> int:
+        """Every block recorded over the walk."""
+        return sum(self.kinds.values())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "visits": self.visits,
+            "offered": dict(self.offered),
+            "blocked": {edge: dict(counts) for edge, counts in self.blocked.items()},
+            "kinds": self.kinds,
+            "unobserved": self.unobserved,
+            "bypassed": self.bypassed,
+        }
+
+
+def block_census(visits: Sequence[Visit]) -> BlockCensus:
+    """What the graph offered over ``visits``, and what blocked the rest.
+
+    Reads the record the walk wrote; it cannot be recomputed afterwards. A guard
+    evaluates the workspace as it was at the moment of choosing, and by the time
+    the run is over the stages that followed have changed it — which is why
+    :class:`Visit` carries the choice set at all, and why summarising a run without
+    it threw away the only copy.
+
+    A visit with no recorded choice set contributes nothing to either mapping. That
+    is the distinction an operator's move needs: a bypass had no menu, and reading
+    it as a node where every edge was shut would put an intervention into the
+    census as evidence about the graph.
+    """
+    offered: dict[str, int] = {}
+    blocked: dict[str, dict[str, int]] = {}
+    unobserved = 0
+    bypassed = 0
+    for visit in visits:
+        if visit.bypassed:
+            bypassed += 1
+        # No node to attribute an offer to, or nothing recorded to attribute.
+        if not visit.stage or (not visit.offered and not visit.blocked):
+            unobserved += 1
+            continue
+        for target in visit.offered:
+            key = f"{visit.stage}->{target}"
+            offered[key] = offered.get(key, 0) + 1
+        for target, kind in visit.blocked.items():
+            per_kind = blocked.setdefault(f"{visit.stage}->{target}", {})
+            per_kind[kind] = per_kind.get(kind, 0) + 1
+    return BlockCensus(
+        visits=len(visits),
+        offered=dict(sorted(offered.items())),
+        blocked={key: dict(sorted(counts.items())) for key, counts in sorted(blocked.items())},
+        unobserved=unobserved,
+        bypassed=bypassed,
+    )
+
+
+def format_block_census(census: BlockCensus) -> str:
+    """The census as a human reads it: what was on the menu, and what was shut."""
+    if not census.offered and not census.blocked:
+        return f"No choice set was recorded over {census.visits} visit(s)."
+    kinds = census.kinds
+    tally = ", ".join(f"{kind} {count}" for kind, count in kinds.items())
+    lines = [
+        f"{len(census.offered)} edge(s) offered over {census.visits} visit(s); "
+        f"{census.blocks} block(s) on {len(census.blocked)} edge(s)"
+        + (f" ({tally})" if tally else "")
+        + f"; {census.unobserved} visit(s) with no choice set, {census.bypassed} bypassed."
+    ]
+    for key in sorted(set(census.offered) | set(census.blocked)):
+        detail = [f"offered {census.offered[key]}"] if key in census.offered else []
+        detail += [f"{kind} {count}" for kind, count in census.blocked.get(key, {}).items()]
+        lines.append(f"  {key:<48} " + ", ".join(detail))
+    return "\n".join(lines)
 
 
 def format_route(state: GraphState) -> str:

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -489,6 +489,82 @@ class GraphWalkTests(unittest.TestCase):
         self.drive_resume(resumed, paths.run_root)
         self.assertEqual(routing_summary(paths)["bypassed"], 0)
 
+    # -- what the walk explored ----------------------------------------------
+
+    def test_the_finished_walk_records_which_edges_it_was_offered(self) -> None:
+        """The census, end to end through the real loop.
+
+        Every visit already recorded the menu it chose from and why the closed
+        edges were closed, and nothing read it once the run was over: the route
+        said where the run went and no artifact said what else was ever available.
+        A walk that offers more edges than it takes is the whole difference between
+        exploring a graph and continuing a list, and it was unreportable.
+        """
+        _operator, manager = self.build()
+        self.assertTrue(self.drive(manager))
+
+        paths = self.only_run()
+        summary = routing_summary(paths)
+        census = summary["census"]
+        self.assertEqual(census["visits"], len(STAGES))
+        declared = {f"{edge.source}->{edge.target}" for edge in StageGraph.adaptive().edges}
+        self.assertEqual((set(census["offered"]) | set(census["blocked"])) - declared, set())
+        self.assertGreater(
+            len(census["offered"]),
+            len(summary["edges"]),
+            msg="a run that was offered no more than it took explored nothing",
+        )
+        # The abandonment terminal, shut by its guard on a run that did not abandon.
+        # The only block on this route, which is what makes it a usable pin.
+        self.assertEqual(census["blocked"], {"06_analysis->finish": {"guard": 1}})
+        self.assertEqual(census["kinds"], {"guard": 1})
+        log = read_text(paths.logs)
+        self.assertIn("route_census", log)
+        self.assertIn("06_analysis->finish", log)
+
+    def test_a_halted_walk_still_records_what_was_on_the_menu(self) -> None:
+        """The branch of `_complete_run` that returns first, and the run where the
+        question matters most: a walk stopped by a budget is exactly the one whose
+        remaining options a reader needs, and it would have been the one exit that
+        reported none of them."""
+        _operator, manager = self.build(graph_max_steps=4)
+        self.assertFalse(self.drive(manager))
+
+        paths = self.only_run()
+        census = routing_summary(paths)["census"]
+        self.assertEqual(census["visits"], 4)
+        self.assertTrue(census["offered"])
+        self.assertIn("route_census", read_text(paths.logs))
+
+    def test_an_operators_jump_is_not_a_node_where_the_graph_was_open(self) -> None:
+        """A bypass arrives with the move already made: no guard was evaluated and
+        nothing was on offer. Counted as a visit at which nothing was blocked, an
+        operator's intervention would enter the census as evidence about the graph —
+        the same error `Visit.offered` exists to keep out of the archive's edge
+        observations, one artifact along."""
+        _operator, manager = self.build(stage_graph=StageGraph.adaptive(), routing_mode="agent")
+        jumped = {"done": False}
+        real_run_stage = manager._run_stage
+
+        def run_stage(paths, stage):
+            approved = real_run_stage(paths, stage)
+            if stage.slug == STAGE_06.slug and not jumped["done"]:
+                jumped["done"] = True
+                manager._jump_target_stage = STAGE_05
+                manager._jump_reason = "Operator sent it back."
+            return approved
+
+        with patch.object(manager, "_run_stage", side_effect=run_stage), patch.object(
+            manager.router, "choose", side_effect=lambda **kw: _advance(kw["stage"])
+        ):
+            self.drive(manager)
+
+        census = routing_summary(self.only_run())["census"]
+        self.assertEqual(census["bypassed"], 1)
+        self.assertGreaterEqual(census["unobserved"], 1)
+        self.assertNotIn("06_analysis->05_experimentation", census["offered"])
+        self.assertNotIn("06_analysis->05_experimentation", census["blocked"])
+
     # -- the checks have to be satisfiable -----------------------------------
 
     def test_every_guard_passes_on_a_completed_run(self) -> None:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -539,6 +539,66 @@ class RouterTests(unittest.TestCase):
         self.assertEqual(summary["revisits"], 1)
         self.assertEqual(summary["agent_directed"], 1)
 
+    def test_the_summary_carries_what_was_offered_and_what_blocked_the_rest(self) -> None:
+        """The census, and the hole it fills.
+
+        `edges` and `decisions` are about the moves the run *made*. Every visit also
+        records which edges were live and which were shut and by what, and this
+        function read neither — so a finished run could say where it went and could
+        not say what it was ever offered. The exploration happened and left no
+        record of its own shape.
+        """
+        state = GraphState()
+        enter(self.paths, state, STAGE_06)
+        leave(
+            self.paths, state, chose="05_experimentation", kind="revisit", reason="thin",
+            default_choice="07_writing", agent_directed=True, score_total=0.6,
+            offered=("05_experimentation", "07_writing"),
+            blocked={"finish": "guard", "02_hypothesis_generation": "visits"},
+        )
+
+        census = routing_summary(self.paths)["census"]
+        self.assertEqual(
+            census["blocked"],
+            {
+                "06_analysis->finish": {"guard": 1},
+                "06_analysis->02_hypothesis_generation": {"visits": 1},
+            },
+        )
+        self.assertEqual(
+            census["offered"],
+            {"06_analysis->05_experimentation": 1, "06_analysis->07_writing": 1},
+        )
+        self.assertEqual(census["kinds"], {"guard": 1, "visits": 1})
+        self.assertEqual(census["visits"], 1)
+        self.assertEqual((census["unobserved"], census["bypassed"]), (0, 0))
+
+    def test_a_bypassed_visit_contributes_no_offer_and_no_block(self) -> None:
+        """The same rule that keeps a jump out of `edges`, applied to the census.
+
+        A bypass had no menu. Counted as a visit where nothing was blocked, an
+        operator's intervention would read as evidence that the graph was wide open
+        at that node; counted as one where nothing was offered, as evidence that it
+        was shut. It is neither, and `unobserved` is where it goes.
+        """
+        state = GraphState()
+        enter(self.paths, state, STAGE_06)
+        leave(
+            self.paths, state, chose="03_study_design", kind="revisit",
+            reason="Operator redirected the run.", default_choice="", agent_directed=False,
+            score_total=None, bypassed=True,
+        )
+
+        summary = routing_summary(self.paths)
+        self.assertEqual(summary["census"]["offered"], {})
+        self.assertEqual(summary["census"]["blocked"], {})
+        self.assertEqual(summary["census"]["unobserved"], 1)
+        self.assertEqual(summary["census"]["bypassed"], 1)
+        # Still counted as a visit. A summary that discards a move reports a route
+        # shorter than the one the run walked.
+        self.assertEqual(summary["census"]["visits"], 1)
+        self.assertEqual(summary["edges"], {})
+
     def test_the_terminal_line_says_who_chose(self) -> None:
         self.assertIn("agent", format_decision(RoutingDecision("07_writing", "advance", "r", "07_writing", True)))
         self.assertIn(

--- a/tests/test_stage_graph.py
+++ b/tests/test_stage_graph.py
@@ -16,14 +16,19 @@ import unittest
 from pathlib import Path
 
 from src.stage_graph import (
+    BLOCK_KINDS,
     DEFAULT_MAX_VISITS,
     FINISH,
     GUARDS,
     Edge,
     GraphState,
+    GuardResult,
+    Move,
     StageGraph,
     Visit,
+    block_census,
     enter,
+    format_block_census,
     format_route,
     leave,
     load_graph_state,
@@ -417,6 +422,206 @@ class AdaptiveTopologyTests(unittest.TestCase):
                     }
                 ),
             )
+
+
+class BlockCensusTests(unittest.TestCase):
+    """What the walk was offered, and what shut the rest.
+
+    The route says where the run went. Every visit also records the menu it chose
+    from and why each closed edge was closed, and until this census existed nothing
+    read that after the run — so a graph-structured run reported exactly what a
+    linear one would. These tests are about the two ways that record can be
+    misread: pooling an edge that was never offered with one that was refused, and
+    pooling an operator's intervention with either.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    @staticmethod
+    def visit(stage: str, *, offered=(), blocked=None, bypassed: bool = False, chose: str = "") -> Visit:
+        return Visit(
+            stage=stage,
+            entered_at="t",
+            chose=chose,
+            offered=tuple(offered),
+            blocked=dict(blocked or {}),
+            bypassed=bypassed,
+        )
+
+    def test_a_block_is_counted_per_edge_and_per_kind(self) -> None:
+        """The unit is the edge, not the target: the same target reached from two
+        nodes is two different moves, and pooling them makes a guard that shuts one
+        of them look twice as strict as it is."""
+        census = block_census(
+            [
+                self.visit("06_analysis", offered=("05_experimentation",), blocked={"07_writing": "guard"}),
+                self.visit("06_analysis", offered=("05_experimentation",), blocked={"07_writing": "guard"}),
+                self.visit("08_dissemination", blocked={"07_writing": "visits"}),
+            ]
+        )
+        self.assertEqual(
+            census.blocked,
+            {
+                "06_analysis->07_writing": {"guard": 2},
+                "08_dissemination->07_writing": {"visits": 1},
+            },
+        )
+        self.assertEqual(census.offered, {"06_analysis->05_experimentation": 2})
+        self.assertEqual(census.visits, 3)
+
+    def test_the_kind_tally_is_the_sum_of_the_per_edge_columns(self) -> None:
+        """Derived, so the two numbers cannot drift. A separate tally kept beside the
+        per-edge one is a second encoding of one fact, and the one nobody updates is
+        the one that gets quoted."""
+        census = block_census(
+            [
+                self.visit("06_analysis", blocked={"07_writing": "guard"}),
+                self.visit("06_analysis", blocked={"07_writing": "guard"}),
+                self.visit("07_writing", blocked={"08_dissemination": "steps"}),
+            ]
+        )
+        # Three blocks on two edges: the tally counts blocks, not edges.
+        self.assertEqual(census.kinds, {"guard": 2, "steps": 1})
+        self.assertEqual(census.blocks, 3)
+        self.assertEqual(len(census.blocked), 2)
+        self.assertEqual(
+            census.blocks,
+            sum(count for per_kind in census.blocked.values() for count in per_kind.values()),
+        )
+
+    def test_a_visit_with_no_choice_set_is_unobserved_rather_than_unblocked(self) -> None:
+        """The distinction the whole census rests on.
+
+        A bypass — `/back`, a rollback, a research round's own jump — arrives with
+        the move already made: no guard was evaluated and nothing was on offer.
+        Counted as a visit at which nothing was blocked, an operator's intervention
+        would enter the census as evidence that the graph was wide open there.
+        """
+        census = block_census(
+            [
+                self.visit("06_analysis", chose="05_experimentation", bypassed=True),
+                self.visit("05_experimentation", offered=("06_analysis",), blocked={"04_implementation": "visits"}),
+            ]
+        )
+        self.assertEqual(census.unobserved, 1)
+        self.assertEqual(census.bypassed, 1)
+        self.assertEqual(census.offered, {"05_experimentation->06_analysis": 1})
+        self.assertEqual(census.blocked, {"05_experimentation->04_implementation": {"visits": 1}})
+        self.assertNotIn("06_analysis->05_experimentation", census.offered)
+
+    def test_a_bypass_that_did_record_a_choice_set_is_counted_on_both_axes(self) -> None:
+        """Not every bypass is choice-set-less, and the two counters say so.
+
+        A resume that starts somewhere other than where the last visit was heading
+        flags a visit the router had already closed with a full menu. Its guards
+        were evaluated, so its offers and blocks are real observations about the
+        graph; the move out of it was still the operator's. One counter would have
+        to throw away one of those two facts.
+        """
+        census = block_census(
+            [
+                self.visit(
+                    "06_analysis",
+                    chose=FINISH,
+                    offered=("05_experimentation",),
+                    blocked={"07_writing": "guard"},
+                    bypassed=True,
+                )
+            ]
+        )
+        self.assertEqual(census.bypassed, 1)
+        self.assertEqual(census.unobserved, 0)
+        self.assertEqual(census.offered, {"06_analysis->05_experimentation": 1})
+        self.assertEqual(census.blocked, {"06_analysis->07_writing": {"guard": 1}})
+
+    def test_a_visit_from_before_the_choice_set_existed_is_not_read_as_an_open_node(self) -> None:
+        """A `stage_graph.json` written before `offered` and `blocked` existed loads
+        as a visit with neither. It is no observation at all, and the denominator has
+        to say so rather than let an old record read as a run nothing ever blocked."""
+        census = block_census([Visit.from_dict({"stage": "06_analysis", "chose": "07_writing"})])
+        self.assertEqual((census.visits, census.unobserved), (1, 1))
+        self.assertEqual(census.offered, {})
+        self.assertEqual(census.blocked, {})
+
+    def test_a_visit_with_no_stage_has_no_edge_to_attribute_anything_to(self) -> None:
+        """`GraphState.from_dict` takes any mapping, and an entry with no stage would
+        otherwise be counted under the edge key `->07_writing`."""
+        census = block_census([Visit.from_dict({"blocked": {"07_writing": "guard"}})])
+        self.assertEqual(census.blocked, {})
+        self.assertEqual(census.unobserved, 1)
+
+    def test_the_census_of_a_real_walk_names_the_edges_the_graph_offered(self) -> None:
+        """Against the shipped adaptive topology rather than a hand-built path, so
+        the keys are edges that exist."""
+        graph = StageGraph.adaptive()
+        state = GraphState()
+        moves = graph.moves(self.paths, "06_analysis", state)
+        state.path.append(
+            Visit(
+                stage="06_analysis",
+                entered_at="t",
+                offered=tuple(sorted(move.target for move in moves if move.admissible)),
+                blocked={move.target: move.blocked_kind for move in moves if move.blocked_kind},
+            )
+        )
+        census = block_census(state.path)
+        declared = {f"{edge.source}->{edge.target}" for edge in graph.edges}
+        self.assertTrue(set(census.offered) | set(census.blocked))
+        self.assertEqual((set(census.offered) | set(census.blocked)) - declared, set())
+        # Nothing is adjudicated on an empty run, so writing is shut and the reason
+        # is a guard rather than a budget.
+        self.assertEqual(census.blocked.get("06_analysis->07_writing"), {"guard": 1})
+
+    def test_the_rendering_says_what_was_offered_and_what_shut_the_rest(self) -> None:
+        rendered = format_block_census(
+            block_census(
+                [self.visit("06_analysis", offered=("05_experimentation",), blocked={"07_writing": "guard"})]
+            )
+        )
+        self.assertIn("06_analysis->05_experimentation", rendered)
+        self.assertIn("06_analysis->07_writing", rendered)
+        self.assertIn("guard 1", rendered)
+
+    def test_an_empty_walk_says_so_rather_than_rendering_an_empty_census(self) -> None:
+        self.assertIn("No choice set", format_block_census(block_census([])))
+
+    # -- the refusal that keeps the census's arithmetic true -----------------
+
+    def test_a_move_blocked_with_no_kind_is_refused_at_construction(self) -> None:
+        """It would be inadmissible and counted under no heading: the route would
+        show an edge the run could not take and the census would show nothing
+        shutting it."""
+        edge = StageGraph.adaptive().out_edges("06_analysis")[0]
+        with self.assertRaises(ValueError):
+            Move(edge, GuardResult(False, "shut"), "shut", "")
+
+    def test_a_move_given_a_kind_but_no_reason_is_refused_at_construction(self) -> None:
+        """The other direction, and the worse one: `admissible` reads the sentence,
+        so the move would be offered to the agent *and* counted as blocked."""
+        edge = StageGraph.adaptive().out_edges("06_analysis")[0]
+        with self.assertRaises(ValueError):
+            Move(edge, GuardResult(True, "fine"), "", "guard")
+
+    def test_a_move_blocked_by_an_undeclared_kind_is_refused_at_construction(self) -> None:
+        """The same refusal `Edge` makes about its kind. A kind outside
+        `BLOCK_KINDS` would be tallied under a heading no reader can interpret, and
+        `default_move` branches on exactly these names."""
+        edge = StageGraph.adaptive().out_edges("06_analysis")[0]
+        with self.assertRaises(ValueError):
+            Move(edge, GuardResult(False, "shut"), "shut", "budget")
+
+    def test_every_declared_kind_is_accepted(self) -> None:
+        """The control. A refusal that rejects the vocabulary it is guarding would
+        pass all three tests above and break every walk."""
+        edge = StageGraph.adaptive().out_edges("06_analysis")[0]
+        for kind in BLOCK_KINDS:
+            self.assertFalse(Move(edge, GuardResult(False, "shut"), "shut", kind).admissible)
+        self.assertTrue(Move(edge, GuardResult(True, "fine"), "", "").admissible)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
AutoR's claim is that it explores a **declared, guarded** graph rather than running a pipeline. At every node `StageGraph.moves()` computes which edges are open and which are shut and by which of the five `BLOCK_KINDS`; `StageRouter.choose` records both on the `Visit`; `leave()` writes them to `evolution/stage_graph.json`.

Then `routing_summary` read neither.

Measured on a default scripted run through the real manager loop: the summary returned eight keys — `edges`, `decisions`, `steps`, `agent_directed`, `revisits`, `bypassed`, `refused`, `route` — and **none of them mentioned an edge the run did not take**. The same run's `Visit` records say it was offered 21 distinct edges over 8 visits and had one shut (the abandonment terminal at `06_analysis`, `guard`); with the taken edges that is all 22 edges the topology declares. What survived the run was the 8 traversals.

*A system whose claim is that it explores a declared, guarded graph reported exactly what a linear pipeline would.*

And the record cannot be rebuilt afterwards: a guard reads the workspace as it was at the moment of choosing, and the stages that followed have overwritten it.

## The census

`block_census(visits)` sums the walk per edge, `source->target`, in both directions: `offered` (visits at which the edge was live) and `blocked` (visits at which it was shut, broken out by kind). `kinds` and `blocks` are properties derived from `blocked` rather than tallies kept beside it, so the totals cannot drift from the columns under them.

`routing_summary` carries it as `census`. `ResearchManager._record_block_census` writes it to the log as `route_census` at the top of `_complete_run` — the only point all three ways out of a walk pass through, and the halt branch returns first, which is the run whose remaining options are worth the most.

**`RunRecord` is untouched.** An earlier review refused widening it with `completed` / `halted_kind` on the grounds that it opens a door the archive's own invariants close. This is census and reporting only.

A bypassed move stays distinguishable from a blocked one — a visit with no recorded choice set is counted as `unobserved`, not as evidence about any edge, which is the same distinction the archive already draws when it refuses to count an operator's override as a traversal.

## On the real run

Run over the first live opus run's recorded path:

```
visits: 5
offered:  02→01, 03→02, 03→04, 04→03, 04→05
blocked:  01→02 {pruned: 1},  02→03 {pruned: 1}
unobserved: 1     bypassed: 2
```

Two of those offers are **backward edges the agent was shown and declined** (`03→02`, `04→03`). That is the thing a plain agent loop cannot report, because it has no declared edge set to decline from — and until now AutoR could not report it either.

## Testing

2211 pass. Mutations, run independently of the author's report:

| Mutation | Tests that die |
| --- | --- |
| drop the census from `routing_summary` | 5 errors |
| count a bypassed visit as an offer | 4 |
| stop writing it to the log | 29 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)