### PR TITLE
Give the two unwired prompt renderers a typed channel each, and make an uncalled import fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ resumable, with redo and rollback.
 ### The one thing the docs will not claim
 
 Approved stage summaries are the only *free-text* cross-stage memory. Every other cross-stage edge is
-a typed artifact with a declared reader: **sixteen channels** in
+a typed artifact with a declared reader: **eighteen typed channels** in
 [`information_flow.py`](src/information_flow.py) each name the exact stage slugs that consume them,
-and the eight produced inside the walk name their producing stage as well. `obligations.json` and
+and the nine channels produced inside the walk name their producing stage as well. `obligations.json` and
 `review_policy.json` cross stages without touching a summary at all — both only behind an agent
 approval gate.
 
@@ -125,7 +125,7 @@ naming them.
 | Conditional terminal edges | `TERMINAL_EDGES` | 1 |
 | Edges in the default (`adaptive`) graph | `StageGraph.adaptive()` | 22 |
 | Edges in `--stage-graph linear` | `StageGraph.linear()` | 9 |
-| Typed information channels | `CHANNELS`, [src/information_flow.py](src/information_flow.py) | 16 |
+| Typed information channels | `CHANNELS`, [src/information_flow.py](src/information_flow.py) | 18 |
 | `validate_*` functions the stage gate calls | `validate_stage_artifacts`, [src/utils.py](src/utils.py) | 17 |
 | Required stage-summary headings | `REQUIRED_STAGE_HEADINGS` | 7 |
 | Rubric criteria (weighted, backend-free) | `CRITERIA`, [src/rubric.py](src/rubric.py) | 8 |
@@ -566,14 +566,15 @@ The complete gate, including every JSON schema that is parsed rather than merely
 ## Execution model
 
 Context is composed per consumer, not per availability. A stage's inbound block is built by
-`render_inbound(ChannelContext(...), CHANNELS)` from the **sixteen** typed channels in
+`render_inbound(ChannelContext(...), CHANNELS)` from the **eighteen** typed channels in
 [src/information_flow.py](src/information_flow.py). Each channel declares `produced_by`, a
 `consumed_by` set of real stage slugs, and a `rationale`;
 `test_every_narrowing_is_argued_for` ([tests/test_information_flow.py](tests/test_information_flow.py))
 fails a channel that withholds itself from a stage without saying why. Withholding has to be argued
 for, not just done.
 
-Three narrowings, because the abstraction is not the point:
+Four narrowings worth knowing, because the abstraction is not the point. Seventeen channels narrow;
+these four are the ones whose reason is not readable off the key:
 
 - the **artifact index** skips Stages 00-02 — they produce no data, results or figures, so the index
   is empty noise there
@@ -582,12 +583,20 @@ Three narrowings, because the abstraction is not the point:
   approval supersedes them. Before that edge was typed, the same H1 went into every prompt from
   Stage 05 on twice — one copy labelled editable, sitting next to the frozen one at exactly the
   stages where the freeze is the point.
+- the **project bootstrap** narrows by exactly one stage and no more. `recommend_entry_stage` can
+  return any stage from 01 to 08, so a fixed early set of readers would withhold the description of
+  the repository from the run that re-enters latest — the one that has seen least of it. Stage 00 is
+  the single exclusion, because `run()` scans the repository *after* intake has finished, so the
+  block is empty there every time. This block deliberately overlaps `# Approved Memory`:
+  `_adopt_project_bootstrap_baseline` copies each below-entry assessment into a stage summary, but
+  `append_approved_stage_summary` keeps only the entries numbered below the stage it writes, so the
+  first approval below the re-entry point erases them and this block becomes the only copy.
 
 `dependency_edges()` returns every `(producer, consumer, channel key)` triple, so the information
 topology can be printed and diffed rather than reconstructed from a pile of `if` statements.
 `_record_inbound_channels` writes the delivered channel keys per stage into the run log.
 
-Honest scope: sixteen blocks are typed. Six more — `obligations_context`, `intake_context_text`,
+Honest scope: eighteen blocks are typed. Six more — `obligations_context`, `intake_context_text`,
 `web_search_context`, `approved_memory`, `handoff_context`, and the `# What the Task Asks For` block
 that `build_prompt` composes inline from
 [`format_deliverables_for_prompt`](src/deliverables.py) — are still delivered by `build_prompt`
@@ -707,7 +716,7 @@ Full file-by-file reference: **[docs/run-artifacts.md](docs/run-artifacts.md)**.
 ```mermaid
 flowchart LR
     P[rigor.py · effort.py<br/>policy: what machinery runs] --> M
-    C[information_flow.py<br/>16 typed channels] --> M
+    C[information_flow.py<br/>18 typed channels] --> M
     M[manager.py<br/>walks the stage graph] --> W[walk<br/>stage_graph · router]
     M --> G[gates<br/>utils · preregistration · experimental_protocol<br/>report_plan · deliverables · validity_review]
     M --> I[improvement<br/>rubric · evolution · pareto]
@@ -735,7 +744,7 @@ flowchart LR
 | [src/writing_manifest.py](src/writing_manifest.py) | The Stage 07 inventory plus the AutoR-owned triage artifact for each output format |
 | [src/approval_agent.py](src/approval_agent.py) | The solo approval gate, its six-choice vocabulary and its unreadable-verdict fallback |
 | [src/preregistration.py](src/preregistration.py) | Freeze, amend, adjudicate, trace |
-| [src/information_flow.py](src/information_flow.py) | Sixteen typed information channels, each with declared readers and a written rationale |
+| [src/information_flow.py](src/information_flow.py) | Eighteen typed information channels, each with declared readers and a written rationale |
 | [src/router.py](src/router.py) | The agent's choice among admissible moves; an off-menu choice is refused and logged |
 | [src/validity_review.py](src/validity_review.py) | The adversarial pass after Stages 05 and 06, and the response gate that follows it |
 | [src/research_rounds.py](src/research_rounds.py) | Stages 03-06 as a repeatable round, bounded by `--max-rounds` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ survives a crash because it was never anywhere else.
 **No conversation crosses a stage boundary.** Stage 05 cannot see Stage 03's
 session. What crosses is `memory.md` — the approved stage summaries — plus
 `handoff/<slug>.md`, the same summaries cut down to Objective / Key Results /
-Files Produced (`write_stage_handoff`, `src/utils.py`), plus sixteen typed
+Files Produced (`write_stage_handoff`, `src/utils.py`), plus eighteen typed
 channels in [`src/information_flow.py`](../src/information_flow.py), each of
 which declares which stages read it. Memory and the handoff are the free text;
 everything else that crosses a boundary is a typed channel or a JSON artifact.
@@ -154,7 +154,7 @@ touching a verdict — see **[framework.md](framework.md)**.
 | --- | --- |
 | [`src/utils.py`](../src/utils.py) | The contract layer. `STAGES`, `RunPaths`/`build_run_paths`, `REQUIRED_STAGE_HEADINGS`, `FIXED_STAGE_OPTIONS`, prompt assembly, `validate_stage_markdown`, `validate_stage_artifacts`, memory rendering, handoff read/write, venue resolution, `run_config.json` I/O, and every default the CLI overrides. |
 | [`src/preregistration.py`](../src/preregistration.py) | Freezes and hashes the hypothesis set before results exist, adjudicates every frozen hypothesis at Stage 06 against a named result artifact, and traces every manuscript claim back to a supported hypothesis at Stage 07. A post-freeze change is legal only as an `amend_preregistration` amendment carrying the previous digest. |
-| [`src/experimental_protocol.py`](../src/experimental_protocol.py) | Declares the primary metric, the seed count and each baseline's `why_competent` and `tuning_budget` before the experiments run. `MIN_SEEDS_FOR_A_VERDICT = 2` refuses a supported/refuted verdict resting on one run unless the run says why one run settles it. |
+| [`src/experimental_protocol.py`](../src/experimental_protocol.py) | Declares the primary metric, the seed count and each baseline's `why_competent` and `tuning_budget` before the experiments run. `MIN_SEEDS_FOR_A_VERDICT = 2` refuses a supported/refuted verdict resting on one run unless the run says why one run settles it. The declared values reach Stages 04-07 through the `experimental_protocol` channel: until they did, the protocol was a standard the run was measured against and never shown. |
 | [`src/validity_review.py`](../src/validity_review.py) | The adversarial pass after Stages 05 and 06 (`REVIEWED_STAGE_NUMBERS`). Asks why the result is wrong across ten named failure modes rather than whether the stage is complete, and requires the next stage to answer every finding. Has no authority to approve or reject. |
 | [`src/manifest.py`](../src/manifest.py) | `run_manifest.json`: stage lifecycle, status transitions, rollback and stale marking, memory rebuild from approved entries. |
 | [`src/artifact_index.py`](../src/artifact_index.py) | Scans `data/`, `results/`, `figures/`; infers or reads declared schemas; writes `artifact_index.json`. |
@@ -204,11 +204,11 @@ for the argument.
 
 | Module | Responsibility |
 | --- | --- |
-| [`src/information_flow.py`](../src/information_flow.py) | Sixteen typed channels (`CHANNELS`). Each declares `produced_by`, a `consumed_by` set of real stage slugs, and a rationale for every narrowing. `render_inbound()` composes a stage's context per consumer; `dependency_edges()` prints the producer→consumer topology. |
+| [`src/information_flow.py`](../src/information_flow.py) | Eighteen typed channels (`CHANNELS`). Each declares `produced_by`, a `consumed_by` set of real stage slugs, and a rationale for every narrowing. `render_inbound()` composes a stage's context per consumer; `dependency_edges()` prints the producer→consumer topology. |
 | [`src/prompt_fragments.py`](../src/prompt_fragments.py) | The rules every stage prompt shares, held once. `compose_stage_template` orders them: the stage's own instructions, then the output-format rules that constrain them, then `RUN_SAFETY`. |
 | [`src/intake.py`](../src/intake.py) | Stage 00: clarification-question parsing, resource classification and ingestion, `intake_context.json`. Runs before the graph walk begins. |
 | [`src/bootstrap.py`](../src/bootstrap.py) | `--paper-corpus`: scans your prior papers (PDF/LaTeX/BibTeX) into a researcher profile, citation neighborhood, and style profile. |
-| [`src/project_bootstrap.py`](../src/project_bootstrap.py) | `--project-root`: scans an existing repository, assesses per-stage completion, recommends a re-entry stage. |
+| [`src/project_bootstrap.py`](../src/project_bootstrap.py) | `--project-root`: scans an existing repository, assesses per-stage completion, recommends a re-entry stage. The scan reaches every stage the run can be dropped into through the `project_context` channel. It overlaps `# Approved Memory`, which carries the same readings as carry-forward stage summaries, and the overlap is kept on purpose: `append_approved_stage_summary` drops every memory entry at or above the stage it writes, so a revisit below the re-entry point leaves the channel block as the only copy. |
 | [`src/prompts/`](../src/prompts) | One markdown template per stage, plus intake and bootstrap templates. Editing these changes agent behaviour with no code change. |
 | [`src/skills/`](../src/skills) | Agent skills, installed into each run's `.claude/skills/` by [`src/run_skills.py`](../src/run_skills.py). Pull-based counterpart to the templates: loaded only when the model judges one relevant. The install path is load-bearing — the operator runs with `cwd=run_root`, so skills left in the AutoR checkout are never discovered. |
 
