### PR TITLE
Correct sixteen claims that today's six merges made false

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,10 +945,13 @@ its questions one at a time.
 Things the mechanisms above do not close. Each is also the next thing worth building, named at the
 code that would have to change.
 
-- **A crashed adversarial pass is indistinguishable from a clean result.** `_write_review(...,
-  failed=True)` records `reviewer_failed: true` ([src/validity_review.py](src/validity_review.py)) and
-  no production code reads that flag. Zero findings and a reviewer that never returned are the same
-  input to `validate_validity_response`: nothing owed, gate open.
+- **A validity review that did not complete is disclosed, not enforced.** `_write_review(...,
+  completion=...)` now records `completed` / `crashed` / `unreadable`
+  ([src/validity_review.py](src/validity_review.py)), the manager re-asks once and names the stage in
+  the run's closing line — but the gate still opens. `validate_validity_response` is deliberately not
+  the enforcement point, because it feeds Stage 06's retry loop and a Stage 06 agent cannot re-run
+  Stage 05's adversarial pass. So a stage whose reviewer never returned is approved with a banner
+  rather than refused.
 - **Attribution stops at the log.** `_record_inbound_channels` writes which channels reached each
   stage, but `RunRecord` ([src/archive.py](src/archive.py)) has no channel field, so "this edge
   helped" cannot yet become "this information helped".

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ touching a verdict — see **[framework.md](framework.md)**.
 | --- | --- |
 | [`main.py`](../main.py) | CLI parsing, backend and reviewer construction, archive wiring, new-run vs resume dispatch. Contains no workflow logic. |
 | [`studio.py`](../studio.py) | Three-line shim over `src/backend/studio_http.main`. |
