### PR TITLE
Let a run say what its graph bought over the pipeline inside it

### DIFF
--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -658,6 +658,110 @@ def load_graph_state(paths: RunPaths, *, max_steps: int | None = None, max_visit
 
 def save_graph_state(paths: RunPaths, state: GraphState) -> None:
     write_text(state_file(paths), json.dumps(state.to_dict(), indent=2, ensure_ascii=False))
+    record_graph_effect(paths, state)
+
+
+GRAPH_EFFECT_FILENAME = "graph_effect.json"
+
+
+def effect_file(paths: RunPaths) -> Path:
+    return paths.evolution_dir / GRAPH_EFFECT_FILENAME
+
+
+def graph_effect(state: GraphState) -> dict[str, Any]:
+    """What the topology bought over the linear pipeline it contains.
+
+    The adaptive graph is one of this project's two central claims, and until now no run
+    could say whether it had done anything. ``stage_graph.json`` records every visit, but
+    reading a departure rate out of it correctly is easy to get wrong in three ways, and
+    :class:`Visit` carries a field against each:
+
+    * ``bypassed`` -- a ``/back``, a rollback after retry exhaustion or a round decision had
+      no choice set. Counting those as decisions reads an operator's intervention as
+      evidence about an edge.
+    * ``offered`` -- a node with one live move is not a decision. Pooling it with the rest
+      makes the denominator the pipeline's length rather than the number of choices, and
+      every graph then looks equally unused.
+    * ``refusal`` -- the agent answered and the answer was not used, because it was lost or
+      off-menu. That is not the agent agreeing with the default, and the difference is the
+      difference between "the graph is not wanted" and "the graph is not reaching anyone".
+
+    The measured answer on twelve benchmark runs, with the fix that made verdicts readable
+    already in: 81 decision points, 74 agreements, 6 departures, 1 refusal. So the freedom
+    is real, it reaches the router, and the router declines it 91% of the time. That is the
+    least flattering reading available and it is the one the evidence supports, which is
+    why this file writes it rather than leaving the claim unmeasured.
+    """
+    decision_points = departed = refused = agreed = bypassed = 0
+    single_move = 0
+    blocked_by: dict[str, int] = {}
+
+    for visit in state.path:
+        for kind in visit.blocked.values():
+            blocked_by[kind] = blocked_by.get(kind, 0) + 1
+        if visit.bypassed:
+            bypassed += 1
+            continue
+        if len(visit.offered) <= 1:
+            single_move += 1
+            continue
+        decision_points += 1
+        if visit.refusal:
+            refused += 1
+        elif visit.chose and visit.chose != visit.default_choice:
+            departed += 1
+        else:
+            agreed += 1
+
+    return {
+        "steps": len(state.path),
+        "nodes_with_one_live_move": single_move,
+        "nodes_bypassing_the_router": bypassed,
+        "decision_points": decision_points,
+        "departed_from_the_default": departed,
+        "agreed_with_the_default": agreed,
+        "answers_refused_or_lost": refused,
+        "departure_rate": round(departed / decision_points, 3) if decision_points else None,
+        "moves_blocked_by": blocked_by,
+        "verdict": _graph_effect_sentence(decision_points, departed, refused),
+    }
+
+
+def _graph_effect_sentence(decision_points: int, departed: int, refused: int) -> str:
+    """One line a human can act on, written to be unflattering when that is the truth."""
+    if decision_points == 0:
+        return (
+            "No node on this run offered more than one live move, so the graph could not "
+            "have differed from a linear pipeline and nothing here is evidence about it."
+        )
+    if departed == 0 and refused == 0:
+        return (
+            f"{decision_points} node(s) offered a real choice and the router took the "
+            "default at every one: on this run the graph was a linear pipeline."
+        )
+    if departed == 0:
+        return (
+            f"{decision_points} node(s) offered a real choice and the router departed at "
+            f"none of them, but {refused} answer(s) were refused or lost -- so this run is "
+            "evidence about the routing channel, not about the topology."
+        )
+    return (
+        f"The router departed from the default at {departed} of {decision_points} node(s) "
+        f"that offered a real choice ({100 * departed / decision_points:.0f}%)"
+        + (f", with {refused} answer(s) refused or lost." if refused else ".")
+    )
+
+
+def record_graph_effect(paths: RunPaths, state: GraphState) -> dict[str, Any]:
+    """Write :func:`graph_effect` beside the state it is derived from.
+
+    Derived rather than accumulated: unlike the review panel's, every input is already in
+    ``stage_graph.json``, so recomputing from the current state is always right and a
+    resumed or rolled-back run cannot leave a stale tally behind.
+    """
+    effect = graph_effect(state)
+    write_text(effect_file(paths), json.dumps(effect, indent=2, ensure_ascii=False))
+    return effect
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_graph_effect.py
+++ b/tests/test_graph_effect.py
@@ -1,0 +1,135 @@
+"""What the adaptive graph bought over the linear pipeline inside it.
+
+The graph is one of this project's two central claims and no run could say whether it had
+done anything. Measured across twelve benchmark runs, with the verdict-parsing fix already
+in so the router's answers actually arrive: 81 decision points, 74 agreements, 6 departures,
+1 refusal. The freedom is real, it reaches the router, and the router declines it 91% of the
+time. This file exists so a run states that itself instead of leaving the claim unmeasured.
+
+Three ways to compute the rate wrongly, one field of `Visit` against each: `bypassed`
+(operator interventions are not routing decisions), `offered` (a node with one live move is
+not a choice), and `refusal` (an answer that was lost is not an agreement).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.stage_graph import (
+    GraphState,
+    Visit,
+    effect_file,
+    graph_effect,
+    record_graph_effect,
+    save_graph_state,
+)
+from src.utils import build_run_paths, ensure_run_layout
+
+
+def visit(stage="01", *, offered=(), chose="", default="", refusal="", bypassed=False,
+          blocked=None) -> Visit:
+    return Visit(stage=stage, entered_at="t", offered=tuple(offered), chose=chose,
+                 default_choice=default, refusal=refusal, bypassed=bypassed,
+                 blocked=dict(blocked or {}), kind="advance", left_at="t")
+
+
+def state(*visits: Visit) -> GraphState:
+    s = GraphState()
+    s.path = list(visits)
+    return s
+
+
+class DenominatorTest(unittest.TestCase):
+    """A node without a real alternative is not a decision the graph made."""
+
+    def test_a_single_live_move_is_not_a_decision_point(self) -> None:
+        e = graph_effect(state(visit(offered=("02",), chose="02", default="02")))
+        self.assertEqual(e["decision_points"], 0)
+        self.assertEqual(e["nodes_with_one_live_move"], 1)
+        self.assertIsNone(e["departure_rate"])
+
+    def test_a_bypassed_move_is_not_a_decision_point(self) -> None:
+        """A /back or a rollback had no choice set; counting it reads an operator as an edge."""
+        e = graph_effect(state(visit(offered=("02", "03"), chose="03", bypassed=True)))
+        self.assertEqual(e["decision_points"], 0)
+        self.assertEqual(e["nodes_bypassing_the_router"], 1)
+
+    def test_a_run_with_no_choices_says_it_is_not_evidence(self) -> None:
+        e = graph_effect(state(visit(offered=("02",), chose="02", default="02")))
+        self.assertIn("nothing here is evidence about it", e["verdict"])
+
+
+class WhatTheRouterDidTest(unittest.TestCase):
+    def test_agreeing_with_the_default_is_counted_as_agreement(self) -> None:
+        e = graph_effect(state(visit(offered=("02", "05"), chose="02", default="02")))
+        self.assertEqual((e["decision_points"], e["agreed_with_the_default"]), (1, 1))
+        self.assertEqual(e["departed_from_the_default"], 0)
+
+    def test_a_departure_is_counted_and_rated(self) -> None:
+        e = graph_effect(state(
+            visit(offered=("02", "05"), chose="05", default="02"),
+            visit(offered=("03", "06"), chose="03", default="03"),
+        ))
+        self.assertEqual(e["departed_from_the_default"], 1)
+        self.assertEqual(e["departure_rate"], 0.5)
+
+    def test_a_refused_answer_is_not_an_agreement(self) -> None:
+        """The difference between "the graph is not wanted" and "it reaches nobody"."""
+        e = graph_effect(state(
+            visit(offered=("02", "05"), chose="02", default="02", refusal="off-menu")
+        ))
+        self.assertEqual(e["answers_refused_or_lost"], 1)
+        self.assertEqual(e["agreed_with_the_default"], 0)
+        self.assertIn("routing channel, not about the topology", e["verdict"])
+
+    def test_blocked_moves_are_tallied_by_kind(self) -> None:
+        e = graph_effect(state(
+            visit(offered=("02",), chose="02", blocked={"05": "guard", "07": "visits"}),
+            visit(offered=("03",), chose="03", blocked={"06": "guard"}),
+        ))
+        self.assertEqual(e["moves_blocked_by"], {"guard": 2, "visits": 1})
+
+
+class TheVerdictIsUnflatteringWhenTrueTest(unittest.TestCase):
+    def test_a_purely_linear_run_says_so_in_words(self) -> None:
+        """Nine of twelve benchmark runs looked exactly like this."""
+        e = graph_effect(state(*[visit(offered=("02", "05"), chose="02", default="02")] * 6))
+        self.assertIn("the graph was a linear pipeline", e["verdict"])
+
+    def test_a_run_that_used_the_graph_reports_the_rate(self) -> None:
+        e = graph_effect(state(
+            visit(offered=("02", "05"), chose="05", default="02"),
+            *[visit(offered=("03", "06"), chose="03", default="03")] * 3,
+        ))
+        self.assertIn("1 of 4", e["verdict"])
+        self.assertIn("25%", e["verdict"])
+
+
+class PersistenceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+
+    def test_saving_the_state_writes_the_effect_beside_it(self) -> None:
+        save_graph_state(self.paths, state(visit(offered=("02", "05"), chose="05", default="02")))
+        payload = json.loads(effect_file(self.paths).read_text(encoding="utf-8"))
+        self.assertEqual(payload["departed_from_the_default"], 1)
+
+    def test_it_is_derived_not_accumulated_so_a_rollback_cannot_leave_a_stale_tally(self) -> None:
+        record_graph_effect(self.paths, state(
+            visit(offered=("02", "05"), chose="05", default="02"),
+            visit(offered=("03", "06"), chose="06", default="03"),
+        ))
+        record_graph_effect(self.paths, state(visit(offered=("02", "05"), chose="02", default="02")))
+        payload = json.loads(effect_file(self.paths).read_text(encoding="utf-8"))
+        self.assertEqual(payload["departed_from_the_default"], 0)
+        self.assertEqual(payload["decision_points"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The gap

The adaptive stage graph is one of this project's two central claims, and **no run could say whether it had done anything**. `stage_graph.json` records every visit; nothing ever read it back. "Self-improving topology" was asserted and never measured.

## Measured, across the twelve scored ResearchClawBench runs

| | |
|---|---|
| nodes offering more than one live move | **81** |
| router **departed** from the default | **6** |
| router **agreed** with the default | **74** |
| answer refused or lost | **1** |
| runs that were linear end to end | **9 of 12** |

**The freedom is real, it reaches the router, and the router declines it 91% of the time.**

Nor does using it track score: the highest run (Physics_001, 37.1) was purely linear; the second (Physics_000, 36.9) departed 3 times.

## Why the number is trustworthy

`Visit` already carries a field against each of the three ways to compute this wrongly, and all three are used:

- **`bypassed`** — a `/back`, a rollback after retry exhaustion or a round decision had no choice set. Counting those reads an operator's intervention as evidence about an edge.
- **`offered`** — a node with one live move is not a decision. Pooling it makes the denominator the pipeline's *length*, and every graph then looks equally unused.
- **`refusal`** — the agent answered and the answer was lost or off-menu. That is **not** agreement with the default. The difference is "the graph is not wanted" versus "the graph reaches nobody" — and it matters here: the archived corpus this field was added for had **23 of 27** such visits; this set of twelve has **1 of 81**. The verdict-parsing fix is what moved it.

My own first hand-count of this ignored `refusal` and got a different answer. The implementation recomputes 81 / 6 / 74 / 1 on the real run trees, matching the corrected measurement exactly.

## Design

Derived, not accumulated — unlike `record_panel_effect`. Every input is already in the state, so recomputing is always right and a resumed or rolled-back run cannot leave a stale tally behind.

The verdict sentence is written to be unflattering when that is the truth:

> *"6 node(s) offered a real choice and the router took the default at every one: on this run the graph was a linear pipeline."*

A run with no multi-move node says it is **not evidence about the topology at all**, rather than reporting a departure rate of zero — an unused graph and an unusable one are different claims.

## What this does not do

It does not make the graph better, and it does not argue the graph is worthless: 12 runs on one benchmark cannot settle that. It makes the claim checkable, so the next change to the topology can be judged against a baseline instead of an intuition.

## Tests

11 new tests in `tests/test_graph_effect.py`, one per miscount the fields exist to prevent, plus the two verdict shapes and the derived-not-accumulated property. Full suite **2239 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)