@@ -305,10 +305,14 @@ Steps 3-7 are `build_prompt` (`src/utils.py`); a continuation attempt takes
 `build_continuation_prompt` instead, which always sends the handoff
 because it sends no memory at all.
 
-Three channel narrowings worth knowing, because they are what "typed" buys:
+Four channel narrowings worth knowing, because they are what "typed" buys:
 the artifact index skips Stages 00-02, which produce none; the writing manifest
-reaches Stage 07 alone; and the mutable Stage 02 hypotheses stop at
-`04_implementation`, where the freeze supersedes them.
+reaches Stage 07 alone; the mutable Stage 02 hypotheses stop at
+`04_implementation`, where the freeze supersedes them; and the project bootstrap
+withholds itself from Stage 00 and from nowhere else, because the scan runs after
+intake and `recommend_entry_stage` can drop the walk into any of the other eight.
+Almost every channel narrows — these four are the ones whose reason is not
+readable off the key.
 
 Five blocks are still passed as arguments rather than declared as channels:
 `obligations_context`, `intake_context_text`, `web_search_context`,

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -293,7 +293,7 @@ write up an abandoned round is a correctness property rather than a routing pref
 The control loop, per step:
 
 1. **Compose the prompt.** `render_inbound(ChannelContext(...), CHANNELS)` builds the stage's inbound
-   context from the sixteen typed channels in [`information_flow.py`](../src/information_flow.py).
+   context from the eighteen typed channels in [`information_flow.py`](../src/information_flow.py).
    Each channel declares `produced_by`, a `consumed_by` set of real stage slugs, and a written
    `rationale`; a test fails any channel that withholds itself from a stage without saying why.
 2. **Execute.** The prompt is written verbatim to `prompt_cache/` and handed to the coding agent CLI
@@ -393,7 +393,7 @@ An explicit `--flag`/`--no-flag` always beats the level. The validity chain is n
 | [`stage_graph.py`](../src/stage_graph.py) | Nodes, edges, guards, visit budgets, and the two topologies. |
 | [`router.py`](../src/router.py) | The agent's pick among admissible moves, and the refusal of an off-menu or unjustified one. |
 | [`research_rounds.py`](../src/research_rounds.py) | Stages 03–06 as a repeatable round with a recorded closing decision. |
-| [`information_flow.py`](../src/information_flow.py) | Sixteen typed context channels with declared readers and written rationales. |
+| [`information_flow.py`](../src/information_flow.py) | Eighteen typed context channels with declared readers and written rationales. |
 
 ### Gates — what a stage must produce to be accepted
 
@@ -939,7 +939,7 @@ What a reader can take from this system, in descending order of how transferable
    explained rather than hidden, revisit-reason deduplication, and a learning component that is
    structurally forbidden from weakening the guards it learns around.
 
-5. **A typed information-flow layer for agent prompts.** Sixteen channels, each naming its producer,
+5. **A typed information-flow layer for agent prompts.** Eighteen typed channels, each naming its producer,
    its consumers by stage slug, and a written rationale for every narrowing — with a test that fails
    a channel that withholds itself without an argument. It makes "what did this stage actually see?"
    a diffable topology instead of a reconstruction from `if` statements.

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -642,9 +642,25 @@ See [Recursive Self-Improvement](self-improvement.md).
 | `bootstrap/` | the `--project-root` scan, all of it: `project_state.json`, `experiment_inventory.json`, `writing_state.json`, `stage_assessments.json`, `scan_metadata.json`, `bootstrap_summary.md` | — |
 | `profile/` | the `--paper-corpus` scan — derived researcher profile and style notes: `research_profile.json`, `citation_neighborhood.json`, `style_profile.json`, `corpus_manifest.json`, `style_notes.md`, `bootstrap_summary.md` | — |
 
-The two scans do not share a directory. `--project-root` is the only writer of
-`bootstrap/`: `save_project_bootstrap` emits all six files there in one call,
-before the bootstrap stage runs. `--paper-corpus` writes nothing to
+The two scans do not share a directory. `--project-root` is the only scan that
+writes `bootstrap/`: `save_project_bootstrap` emits all six files there in one
+call, before the bootstrap stage runs. It is not the last writer, though.
+`src/prompts/project_bootstrap.md` points the bootstrap agent at
+`{{WORKSPACE_BOOTSTRAP_DIR}}` and asks it for four of those six —
+`stage_assessments.json`, `experiment_inventory.json`, `writing_state.json` and
+`bootstrap_summary.md` — so from that stage's approval on, four of the six hold
+whatever the agent wrote. AutoR relies on exactly that for one of them:
+`_run_project_bootstrap` re-reads `load_stage_assessments` after approval and
+prefers it to the scan's own list. The consequence worth knowing is for the
+other: `format_project_context_for_prompt` puts `bootstrap_summary.md` above its
+assessment list, and the template asks for 300-500 words of prose there, so the
+per-stage readings in that section are not guaranteed to survive the bootstrap
+stage — which is why the list under it is never narrowed. The split is pinned by
+`test_the_template_hands_the_agent_four_of_the_six_files_the_scan_wrote`: the two
+the template leaves alone are `project_state.json` and `scan_metadata.json`, and
+the second of those is where the re-entry stage lives.
+
+`--paper-corpus` writes nothing to
 `bootstrap/`; its whole output set goes to `profile/`, and it gets there a
 different way — `src/prompts/bootstrap.md` points the agent at
 `{{WORKSPACE_PROFILE_DIR}}` and asks it for `research_profile.json`,

--- a/src/information_flow.py
+++ b/src/information_flow.py
@@ -24,11 +24,23 @@ cannot become "this information helped".
 
 **The graph is inspectable.** ``dependency_edges()`` returns the producer →
 consumer pairs, so the information topology can be printed, tested, and diffed
-rather than reconstructed by reading sixteen ``if`` statements.
+rather than reconstructed by reading a pile of ``if`` statements.
 
 A channel is deliberately allowed to have no producer (``produced_by=None``):
-run configuration, the researcher profile and the deliverable contract come
-from outside the stage graph.
+run configuration, the researcher profile, the deliverable contract and the
+scan of an existing project repository come from outside the stage graph.
+
+**A renderer with no caller is not a channel.** Two of them shipped that way.
+``format_protocol_for_prompt`` was imported by nothing outside its own tests,
+so the primary metric, planned seed count and per-baseline tuning budgets that
+Stage 03 declares reached no prompt as data — Stage 05's template names the file
+path, and the templates for 04, 06 and 07 do not mention the protocol at all.
+``format_project_context_for_prompt`` was worse than uncalled: ``src.manager``
+imported the name and never called it, so a grep for the symbol answered "wired"
+and a run started with ``--project-root`` walked the stage graph over a
+repository no prompt described. ``experimental_protocol`` and ``project_context`` are the
+two edges; ``test_no_prompt_renderer_is_imported_without_being_called`` is the
+guard for the trap that hid the second one.
 
 **A constraint has to arrive while it can still be obeyed.** The figure ceiling
 was the worst case of the opposite: ``MAX_REPORT_FIGURES`` reached Stage 07 and
@@ -303,6 +315,22 @@ def _preregistration(context: ChannelContext) -> str | None:
     return format_preregistration_for_prompt(prereg) if prereg is not None else None
 
 
+def _experimental_protocol(context: ChannelContext) -> str | None:
+    from .experimental_protocol import (
+        format_protocol_for_prompt,
+        load_experimental_protocol,
+    )
+
+    protocol = load_experimental_protocol(context.paths)
+    return format_protocol_for_prompt(protocol) if protocol is not None else None
+
+
+def _project_context(context: ChannelContext) -> str | None:
+    from .project_bootstrap import format_project_context_for_prompt
+
+    return format_project_context_for_prompt(context.paths)
+
+
 def _rounds(context: ChannelContext) -> str | None:
     from .research_rounds import format_rounds_for_prompt
 