-| [`rcb_agent.py`](../rcb_agent.py) | The ResearchClawBench adapter entry point: its own unattended defaults, `BENCHMARK_MIN_REPORT_FIGURES = 3`, and the only production caller of `resolve_cross_reviewer`. |
+| [`rcb_agent.py`](../rcb_agent.py) | The ResearchClawBench adapter entry point: its own unattended defaults, `BENCHMARK_MIN_REPORT_FIGURES = 3`, and one of the two production callers of `resolve_cross_reviewer`, the other being `main.py` through `create_cross_reviewer`. |
 | [`tools/score_rcb_run.py`](../tools/score_rcb_run.py) | Scores a finished benchmark run. `--judge reference` (the default) is gpt-5.1, which is what ResearchClawBench itself scores with; `--judge vertex` is the Anthropic fallback. |
 | [`tools/archive_sample_complexity.py`](../tools/archive_sample_complexity.py) | Prints how many runs the archive needs before an edge becomes believable, then exits. |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -237,19 +237,19 @@ approval. See [Stage Contract](stage-contract.md#2-the-artifact-gate).
 | `--panel-rounds N` | `2` | Maximum deliberation rounds. Round 1 is always independent; later rounds run only on disagreement. |
 | `--panel-models ROLE=MODEL...` | — | Assign a model per seat, as `role=model` or `role=backend:model` (`pi=opus skeptic=codex:default`). Heterogeneity is the lever with the best evidence behind it. |
 | `--persona PATH` | — | Markdown description of the researcher the panel stands in for, injected into every seat so they hold one consistent bar. |
-| `--cross-review {auto,gemini,off}` | `auto` | Independent second opinion on each approval, from a different model family. It can veto an approval it cannot defend and can never override a refusal, so it only makes the gate stricter. `auto` enables it when a Gemini backend is configured. **Accepted but inert here** — see below. |
-| `--cross-review-model MODEL` | `gemini-3.1-pro-preview` | Model for the cross-model reviewer (`DEFAULT_CROSS_REVIEW_MODEL`, `src/cross_reviewer.py`). Inert on `main.py` for the same reason. |
+| `--cross-review {auto,gemini,off}` | `auto` | Independent second opinion on each approval, from a different model family. It can veto an approval it cannot defend and can never override a refusal, so it only makes the gate stricter. `auto` enables it when a Gemini backend is configured. Refused behind `--fake-operator` — see below. |
+| `--cross-review-model MODEL` | `gemini-3.1-pro-preview` | Model for the cross-model reviewer (`DEFAULT_CROSS_REVIEW_MODEL`, `src/cross_reviewer.py`). |
 
-> **Both cross-review flags do nothing on `main.py` today.** `main.py` imports
-> `resolve_cross_reviewer` and never calls it; the only production caller is
-> `rcb_agent.py`, which passes the result to `ResearchManager` as
-> `cross_reviewer`. The flags parse and are then **dropped** — nothing in
-> `main.py` reads `args.cross_review` or `args.cross_review_model` after
-> `parse_args`, and neither value is recorded anywhere: `initialize_run_config`
-> has no such key, and `main.py` never dumps its argv. So a resumed or audited
-> run carries no trace that they were passed, which makes the inertness harder
-> to notice than it would be if the values were written down. Tracked in
-> [Framework → What has not been
+> **Two things the cross-review flags still do not do.** They are live on both
+> entry points now — `main.py` seats the reviewer through `create_cross_reviewer`
+> — but neither value is recorded anywhere: `initialize_run_config` has no such
+> key and `main.py` never dumps its argv, so a **resumed run re-decides the mode
+> from whatever credentials are in the environment that day** rather than from
+> what was asked for. And `_collect_review_decision` returns before
+> `_apply_cross_review` whenever no automated reviewer is seated, so **under a
+> manual gate the reviewer is built and nothing consults it**. Behind
+> `--fake-operator` it is refused outright, so the audit is only ever exercised
+> against a stubbed verdict. Tracked in [Framework → What has not been
 > established](framework.md#7-what-has-not-been-established) and in the README's
 > Limits section.
 
@@ -555,12 +555,11 @@ Read the `main.py` tables above for what each one does. Three of them differ in
 kind rather than in default, and the two parsers are mirror images about it —
 each declares a flag the other one honours and it does not:
 
-- **`--cross-review` and `--cross-review-model` are live here and inert on
-  `main.py`.** `rcb_agent.py` is the only production caller of
-  `resolve_cross_reviewer`, and it hands the result to `ResearchManager` as
-  `cross_reviewer`, so the second opinion described in [Review
-  panel](#review-panel) actually runs on this path. Defaults match `main.py`'s:
-  `auto`, and `gemini-3.1-pro-preview` for the model.
+- **`--cross-review` and `--cross-review-model` are live on both entry points.**
+  `rcb_agent.py` and `main.py` both call `resolve_cross_reviewer` and hand the
+  result to `ResearchManager` as `cross_reviewer`, so the second opinion
+  described in [Review panel](#review-panel) runs on either. Defaults are the
+  same: `auto`, and `gemini-3.1-pro-preview` for the model.
 - **`--routine-model` is inert here and live on `main.py`.** It parses, and its
   `--help` text promises a cheaper model for routine-tier stages, but
   `args.routine_model` is read nowhere in `rcb_agent.py`: under `--effort-tiers`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ outside a run directory. See [Filesystem locations](#filesystem-locations).
 | `claude` on `PATH` ([Claude Code](https://docs.claude.com/en/docs/claude-code)) | real runs with `--operator claude`, and all Studio runs |
 | `codex` on `PATH` ([Codex CLI](https://developers.openai.com/codex/cli)) | real runs with `--operator codex` |
 | A LaTeX toolchain (`pdflatex`/`latexmk`) | Stage 07 compiling a PDF — only with `--output-format latex`; the default markdown mode needs no TeX |
-| `pip install google-genai` | the three Gemini-backed optional paths: `--web-search gemini`, `--research-diagram`, and `--cross-review` (which is wired on the `rcb_agent.py` entry point only — `main.py` accepts the flag and never uses it) |
+| `pip install google-genai` | the three Gemini-backed optional paths: `--web-search gemini`, `--research-diagram`, and `--cross-review` (live on both entry points; refused behind `--fake-operator`) |
 | `pip install pyyaml` | reading the API key out of `configs/diagram_config.yaml`; not needed if you set the key in the environment |
 
 **AutoR itself has no third-party Python dependencies.** Every import of one is
@@ -51,8 +51,7 @@ The three do not fail alike, and only one of them is a soft *unavailable*:
   blocker: it is inferred rather than observed, so it warns.)
 - **`--research-diagram` warns and continues.** The call is wrapped; a missing
   package or key prints `Diagram generation failed: ...` and the stage stands.
-- **`--cross-review` records an unavailable verdict** — on the `rcb_agent.py`
-  path, the only one where the flag is wired. `CrossVerdict` keeps
+- **`--cross-review` records an unavailable verdict.** `CrossVerdict` keeps
   `unavailable` distinct from agreement, so a reviewer that could not run is
   not counted as one that approved.
 

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1017,10 +1017,13 @@ any.
   refused, and until then two of the three comparisons have nothing to compare against.
 - **Standing rules and obligations never reach a panel seat.** Both are injected only into the solo
   reviewer's prompt, so `--review-panel` silently loses two of the accumulation mechanisms.
-- **The cross-model veto is unreachable from `main.py`.** It is wired on the `rcb_agent.py` path
-  only.
-- **A crashed adversarial reviewer is indistinguishable from a clean result.** `reviewer_failed:
-  true` is written and nothing reads it.
+- **The cross-model veto does not survive a resume, and never sees a human approval.** `main.py`
+  seats it through `create_cross_reviewer`, so it is no longer benchmark-only — but the mode is
+  absent from the keys `load_run_config` reads, so a resumed run re-decides it from whatever
+  credentials are in the environment that day; and `_collect_review_decision` returns before
+  `_apply_cross_review` when no automated reviewer is seated, so under a manual gate the reviewer
+  is built and nothing consults it. It is also refused outright behind `--fake-operator`, so the
+  audit is only ever exercised against a stubbed verdict.
 - **The chain is bypassable in unattended mode, and now deliberately so.** A stage that burns its
   attempts against the gate is auto-skipped, up to three per run; past that the terminal edge routes
   to the writing stage *around* the validity guard (§6.5). The bypass used to be an accident of the

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -491,22 +491,21 @@ or unattended switch of its own.
 --no-synthesis          Skip the operator-backed report synthesis pass and use only the
                         deterministic fallback.
 --fake-operator         Smoke-test the adapter. rcb_agent.py threads fake_mode into the
-                        operator, the approval reviewer and each panel it seats. It does
-                        not reach the cross-model reviewer, which is built separately by
-                        resolve_cross_reviewer and has no fake mode: pair it with
-                        --cross-review off for a run that makes no external call.
+                        operator, the approval reviewer and each panel it seats, and
+                        ResearchManager now refuses a cross reviewer behind a fake
+                        operator for every caller, so a fake run makes no external call
+                        without --cross-review off.
 --export-only           Skip the pipeline and only re-export the most recent run in the
                         workspace. Use this to recover deliverables from an interrupted job
                         — but note that the export prunes images, so it is not a read-only
                         operation.
 ```
 
-**`--cross-review` is live on this path only.** `main.py` declares and parses the same two
-flags, but `resolve_cross_reviewer` is called from `rcb_agent.py` and nowhere else, so on the
-interactive CLI the flags are accepted and then do nothing. The benchmark adapter is the only
-place the cross-model veto is actually wired to a gate.
+**`--cross-review` is live on both paths now.** `main.py` seats it through
+`create_cross_reviewer`; this adapter builds it directly. What differs is that the interactive
+path re-decides the mode on resume, because the value is recorded in no run config.
 
-That inertness runs both ways, and `--cross-review` is not the only flag it touches: the two
+Other flags are still inert on one side or the other, and the two
 parsers are mirror images, each declaring something the other honours and it does not —
 `--routine-model` is the one that works on `main.py` and not here. `docs/cli-reference.md`
 diffs the two parsers row by row.
@@ -846,13 +845,13 @@ an execution backend. Expect exit code 0, a `report/report.md`, and a figure pub
 into the run tree, so a fake run normally exports `"report_source": "stage"` even while
 auto-skipping stages. Read the source off the final JSON line rather than assuming it.
 
-**`--cross-review off` is not optional if you want a free run.** `--fake-operator` does not
-reach the cross-model reviewer: `rcb_agent.py` builds that one through
-`resolve_cross_reviewer`, whose default `auto` seats a live `GeminiCrossReviewer` whenever
-`resolve_backend` finds a usable Gemini backend — and the Vertex project it will accept
-includes `ANTHROPIC_VERTEX_PROJECT_ID`, so the boxes the web-search section above is written
-for are exactly the ones where a "fake" run makes real calls, one per approval, each capable
-of vetoing it.
+**`--cross-review off` used to be mandatory for a free run, and no longer is.**
+`resolve_cross_reviewer`'s default `auto` seats a live `GeminiCrossReviewer` whenever
+`resolve_backend` finds a usable Gemini backend — and the Vertex project it accepts includes
+`ANTHROPIC_VERTEX_PROJECT_ID`, so the boxes the web-search section above is written for were
+exactly the ones where a "fake" run made real calls, one per approval, each capable of vetoing
+it. `ResearchManager` now refuses a cross reviewer behind a fake operator whatever the caller
+passed, so the flag is belt to that braces rather than the only thing holding it.
 
 `--max-auto-skips 9` lifts the budget above the default of 3, so a fake run whose stages
 exhaust their retries reaches the export instead of aborting part-way; how many it actually

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -1145,10 +1145,12 @@ indistinguishable in the run directory from one nobody raised.
 "any problems": an open-ended critique reliably returns prose quality, which is
 not what is dangerous here. `severity` is `critical`, `major` or `minor`.
 
-A reviewer that crashed records `reviewer_failed: true`, and `note` carries
-what went wrong. An empty finding list from a failed critique would read as
-"nothing wrong" — though see [Limits](../README.md#limits): the flag is written
-and nothing currently reads it.
+A reviewer that crashed records `completion: "crashed"`, an answer with no
+findings object records `"unreadable"`, and `note` carries what went wrong.
+`reviewer_failed` is still derived from `completion` for readers of this schema.
+An empty finding list from a failed critique would read as "nothing wrong", so
+the manager re-asks once and then names the stage in the run's closing line; see
+[Limits](../README.md#limits) for what that disclosure does and does not do.
 
 **When a review panel left concerns standing**, those concerns *become* the
 findings and no second critic runs: `ValidityReviewer.review` calls

--- a/docs/tutorial_zh.md
+++ b/docs/tutorial_zh.md
@@ -90,7 +90,7 @@ AutoR 负责的是更上层的 research loop，而不是重新发明一个新的
 | `--archive PATH` / `--archive-report` | 跨 run 记录走过哪些边、收益如何；默认只记录不干预 |
 | `--trial ID --capability X --arm on` / `--trial-report` | 成对 A/B 试验及其统计报告；三个参数必须一起给 |
 | `--web-search {auto,gemini,native}` | 执行器怎么搜网页；`gemini` 用于内置搜索被禁用的部署 |
-| `--cross-review {auto,gemini,off}` | 换一个模型家族复核批准。**注意：目前只有 `rcb_agent.py` 那条路径真的会装上它，`main.py` 上还没接线** |
+| `--cross-review {auto,gemini,off}` | 换一个模型家族复核批准。**注意：`--fake-operator` 下会被拒绝装载，且这个选择不会随 `--resume-run` 保留** |
 
 这张表是提醒，不是参考手册。每个参数的准确语义、默认值、恢复 run 时是否保留，都在 [cli-reference.md](cli-reference.md) 里。
 
@@ -108,7 +108,7 @@ AutoR 负责的是更上层的 research loop，而不是重新发明一个新的
 | Claude Code 或 Codex CLI | 必需 | 真正执行研究任务时需要其中之一 |
 | TeX 环境 | 只有 `--output-format latex` 才需要 | 默认 Stage 07 写的是 `workspace/report/report.md`；要 LaTeX 源文件和可编译 PDF 才需要 TeX |
 | `PyMuPDF` | 可选 | 如果你要用 `--paper-corpus` 读取 PDF 内容，推荐安装 |
-| `google-genai` | 可选 | 不只是画图用：`--research-diagram`、`--web-search gemini` 和 `--cross-review gemini`（这条目前只在 `rcb_agent.py` 上接线，见 2.2）共用这一个 SDK。没装它时 `--web-search gemini` 会直接报 `Error: --web-search gemini cannot work here: ...` 并以退出码 1 结束 |
+| `google-genai` | 可选 | 不只是画图用：`--research-diagram`、`--web-search gemini` 和 `--cross-review gemini`（两条入口都已接线，见 2.2）共用这一个 SDK。没装它时 `--web-search gemini` 会直接报 `Error: --web-search gemini cannot work here: ...` 并以退出码 1 结束 |
 | `Pillow` | 可选 | 只有 `--research-diagram` 需要 |
 | `PyYAML` | 可选 | 只有当你把 Gemini key 写进 `configs/diagram_config.yaml` 时才需要（画图、搜索、cross-review 共用同一个 key 读取逻辑）。缺它只会打一条 warning，然后当成“没有配 key” |
 

--- a/src/router.py
+++ b/src/router.py
@@ -581,13 +581,17 @@ def routing_summary(paths: RunPaths) -> dict[str, Any]:
     reports a route shorter than the one the run walked.
 
     **`census` is the other half of the walk.** `edges` and `decisions` are about
-    moves the run *made*; every visit also records which edges were live and which
-    were shut and by what (:attr:`src.stage_graph.Visit.blocked`), and this function
-    read neither. So a finished run could say where it went and could not say what
-    it was ever offered — the exploration happened and left no record of its own
-    shape. :func:`src.stage_graph.block_census` sums it per edge. A bypassed visit
-    contributes no offer and no block, for the same reason it contributes no edge:
-    nothing was evaluated.
+    moves the run *made*. `decisions` already carried each visit's `offered` set,
+    and `offered_payoffs` consumes it — so what was missing was narrower than "the
+    exploration left no record": :attr:`src.stage_graph.Visit.blocked` was read by
+    nothing, and there was no per-edge total over the whole walk.
+    :func:`src.stage_graph.block_census` supplies both.
+
+    A visit with no recorded choice set contributes neither an offer nor a block,
+    because nothing was evaluated — an operator's `/back`, a rollback, a round's own
+    jump. A bypass that *did* record a choice set contributes both, because those
+    guard evaluations happened even though the move out was the operator's, and
+    :attr:`BlockCensus.bypassed` counts it separately so neither reading is forced.
     """
     payload = _load_json(paths.evolution_dir / "stage_graph.json")
     if not isinstance(payload, dict):

--- a/src/trials.py
+++ b/src/trials.py
@@ -125,11 +125,11 @@ SELECTS_ON_THE_OUTCOME: frozenset[str] = frozenset(
 class Outcome:
     """The measure a trial's difference is a difference *in*.
 
-    Three fields because the report needs three different things from it and each was
-    previously a literal somewhere else: ``unit`` names the scale on the
-    mean-difference line, ``measured_by`` names the instrument for a reader deciding
-    whether the number is comparable to anything, and ``selected_on_by`` is what the
-    circularity refusal reads. Keeping them on one object is what makes the refusal
+    Four fields, three of which the report needs separately: ``unit`` names the scale
+    on the mean-difference line and was previously a literal there, ``measured_by``
+    names the instrument for a reader deciding whether the number is comparable to
+    anything, and ``selected_on_by`` is what the circularity refusal reads. ``key``
+    identifies the outcome in :data:`DECLARED_OUTCOMES` and in the refusal message. Keeping them on one object is what makes the refusal
     keyed on the pair rather than on the capability: an outcome the run can read
     during the run carries the capabilities that read it, and an outcome computed
     after the workspace is finished carries none.

--- a/src/validity_review.py
+++ b/src/validity_review.py
@@ -547,9 +547,12 @@ class ValidityReviewer:
         This used to be a fourth private copy of the same idea, and the narrowest: it tried
         the whole string and then ``text[first '{' : last '}']``. On an adversarial review
         that read a JSON artifact before answering, that slice spans both objects and parses
-        as neither -- and this parser's failure is silent, because :meth:`_parse` returns an
-        empty list either way. The run then records that the validity reviewer attacked the
-        stage and raised nothing, which is the opposite of what happened.
+        as neither. Its failure used to be silent, because :meth:`_parse` returned an empty
+        list either way and the run then recorded that the reviewer had attacked the stage and
+        raised nothing. It is no longer silent: :meth:`review` treats a ``None`` payload as
+        ``UNREADABLE``, re-asks once, and discloses a pass that never completed. Returning
+        ``None`` rather than ``{}`` is what keeps that distinguishable from ``{"findings": []}``,
+        which is a clean review the prompt explicitly blesses.
         """
         return extract_json_payload(raw, verdict_key="findings")
 

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -537,11 +537,13 @@ class GraphWalkTests(unittest.TestCase):
         self.assertIn("route_census", read_text(paths.logs))
 
     def test_an_operators_jump_is_not_a_node_where_the_graph_was_open(self) -> None:
-        """A bypass arrives with the move already made: no guard was evaluated and
-        nothing was on offer. Counted as a visit at which nothing was blocked, an
-        operator's intervention would enter the census as evidence about the graph —
-        the same error `Visit.offered` exists to keep out of the archive's edge
-        observations, one artifact along."""
+        """An operator's jump arrives with the move already made, so the router never
+        built a menu and no guard was evaluated. Counted as a visit at which nothing
+        was blocked, that intervention would enter the census as evidence about the
+        graph — the same error `Visit.offered` exists to keep out of the archive's
+        edge observations, one artifact along. The rule is about the missing choice
+        set, not about the bypass flag: a bypass that did record one contributes on
+        both axes and is counted separately as `bypassed`."""
         _operator, manager = self.build(stage_graph=StageGraph.adaptive(), routing_mode="agent")
         jumped = {"done": False}
         real_run_stage = manager._run_stage

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -542,11 +542,10 @@ class RouterTests(unittest.TestCase):
     def test_the_summary_carries_what_was_offered_and_what_blocked_the_rest(self) -> None:
         """The census, and the hole it fills.
 
-        `edges` and `decisions` are about the moves the run *made*. Every visit also
-        records which edges were live and which were shut and by what, and this
-        function read neither — so a finished run could say where it went and could
-        not say what it was ever offered. The exploration happened and left no
-        record of its own shape.
+        `edges` and `decisions` are about the moves the run *made*. `decisions`
+        already carried each visit's `offered` set, so the hole was narrower than
+        "no record of the exploration": `Visit.blocked` was read by nothing, and
+        there was no per-edge total over the whole walk.
         """
         state = GraphState()
         enter(self.paths, state, STAGE_06)
@@ -573,13 +572,16 @@ class RouterTests(unittest.TestCase):
         self.assertEqual(census["visits"], 1)
         self.assertEqual((census["unobserved"], census["bypassed"]), (0, 0))
 
-    def test_a_bypassed_visit_contributes_no_offer_and_no_block(self) -> None:
+    def test_a_visit_with_no_choice_set_contributes_no_offer_and_no_block(self) -> None:
         """The same rule that keeps a jump out of `edges`, applied to the census.
 
-        A bypass had no menu. Counted as a visit where nothing was blocked, an
-        operator's intervention would read as evidence that the graph was wide open
-        at that node; counted as one where nothing was offered, as evidence that it
-        was shut. It is neither, and `unobserved` is where it goes.
+        This is about a visit with *no menu* — not about every bypass. A bypass that
+        did record a choice set contributes on both axes, which
+        `test_a_bypass_that_did_record_a_choice_set_is_counted_on_both_axes` pins.
+        Counted as a visit where nothing was blocked, an operator's intervention
+        would read as evidence that the graph was wide open at that node; counted as
+        one where nothing was offered, as evidence that it was shut. It is neither,
+        and `unobserved` is where it goes.
         """
         state = GraphState()
         enter(self.paths, state, STAGE_06)

--- a/tests/test_stage_graph.py
+++ b/tests/test_stage_graph.py
@@ -428,9 +428,9 @@ class BlockCensusTests(unittest.TestCase):
     """What the walk was offered, and what shut the rest.
 
     The route says where the run went. Every visit also records the menu it chose
-    from and why each closed edge was closed, and until this census existed nothing
-    read that after the run — so a graph-structured run reported exactly what a
-    linear one would. These tests are about the two ways that record can be
+    from and why each closed edge was closed; `routing_summary` published the menu
+    under `decisions` and never the closures, and nothing totalled either per edge
+    over the whole walk. These tests are about the two ways that record can be
     misread: pooling an edge that was never offered with one that was refused, and
     pooling an operator's intervention with either.
     """

--- a/tests/test_trials_circularity.py
+++ b/tests/test_trials_circularity.py
@@ -123,7 +123,7 @@ class ACircularTrialIsRefusedTests(unittest.TestCase):
 
     def test_the_rubric_outcome_carries_the_module_constant(self) -> None:
         """One rule, not two. `SELECTS_ON_THE_OUTCOME` is named by
-        `docs/self-improvement.md` and by three docstrings; the refusal now reads
+        `docs/self-improvement.md` and by the module docstring of `src/trials.py`; the refusal now reads
         `RUBRIC_TOTAL.selected_on_by`. If those two ever hold different sets, the doc
         describes a gate that is not the one running."""
         self.assertEqual(RUBRIC_TOTAL.selected_on_by, SELECTS_ON_THE_OUTCOME)

--- a/tests/test_validity_completion.py
+++ b/tests/test_validity_completion.py
@@ -314,17 +314,27 @@ class DisclosureBannerTest(CompletionTestCase):
         self.assertIn("not because none were found", banner)
 
     def test_a_completed_run_prints_the_banner_beside_all_stages_approved(self) -> None:
-        """Both sentences are true separately; alone the first one reads as a clean bill."""
+        """Both sentences are true separately; alone the first one reads as a clean bill.
+
+        The tail, not the whole stream. `_run_validity_review` already prints its own
+        warning containing "did not complete", so asserting over everything printed
+        passes whether or not `_complete_run` says anything — measured: deleting the
+        disclosure from the closing line left all 2,148 tests green. What has to be
+        held is that the sentence appears *beside the closing line*, because that
+        line is the one a reader takes as the verdict on the run.
+        """
         stream = io.StringIO()
         manager = self.manager(ScriptedOperator((1, "")))
         manager.ui = TerminalUI(output_stream=stream, interactive=False)
         manager._run_validity_review(self.paths, STAGE_05, "# Stage 05")  # noqa: SLF001
+        already_printed = len(stream.getvalue())
 
         manager._complete_run(self.paths)  # noqa: SLF001
 
-        printed = stream.getvalue()
-        self.assertIn("All stages approved", printed)
-        self.assertIn("did not complete", printed)
+        closing = stream.getvalue()[already_printed:]
+        self.assertIn("All stages approved", closing)
+        self.assertIn("did not complete", closing)
+        self.assertIn("not because none were found", closing)
         self.assertIn("validity_review_not_completed", read_text(self.paths.logs))
 
     def test_a_completed_run_with_every_pass_intact_prints_only_the_usual_line(self) -> None:


### PR DESCRIPTION
Every branch merged today was reviewed adversarially afterwards. Five reviews came back FIX_FIRST, and the finding was the same class each time: **the code was right and the prose around it had gone stale in the same commit.** This is that cleanup, plus the one test that turned out to hold nothing.

## The cross-model veto is wired now, and seven places still said it was not

#201 updated the README bullet and nothing else:

| File | Claim |
| --- | --- |
| `docs/framework.md` §8 | "The cross-model veto is unreachable from `main.py`" |
| `docs/configuration.md` ×2 | "`main.py` accepts the flag and never uses it" |
| `docs/cli-reference.md` ×2 | "**Accepted but inert here**", plus a whole note ending "the flags parse and are then **dropped**" |
| `docs/architecture.md` | "the only production caller of `resolve_cross_reviewer`" |
| `docs/researchclawbench.md` ×3 | "live on this path only", "a 'fake' run makes real calls, one per approval" |
| `docs/tutorial_zh.md` ×2 | "目前只有 `rcb_agent.py` 那条路径真的会装上它" |

One was actively harmful. `researchclawbench.md` told the reader `--cross-review off` was *"not optional if you want a free run"* — which the manager-level fake-operator refusal made untrue. A reader following it was being told to pass a flag against a cost that no longer exists.

§8 now carries the two limits that **are** true and were found while wiring it: the mode is absent from the keys `load_run_config` reads, so a resumed run re-decides it from the day's credentials; and `_collect_review_decision` returns before `_apply_cross_review` when no automated reviewer is seated, so under a manual gate the reviewer is built and nothing consults it.

## A test that held nothing

`test_a_completed_run_prints_the_banner_beside_all_stages_approved` asserted over the **whole** printed stream. `_run_validity_review` already prints "did not complete" before `_complete_run` runs, so deleting the disclosure from the closing line left **all 2,148 tests green**. It now snapshots the stream length and asserts over the tail — the closing line is the one a reader takes as the verdict on the run. That mutation now dies.

## Overstated premises in the census work

`routing_summary` already published each visit's `offered` set under `decisions`, and `offered_payoffs` consumes it. So *"this function read neither"* and *"could not say what it was ever offered"* were both too strong. The true claim is narrower: `Visit.blocked` was unread, and there was no per-edge total over the whole walk. Corrected in `src/router.py` and two test docstrings.

Separately, the router said *"a bypassed visit contributes no offer and no block"* — which the branch's own `test_a_bypass_that_did_record_a_choice_set_is_counted_on_both_axes` refutes. The rule is about a **missing choice set**, not about the bypass flag. Corrected, and the test whose name stated the wrong general rule renamed.

## A docstring falsified one hunk away from the change that falsified it

`_extract_json` still said its failure was silent *"because `_parse` returns an empty list either way"*. `review()` stopped calling `_parse` in the same commit.

## And four more

- The README Limits bullet for the adversarial pass described the state before #202 closed it. It now says what is actually true: the failure is **disclosed, not enforced** — `validate_validity_response` is deliberately not the enforcement point, so a stage whose reviewer never returned is approved with a banner rather than refused.
- `docs/run-artifacts.md` pointed readers at that stale bullet and documented `reviewer_failed` as the primary field; it is now derived from `completion`.
- `Outcome`'s docstring said "three fields" of a four-field dataclass, and claimed each was "previously a literal somewhere else" — true of one.
- A test docstring said `SELECTS_ON_THE_OUTCOME` is named by "three docstrings"; an AST walk over `src/`, `tests/`, `tools/` and `main.py` finds one besides itself.

## Testing

2220 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)