### PR TITLE
Stop skipping a stage for running out of tries

### DIFF
--- a/main.py
+++ b/main.py
@@ -266,9 +266,12 @@ def parse_args() -> argparse.Namespace:
         "--max-attempts",
         type=int,
         default=MAX_STAGE_ATTEMPTS,
-        help="Attempts allowed per stage before AutoR escalates or auto-skips. Each retry "
-             "re-runs the stage with the previous attempt's validation errors attached. "
-             f"Defaults to {MAX_STAGE_ATTEMPTS}.",
+        help="Attempts allowed per stage before AutoR escalates or auto-skips. "
+             "**Omitted, the default, means no limit**: a stage is retried until it passes its "
+             "gate, because exhausting the budget does not stop the run, it skips the "
+             "stage and writes a report standing on nothing. Each retry re-runs the stage "
+             "with the previous attempt's validation errors attached. "
+             "Omit it for no limit; pass an integer to cap.",
     )
     parser.add_argument(
         "--review-operator",

--- a/src/manager.py
+++ b/src/manager.py
@@ -168,6 +168,9 @@ from .utils import (
     FIXED_STAGE_OPTIONS,
     INTAKE_STAGE,
     MAX_STAGE_ATTEMPTS,
+    STUCK_AFTER_IDENTICAL_FAILURES,
+    attempts_exhausted,
+    is_stuck,
     STAGES,
     WRITING_STAGE,
     RunPaths,
@@ -227,7 +230,7 @@ class ResearchManager:
         unattended: bool = False,
         max_auto_skips: int = 3,
         max_rounds: int = 1,
-        max_stage_attempts: int = MAX_STAGE_ATTEMPTS,
+        max_stage_attempts: int | None = MAX_STAGE_ATTEMPTS,
         web_search_context: str | None = None,
         min_report_figures: int | None = None,
         web_search_mode: str | None = None,
@@ -1359,7 +1362,7 @@ class ResearchManager:
         mark_stage_execution_started(paths, stage)
 
         while True:
-            if attempt_no > self.max_stage_attempts:
+            if attempts_exhausted(attempt_no, self.max_stage_attempts):
                 self.ui.show_status(
                     f"{stage.stage_title} failed after {self.max_stage_attempts} attempts. Escalating to user.",
                     level="error",
@@ -1641,7 +1644,7 @@ class ResearchManager:
         continue_session = False
 
         while True:
-            if attempt_no > self.max_stage_attempts:
+            if attempts_exhausted(attempt_no, self.max_stage_attempts):
                 self.ui.show_status(
                     f"{stage.stage_title} failed after {self.max_stage_attempts} attempts. Escalating to user.",
                     level="error",
@@ -1802,7 +1805,7 @@ class ResearchManager:
         continue_session = False
 
         while True:
-            if attempt_no > self.max_stage_attempts:
+            if attempts_exhausted(attempt_no, self.max_stage_attempts):
                 self.ui.show_status(
                     f"{stage.stage_title} failed after {self.max_stage_attempts} attempts. Escalating to user.",
                     level="error",
@@ -2108,6 +2111,10 @@ class ResearchManager:
         revision_feedback: str | None = None
         continue_session = False
         last_validation_errors: list[str] = []
+        #: One entry per *failed* attempt in this stage run, newest last. The stuck check
+        #: reads only the tail, but keeping the whole list means the log can say how many
+        #: attempts it took rather than only that it stopped.
+        recent_failures: list[list[str]] = []
         mark_stage_execution_started(paths, stage)
 
         # Optional pre-loaded revision feedback. The Studio (or any other
@@ -2143,18 +2150,39 @@ class ResearchManager:
                 pass
 
         while True:
-            if loop_attempts - (polish_rounds - entry_polish_rounds) >= self.max_stage_attempts:
-                error = (
-                    f"Exceeded {self.max_stage_attempts} attempts in the current stage run. "
-                    f"Last validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
-                )
+            # The main stage loop, and the one that actually fires: it counts attempts
+            # net of polish rounds, so its comparison is `>=` against the ceiling rather
+            # than `>` against the attempt number. Reading zero as a ceiling here means
+            # "no attempts allowed" and every stage fails before it starts, which is the
+            # opposite of no limit. Same predicate, offset by one to match the `>=`.
+            stuck = is_stuck(recent_failures)
+            if stuck or attempts_exhausted(
+                loop_attempts - (polish_rounds - entry_polish_rounds) + 1,
+                self.max_stage_attempts,
+            ):
+                if stuck:
+                    error = (
+                        f"{STUCK_AFTER_IDENTICAL_FAILURES} consecutive attempts failed in "
+                        f"exactly the same way, so another one cannot help. Repeated "
+                        f"validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
+                    )
+                else:
+                    error = (
+                        f"Exceeded {self.max_stage_attempts} attempts in the current stage run. "
+                        f"Last validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
+                    )
                 self.ui.show_status(
-                    f"{stage.stage_title} failed after {self.max_stage_attempts} attempts in this run.",
+                    f"{stage.stage_title} "
+                    + (
+                        f"made no progress across {STUCK_AFTER_IDENTICAL_FAILURES} identical failures."
+                        if stuck
+                        else f"failed after {self.max_stage_attempts} attempts in this run."
+                    ),
                     level="error",
                 )
                 append_log_entry(
                     paths.logs,
-                    f"{stage.slug} max_attempts_exceeded",
+                    f"{stage.slug} " + ("stage_stuck" if stuck else "max_attempts_exceeded"),
                     error,
                 )
                 mark_stage_failed_manifest(paths, stage, error)
@@ -2376,6 +2404,7 @@ class ResearchManager:
                             "with no placeholder markers and ensure every required section is substantively filled."
                         )
                         last_validation_errors = list(validation_errors)
+                        recent_failures.append(list(validation_errors))
                         continue_session = True
                         attempt_no += 1
                         continue

--- a/src/utils.py
+++ b/src/utils.py
@@ -64,7 +64,71 @@ def code_version() -> str:
     _code_version_cache = sha[:12] + suffix
     return _code_version_cache
 DEFAULT_VENUE = "neurips_2025"
-MAX_STAGE_ATTEMPTS = 5
+#: Attempts a stage may take before AutoR gives up on it. **None means no limit, and
+#: None is the default.**
+#:
+#: It used to be 5, and the ceiling was doing harm rather than good. Exhausting it does not
+#: stop the run: it auto-skips the stage and carries on, so the budget's real effect was to
+#: convert "this stage is taking a while" into "this stage did not happen" -- silently, in
+#: an artifact that still looks like a finished run. A ResearchClawBench run watched live
+#: skipped its literature survey and its hypothesis generation that way and went on to write
+#: a report standing on neither, and the cause was not the research: the reviewing backend
+#: was emitting its verdict after a tool transcript AutoR could not yet parse (#176), so
+#: every attempt was refused by the parser and the stage ran out of tries it never needed.
+#:
+#: A skipped stage is the expensive failure. Waiting is not. An integer still caps, for a
+#: caller who wants a bound.
+#:
+#: The sentinel is ``None`` rather than ``0`` because ``0`` was already a value with a
+#: meaning -- "allow no attempts, fail at once", which is how a test forces the skip path.
+#: Overloading it would have made that test hang forever instead of failing, and a lever
+#: that silently becomes its own opposite is worse than a slightly longer type.
+MAX_STAGE_ATTEMPTS: int | None = None
+
+
+#: Consecutive attempts that may fail *in exactly the same way* before a stage is
+#: declared stuck. Removing the attempt ceiling removes the only thing that used to stop
+#: a stage that cannot pass, and an unbounded retry of a stage whose fixture can never
+#: satisfy its own gate is a run that never ends -- a worse outcome than the skip the
+#: ceiling was removed to prevent, because it produces nothing at all rather than
+#: something with a hole in it.
+#:
+#: The stop is *no progress*, not *no patience*. A stage that fails differently each time
+#: is working through its problems and gets as many attempts as it needs; a stage whose
+#: validation errors are byte-identical three times running has shown that another
+#: attempt cannot help. That distinction is the whole reason the count is on repeats
+#: rather than on tries.
+STUCK_AFTER_IDENTICAL_FAILURES = 3
+
+
+def is_stuck(recent_failures: Sequence[Sequence[str]]) -> bool:
+    """Whether the last :data:`STUCK_AFTER_IDENTICAL_FAILURES` attempts failed identically.
+
+    Order within one attempt's errors is not meaningful -- validators run in whatever
+    order they are registered -- so the comparison is over the sorted set. Two attempts
+    that surfaced the same problems in a different order made the same amount of
+    progress, which is none.
+    """
+    if len(recent_failures) < STUCK_AFTER_IDENTICAL_FAILURES:
+        return False
+    window = recent_failures[-STUCK_AFTER_IDENTICAL_FAILURES:]
+    signatures = {tuple(sorted(str(item) for item in errors)) for errors in window}
+    if len(signatures) != 1:
+        return False
+    # An attempt that recorded no errors at all did not fail in a way we can compare.
+    # Treating an empty signature as a repeat would stop a stage that is failing for a
+    # reason no validator named, which is the case most in need of another attempt.
+    return bool(next(iter(signatures)))
+
+
+def attempts_exhausted(attempt_no: int, ceiling: int | None) -> bool:
+    """Whether *attempt_no* has run past *ceiling*, with ``None`` meaning no ceiling.
+
+    A predicate rather than four copies of the comparison: the call sites are the places
+    a stage can be sent back from, they do not all compare the same way, and one added
+    later should not have to remember that None is special.
+    """
+    return ceiling is not None and attempt_no > ceiling
 DEFAULT_CODEX_SANDBOX = "workspace-write"
 CODEX_SANDBOX_CHOICES = {"read-only", "workspace-write", "danger-full-access"}
 

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -21,6 +21,7 @@ from src.operator import ClaudeOperator
 from src.terminal_ui import TerminalUI
 from src.utils import (
     MAX_STAGE_ATTEMPTS,
+    attempts_exhausted,
     STAGES,
     build_continuation_prompt,
     build_run_paths,
@@ -35,12 +36,28 @@ from src.utils import (
 
 
 class TestMaxStageAttemptsConstant(unittest.TestCase):
-    def test_max_stage_attempts_is_positive_integer(self):
-        self.assertIsInstance(MAX_STAGE_ATTEMPTS, int)
-        self.assertGreater(MAX_STAGE_ATTEMPTS, 0)
+    """The default is no ceiling, and the sentinel is not a number.
 
-    def test_default_value_is_five(self):
-        self.assertEqual(MAX_STAGE_ATTEMPTS, 5)
+    It was 5. Exhausting it does not stop a run -- it auto-skips the stage and carries
+    on -- so the ceiling's real effect was to turn "this stage is taking a while" into
+    "this stage did not happen", inside an artifact that still reads as a finished run.
+    A live ResearchClawBench run skipped its literature survey and its hypothesis
+    generation exactly that way.
+    """
+
+    def test_the_default_is_no_ceiling(self):
+        self.assertIsNone(MAX_STAGE_ATTEMPTS)
+        self.assertFalse(attempts_exhausted(10_000, MAX_STAGE_ATTEMPTS))
+
+    def test_the_sentinel_is_none_and_not_zero(self):
+        # Zero already meant something: allow no attempts, fail at once. It is how a test
+        # forces the skip path. Overloading it would turn that lever into its opposite and
+        # hang the run instead of failing it.
+        self.assertTrue(attempts_exhausted(1, 0))
+
+    def test_an_integer_ceiling_still_caps(self):
+        self.assertFalse(attempts_exhausted(5, 5))
+        self.assertTrue(attempts_exhausted(6, 5))
 
 
 class TestRecoveryContextInContinuationPrompt(unittest.TestCase):
@@ -228,7 +245,7 @@ class TestRunStageMaxAttempts(unittest.TestCase):
         self.operator.run_stage.assert_called_once()
         self.assertTrue(self.paths.stage_file(stage).exists())
 
-    def test_the_attempt_ceiling_defaults_to_the_module_value_and_can_be_raised(self):
+    def test_the_attempt_ceiling_defaults_to_no_limit_and_can_be_set(self):
         from src.manager import ResearchManager
 
         default = ResearchManager(
@@ -238,6 +255,7 @@ class TestRunStageMaxAttempts(unittest.TestCase):
             ui=self.ui,
         )
         self.assertEqual(default.max_stage_attempts, MAX_STAGE_ATTEMPTS)
+        self.assertIsNone(default.max_stage_attempts)
 
         # A caller with time to spend can buy more retries, which is the whole point: each one
         # re-runs the stage with the previous attempt's validation errors attached.
@@ -246,9 +264,9 @@ class TestRunStageMaxAttempts(unittest.TestCase):
             runs_dir=self.runs_dir,
             operator=self.operator,
             ui=self.ui,
-            max_stage_attempts=MAX_STAGE_ATTEMPTS + 4,
+            max_stage_attempts=9,
         )
-        self.assertEqual(raised.max_stage_attempts, MAX_STAGE_ATTEMPTS + 4)
+        self.assertEqual(raised.max_stage_attempts, 9)
 
     def test_the_recorded_ceiling_is_the_instance_value_not_a_constant(self):
         # Pinning a value other than 0 is what proves the loop reads self.max_stage_attempts:

--- a/tests/test_stage_stuck.py
+++ b/tests/test_stage_stuck.py
@@ -1,0 +1,72 @@
+"""Unlimited attempts still have to end, and the thing that ends them is progress.
+
+Removing the attempt ceiling removed the only thing that stopped a stage which cannot
+pass. That is not obviously an improvement: a run that never ends produces *nothing*,
+which is worse than the skipped stage the ceiling was removed to prevent, because a run
+with a hole in it at least has a report.
+
+So the stop is "no progress", not "no patience". A stage failing differently each time is
+working through its problems and gets as many attempts as it needs. A stage whose
+validation errors are identical three times running has demonstrated that another attempt
+cannot help, and the run says so in those words rather than reporting an exhausted budget
+it no longer has.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.utils import STUCK_AFTER_IDENTICAL_FAILURES as K
+from src.utils import attempts_exhausted, is_stuck
+
+
+class IsStuckTest(unittest.TestCase):
+    def test_identical_failures_are_stuck(self) -> None:
+        self.assertTrue(is_stuck([["missing sources.json"]] * K))
+
+    def test_one_short_of_the_window_is_not_stuck(self) -> None:
+        self.assertFalse(is_stuck([["missing sources.json"]] * (K - 1)))
+
+    def test_reordered_errors_are_the_same_failure(self) -> None:
+        # Validators run in registration order, which is not meaningful. Two attempts that
+        # surfaced the same problems in a different order made the same progress: none.
+        self.assertTrue(is_stuck([["a", "b"], ["b", "a"], ["a", "b"]][:K] * 1))
+
+    def test_a_stage_failing_differently_gets_to_keep_going(self) -> None:
+        self.assertFalse(is_stuck([["a"], ["b"], ["c"]]))
+
+    def test_progress_then_a_repeat_only_counts_the_tail(self) -> None:
+        self.assertFalse(is_stuck([["a"], ["a"], ["b"]]))
+        self.assertTrue(is_stuck([["a"], ["b"], ["b"], ["b"]]))
+
+    def test_an_attempt_with_no_recorded_errors_is_not_a_repeat(self) -> None:
+        # A failure no validator named is the case most in need of another attempt, and
+        # three of them would otherwise read as three identical failures.
+        self.assertFalse(is_stuck([[]] * K))
+        self.assertFalse(is_stuck([[], [], []]))
+
+    def test_an_empty_history_is_not_stuck(self) -> None:
+        self.assertFalse(is_stuck([]))
+
+    def test_the_window_is_the_published_constant(self) -> None:
+        # Pins the relationship rather than the number: the rule is "K identical", so a
+        # history of K-1 must not trip it and a history of K must.
+        history = [["same"]] * K
+        self.assertTrue(is_stuck(history))
+        self.assertFalse(is_stuck(history[: K - 1]))
+
+
+class TheTwoStopsAreIndependentTest(unittest.TestCase):
+    def test_no_ceiling_does_not_mean_no_stop(self) -> None:
+        self.assertFalse(attempts_exhausted(500, None))
+        self.assertTrue(is_stuck([["same"]] * K))
+
+    def test_a_ceiling_still_stops_a_stage_that_is_making_progress(self) -> None:
+        # The two answer different questions. Progress does not buy an unlimited run when
+        # the caller asked for a bound.
+        self.assertFalse(is_stuck([["a"], ["b"], ["c"]]))
+        self.assertTrue(attempts_exhausted(6, 5))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`MAX_STAGE_ATTEMPTS` was 5, and **exhausting it does not stop a run** — it auto-skips the stage and carries on. So the ceiling's real effect was to convert *"this stage is taking a while"* into *"this stage did not happen"*, silently, inside an artifact that still reads as a finished run.

## Watched live

A ResearchClawBench paired trial, control arm, `Energy_001`:

```
01_literature_survey        8 attempts → skipped
02_hypothesis_generation    8 attempts → skipped
03_study_design             8 attempts → approved
```

Eight hours in, two stages gone, and the report would have been written standing on neither.

**The cause was not the research.** The reviewing backend is an agent: it narrates, runs tools, prints their output, and emits the verdict as its final message. AutoR could not yet parse that (fixed since, in [#176](https://github.com/tangxiangru/AutoR/pull/176)), so every attempt was refused by the parser and the stage ran out of tries it never needed. The budget turned a parsing bug into two missing stages.

## The change

Default is now no ceiling. An integer still caps, for a caller who wants a bound.

**The sentinel is `None`, not `0`** — because `0` already meant something: *allow no attempts, fail at once*, which is how `test_stage_can_be_skipped_after_exhausted_retries` forces the skip path. Overloading it turns that lever into its exact opposite and **hangs** the run instead of failing it, which is what happened while writing this.

## Removing a stop means adding one

Removing the ceiling removes the only thing that stopped a stage which *cannot* pass, and a run that never ends is worse than one with a hole in it: it produces nothing at all. The fake-pipeline test whose Stage 07 deliberately fails its own gate went from failing to hanging.

So the stop is now **no progress**, not **no patience**:

| Situation | Outcome |
|:---|:---|
| fails differently each attempt | keeps going, as many attempts as it needs |
| identical validation errors 3× running | stops, and the log says *"made no progress across 3 identical failures"* |

Two details that are load-bearing:

- **Errors compare as a sorted set.** Validators run in registration order, so two attempts that surfaced the same problems in a different order made the same progress: none.
- **An attempt that recorded no errors is not a repeat.** A failure no validator named is the case *most* in need of another try; counting three of those as identical would stop precisely the stage that deserves patience.

## Verification

2,254 tests, 14 new.

| Mutant | Result |
|:---|:---|
| `None` stops meaning unlimited | killed (3) |
| stuck check never fires | **hangs** — the mutant's own failure mode |
| manager stops recording failures | **hangs** |
| window of 1 (one failure = stuck) | killed (4) |
| empty signature counts as a repeat | killed |
| `sorted()` dropped — reordering reads as progress | killed |

Three pre-existing tests pinned the old default; they are rewritten to test the new contract rather than to flip an assertion, including one that pins `0` still meaning fail-at-once.

**Worth flagging about my own method:** a timeout mid-sweep left one mutation applied, and I then backed *that* up as the baseline — so the next two results were measured against a mutated tree. Two of the "kills" I first recorded were a bad test id resolving to a loader error. Both were caught by re-running the baseline between mutants, which is the only reason the table above is trustworthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)