@@ -387,6 +415,43 @@ CHANNELS: tuple[Channel, ...] = (
         ),
     ),
     Channel(
+        key="project_context",
+        heading="# Existing Project Repository (from the project bootstrap)",
+        produced_by=None,
+        consumed_by=_from("01_literature_survey"),
+        build=_project_context,
+        preface=(
+            "This run was started against a repository that already existed. What follows "
+            "is what the scan found in it, not what this run produced.\n"
+            "- An assessment is a reading of the files, not a result. Confirm it against "
+            "the repository before building on it, and say so in your stage summary when it "
+            "turns out to be wrong.\n"
+            "- Every stage the scan assessed is listed, each marked either carried forward "
+            "— this run accepted that stage as already done — or still owed. The carried-"
+            "forward ones were also written into `# Approved Memory` as stage summaries, so "
+            "you may meet them twice; that is deliberate, because a revisit to a stage below "
+            "the re-entry point rewrites that section and drops them, and this block is then "
+            "the only copy left."
+        ),
+        rationale=(
+            "`recommend_entry_stage` returns any stage from 01 to 08, so no fixed early set "
+            "of readers is right: the run that re-enters at Stage 07 to write up results "
+            "that already exist is the run that most needs to be told what the repository "
+            "holds, and a `{03,04,05,07}` would withhold it from exactly that run. Stage 00 "
+            "is the one stage that provably cannot read it — `run()` calls "
+            "`_run_project_bootstrap` after `_run_intake`, so no scan exists while intake is "
+            "running and the block would be empty every time. On a run without "
+            "`--project-root` the channel is silent at every stage, which is what an "
+            "unconditional edge to a conditional artifact should look like. This block does "
+            "overlap `# Approved Memory` — `_adopt_project_bootstrap_baseline` copies each "
+            "below-entry assessment into a stage summary — and the overlap is kept rather "
+            "than trimmed: `append_approved_stage_summary` retains only the entries numbered "
+            "below the stage it writes, so approving the `07_writing → 01_literature_survey` "
+            "revisit on a run that re-entered at 07 erases Stages 02-06 from memory, and the "
+            "scan's reading of them survives only here."
+        ),
+    ),
+    Channel(
         key="idea_pool",
         heading="## Candidate Hypothesis Pool",
         produced_by=None,
@@ -454,6 +519,39 @@ CHANNELS: tuple[Channel, ...] = (
         consumed_by=_from("05_experimentation"),
         build=_preregistration,
         rationale="From the freeze onward this is the authoritative statement of what the run predicted.",
+    ),
+    Channel(
+        key="experimental_protocol",
+        heading="# Experimental Protocol (declared at Stage 03)",
+        produced_by="03_study_design",
+        consumed_by=frozenset(
+            {"04_implementation", "05_experimentation", "06_analysis", "07_writing"}
+        ),
+        build=_experimental_protocol,
+        preface=(
+            "Stage 04 builds for this protocol and Stage 05 spends it. A harness fixed to "
+            "one seed, or with no way to give a baseline the budget declared below, cannot "
+            "be made to obey the protocol at Stage 05 without going back through the "
+            "`05_experimentation → 04_implementation` revisit edge and rebuilding it — an "
+            "edge here is cheaper than that repair. Stage 04's smoke run is not the "
+            "experiment: build for the planned seeds and the declared budgets, do not spend "
+            "them there."
+        ),
+        rationale=(
+            "Stage 03 writes it and four later stages are bound by it, none of which is "
+            "shown its contents anywhere else. Stage 05's template names the file path and "
+            "states the obligations it creates; the templates for 04, 06 and 07 do not "
+            "mention it. 04 builds the harness that has to run `planned_seeds` runs and "
+            "each declared baseline. 05 owes each baseline the budget it declared. 06 may "
+            "not replace the primary metric with one that came out better, and "
+            "`validate_outcome_statistics` refuses a `supported` or `refuted` verdict "
+            "without `statistics.n_seeds` — the count the design planned reaches its prompt "
+            "here or not at all. 07 reports that metric and states a budget shortfall as a "
+            "limitation. Stage 03 is the author and its own template carries the schema and "
+            "the rules, so re-sending the file to its writer would restate the instruction "
+            "rather than deliver anything; Stages 00-02 precede the design; Stage 08 "
+            "packages a comparison it cannot re-run."
+        ),
     ),
     Channel(
         key="settled_reasoning",

--- a/src/manager.py
+++ b/src/manager.py
@@ -11,7 +11,6 @@ from .bootstrap import (
     bootstrap_profile_exists,
     format_corpus_for_prompt,
     format_corpus_stats_for_log,
-    format_profile_for_prompt,
     missing_bootstrap_profile_artifacts,
     scan_corpus,
 )
@@ -27,7 +26,10 @@ from .obligations import (
 )
 from .review_policy import load_policy, policy_summary, record_correction
 from .project_bootstrap import (
-    format_project_context_for_prompt,
+    # `format_project_context_for_prompt` is deliberately absent: the
+    # `project_context` channel delivers it. Importing it here and never calling
+    # it is what made a grep for the symbol answer "wired" while no prompt
+    # carried the block.
     format_project_scan_for_prompt,
     format_scan_stats_for_log,
     load_recommended_entry_stage,
@@ -49,16 +51,12 @@ from .intake import (
     parse_intake_clarification_question,
     save_intake_context
 )
-from .artifact_index import format_artifact_index_for_prompt, write_artifact_index
-from .experiment_manifest import format_experiment_manifest_for_prompt, write_experiment_manifest
+from .artifact_index import write_artifact_index
+from .experiment_manifest import write_experiment_manifest
 from .hypothesis_manifest import write_hypothesis_manifest
 from .information_flow import CHANNELS, ChannelContext, render_inbound
 from .prompt_fragments import compose_stage_template
-from .validity_review import (
-    ValidityReviewer,
-    ValidityReviewOutcome,
-    format_findings_for_prompt,
-)
+from .validity_review import ValidityReviewer, ValidityReviewOutcome
 from .research_rounds import (
     ROUND_CLOSING_STAGE_NUMBER,
     RoundIntent,
@@ -69,15 +67,12 @@ from .research_rounds import (
     unreopened_abandonment,
     read_round_decision,
     format_round_status,
-    format_rounds_for_prompt,
     load_rounds,
     record_round,
     resume_stage_slug_for,
 )
 from .preregistration import (
     amend_preregistration,
-    format_outcomes_for_prompt,
-    format_preregistration_for_prompt,
     freeze_preregistration,
     load_preregistration,
 )
@@ -157,7 +152,6 @@ from .ideation_panel import (
 )
 from .writing_manifest import (
     build_writing_manifest,
-    format_manifest_for_prompt,
     generate_layout_review,
     generate_report_review,
 )
@@ -190,7 +184,6 @@ from .utils import (
     ensure_run_config,
     ensure_run_layout,
     format_stage_template,
-    format_venue_for_prompt,
     filtered_approved_memory,
     initialize_memory,
     initialize_run_config,

--- a/src/project_bootstrap.py
+++ b/src/project_bootstrap.py
@@ -766,8 +766,59 @@ def format_project_scan_for_prompt(result: ProjectBootstrapResult) -> str:
     return "\n".join(parts)
 
 
+#: Written after each assessment line, saying what this run did with that reading
+#: rather than restating the reading. ``_adopt_project_bootstrap_baseline`` accepts
+#: every stage below the recommended entry stage as already done and writes it an
+#: approved stage summary; the entry stage and everything after it are the run's
+#: own work. The distinction cannot be in ``bootstrap_summary.md``: that file is
+#: written by ``save_project_bootstrap`` before the operator's turn, and the entry
+#: stage is decided and stored by ``save_recommended_entry_stage`` after it. Nor is
+#: it in any one place in ``memory.md``. This mark is where it is written down.
+CARRIED_FORWARD_MARK = "carried forward: this run accepted it and did not redo it"
+STILL_OWED_MARK = "still owed: this run has to do this stage itself"
+
+
 def format_project_context_for_prompt(paths: RunPaths) -> str | None:
-    """Format the project bootstrap context for injection into stage prompts."""
+    """Format the project bootstrap context for injection into stage prompts.
+
+    Delivered by the ``project_context`` channel in ``src.information_flow``.
+
+    **Every assessment is listed, and the overlap with approved memory is real.**
+    An earlier version of this function dropped the assessments below the
+    recommended entry stage, on the argument that
+    ``_adopt_project_bootstrap_baseline`` had already written each of them into
+    ``memory.md`` as an approved stage summary, so listing them here would send
+    the same reading twice. The measurement that retired that argument is that
+    memory's copy is not durable: ``append_approved_stage_summary`` keeps only
+    the entries numbered below the stage being written, so any approval at a
+    stage below the re-entry point erases the carry-forward entries above it.
+    Take ``07_writing → 01_literature_survey`` (a ``guard="always"`` revisit
+    edge) on a run that re-entered at Stage 07: approving that Stage 01 leaves
+    memory holding Stage 01 alone, and the readings for Stages 02-06 exist
+    nowhere but here. A block that had narrowed them away would have deleted the
+    last copy of what the run was told about the repository it is working in.
+    ``test_an_approval_below_the_entry_stage_erases_memorys_copy`` runs that path.
+
+    **The summary section above the list is not a second copy to fall back on.**
+    ``save_project_bootstrap`` writes ``bootstrap_summary.md`` once, from
+    ``result.summary or _generate_summary_text(result)``, before the bootstrap
+    operator's turn; ``src/prompts/project_bootstrap.md`` then instructs the agent
+    to write ``{{WORKSPACE_BOOTSTRAP_DIR}}/bootstrap_summary.md`` as prose, and
+    that placeholder resolves to ``paths.bootstrap_dir`` — the same path
+    ``load_project_bootstrap_summary`` reads, in the directory the operator runs
+    against. So the section this function puts above the list is agent-owned from
+    the first approved bootstrap onward and may contain no per-stage line at all.
+    That is not an argument against the list; it is the reason the list has to be
+    complete, because it is the only part of this block whose per-stage coverage
+    is decided by code. ``test_the_summary_above_the_list_is_agent_owned``
+    measures it by overwriting the file the template names.
+
+    What the list adds over the summary above it is therefore ``CARRIED_FORWARD_MARK``
+    versus ``STILL_OWED_MARK`` — which stages this run accepted from the scan and
+    which it still owes — plus, whenever the agent has rewritten the summary, the
+    per-stage readings themselves. With no entry stage recorded nothing was carried
+    forward, so every stage is marked owed.
+    """
     if not project_bootstrap_exists(paths):
         return None
 
@@ -777,12 +828,15 @@ def format_project_context_for_prompt(paths: RunPaths) -> str | None:
     if summary:
         parts.append(f"## Project Bootstrap Summary\n\n{summary}")
 
-    assessments = load_stage_assessments(paths)
+    entry_stage = load_recommended_entry_stage(paths)
+    assessments = load_stage_assessments(paths) or []
     if assessments:
         lines = ["## Project Stage Assessments"]
         for a in assessments:
+            carried = entry_stage is not None and a.stage_number < entry_stage
+            mark = CARRIED_FORWARD_MARK if carried else STILL_OWED_MARK
             lines.append(f"- **Stage {a.stage_number:02d} ({a.stage_name}):** "
-                        f"{a.status} (confidence: {a.confidence})")
+                        f"{a.status} (confidence: {a.confidence}) — {mark}")
         parts.append("\n".join(lines))
 
     return "\n\n".join(parts) if parts else None

--- a/tests/test_a_renderer_with_no_caller.py
+++ b/tests/test_a_renderer_with_no_caller.py
@@ -1,0 +1,645 @@
+"""Two prompt renderers that were tested, documented, and reached no prompt.
+
+``format_protocol_for_prompt`` and ``format_project_context_for_prompt`` each
+had unit tests asserting what their output contains, and neither had a
+production caller. The consequence was not cosmetic. The experimental protocol
+is the run's own answer to "what would count as having shown it" — the primary
+metric, the planned seed count, and a tuning budget per baseline — and no stage
+prompt carried any of it: Stage 05's template names the file path, and the
+templates for 04, 06 and 07 do not mention the protocol at all. A run started
+with ``--project-root`` walked every stage over a repository that no prompt
+described.
+
+**What made the second one invisible.** ``src.manager`` imported
+``format_project_context_for_prompt`` and never called it, so the cheapest
+check — grep for the symbol — reported it wired. Nine more prompt renderers
+were imported there and uncalled, left behind when ``information_flow`` took
+delivery over, so the camouflage was not a one-off.
+``test_no_prompt_renderer_is_imported_without_being_called`` is the guard, and
+it is an AST check on calls rather than a text search on names, because a text
+search is the thing that was fooled.
+
+**What the second block overlaps.** ``project_context`` and ``# Approved Memory``
+do carry the same readings at the moment the scan finishes, because
+``_adopt_project_bootstrap_baseline`` writes each below-entry assessment into
+``memory.md`` as a stage summary. The first version of this channel narrowed the
+assessment list to remove that overlap. ``TheOverlapWithApprovedMemoryTest``
+measures why that was wrong: memory keeps only the entries below the stage it
+last wrote, so the first approval under the re-entry point deletes its copy, and
+the summary section above the list is not a fallback because the bootstrap
+template hands that file to the agent. The list is complete again.
+
+These tests hold the topology, the arrival of the numbers, and the facts the
+overlap argument turns on — not the wording of either block.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.evolution import EvolutionConfig
+from src.information_flow import ALL_STAGES, CHANNELS, ChannelContext, render_inbound
+from src.manager import ResearchManager
+from src.operator import ClaudeOperator
+from src.project_bootstrap import (
+    CARRIED_FORWARD_MARK,
+    STILL_OWED_MARK,
+    CodeState,
+    ExperimentState,
+    ProjectBootstrapResult,
+    StageAssessment,
+    WritingState,
+    format_project_context_for_prompt,
+    load_project_bootstrap_summary,
+    recommend_entry_stage,
+    save_project_bootstrap,
+)
+from src.stage_graph import REVISIT_EDGES
+from src.terminal_ui import TerminalUI
+from src.utils import (
+    INTAKE_STAGE,
+    STAGES,
+    append_approved_stage_summary,
+    approved_stage_numbers,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    initialize_memory,
+    read_text,
+    write_text,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+
+BY_KEY = {channel.key: channel for channel in CHANNELS}
+STAGE = {stage.slug: stage for stage in STAGES}
+STAGE[INTAKE_STAGE.slug] = INTAKE_STAGE
+
+
+def _imported_and_called(path: Path) -> tuple[set[str], set[str]]:
+    """Prompt-renderer names this module imports, and the names it calls."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported = {
+        alias.asname or alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+        if (alias.asname or alias.name.split(".")[0]).endswith("_for_prompt")
+    }
+    called = {
+        node.func.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    return imported, called
+
+
+class ImportIsNotWiringTest(unittest.TestCase):
+    def test_no_prompt_renderer_is_imported_without_being_called(self) -> None:
+        dead: list[str] = []
+        for path in sorted(SRC.rglob("*.py")):
+            imported, called = _imported_and_called(path)
+            for name in sorted(imported - called):
+                dead.append(
+                    f"{path.relative_to(REPO_ROOT)} imports {name} and never calls it — "
+                    "either wire it into a channel or drop the import; an uncalled import "
+                    "makes a grep for the symbol answer 'wired'"
+                )
+        self.assertEqual(dead, [], "\n" + "\n".join(dead))
+
+    def test_the_scan_looks_at_a_population_that_contains_renderers(self) -> None:
+        """Control: with no imports found, the check above passes on anything."""
+        seen = set()
+        for path in sorted(SRC.rglob("*.py")):
+            imported, _ = _imported_and_called(path)
+            seen |= imported
+        self.assertGreaterEqual(len(seen), 5, sorted(seen))
+
+    def test_both_renderers_this_module_is_about_are_reached_from_a_channel(self) -> None:
+        """The positive half: the two names now appear in a channel builder."""
+        source = (SRC / "information_flow.py").read_text(encoding="utf-8")
+        for name in ("format_protocol_for_prompt", "format_project_context_for_prompt"):
+            with self.subTest(renderer=name):
+                self.assertIn(f"{name}(", source)
+
+
+def _protocol_payload() -> dict[str, object]:
+    return {
+        "declared_at": "2026-04-04T10:00:00",
+        "primary_metric": "held-out accuracy",
+        "planned_seeds": 5,
+        "baselines": [
+            {
+                "name": "long-context prompting",
+                "why_competent": "the standard approach and the one the method must beat",
+                "tuning_budget": "20 prompt-search configurations, the same as the method",
+            }
+        ],
+    }
+
+
+class ExperimentalProtocolChannelTest(unittest.TestCase):
+    """Where the declared metric, seed count and budgets arrive."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        self.channel = BY_KEY["experimental_protocol"]
+
+    def _write_protocol(self) -> None:
+        self.paths.experimental_protocol.parent.mkdir(parents=True, exist_ok=True)
+        write_text(self.paths.experimental_protocol, json.dumps(_protocol_payload(), indent=2))
+
+    def _inbound(self, slug: str) -> tuple[str, list[str]]:
+        return render_inbound(
+            ChannelContext(paths=self.paths, stage=STAGE[slug], attempt_no=1), CHANNELS
+        )
+
+    def test_the_protocol_is_produced_by_the_stage_whose_template_asks_for_it(self) -> None:
+        self.assertEqual(self.channel.produced_by, "03_study_design")
+        template = (SRC / "prompts" / "03_study_design.md").read_text(encoding="utf-8")
+        self.assertIn("experimental_protocol.json", template)
+
+    def test_the_only_templates_that_name_the_protocol_are_03_and_05(self) -> None:
+        """The rationale argues the four consumers are served nowhere else: Stage
+        05's template names the file path and states the obligations, and 04, 06
+        and 07 do not mention it. That is the argument for the edge, so it has to
+        fail when it stops being true rather than sit in a docstring."""
+        named = {
+            path.stem
+            for path in sorted((SRC / "prompts").glob("*.md"))
+            if "experimental_protocol.json" in path.read_text(encoding="utf-8")
+        }
+        self.assertEqual(
+            named,
+            {"03_study_design", "05_experimentation"},
+            "a template started or stopped naming the protocol — rewrite "
+            "experimental_protocol.rationale to match",
+        )
+
+    def test_every_stage_the_protocol_binds_is_sent_it(self) -> None:
+        for slug in ("04_implementation", "05_experimentation", "06_analysis", "07_writing"):
+            with self.subTest(stage=slug):
+                self.assertIn(slug, self.channel.consumed_by)
+
+    def test_the_author_is_not_sent_its_own_file_back(self) -> None:
+        """Stage 03's own template carries the schema and the rules for writing it,
+        so a block echoing the file to its writer restates an instruction rather
+        than delivering anything. Contrast ``report_plan``, which does reach its
+        producer: a Stage 06 gate refuses a slot whose ``source_artifact`` is
+        missing, so a second round's Stage 03 has a repair to make from the block.
+        Nothing downstream refuses a protocol for having changed."""
+        self.assertNotIn("03_study_design", self.channel.consumed_by)
+
+    def test_the_stages_that_cannot_act_on_it_are_not_sent_it(self) -> None:
+        for slug in ("00_intake", "01_literature_survey", "02_hypothesis_generation"):
+            with self.subTest(stage=slug):
+                self.assertNotIn(slug, self.channel.consumed_by)
+        self.assertNotIn(
+            "08_dissemination",
+            self.channel.consumed_by,
+            "Stage 08 packages a comparison it cannot re-run",
+        )
+
+    def test_the_declared_numbers_reach_the_stage_that_spends_them(self) -> None:
+        """Stage 05 owes each baseline its budget and the metric its result. Before
+        this channel, its prompt carried the path to the file and none of its
+        contents."""
+        self._write_protocol()
+        text, delivered = self._inbound("05_experimentation")
+        self.assertIn("experimental_protocol", delivered)
+        self.assertIn("held-out accuracy", text)
+        self.assertIn("20 prompt-search configurations", text)
+        self.assertIn("long-context prompting", text)
+        self.assertIn("Planned seeds: 5", text)
+
+    def test_the_analysis_stage_is_told_the_metric_it_may_not_replace(self) -> None:
+        self._write_protocol()
+        text, delivered = self._inbound("06_analysis")
+        self.assertIn("experimental_protocol", delivered)
+        self.assertIn("held-out accuracy", text)
+
+    def test_a_stage_outside_the_consumer_set_receives_none_of_it(self) -> None:
+        self._write_protocol()
+        for slug in ("03_study_design", "08_dissemination"):
+            text, delivered = self._inbound(slug)
+            with self.subTest(stage=slug):
+                self.assertNotIn("experimental_protocol", delivered)
+                self.assertNotIn("20 prompt-search configurations", text)
+
+    def test_the_block_is_silent_until_the_design_declares_one(self) -> None:
+        """An empty heading before Stage 03 has written the file would teach the run
+        that the protocol is optional."""
+        _, delivered = self._inbound("05_experimentation")
+        self.assertNotIn("experimental_protocol", delivered)
+
+    def test_the_preface_separates_building_for_it_from_spending_it(self) -> None:
+        """The preface is the only instruction that travels with the block, and it
+        is the same text for every consumer. Stage 04's own template requires a
+        smoke run, so a block that reached it saying only "run the planned seeds"
+        would pull the experiment two stages early."""
+        preface = self.channel.preface.lower()
+        self.assertIn("stage 04 builds for this protocol", preface)
+        self.assertIn("smoke run is not the experiment", preface)
+
+    def test_the_repair_the_preface_names_is_a_real_edge(self) -> None:
+        """The preface argues the cost of arriving late by naming the revisit edge
+        that pays it. A preface citing an edge the graph does not have is prose."""
+        self.assertIn("`05_experimentation → 04_implementation`", self.channel.preface)
+        self.assertIn(
+            ("05_experimentation", "04_implementation"),
+            {(edge.source, edge.target) for edge in REVISIT_EDGES},
+        )
+
+    def test_the_preface_does_not_restate_the_body(self) -> None:
+        """``format_protocol_for_prompt`` already carries the metric rule and the
+        budget rule inside the block. Saying them again in the preface would be
+        the same defect as the duplicated hypotheses this module exists to fix."""
+        preface = self.channel.preface.lower()
+        self.assertNotIn("do not switch to a metric", preface)
+        self.assertNotIn("tuning budget declared above", preface)
+
+    def test_the_body_the_preface_defers_to_is_actually_there(self) -> None:
+        """Control for the test above: an empty body makes both absences vacuous."""
+        self._write_protocol()
+        body = self.channel.build(
+            ChannelContext(paths=self.paths, stage=STAGE["05_experimentation"], attempt_no=1)
+        )
+        self.assertIn("do not switch to a metric that came out better", body)
+        self.assertIn("tuning budget declared above", body)
+
+
+def _assessments() -> list[StageAssessment]:
+    return [
+        StageAssessment(1, "Literature Survey", "complete", "high", ["12 references in refs.bib"]),
+        StageAssessment(4, "Implementation", "complete", "high", ["15 code files"]),
+        StageAssessment(5, "Experimentation", "partial", "medium", ["1 result file"]),
+        StageAssessment(7, "Writing", "not_started", "medium", ["no .tex file"]),
+    ]
+
+
+def _scan_result(entry_stage: int) -> ProjectBootstrapResult:
+    return ProjectBootstrapResult(
+        project_root="/tmp/my-project",
+        scanned_at="2026-04-04T10:00:00",
+        total_files=42,
+        code_state=CodeState(
+            languages=["Python"], frameworks=["pytorch"], entry_points=["train.py"],
+            total_code_files=15, status="complete", evidence=["15 code files"],
+        ),
+        experiment_state=ExperimentState(
+            config_files=["configs/exp1.yaml"], result_files=["results/metrics.json"],
+            status="partial", evidence=["1 config, 1 result"],
+        ),
+        writing_state=WritingState(
+            tex_files=[], bib_files=["paper/refs.bib"], status="not_started",
+            evidence=["no .tex file"],
+        ),
+        stage_assessments=_assessments(),
+        recommended_entry_stage=entry_stage,
+        file_tree_sample=["train.py", "model.py"],
+    )
+
+
+class ProjectContextChannelTest(unittest.TestCase):
+    """A repository the run did not create, described to the stages working in it."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        self.channel = BY_KEY["project_context"]
+
+    def _inbound(self, slug: str) -> tuple[str, list[str]]:
+        return render_inbound(
+            ChannelContext(paths=self.paths, stage=STAGE[slug], attempt_no=1), CHANNELS
+        )
+
+    def test_the_channel_is_silent_on_a_run_with_no_project_root(self) -> None:
+        """Most runs start from nothing. The block must not appear as an empty
+        heading on every one of them."""
+        for slug in ("01_literature_survey", "07_writing"):
+            text, delivered = self._inbound(slug)
+            with self.subTest(stage=slug):
+                self.assertNotIn("project_context", delivered)
+                self.assertNotIn("Existing Project Repository", text)
+
+    def test_every_stage_the_run_can_be_dropped_into_is_a_consumer(self) -> None:
+        """The constraint that rules out a fixed early set. ``recommend_entry_stage``
+        picks where the walk starts, and its answer is not bounded above by the
+        early stages: a repository with everything through Stage 07 already done
+        re-enters at 08, and that run has seen less of the repository than any
+        other, not more."""
+        for stage in STAGES:
+            with self.subTest(stage=stage.slug):
+                self.assertIn(stage.slug, self.channel.consumed_by)
+
+    def test_the_entry_stage_is_not_bounded_by_the_early_stages(self) -> None:
+        """The control for the test above: without this, "all eight" is an
+        unargued width rather than the answer to a live range."""
+        complete_through = lambda last: [  # noqa: E731
+            StageAssessment(n, f"Stage {n}", "complete" if n <= last else "not_started",
+                            "medium", [])
+            for n in range(1, 9)
+        ]
+        self.assertEqual(recommend_entry_stage(complete_through(7)), 8)
+        self.assertEqual(recommend_entry_stage(complete_through(6)), 7)
+        self.assertEqual(recommend_entry_stage(complete_through(5)), 6)
+
+    def test_intake_is_the_only_stage_left_out(self) -> None:
+        self.assertNotIn(INTAKE_STAGE.slug, self.channel.consumed_by)
+        self.assertEqual(
+            len(self.channel.consumed_by), len(ALL_STAGES) - 1, sorted(self.channel.consumed_by)
+        )
+
+    def test_intake_is_left_out_because_it_finishes_before_the_scan_starts(self) -> None:
+        """The one exclusion has to be a fact about the code, not a preference.
+        ``run()`` calls the scan after intake has been approved, so the block
+        would be empty at Stage 00 on every run that has one."""
+        import inspect
+
+        source = inspect.getsource(ResearchManager.run)
+        self.assertLess(
+            source.index("self._run_intake("),
+            source.index("self._run_project_bootstrap("),
+            "the scan now runs before intake; 00_intake can read it and the "
+            "exclusion in project_context.rationale is no longer true",
+        )
+
+    def test_the_scan_reaches_the_stage_the_run_re_enters_at(self) -> None:
+        save_project_bootstrap(self.paths, _scan_result(entry_stage=7))
+        text, delivered = self._inbound("07_writing")
+        self.assertIn("project_context", delivered)
+        self.assertIn("Existing Project Repository", text)
+        self.assertIn("Project Bootstrap Summary", text)
+
+
+class TheOverlapWithApprovedMemoryTest(unittest.TestCase):
+    """What this block and ``# Approved Memory`` each hold, measured.
+
+    An earlier version of this channel dropped every assessment below the
+    recommended entry stage, arguing that ``_adopt_project_bootstrap_baseline``
+    had already written those readings into ``memory.md`` so the block would
+    otherwise send them twice. One measurement retires that argument and it is
+    about memory, not about this block: ``append_approved_stage_summary`` keeps
+    only the entries numbered below the stage it writes, so the first approval at
+    a stage below the re-entry point destroys memory's copy. A narrowed list would
+    have been the deletion of the last copy.
+
+    The second thing measured here is what the section *above* the list is worth
+    as a fallback, and the answer is nothing that code decides:
+    ``src/prompts/project_bootstrap.md`` asks the agent to write
+    ``bootstrap_summary.md`` itself, at the path ``load_project_bootstrap_summary``
+    reads, so from the first approved bootstrap on it is prose of the agent's
+    choosing and need not name a stage at all. That is why the argument for the
+    complete list rests on the memory measurement alone, and why an AST scan for
+    a Python assignment to ``ProjectBootstrapResult.summary`` — which is what
+    stood here before — was the wrong control: the write it should have been
+    looking for is made by an agent under ``bypassPermissions``, not by a caller.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.runs_dir = Path(self._tmp.name) / "runs"
+        self.runs_dir.mkdir()
+        self.paths = build_run_paths(self.runs_dir / "run_0001")
+        ensure_run_layout(self.paths)
+        ensure_run_config(self.paths, model="sonnet", venue="neurips_2025")
+        initialize_memory(self.paths, "project context")
+        write_text(self.paths.user_input, "project context")
+        ui = TerminalUI()
+        self.manager = ResearchManager(
+            project_root=REPO_ROOT,
+            runs_dir=self.runs_dir,
+            operator=ClaudeOperator(model="sonnet", fake_mode=True, ui=ui),
+            ui=ui,
+            output_stream=io.StringIO(),
+            evolution=EvolutionConfig(rounds=0),
+        )
+
+    def _adopt(self, entry_stage: int) -> None:
+        save_project_bootstrap(self.paths, _scan_result(entry_stage))
+        self.manager._adopt_project_bootstrap_baseline(  # noqa: SLF001
+            self.paths, _assessments(), entry_stage
+        )
+
+    def _assessment_list(self) -> str:
+        block = format_project_context_for_prompt(self.paths) or ""
+        self.assertIn("## Project Stage Assessments", block)
+        return block.split("## Project Stage Assessments", 1)[1]
+
+    def test_the_generated_summary_and_memory_carry_the_same_readings(self) -> None:
+        """The overlap this block is accused of, at the one moment it is real.
+
+        The file ``save_project_bootstrap`` writes is
+        ``result.summary or _generate_summary_text(result)``, and the generated
+        text lists every stage's status, confidence *and* evidence — the same
+        evidence strings ``_adopt_project_bootstrap_baseline`` puts in
+        ``memory.md``. So immediately after the scan, before the bootstrap agent
+        has taken its turn, the block and memory do say the same thing. That is
+        the whole of the duplication argument, and the next two tests are why it
+        does not survive either forward or backward in time.
+        """
+        self._adopt(entry_stage=5)
+        block = format_project_context_for_prompt(self.paths) or ""
+        summary_section = block.split("## Project Stage Assessments", 1)[0]
+        memory = read_text(self.paths.memory)
+        for evidence in ("12 references in refs.bib", "15 code files"):
+            with self.subTest(evidence=evidence):
+                self.assertIn(evidence, summary_section)
+                self.assertIn(evidence, memory)
+
+    def test_the_summary_above_the_list_is_agent_owned(self) -> None:
+        """Forward in time: the generated text does not survive the agent's turn.
+
+        ``src/prompts/project_bootstrap.md`` asks for a 300-500 word prose summary
+        at the path ``load_project_bootstrap_summary`` reads, so from the first
+        approved bootstrap onward the section above the list is whatever the agent
+        wrote and need not mention a stage. Overwrite it as the template asks and
+        every per-stage reading leaves the summary section — while the list still
+        names all four stages. The list is the only part of this block whose
+        per-stage coverage is decided by code, which is why it may not be narrowed.
+        """
+        self._adopt(entry_stage=5)
+        write_text(
+            self.paths.bootstrap_dir / "bootstrap_summary.md",
+            "This project trains a small transformer on a synthetic copy task. The "
+            "implementation looks finished, the experiments are partly run, and "
+            "nothing has been written up. Re-enter at Stage 05.\n",
+        )
+        block = format_project_context_for_prompt(self.paths) or ""
+        summary_section = block.split("## Project Stage Assessments", 1)[0]
+        self.assertIn("## Project Bootstrap Summary", summary_section)
+        for evidence in ("12 references in refs.bib", "15 code files"):
+            with self.subTest(evidence=evidence):
+                self.assertNotIn(evidence, summary_section)
+        listed = self._assessment_list()
+        for number in ("Stage 01", "Stage 04", "Stage 05", "Stage 07"):
+            with self.subTest(stage=number):
+                self.assertIn(number, listed)
+
+    def test_the_prompt_asks_the_agent_to_write_the_file_the_summary_is_read_from(self) -> None:
+        """Anchor for the test above, on the template rather than on Python.
+
+        An AST scan for a caller assigning ``ProjectBootstrapResult.summary`` used
+        to stand here, and it could not see this write at all: the writer is the
+        agent. ``_build_project_bootstrap_prompt`` resolves
+        ``{{WORKSPACE_BOOTSTRAP_DIR}}`` through ``format_stage_template``, so the
+        prompt that actually goes out names an absolute path — and writing that
+        path is what ``load_project_bootstrap_summary`` then returns. Change either
+        end and this fails.
+        """
+        target = (self.paths.bootstrap_dir / "bootstrap_summary.md").resolve()
+        template = (SRC / "prompts" / "project_bootstrap.md").read_text(encoding="utf-8")
+        self.assertIn("{{WORKSPACE_BOOTSTRAP_DIR}}/bootstrap_summary.md", template)
+
+        prompt = self.manager._build_project_bootstrap_prompt(  # noqa: SLF001
+            self.paths,
+            ResearchManager.PROJECT_BOOTSTRAP_STAGE,
+            "## Repository File Tree (sample)",
+            REPO_ROOT,
+            None,
+            False,
+        )
+        self.assertIn(str(target), prompt)
+
+        write_text(target, "whatever the agent decided to write\n")
+        self.assertEqual(
+            load_project_bootstrap_summary(self.paths),
+            "whatever the agent decided to write",
+        )
+
+    def test_the_template_hands_the_agent_four_of_the_six_files_the_scan_wrote(self) -> None:
+        """Which of the scan's artifacts the bootstrap stage may replace.
+
+        ``save_project_bootstrap`` writes six files and the template asks the agent
+        for four of them, so "the scan said so" is only true of the two it does not
+        ask for. That is not a detail: ``scan_metadata.json`` is one of the two, and
+        it holds the re-entry stage that decides which stages
+        ``_adopt_project_bootstrap_baseline`` marks approved without doing them.
+        Moving a filename across this line changes who chooses that, so it should
+        cost a failing test and an argument.
+        """
+        save_project_bootstrap(self.paths, _scan_result(entry_stage=5))
+        written = {p.name for p in self.paths.bootstrap_dir.iterdir() if p.is_file()}
+        self.assertEqual(len(written), 6, sorted(written))
+
+        template = (SRC / "prompts" / "project_bootstrap.md").read_text(encoding="utf-8")
+        asked_for = {
+            match
+            for match in re.findall(r"\{\{WORKSPACE_BOOTSTRAP_DIR\}\}/([\w.]+)", template)
+        }
+        self.assertEqual(
+            asked_for & written,
+            {
+                "stage_assessments.json",
+                "experiment_inventory.json",
+                "writing_state.json",
+                "bootstrap_summary.md",
+            },
+        )
+        self.assertEqual(
+            written - asked_for, {"project_state.json", "scan_metadata.json"}
+        )
+
+    def test_an_approval_below_the_entry_stage_erases_memorys_copy(self) -> None:
+        """Backward in time: memory's copy is not durable either.
+
+        ``07_writing → 01_literature_survey`` is a ``guard="always"`` revisit
+        edge, and ``recommend_entry_stage`` can put the walk at Stage 07. Once
+        that Stage 01 is approved, ``append_approved_stage_summary`` keeps only
+        the entries numbered below 1 — so Stages 02-06 leave memory and the scan's
+        reading of them exists nowhere but in this block.
+        """
+        self.assertIn(
+            ("07_writing", "01_literature_survey"),
+            {(edge.source, edge.target) for edge in REVISIT_EDGES},
+        )
+        self._adopt(entry_stage=7)
+        self.assertEqual(
+            approved_stage_numbers(read_text(self.paths.memory)), {1, 2, 3, 4, 5, 6}
+        )
+
+        append_approved_stage_summary(
+            self.paths.memory, STAGE["01_literature_survey"], "# Stage 01: redone\n"
+        )
+        memory = read_text(self.paths.memory)
+        self.assertEqual(approved_stage_numbers(memory), {1})
+        self.assertNotIn("15 code files", memory)
+        self.assertIn("15 code files", format_project_context_for_prompt(self.paths) or "")
+
+    def test_every_assessment_is_listed_whatever_the_entry_stage(self) -> None:
+        """The consequence of both measurements: no assessment is withheld."""
+        self._adopt(entry_stage=5)
+        listed = self._assessment_list()
+        for number in ("Stage 01", "Stage 04", "Stage 05", "Stage 07"):
+            with self.subTest(stage=number):
+                self.assertIn(number, listed)
+
+    def test_each_line_says_whether_this_run_accepted_that_stage_or_owes_it(self) -> None:
+        """What the list adds over the summary above it. The status is duplicated
+        on purpose; the carried/owed split is written down here and nowhere else —
+        ``bootstrap_summary.md`` predates the entry-stage decision, and memory
+        holds it only as one carry-forward sentence per stage."""
+        self._adopt(entry_stage=5)
+        listed = self._assessment_list()
+        by_stage = {
+            line.split("(", 1)[0].strip(" -*"): line
+            for line in listed.splitlines()
+            if line.startswith("- **Stage")
+        }
+        self.assertEqual(sorted(by_stage), ["Stage 01", "Stage 04", "Stage 05", "Stage 07"])
+        self.assertIn(CARRIED_FORWARD_MARK, by_stage["Stage 01"])
+        self.assertIn(CARRIED_FORWARD_MARK, by_stage["Stage 04"])
+        self.assertIn(STILL_OWED_MARK, by_stage["Stage 05"])
+        self.assertIn(STILL_OWED_MARK, by_stage["Stage 07"])
+
+    def test_with_no_entry_stage_recorded_every_stage_is_owed(self) -> None:
+        """``load_recommended_entry_stage`` returns ``None`` when the scan metadata
+        is missing or unparseable. Nothing was carried forward in that case, so
+        marking a stage accepted would tell the run it may skip work it owes."""
+        save_project_bootstrap(self.paths, _scan_result(entry_stage=5))
+        (self.paths.bootstrap_dir / "scan_metadata.json").unlink()
+        listed = self._assessment_list()
+        self.assertNotIn(CARRIED_FORWARD_MARK, listed)
+        self.assertEqual(listed.count(STILL_OWED_MARK), len(_assessments()))
+
+    def test_the_prompt_the_stage_actually_receives_carries_both_halves(self) -> None:
+        """End to end through ``_build_stage_prompt``: the marked list in the
+        channel block, the carry-forward sentence in ``# Approved Memory``."""
+        self._adopt(entry_stage=5)
+        prompt = self.manager._build_stage_prompt(  # noqa: SLF001
+            self.paths, STAGE["05_experimentation"], None, False
+        )
+        self.assertIn("# Existing Project Repository (from the project bootstrap)", prompt)
+        self.assertIn("Bootstrap carry-forward status:", prompt)
+        block = prompt.split("Existing Project Repository", 1)[1]
+        self.assertIn("Stage 05 (Experimentation)", block)
+        self.assertIn(CARRIED_FORWARD_MARK, block)
+
+    def test_the_preface_does_not_deny_the_overlap_it_creates(self) -> None:
+        """The rationale and preface are the part of this that a reviewer reads.
+        Both were wrong before, and a sentence saying the carried-forward stages
+        are *only* in memory is the specific claim the two measurements refuted."""
+        channel = BY_KEY["project_context"]
+        self.assertIn("only copy left", channel.preface)
+        self.assertIn("append_approved_stage_summary", channel.rationale)
+        self.assertNotIn("the ones the run still owes", channel.preface)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doc_counts.py
+++ b/tests/test_doc_counts.py
@@ -13,6 +13,27 @@ deliberately narrow — a fixed list of (phrase, live value) pairs — because a
 "find every number in the docs" check would be all false positives. Adding a row here
 is how a new claim gets protected.
 
+**A count written in digits is checked against the same symbol.** The word scan
+alone let two README sites keep saying `16` through the commit that took
+``CHANNELS`` to 18, and the sweep meant to catch that was ``grep -rni sixteen``,
+which cannot match a digit. One of the two was the architecture diagram.
+
+**A row of the README's "counts you can re-derive" table is re-derived, or exempt
+by name.** Its values are digits in the cell *after* the noun, so neither numeral
+scan can see them at all. Every row is in ``RE_DERIVABLE_TABLE_ROWS`` or in
+``UNDERIVABLE_TABLE_ROWS`` with a reason, so deleting a row from the checked list
+fails rather than quietly retiring the claim.
+
+``COUNTED_NOUNS`` has no such coverage rule and deleting a row from it is a
+surviving mutation. That is deliberate rather than missed: its population is
+prose. Scanning the four tracked docs for every spelled-out numeral before a
+phrase containing "channel" or "edge" returned forty-eight phrases when this note
+was written, and thirty-one of them were ordinary sentences no symbol counts —
+"one edge out of each node", "eighteen edges to twenty-two", "Six of the eight
+forward edges". A coverage rule there would be an exemption list longer than the
+check, which is the same reason the scan is a fixed list of phrases and not a
+search for numbers.
+
 **A doc may not cite a line number in this repo's own source.** Of the forty-four
 `file.py:NNN` references the docs carried before this test existed, twelve of twelve
 spot-checked pointed at the wrong line, and two of the survivors were right by
@@ -29,10 +50,10 @@ import re
 import unittest
 from pathlib import Path
 
-from src.information_flow import CHANNELS
+from src.information_flow import ALL_STAGES, CHANNELS
 from src.rubric import CRITERIA
-from src.stage_graph import _ADVANCE_GUARDS, REVISIT_EDGES, StageGraph
-from src.utils import STAGES
+from src.stage_graph import _ADVANCE_GUARDS, REVISIT_EDGES, TERMINAL_EDGES, StageGraph
+from src.utils import REQUIRED_STAGE_HEADINGS, STAGES
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -57,12 +78,31 @@ def _forward_edges() -> int:
     return sum(1 for edge in StageGraph.adaptive().edges if edge.kind != "revisit")
 
 
+def _channels_with_a_producer() -> int:
+    """Channels whose information is made by a stage rather than by the run config."""
+    return sum(1 for channel in CHANNELS if channel.produced_by is not None)
+
+
+def _channels_that_narrow() -> int:
+    """Channels that withhold themselves from at least one stage.
+
+    The README lists four narrowings by name and this is why that list is not a
+    count: almost every channel narrows, and the four are the ones whose reason is
+    not readable off the key.
+    """
+    return sum(1 for channel in CHANNELS if set(channel.consumed_by) != set(ALL_STAGES))
+
+
 #: ``(noun, live value)``. Every spelled-out numeral immediately before *noun* in a
 #: tracked document must equal *value*. The noun is matched case-insensitively and
 #: must be the whole phrase, so "typed channels" does not also catch "channels".
 COUNTED_NOUNS: tuple[tuple[str, int], ...] = (
     ("typed channels", len(CHANNELS)),
     ("typed information channels", len(CHANNELS)),
+    ("typed context channels", len(CHANNELS)),
+    ("blocks are typed", len(CHANNELS)),
+    ("channels produced inside the walk", _channels_with_a_producer()),
+    ("channels narrow", _channels_that_narrow()),
     ("backward edges", len(REVISIT_EDGES)),
     ("backward moves", len(REVISIT_EDGES)),
     ("dotted edges", len(REVISIT_EDGES)),
@@ -71,7 +111,83 @@ COUNTED_NOUNS: tuple[tuple[str, int], ...] = (
     ("guarded forward edges", len(_ADVANCE_GUARDS)),
 )
 
-TRACKED_DOCS = ("README.md", "docs/architecture.md", "docs/self-improvement.md")
+#: Three documents state the channel count and ``docs/framework.md`` states it
+#: three times, but the framework was outside this scan: two of the three could
+#: not go stale and the third could, and nothing said which was which. It is
+#: tracked now, and the phrase it uses that the others do not — "typed context
+#: channels" — is a row above.
+TRACKED_DOCS = (
+    "README.md",
+    "docs/architecture.md",
+    "docs/self-improvement.md",
+    "docs/framework.md",
+)
+
+#: ``(row label, live value)`` for the README table headed "Every number below comes
+#: from a named symbol in the source. Re-derive them". These values are digits in a
+#: table cell, so neither numeral scan above can see them: the channel row sat at 16
+#: through the commit that took ``CHANNELS`` to 18 and nothing went red.
+RE_DERIVABLE_TABLE_ROWS: tuple[tuple[str, int], ...] = (
+    ("Stages (nodes in the walk)", len(STAGES)),
+    ("Guarded forward edges", len(_ADVANCE_GUARDS)),
+    ("Backward edges", len(REVISIT_EDGES)),
+    ("Conditional terminal edges", len(TERMINAL_EDGES)),
+    ("Edges in the default (`adaptive`) graph", _adaptive_edges()),
+    ("Edges in `--stage-graph linear`", len(StageGraph.linear().edges)),
+    ("Typed information channels", len(CHANNELS)),
+    ("Required stage-summary headings", len(REQUIRED_STAGE_HEADINGS)),
+    ("Rubric criteria (weighted, backend-free)", len(CRITERIA)),
+)
+
+
+#: Rows of the same table whose value no symbol in this module can produce, each
+#: with the reason it is exempt. A row in neither this mapping nor
+#: ``RE_DERIVABLE_TABLE_ROWS`` fails ``test_every_row_of_that_table_is_accounted_for``,
+#: because otherwise the cheapest way to pass the check above is to delete a row
+#: from it and leave the claim standing in the README.
+UNDERIVABLE_TABLE_ROWS: dict[str, str] = {
+    "`validate_*` functions the stage gate calls": (
+        "the count is of call sites inside validate_stage_artifacts, not of a "
+        "collection; counting them here would be a second implementation of the "
+        "gate rather than a re-derivation of it"
+    ),
+    "Flags on `main.py` / `rcb_agent.py`": (
+        "two numbers in one cell, and parse_args builds them imperatively"
+    ),
+    "Python modules / lines / tests": (
+        "the stated symbol is 'the tree'; the test count in particular moves with "
+        "every branch in flight, so pinning it here would red the suite on merges "
+        "that changed nothing about it"
+    ),
+}
+
+#: The sentence the table promises under. Split on it rather than counting tables,
+#: so that a new table added above cannot silently take this one's place.
+RE_DERIVABLE_TABLE_PROMISE = (
+    "Every number below comes from a named symbol in the source. Re-derive them"
+)
+
+
+def _re_derivable_table(path: Path) -> dict[str, str]:
+    """``{first cell: last cell}`` for the first markdown table after the promise."""
+    text = path.read_text(encoding="utf-8")
+    if RE_DERIVABLE_TABLE_PROMISE not in text:
+        return {}
+    rows: dict[str, str] = {}
+    started = False
+    for line in text.split(RE_DERIVABLE_TABLE_PROMISE, 1)[1].splitlines():
+        stripped = line.strip()
+        if not (stripped.startswith("|") and stripped.endswith("|")):
+            if started:
+                break
+            continue
+        started = True
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) < 2 or set(cells[0]) <= {"-", ":", " "} or cells[0] == "Count":
+            continue
+        rows[cells[0]] = cells[-1]
+    return rows
+
 
 #: Line references outside this repo's own tree. The reader is being sent to a pinned
 #: artifact somewhere else, which this repo cannot re-derive and does not churn.
@@ -103,6 +219,96 @@ class CountsInProseMatchTheSymbolTests(unittest.TestCase):
                             f"counts {value} ({spelled(value)})"
                         )
         self.assertEqual(wrong, [], "\n".join(wrong))
+
+    def test_a_count_written_in_digits_matches_its_symbol_too(self) -> None:
+        """The same nouns, counted in digits instead of words.
+
+        A channel was added and the two README sites that state the count as `16`
+        rather than "sixteen" stayed behind, because the scan above requires a
+        spelled-out numeral and the sweep that was supposed to catch the rot was
+        `grep -rni sixteen` — which cannot match a digit by construction. One of
+        the two was the architecture diagram, the only picture of the layer.
+        """
+        wrong: list[str] = []
+        for name in TRACKED_DOCS:
+            text = (REPO / name).read_text(encoding="utf-8")
+            for noun, value in COUNTED_NOUNS:
+                spaced = r"\s+".join(re.escape(word) for word in noun.split())
+                pattern = re.compile(r"\b(\d+)\s+" + spaced + r"\b", re.IGNORECASE)
+                for match in pattern.finditer(text):
+                    if int(match.group(1)) != value:
+                        line = text[: match.start()].count("\n") + 1
+                        wrong.append(
+                            f"{name}:{line} says '{match.group(0)}' but the symbol "
+                            f"counts {value}"
+                        )
+        self.assertEqual(wrong, [], "\n".join(wrong))
+
+    def test_the_re_derivable_table_rows_are_re_derivable(self) -> None:
+        """The README's own promise, enforced on the rows that can keep it.
+
+        The table is introduced with "Every number below comes from a named symbol
+        in the source. Re-derive them", and nothing did: its channel row said 16
+        against a `CHANNELS` of 18. Neither scan above can reach it — the value is
+        a digit in the cell *after* the noun, not a numeral before it.
+
+        Rows whose value no symbol here can produce are exempt by name in
+        `UNDERIVABLE_TABLE_ROWS`, with the reason. Listing one of those as
+        re-derivable would put a hand-typed number in a test and call it a
+        measurement.
+        """
+        rows = _re_derivable_table(REPO / "README.md")
+        wrong: list[str] = []
+        for label, value in RE_DERIVABLE_TABLE_ROWS:
+            found = rows.get(label)
+            self.assertIsNotNone(
+                found,
+                f"README.md no longer has a re-derivable table row labelled "
+                f"{label!r}; if it was renamed, rename it here too — a row that "
+                f"stops matching stops being checked, silently",
+            )
+            assert found is not None  # for type checkers; assertIsNotNone above
+            if found != str(value):
+                wrong.append(f"README.md row {label!r} says {found}, {value} is live")
+        self.assertEqual(wrong, [], "\n".join(wrong))
+
+    def test_every_row_of_that_table_is_accounted_for(self) -> None:
+        """Deleting a row from the checked list has to cost something.
+
+        The check above iterates the rows *it* declares, so the cheapest way to
+        pass it is to stop declaring one while the number stays in the README —
+        the same shape as the defect it was written for. Every row of the table is
+        therefore either re-derived or exempt by name with a reason, and a new row
+        is neither until someone says which.
+        """
+        rows = set(_re_derivable_table(REPO / "README.md"))
+        declared = {label for label, _ in RE_DERIVABLE_TABLE_ROWS}
+        self.assertEqual(
+            rows - declared - set(UNDERIVABLE_TABLE_ROWS),
+            set(),
+            "README table rows that are neither re-derived nor exempt",
+        )
+        self.assertEqual(
+            (declared | set(UNDERIVABLE_TABLE_ROWS)) - rows,
+            set(),
+            "labels claimed here that the README table no longer has",
+        )
+
+    def test_the_table_scan_reads_a_table_that_has_the_stale_shape(self) -> None:
+        """Control for both tests above: a parser that finds nothing passes anything.
+
+        The failure this guards against is not a wrong number but an empty
+        population — a changed table format, a moved heading, a `_re_derivable_table`
+        that returns `{}`. It also pins the promise the rows are checked against, so
+        deleting the sentence and keeping the table cannot quietly retire them.
+        """
+        text = (REPO / "README.md").read_text(encoding="utf-8")
+        self.assertIn(RE_DERIVABLE_TABLE_PROMISE, text)
+        rows = _re_derivable_table(REPO / "README.md")
+        self.assertGreaterEqual(len(rows), len(RE_DERIVABLE_TABLE_ROWS))
+        for label, _ in RE_DERIVABLE_TABLE_ROWS:
+            with self.subTest(row=label):
+                self.assertRegex(rows[label], r"^\d+$")
 
     def test_the_rubric_version_in_the_docs_is_the_live_one(self) -> None:
         """A bump splits the archive in two; a doc still naming the old one is a lie.


### PR DESCRIPTION
`format_protocol_for_prompt` (src/experimental_protocol.py) and
`format_project_context_for_prompt` (src/project_bootstrap.py) were both tested,
both documented, and reached no stage prompt. On `origin/main` at fdded57,
`git grep format_protocol_for_prompt` returns its definition and two lines of
`tests/test_experimental_protocol.py`; `git grep format_project_context_for_prompt`
returns its definition, two test lines, and an import in `src/manager.py` that
nothing in that file calls.

**What that cost.** The experimental protocol is the run's own answer to "what
would count as having shown it" — the primary metric, the planned seed count, and
a tuning budget per baseline, declared at Stage 03 before any result exists. None
of it reached a prompt as data. Counted over `src/prompts/0*.md`, the string
"experimental protocol" appears in exactly two templates: `03_study_design.md`
(twice) and `05_experimentation.md` (once, the file path plus the obligations it
creates). 04, 06, 07 and 08 do not mention it. So the stage that builds the
harness was never told how many seeds it has to support, and the stage that
adjudicates was never told which metric it may not replace — while
`validate_experimental_protocol` and `validate_outcome_statistics` refused them
for it from Stage 05 on. A run started with `--project-root` was worse: it walked
the stage graph over a repository that no prompt described.

**What hid the second one.** `src/manager.py` imported
`format_project_context_for_prompt` and never called it, so the cheapest check —
grep for the symbol — reported it wired. Running this branch's own AST instrument
over `origin/main`'s `src/` reports 10 prompt renderers imported and never called,
all 10 in `src/manager.py`: `format_artifact_index_for_prompt`,
`format_experiment_manifest_for_prompt`, `format_findings_for_prompt`,
`format_manifest_for_prompt`, `format_outcomes_for_prompt`,
`format_preregistration_for_prompt`, `format_profile_for_prompt`,
`format_project_context_for_prompt`, `format_rounds_for_prompt` and
`format_venue_for_prompt` — left behind as `information_flow` took delivery over,
one of them (`format_findings_for_prompt`) as recently as #202. All 10 imports are
gone and the same instrument reports 0 here.
`test_no_prompt_renderer_is_imported_without_being_called` fails on the next one;
it counts `ast.Call` nodes rather than name occurrences, because a text search is
what was fooled.

**The channels.** `experimental_protocol` is produced by `03_study_design` and
consumed by 04, 05, 06 and 07 — not by its own author, whose template already
carries the schema and the rules, and not by 08, which packages a comparison it
cannot re-run. Its preface separates building for the protocol from spending it,
because Stage 04's template requires a smoke run and a blanket "run the planned
seeds" would pull the experiment two stages early; the repair it prices is the
real `05_experimentation → 04_implementation` revisit edge, asserted against
`REVISIT_EDGES`.

`project_context` has no producer and reaches every stage from 01 to 08.
`recommend_entry_stage` returns any of those eight, so a fixed early set would
withhold the description of the repository from the run that re-enters latest —
the one that has seen least of it. Stage 00 is the single exclusion and it is a
fact about the code, not a preference: `run()` calls `_run_project_bootstrap`
after `_run_intake`, asserted by reading the source order.

**The assessment list is complete, and the overlap with `# Approved Memory` is
real and kept.** `_adopt_project_bootstrap_baseline` copies every below-entry
assessment into `memory.md` as a stage summary, so at the moment the scan finishes
the two do say the same thing. Narrowing the list is still wrong, because memory's
copy is not durable: `append_approved_stage_summary` retains only the entries
numbered below the stage it writes. `07_writing → 01_literature_survey` is a
`guard="always"` revisit edge and `recommend_entry_stage` returns 8 for a
repository complete through Stage 07, so a run can re-enter at 07 and take it.
Measured on that path: after `_adopt_project_bootstrap_baseline(entry_stage=7)`
memory holds Stages 1-6; after Stage 01 is approved it holds Stage 01 alone, "15
code files" is gone from memory, and the only surviving copy of the scan's reading
of Stages 02-06 is this block.

The section above the list is not a second copy to fall back on, and this is the
correction to an earlier draft of this branch, which claimed
`bootstrap_summary.md` "is always the generated one" on the strength of an AST
scan finding no Python caller that sets `ProjectBootstrapResult.summary`. The
writer it should have been looking for is not a caller.
`src/prompts/project_bootstrap.md` section 4 asks the agent for 300-500 words of
prose at `{{WORKSPACE_BOOTSTRAP_DIR}}/bootstrap_summary.md`, `format_stage_template`
resolves that placeholder to `paths.bootstrap_dir`, and
`load_project_bootstrap_summary` reads exactly that path — under
`bypassPermissions`. Measured: after `save_project_bootstrap` the block carries
"15 code files" and "12 references in refs.bib"; after a plausible agent-authored
summary replaces that file it carries neither, while the list still names all four
stages. That strengthens the case for the complete list rather than weakening it,
and it is now the thing the tests hold:
`test_the_summary_above_the_list_is_agent_owned` performs the overwrite and
`test_the_prompt_asks_the_agent_to_write_the_file_the_summary_is_read_from`
anchors it on the template and the real prompt instead of on an AST scan that
cannot see an agent.

Four of the six files `save_project_bootstrap` writes are handed back to the agent
by that template; the two it leaves alone are `project_state.json` and
`scan_metadata.json`, and the second is where the re-entry stage lives.
`test_the_template_hands_the_agent_four_of_the_six_files_the_scan_wrote` pins the
split, so moving a filename across it costs a failing test. docs/run-artifacts.md
said `--project-root` was "the only writer of `bootstrap/`"; it now says it is the
only *scan* that writes there and names the four the agent may replace.

**Counts.** `len(CHANNELS)` is 18, up from 16; channels with a producer 9, up from
8; channels that withhold themselves from at least one stage 17, up from 15.
README.md, docs/architecture.md and docs/framework.md say eighteen, the README's
"eight produced inside the walk" says nine, and the README's narrowings paragraph
now says seventeen channels narrow so that "four narrowings" reads as the curated
list it is rather than as a count.

Two README sites state that count in digits and both were correct at 16 on main:
the "counts you can re-derive" table row and the architecture mermaid node. Both
now say 18. Neither could go red, and the sweep meant to catch them was
`grep -rni sixteen`, which cannot match a digit — so
`tests/test_doc_counts.py` grew three rules rather than two corrected numbers:
`test_a_count_written_in_digits_matches_its_symbol_too` runs the existing noun
list against digit numerals, `test_the_re_derivable_table_rows_are_re_derivable`
re-derives nine of the table's twelve rows from their named symbols, and
`test_every_row_of_that_table_is_accounted_for` requires every row to be either
re-derived or exempt by name with a reason, so deleting a row from the checked
list fails instead of quietly retiring the claim. The three exempt rows are the
`validate_*` count, the two `parse_args` flag counts and the modules/lines/tests
row whose stated symbol is "the tree".

`COUNTED_NOUNS` deliberately has no equivalent coverage rule and deleting a row
from it survives. Its population is prose: scanning the four tracked docs for
every spelled-out numeral before a phrase containing "channel" or "edge" returns
48 phrases, 31 of which are ordinary sentences no symbol counts ("one edge out of
each node", "eighteen edges to twenty-two"). That measurement is written into the
module docstring so the hole is documented rather than rediscovered.

Mutations, all 28 applied to this tree and reverted after, 27 killed:

- protocol builder returns `None` → 5 failures, incl.
  `test_the_declared_numbers_reach_the_stage_that_spends_them`
- `project_context` builder returns `None` → 4, incl.
  `test_the_scan_reaches_the_stage_the_run_re_enters_at`
- re-add the dead `src/manager.py` import → 1,
  `test_no_prompt_renderer_is_imported_without_being_called`
- narrow `project_context` to `{03,04,05,07}` → 2; widen it to include intake → 2
- send the protocol back to Stage 03 → 2; drop Stage 04 from its consumers → 1;
  replace its preface → 2
- restore the assessment narrowing → 4, incl.
  `test_the_summary_above_the_list_is_agent_owned`; treat a missing entry stage as
  "everything carried forward" → 1; move the boundary to `<=` → 1; drop the
  `## Project Bootstrap Summary` section → 5
- delete the "only copy left" sentence from the preface → 1
- point template section 4 at another filename → 2; read the summary from a file
  the prompt never names → 4; add `scan_metadata.json` to what the template asks
  for → 1
- "sixteen typed channels" in README.md → 1; in docs/framework.md → 1;
  "Sixteen channels narrow" → 1; "eight channels produced inside the walk" → 1
- `16` in the mermaid node → 1,
  `test_a_count_written_in_digits_matches_its_symbol_too`
- `16` in the table row → 1; rename the row → 3; blind the table parser → 3;
  delete the promise the rows are checked against → 3; stop declaring a row → 1;
  add an undeclared row → 1
- **survivor:** deleting a `COUNTED_NOUNS` row, for the reason above

`python -m py_compile main.py src/*.py tests/*.py` clean;
`python -m unittest discover -s tests -q` runs 2290 tests, OK (skipped=1), against
2254 on `origin/main` at fdded57. The +36 is 32 tests in
`tests/test_a_renderer_with_no_caller.py` and 4 added to `tests/test_doc_counts.py`,
which goes from 6 to 10.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)