### PR TITLE
Give a panel seat what the solo reviewer already sees, and let a panel leave a debt

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,10 +975,14 @@ code that would have to change.
   the population that justified the leniency is empty, since the freeze runs before every attempt
   from Stage 05 on and every validation is post-attempt, so the only way to arrive without a stamp
   is to have deleted it.
-- **Standing rules and obligations never reach a panel seat.** Both are injected only into the solo
-  reviewer's prompt. Under `--review-panel`, no seat is shown the accumulated rules and no seat is
-  asked whether an inherited obligation was met — and because neither the seat nor the chair prompt
-  asks for `carry_forward`, a panel run essentially never creates an obligation either.
+- **Standing rules and obligations now reach a panel seat, but not the cross-model auditor.** Every
+  seat and the chair are shown both, through `ReviewPanel._context_block`, and both return formats
+  ask for `carry_forward` and `discharged`, so `--rigor max` no longer runs with fewer live
+  mechanisms than `--rigor standard`. What is still outside is the third reviewer:
+  `format_policy_for_prompt` and `format_for_review_prompt` are imported by
+  [src/approval_agent.py](src/approval_agent.py) and [src/review_panel.py](src/review_panel.py) and
+  by nothing else, so `CrossModelReviewer.build_prompt` audits an approval without being told what
+  this run has already required of it or what it still owes.
 - **The cross-model veto now reaches both front ends, but no test runs it against a real model, it
   does not survive a resume, and it never sees a human approval.** `main.py` seats it through
   `create_cross_reviewer`, which both `ResearchManager` constructions call — and which refuses the

--- a/docs/development.md
+++ b/docs/development.md
@@ -106,7 +106,7 @@ its own docstring, not everything it touches.
 | The validity chain | `test_preregistration.py`, `test_experimental_protocol.py`, `test_validity_review.py`, `test_hypothesis_manifest.py`, `test_evidence_ledger.py`, `test_report_plan.py`, `test_report_plan_robustness.py`, `test_report_plan_stamping.py`, `test_task_deliverables_contract.py` |
 | Manifests, indexes, rollback | `test_run_manifest.py`, `test_stage_rollback.py`, `test_artifact_index.py`, `test_experiment_manifest.py`, `test_writing_pipeline.py` |
 | Improvement loop | `test_rubric.py`, `test_evolution.py` (also covers `pareto.py`), `test_ideation_panel.py` |
-| Review and approval | `test_review_panel.py`, `test_panel_unreachable.py`, `test_cross_reviewer.py`, `test_review_policy.py`, `test_obligations.py`, `test_stage_comments.py`, `test_deliberation.py`, `test_crux_repeat.py`, `test_verdict_extraction.py`, `test_reviewer_unreadable_verdict.py` |
+| Review and approval | `test_review_panel.py`, `test_panel_unreachable.py`, `test_panel_inherits_the_ledger.py`, `test_cross_reviewer.py`, `test_review_policy.py`, `test_obligations.py`, `test_stage_comments.py`, `test_deliberation.py`, `test_crux_repeat.py`, `test_verdict_extraction.py`, `test_reviewer_unreadable_verdict.py` |
 | Archive and self-measurement | `test_archive.py`, `test_archive_evidence.py`, `test_archive_exploration.py`, `test_archive_exploration_wiring.py`, `test_decisions.py`, `test_trials.py`, `test_scorecard.py` |
 | Operators, recovery, backend health | `test_operator_recovery.py`, `test_operator_codex.py`, `test_bounded_recovery.py`, `test_backend_health.py` |
 | Web search | `test_web_search.py`, `test_mcp_web_search.py` |

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1015,8 +1015,12 @@ any.
   consistently, in two trees, one of which no template mentions and nothing renders into a prompt. A
   run resumed from an AutoR that predates the stamp is adopted on its next freeze rather than
   refused, and until then two of the three comparisons have nothing to compare against.
-- **Standing rules and obligations never reach a panel seat.** Both are injected only into the solo
-  reviewer's prompt, so `--review-panel` silently loses two of the accumulation mechanisms.
+- **Standing rules and obligations now reach a panel seat, but not the cross-model auditor.**
+  `ReviewPanel._context_block` renders both for every seat and the chair, through the same two
+  renderers `AutomatedReviewer` calls, so `--review-panel` no longer loses the two accumulation
+  mechanisms. `CrossModelReviewer.build_prompt` still renders neither: `format_policy_for_prompt`
+  and `format_for_review_prompt` are imported by `src/approval_agent.py` and `src/review_panel.py`
+  and by nothing else.
 - **The cross-model veto does not survive a resume, and never sees a human approval.** `main.py`
   seats it through `create_cross_reviewer`, so it is no longer benchmark-only — but the mode is
   absent from the keys `load_run_config` reads, so a resumed run re-decides it from whatever

--- a/docs/review-panel.md
+++ b/docs/review-panel.md
@@ -100,6 +100,71 @@ agreement it already reached.
 
 Raise or lower the ceiling with `--panel-rounds N`.
 
+## What every seat inherits
+
+A run accumulates two records that every later review has to see:
+
+- **Standing rules** (`review_policy.json`) — the corrections earlier refusals demanded, promoted
+  into requirements checked at every gate after them. This is what makes the gate strictly harder
+  as a run proceeds.
+- **Obligations** (`obligations.json`) — what an earlier *approval* said a later stage still owes,
+  injected into that stage's prompt and into that stage's review, so the debt is actually checked.
+
+Both were rendered into `AutomatedReviewer`'s prompt and into nothing else. No seat saw either,
+and neither the seat prompt nor the chair prompt asked for `carry_forward`, so a panel run could
+not create an obligation to inherit in the first place. Stated at the dial, which is the sharpest
+form of it: **`--rigor max` had fewer live mechanisms than `--rigor standard`**, because the higher
+setting swaps the solo reviewer for the panel and the panel could not see what the solo reviewer
+sees. A knob that loses a mechanism as it is turned up is the exact thing the knob exists to
+prevent.
+
+The panel was also *writing* rules it could never read. A panel refusal reaches `record_correction`
+by the same manager path a solo refusal does, so the room was teaching itself lessons it would
+never be shown.
+
+Both blocks now render inside `_context_block`, the one builder the seat prompt and the chair
+prompt share, through `format_policy_for_prompt` and `format_for_review_prompt` — the same two
+renderers the solo reviewer calls, so the two gates argue from one copy of the rules rather than
+two that can drift. An empty policy and an empty ledger render nothing, not a heading over
+nothing.
+
+Same renderer *and* the same arguments. `format_policy_for_prompt` takes a `stage`, which
+withholds the rules this stage's own earlier attempts produced; every review that demands
+anything records one, so a gate that omits the argument raises the bar by a requirement per
+attempt and its retry loop cannot converge. Calling the shared function is therefore necessary
+and not sufficient, which is why the parity here is pinned twice: `assertIs` on the two function
+objects, and `test_neither_gate_judges_a_stage_against_a_rule_its_own_retries_invented`, which
+puts a rule from the stage under review into the fixture so the filter has a row to reject.
+
+### Who may open a debt, and who may close one
+
+| | Any seat | The chair |
+| --- | --- | --- |
+| Records `carry_forward` | yes — carried whatever the rest of the room decides | yes, added to the room's |
+| Refuses over an unmet obligation | yes | yes |
+| `discharged` actually closes one | no — recorded as a claim and put in front of the chair | yes |
+
+The asymmetry is deliberate, because the two directions fail differently. Recording a debt is the
+strict direction: it costs a line in the ledger and buys a check at the stage that owes it, so a
+seat that noticed something must not need four others to agree before the run remembers it — five
+seats make the run *stricter* than one. Discharge is the lenient direction, and five seats must
+not become five chances for someone to accept a restatement as payment, which would make the panel
+weaker than the single reviewer it replaced. So the seats advise and the chair decides.
+
+Three rules follow, and each has a test:
+
+- **The chair's last word closes a debt, and only that.** Its seat verdict when the room never
+  split — a unanimous approval makes no chair call at all — and its synthesis once it has spoken.
+  A position the chair took *before* hearing the objections stops counting once the room splits.
+- **A chair that was asked and could not answer closes nothing.** Unreachable, or unreadable
+  twice, and the debt stays open for a later gate.
+- **Nothing is discharged while a blocking objection stands.** A draft the panel is refusing is a
+  draft that is about to change, and closing a debt against it is the approval the blocking rule
+  just refused, wearing another name.
+
+Every claim a seat made is in the record next to what the chair did with it, so a discharge the
+chair declined is visible rather than lost.
+
 ## Measuring whether it helped
 
 Every panel run contains its own control arm for free: **the chair's round-1 verdict is a
@@ -220,12 +285,17 @@ Stage 08 reads `workspace/reviews/`, and a run's auditability is the product's w
 panel that reported only its verdict would be less inspectable than the single reviewer it
 replaced.
 
+Each seat's own `carry_forward` and `discharged` are recorded per verdict, and the deliberation's
+`carry_forward` and `discharged` are what the run's ledger was actually handed. The gap between
+the two is the discharge claims the chair did not take.
+
 The run log gets a one-line summary per gate:
 
 ```
 03_study_design attempt 1 panel_decision
 rounds: 2
 positions: Principal Investigator=approve; Domain Expert=approve; Methodologist=custom_feedback; ...
+obligations: 1 carried forward, 0 discharged
 chair_overridden: True
 final_choice: 4
 ```

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -395,20 +395,28 @@ one point cannot inflate the ledger.
 
 Absent unless the run uses the **automated** approval gate — `record_obligations`
 and `discharge_obligations` are reached only from the automated reviewer's
-decision, so a manual human gate never writes this file. See
-[Limits](../README.md#limits): obligations are injected into the solo reviewer's
-prompt only — `_build_review_prompt` carries the ledger and the panel's
-`_build_member_prompt` does not — so a seated review panel never sees them,
-however it was seated.
+decision, so a manual human gate never writes this file.
+
+Both automated gates are shown the ledger, through one renderer:
+`AutomatedReviewer._build_review_prompt` calls `format_for_review_prompt` for the
+solo reviewer, and `ReviewPanel._context_block` calls the same function for every
+seat and for the chair. A panel also *writes* to this file — any seat's
+`carry_forward` entries are carried whatever the room decides — but only the
+chair's last word discharges anything, and nothing is discharged while a blocking
+objection stands. See [the panel's own doc](review-panel.md) for that asymmetry.
 
 ### `review_policy.json`
 
 The standing rules the run has learned about its own work. Written by
 [`src/review_policy.py`](../src/review_policy.py) whenever a correction is
 demanded or an already-given approval is undone, and injected into every
-subsequent *solo* review prompt. As with obligations, the injection point is
-`_build_review_prompt`; a review panel's seats and chair are prompted elsewhere
-and are not shown the rules.
+subsequent review prompt. As with obligations, one renderer serves both gates:
+`format_policy_for_prompt` is called by `AutomatedReviewer._standing_rules_block`
+for the solo reviewer and by `ReviewPanel._standing_rules_block` for every seat
+and the chair. Both pass `stage`, which withholds the rules the stage under
+review produced in its own earlier attempts — a review that demands anything
+records one, so injecting them would raise the bar by a requirement per attempt
+and the retry loop could not converge.
 
 ```json
 {

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -25,6 +25,28 @@ blocking objection survives the final round, approval is refused *in code* — n
 chair nicely. A prompt-level rule that the chair can talk itself out of is not a rule, and a
 gate that cannot say no is not a gate.
 
+**What the room inherits.** A run accumulates two things every later review has to see: the
+standing rules earlier refusals produced (:mod:`src.review_policy`) and the obligations earlier
+approvals attached (:mod:`src.obligations`). Both reached the solo reviewer's prompt and neither
+reached a seat, so turning ``--rigor`` from ``standard`` up to ``max`` swapped one reviewer that
+reads them for five that do not — a dial that loses a mechanism as it is turned up. Worse in one
+direction than a plain omission: ``ResearchManager._record_review_correction`` promotes a *panel*
+refusal into ``review_policy.json`` exactly as it does a solo one, so the panel was writing
+standing rules it would never read back. Both blocks now reach every seat and the chair, through
+the same two renderers the solo reviewer calls rather than a second copy of the wording — and
+with the same arguments, which is the half a shared function does not give you for free: without
+``stage``, ``format_policy_for_prompt`` shows the room the rules the stage's own retries invented
+and the bar it is judged against rises by one requirement per attempt.
+
+**Who may create a debt, and who may close one.** Both halves are needed: a seat that cannot
+answer ``carry_forward`` cannot leave an obligation behind, and a panel run that never creates
+one has nothing to inherit at the next gate. The two directions are deliberately asymmetric,
+because they fail asymmetrically. Any seat may record a debt, and every seat's entries are
+carried whatever the rest of the room decides — five seats then make a run *stricter* than one.
+Discharge is the lenient direction, so five seats must not make it five chances to write an
+obligation off: only the chair's last word closes one, and nothing is closed while a blocking
+objection stands. Every seat's claim is still recorded and put in front of the chair.
+
 Every position, including dissent that lost, is written to ``workspace/reviews/panel/``. A
 panel that hides how it split is less auditable than the single reviewer it replaced.
 """
@@ -32,7 +54,7 @@ panel that hides how it split is less auditable than the single reviewer it repl
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -43,6 +65,8 @@ from .approval_agent import (
     AutomatedReviewer,
     ReviewDecision,
 )
+from .obligations import format_for_review_prompt, load_ledger
+from .review_policy import format_policy_for_prompt, load_policy
 from .terminal_ui import TerminalUI
 from .utils import (
     RunPaths,
@@ -332,6 +356,19 @@ class PanelVerdict:
     concerns: tuple[str, ...] = ()
     failed: bool = False
     abstained: bool = False
+    #: Debts this seat asked a later stage to settle. Carried whatever the room decides.
+    carry_forward: tuple[Any, ...] = ()
+    #: Inherited obligation ids this seat believes were met. A claim, not a closure: only
+    #: :meth:`PanelDeliberation.settled_obligations` decides which of these are applied.
+    discharged: tuple[str, ...] = ()
+
+    #: Refused outright, because ``frozen=True`` otherwise makes this *conditionally*
+    #: hashable: ``carry_forward`` holds whatever ``record_obligations`` accepts, which
+    #: includes dicts, so a verdict from a seat that carried nothing hashes and the same
+    #: verdict from a seat that carried a debt raises ``TypeError`` from inside the tuple.
+    #: A container that works until a seat uses a feature is worse than one that never
+    #: does; nothing in the tree hashes a verdict, and this is why it may not start.
+    __hash__ = None  # type: ignore[assignment]
 
     @property
     def approves(self) -> bool:
@@ -361,6 +398,8 @@ class PanelVerdict:
             "concerns": list(self.concerns),
             "failed": self.failed,
             "abstained": self.abstained,
+            "carry_forward": list(self.carry_forward),
+            "discharged": list(self.discharged),
         }
 
 
@@ -375,6 +414,13 @@ class PanelDeliberation:
     member_calls: int = 0
     #: Which seat chairs, so :attr:`solo_baseline` can find its round-1 verdict.
     chair_key: str = ""
+    #: Whether the room went to the chair at all. A unanimous approval never does, and then
+    #: the chair's seat verdict *is* its last word.
+    chair_asked: bool = False
+    #: What the chair's synthesis step produced, once it has run. Read for the chair's
+    #: ledger positions only, which is why a stand-in written in the chair's place is
+    #: harmless here: every one of them is empty in both fields.
+    chair_verdict: ReviewDecision | None = None
 
     @property
     def final_round(self) -> list[PanelVerdict]:
@@ -382,6 +428,44 @@ class PanelDeliberation:
 
     def blocking_verdicts(self) -> list[PanelVerdict]:
         return [verdict for verdict in self.final_round if verdict.blocking]
+
+    def carried_obligations(self) -> list[Any]:
+        """Every debt the room asked to carry forward: any seat that spoke, plus the chair.
+
+        Union, not intersection, and not the chair's alone. An obligation is the cheap,
+        strict direction — recording one costs a line in the ledger and buys a check at the
+        stage that owes it — so a seat that noticed something must not need four others to
+        agree before the run remembers it. Two seats naming the same debt are both kept
+        here, because who raised it is part of the record; ``record_obligations`` is what
+        collapses them into one entry in the ledger.
+        """
+        entries = [entry for verdict in self.final_round if verdict.counts for entry in verdict.carry_forward]
+        if self.chair_verdict is not None:
+            entries.extend(self.chair_verdict.carry_forward)
+        return entries
+
+    def settled_obligations(self) -> list[str]:
+        """Which inherited debts this review closes — the chair's last word, and only that.
+
+        Discharge is the direction where five seats could make a panel *weaker* than the one
+        reviewer it replaced: five chances for some seat to accept a restatement as payment.
+        So the seats advise and the chair decides, and if a blocking objection survives the
+        final round nothing is closed at all — a draft the panel is refusing is a draft that
+        is about to change, and closing a debt against it is the approval the blocking rule
+        just refused, wearing another name.
+        """
+        if self.blocking_verdicts():
+            return []
+        if self.chair_asked:
+            # Once the room has split, the chair's seat verdict is a position it took before
+            # hearing the objections, so it stops counting as the chair's word. A chair that
+            # was asked and could not answer -- unreachable, or unreadable twice -- has not
+            # said the debt was paid, and the run keeps it open until some later gate does.
+            return [str(item) for item in self.chair_verdict.discharged] if self.chair_verdict else []
+        chair = next(
+            (v for v in self.final_round if v.role_key == self.chair_key and v.counts), None
+        )
+        return [str(item) for item in chair.discharged] if chair is not None else []
 
     @property
     def solo_baseline(self) -> PanelVerdict | None:
@@ -434,6 +518,10 @@ class PanelDeliberation:
             "homogeneous_panel": len({seat for seat in seats}) <= 1,
             "rounds": [[verdict.to_dict() for verdict in group] for group in self.rounds],
             "blocking_after_deliberation": [v.role_key for v in self.blocking_verdicts()],
+            # What the run's ledger will actually be handed, next to each seat's own claim
+            # in `rounds`, so a reader can see which discharge claims the chair did not take.
+            "carry_forward": self.carried_obligations(),
+            "discharged": self.settled_obligations(),
             "chair_overridden": self.chair_overridden,
             "override_reason": self.override_reason,
             "final_choice": self.decision.choice if self.decision else None,
@@ -506,6 +594,20 @@ def resolve_roles(keys: list[str] | None) -> tuple[PanelRole, ...]:
         first = roles[0]
         roles[0] = PanelRole(**{**first.__dict__, "chair": True})
     return tuple(roles)
+
+
+def _obligation_line(entry: Any) -> str:
+    """One human-readable line for a carried debt, for the transcript and the record.
+
+    Display only. ``record_obligations`` is the reader that decides what an entry means —
+    including that a bare string is a legal entry — and it stays the only one, so this
+    reads the same two spellings it does and never rejects anything on its behalf.
+    """
+    if isinstance(entry, dict):
+        text = str(entry.get("obligation") or entry.get("text") or "").strip()
+        target = str(entry.get("target_stage") or entry.get("stage") or "").strip()
+        return f"{text} (target: {target})" if target else text or "(empty obligation)"
+    return str(entry).strip() or "(empty obligation)"
 
 
 class ReviewPanel:
@@ -621,6 +723,15 @@ class ReviewPanel:
 
         deliberation.member_calls = self._calls
         decision = self._enforce_blocking_objections(deliberation)
+        # After the blocking rule, not before: an override rewrites the decision from
+        # scratch, so attaching the ledger positions any earlier would drop them. And on the
+        # one path every outcome passes through, not at each construction site: four of them
+        # build the decision this method returns -- the unanimous early return, the chair's
+        # own verdict, the dissent fallback and the override -- and only one of the four is
+        # the chair. A unanimous room never calls the chair at all, so a fix written into
+        # `_build_chair_prompt` and the chair's arm would reach the rarer half of the runs.
+        decision = self._attach_ledger_positions(deliberation, decision)
+        deliberation.decision = decision
         self._record(paths, deliberation)
         self._render(deliberation)
         return decision
@@ -756,6 +867,12 @@ class ReviewPanel:
             reason=decision.reason,
             feedback=decision.feedback,
             concerns=concerns,
+            # Read off the parsed verdict rather than the raw payload: `_parse_decision`
+            # already type-checks both fields (a `carry_forward` that is not a list, or a
+            # `discharged` that is a number, become empty), so taking them from `payload`
+            # would be a second, weaker reader of the same two fields.
+            carry_forward=tuple(decision.carry_forward),
+            discharged=tuple(str(item) for item in decision.discharged),
         )
 
     @staticmethod
@@ -808,6 +925,7 @@ class ReviewPanel:
             )
 
         chair = self._members[self.chair.key]
+        deliberation.chair_asked = True
         self._calls += 1
         self.ui.show_status(f"Panel chair ({self.chair.title}) is synthesizing the decision...", level="info")
         exit_code, stdout_text, stderr_text = chair.run_prompt(
@@ -836,7 +954,7 @@ class ReviewPanel:
         # failure got the harsher outcome, and the panel already encodes the rule it
         # was breaking: `_round` marks an unreadable seat non-blocking precisely so
         # one bad answer cannot veto.
-        return chair.parse_with_retry(
+        decision = chair.parse_with_retry(
             paths=paths,
             stage=stage,
             attempt_no=attempt_no,
@@ -849,6 +967,15 @@ class ReviewPanel:
                 "panel's own objections.",
             ),
         )
+        # The chair's last word on the ledger — whoever ended up writing it. A chair that
+        # could not be read is answered with a stand-in assembled from the seats' objections,
+        # and no stand-in in this tree carries `carry_forward` or `discharged`
+        # (`NoStandInVerdictClaimsADischargeTests`), so recording one here cannot close a
+        # debt on a chair's behalf. Tracking "did the chair really write this" separately
+        # was a branch no test could tell apart from this one, which is a worse thing to ship
+        # than the case it was guarding against.
+        deliberation.chair_verdict = decision
+        return decision
 
     def _enforce_blocking_objections(self, deliberation: PanelDeliberation) -> ReviewDecision:
         """Refuse approval while a blocking objection stands.
@@ -885,6 +1012,31 @@ class ReviewPanel:
         )
         deliberation.decision = overridden
         return overridden
+
+    def _attach_ledger_positions(
+        self, deliberation: PanelDeliberation, decision: ReviewDecision
+    ) -> ReviewDecision:
+        """Hand the run's ledger what the room decided it owes and what it settled.
+
+        ``ReviewDecision`` is the only channel the manager reads: ``_settle_obligations``
+        takes ``carry_forward`` and ``discharged`` off it and nothing else. Whatever a seat
+        wrote is therefore invisible to the run until it is attached here, which is why this
+        sits on the one path every outcome passes through rather than inside the chair's arm.
+
+        Unconditional, including when the room settled nothing. The decision handed in was
+        parsed from a model's payload and already carries whatever ``carry_forward`` and
+        ``discharged`` that payload asked for; skipping the rewrite when the room's own lists
+        are empty is precisely the case where the two disagree, and it lets a claim the rules
+        just refused ride through unread. ``_enforce_blocking_objections`` does not cover it:
+        that rebuilds the decision only when the chair *approved*, so a chair that refuses
+        while claiming a discharge keeps its own list. Empty in means empty on, which is what
+        every rule in :meth:`PanelDeliberation.settled_obligations` is for.
+        """
+        return replace(
+            decision,
+            carry_forward=deliberation.carried_obligations(),
+            discharged=deliberation.settled_obligations(),
+        )
 
     def _decision_from_dissent(self, verdicts: list[PanelVerdict], *, reason: str) -> ReviewDecision:
         # A room nobody could reach did not agree; it did not meet. `objections` filters
@@ -1030,14 +1182,33 @@ class ReviewPanel:
             "says what it claims.\n"
             "- Mark `blocking` true only for a defect that must be fixed before this stage can "
             "be approved at all. A blocking objection cannot be overruled by the chair, so use "
-            "it for real defects and not for preferences.\n\n"
+            "it for real defects and not for preferences.\n"
+            "- Two sections under Run Context below carry what this run has already decided, "
+            "when it has decided anything: the standing rules earlier refusals produced, and "
+            "the obligations earlier approvals attached to this stage. Check the stage against "
+            "every one of them, not only against your own charter. An inherited obligation "
+            "this stage neither discharged nor reasonably deferred is grounds to refuse, and "
+            "any seat may refuse on one.\n\n"
             "## Return Format\n\n"
             "Return JSON only, with no prose outside the JSON object:\n"
             '{"decision":"approve|suggestion_1|suggestion_2|suggestion_3|custom_feedback|abort",'
-            '"blocking":false,"concerns":["..."],"feedback":"","reason":""}\n\n'
+            '"blocking":false,"concerns":["..."],"feedback":"","reason":"",'
+            '"carry_forward":[{"obligation":"","target_stage":""}],"discharged":[]}\n\n'
             "- `feedback` must be non-empty when `decision` is `custom_feedback`.\n"
             "- `concerns` is a short list of the specific things you checked and found wanting.\n"
             "- `reason` should be concise and specific to your seat.\n"
+            "- `carry_forward` is how your seat approves without letting go. When something "
+            "still needs doing but does not have to stop this stage, record it here instead of "
+            "mentioning it in `reason`: each entry is injected into the prompt of the stage it "
+            "targets and into that stage's review, so it will actually be checked. Your entries "
+            "are carried whatever the rest of the room decides. `target_stage` is a stage slug "
+            "or number and may be omitted to mean 'any later stage'. Use it for real debts, not "
+            "for wishes.\n"
+            "- `discharged` lists the ids of inherited obligations you believe this stage "
+            "genuinely met — on work present in this stage, never on a promise or a "
+            "restatement. Only the chair's list closes a debt; yours is recorded and put in "
+            "front of the chair, so one seat cannot write off an obligation the room did not "
+            "agree was paid.\n"
             f"{self._persona_block()}\n"
             "# Suggested Refinements Available To The Panel\n\n"
             f"1. {suggestions[0]}\n2. {suggestions[1]}\n3. {suggestions[2]}\n\n"
@@ -1068,6 +1239,13 @@ class ReviewPanel:
                     lines.extend(f"- Concern: {item}" for item in verdict.concerns)
                 if verdict.feedback:
                     lines.append(f"- Requested change: {verdict.feedback}")
+                # The seats' ledger positions, so the chair's own list is a decision over
+                # what the room proposed rather than a fresh guess. Carried debts are shown
+                # because the chair should not restate them; discharge claims are shown
+                # because the chair is the only seat that can act on one.
+                lines.extend(f"- Carries forward: {_obligation_line(entry)}" for entry in verdict.carry_forward)
+                if verdict.discharged:
+                    lines.append(f"- Claims discharged: {', '.join(verdict.discharged)}")
                 if verdict.failed:
                     lines.append("- (this member could not be reached)")
                 lines.append("")
@@ -1098,11 +1276,21 @@ class ReviewPanel:
             "instructions that would satisfy the members who raised them.\n"
             "- If a built-in suggestion already captures the panel's ask, select it instead.\n"
             "- Use `abort` only if continuing automatically would be irresponsible.\n"
+            "- The transcript names every debt a seat asked to carry forward and every "
+            "inherited obligation a seat claims was met. The debts are carried whatever you "
+            "decide; the discharges are yours alone, and a claim is a recommendation to you.\n"
             f"{blocking_note}\n"
             "## Return Format\n\n"
             "Return JSON only, with no prose outside the JSON object:\n"
             '{"decision":"approve|suggestion_1|suggestion_2|suggestion_3|custom_feedback|abort",'
-            '"feedback":"","reason":""}\n\n'
+            '"feedback":"","reason":"",'
+            '"carry_forward":[{"obligation":"","target_stage":""}],"discharged":[]}\n\n'
+            "- `carry_forward` records what a later stage still owes. The seats' entries are "
+            "already carried, so add what the room missed rather than restating them.\n"
+            "- `discharged` lists the ids of inherited obligations this stage genuinely met. "
+            "Yours is the only list that closes one. Discharge on work present in this stage "
+            "and on nothing else — and while a blocking objection stands, nothing is "
+            "discharged at all.\n\n"
             f"{self._persona_block()}\n"
             "# Panel Transcript\n\n"
             f"{transcript}\n"
@@ -1110,6 +1298,35 @@ class ReviewPanel:
             f"1. {suggestions[0]}\n2. {suggestions[1]}\n3. {suggestions[2]}\n\n"
             f"{self._context_block(paths=paths, stage=stage, attempt_no=attempt_no, stage_markdown=stage_markdown)}"
         )
+
+    def _standing_rules_block(self, paths: RunPaths, stage: StageSpec) -> str:
+        """The rules this run's earlier refusals produced, rendered for every seat.
+
+        Through ``format_policy_for_prompt``, the renderer the solo reviewer calls: a second
+        copy of that wording would be a second thing to keep in step, and the two prompts
+        have to be arguing from the same rules for the panel to be the *stricter* gate it is
+        sold as. The panel is also what writes these rules — a panel refusal reaches
+        ``record_correction`` by the same manager path a solo refusal does — so before this
+        block existed the gate was teaching itself lessons it could never read back.
+
+        ``stage`` is passed for the same reason
+        :meth:`AutomatedReviewer._standing_rules_block` passes it, and calling the same
+        renderer is not enough on its own: without the argument the room is shown the rules
+        *this* stage's own retries invented, the bar rises by one requirement per attempt
+        because every review that demands anything records one, and the retry loop cannot
+        converge. Under a panel that is five seats reading the moving bar instead of one.
+        """
+        rendered = format_policy_for_prompt(load_policy(paths), stage=stage)
+        if not rendered:
+            return ""
+        return "# Standing Review Rules (learned earlier in this run)\n\n" + rendered + "\n\n"
+
+    def _obligations_block(self, paths: RunPaths, stage: StageSpec) -> str:
+        """Ask this room whether the debts it inherited were actually paid."""
+        rendered = format_for_review_prompt(load_ledger(paths), stage)
+        if not rendered:
+            return ""
+        return "# Inherited Obligations\n\n" + rendered + "\n\n"
 
     def _context_block(
         self,
@@ -1137,7 +1354,12 @@ class ReviewPanel:
             f"- artifact index: `{paths.artifact_index.resolve()}`\n"
             f"- experiment manifest: `{paths.experiment_manifest.resolve()}`\n"
             f"- workspace root: `{paths.workspace_root.resolve()}`\n\n"
-            "# Original Goal\n\n"
+            # Shared by the seat prompt and the chair prompt on purpose. Injecting the two
+            # inherited blocks here is what makes "every seat sees them" structural rather
+            # than a thing two prompt builders each have to remember.
+            + self._standing_rules_block(paths, stage)
+            + self._obligations_block(paths, stage)
+            + "# Original Goal\n\n"
             # Same reader, same fix as the solo reviewer: a seat cannot judge whether a
             # stage did the task on half the task.
             f"{goal_excerpt(read_text(paths.user_input), max_chars=GOAL_EXCERPT_CHARS)}\n\n"
@@ -1181,6 +1403,8 @@ class ReviewPanel:
             (
                 f"rounds: {len(deliberation.rounds)}\n"
                 f"positions: {summary}\n"
+                f"obligations: {len(deliberation.carried_obligations())} carried forward, "
+                f"{len(deliberation.settled_obligations())} discharged\n"
                 f"chair_overridden: {deliberation.chair_overridden}\n"
                 f"final_choice: {deliberation.decision.choice if deliberation.decision else '?'}\n"
                 f"vs single pass: {effect['summary']['verdict']}"
@@ -1205,12 +1429,28 @@ class ReviewPanel:
                     lines.extend([f"- {item}" for item in verdict.concerns] + [""])
                 if verdict.feedback:
                     lines.extend(["Requested change:", "", verdict.feedback, ""])
+                if verdict.carry_forward:
+                    lines.extend(
+                        [f"- Carries forward: {_obligation_line(entry)}" for entry in verdict.carry_forward] + [""]
+                    )
+                if verdict.discharged:
+                    lines.extend([f"- Claims discharged: {', '.join(verdict.discharged)}", ""])
                 if verdict.failed:
                     lines.extend(["_This member could not be reached._", ""])
         decision = deliberation.decision
         lines.extend(["## Outcome", ""])
         if deliberation.chair_overridden:
             lines.extend([f"> Chair approval overridden: {deliberation.override_reason}", ""])
+        # Which claims the chair took and which it left. A seat's claim sits above in its own
+        # round; printing only the applied list would hide the difference between the two.
+        carried = deliberation.carried_obligations()
+        settled = deliberation.settled_obligations()
+        if carried:
+            lines.extend([f"- Carried forward: {_obligation_line(entry)}" for entry in carried])
+        if settled:
+            lines.append(f"- Obligations discharged: {', '.join(settled)}")
+        if carried or settled:
+            lines.append("")
         if decision is not None:
             lines.append(f"- Decision: `{decision.decision_token}` (choice {decision.choice})")
             if decision.reason:

--- a/tests/test_panel_inherits_the_ledger.py
+++ b/tests/test_panel_inherits_the_ledger.py
@@ -1,0 +1,757 @@
+"""What a panel seat inherits from the run, and what a panel run leaves behind.
+
+Two mechanisms accumulate across a run and both used to reach exactly one reader. The
+standing rules earlier refusals produced (`review_policy.json`) and the obligations earlier
+approvals attached (`obligations.json`) were rendered into `AutomatedReviewer`'s prompt and
+nowhere else, and neither the seat prompt nor the chair prompt asked for `carry_forward`, so
+a panel run could not create an obligation either.
+
+The sharp form of that: `--rigor max` had *fewer* live mechanisms than `--rigor standard`,
+because the higher setting swaps the solo reviewer for the panel and the panel could not see
+what the solo reviewer sees. `ParityWithTheSoloReviewerTests` is the test for the dial itself
+— it asserts the two prompts argue from the same rendered blocks, so the panel cannot silently
+fall behind the reviewer it replaces again.
+
+The discharge half is deliberately not symmetric with the carry-forward half, and
+`OnlyTheChairClosesADebtTests` is where that asymmetry is pinned: any seat may record a debt
+(five seats then make the run stricter), only the chair's last word closes one (five seats
+must not become five chances to write one off).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src import approval_agent, obligations as obligations_module, review_panel
+from src import review_policy as review_policy_module
+from src.approval_agent import AutomatedReviewer, ReviewDecision
+from src.manager import ResearchManager
+from src.obligations import (
+    DISCHARGED,
+    OPEN,
+    format_for_review_prompt,
+    load_ledger,
+    record_obligations,
+)
+from src.review_panel import (
+    DEFAULT_PANEL,
+    PanelDeliberation,
+    PanelVerdict,
+    ReviewPanel,
+    resolve_roles,
+)
+from src.review_policy import format_policy_for_prompt, load_policy, record_correction
+from src.terminal_ui import TerminalUI
+from src.utils import STAGES, build_run_paths, ensure_run_config, ensure_run_layout, read_text, write_text
+from tests.test_review_panel import STAGE_01, SUGGESTIONS, _ScriptedPanel
+
+
+STAGE_03 = next(stage for stage in STAGES if stage.slug == "03_study_design")
+RULE = "Every number in a summary must name the file it was read from."
+#: A rule Stage 03's own attempt 1 produced. It binds Stage 04 onward and must reach
+#: neither gate while Stage 03 is the stage under review — see
+#: `format_policy_for_prompt`'s `stage` argument. Without a row the filter has to
+#: reject, every parity assertion in this file would hold with that argument deleted.
+OWN_STAGE_RULE = "State the randomisation seed next to every split this stage defines."
+DEBT = "State a power analysis and justify the sample size before any experiment is run."
+OTHER_DEBT = "Report a confidence interval for every metric, computed from the raw measurements."
+
+
+def _seat_json(
+    decision: str,
+    *,
+    blocking: bool = False,
+    reason: str = "",
+    feedback: str = "",
+    carry_forward: list | None = None,
+    discharged: list | None = None,
+) -> str:
+    """A seat's raw answer, in the grammar the seat prompt asks for."""
+    return json.dumps(
+        {
+            "decision": decision,
+            "blocking": blocking,
+            "reason": reason or f"{decision} from a panel member",
+            "feedback": feedback,
+            "concerns": [],
+            "carry_forward": carry_forward or [],
+            "discharged": discharged or [],
+        }
+    )
+
+
+def _debt(text: str = DEBT, target: str = "03_study_design") -> dict:
+    return {"obligation": text, "target_stage": target}
+
+
+class PromptTestBase(unittest.TestCase):
+    """A run whose ledger and policy are non-empty, and a panel built over it."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "Study the thing.")
+        write_text(self.paths.memory, "# Approved Run Memory\n")
+        ensure_run_config(self.paths, model="sonnet", venue="neurips_2025")
+
+        record_correction(self.paths, stage=STAGE_01, attempt_no=1, text=RULE)
+        record_correction(self.paths, stage=STAGE_03, attempt_no=1, text=OWN_STAGE_RULE)
+        record_obligations(self.paths, stage=STAGE_01, entries=[_debt()])
+
+        self.ui = TerminalUI(output_stream=io.StringIO(), interactive=False)
+        self.panel = ReviewPanel(DEFAULT_PANEL, backend_name="claude", model="sonnet", ui=self.ui)
+
+    def rendered_rules(self, *, stage=STAGE_03) -> str:
+        """What either gate should be showing, for a review of ``stage``."""
+        return format_policy_for_prompt(load_policy(self.paths), stage=stage)
+
+    def seat_prompt(self, role=None, *, previous=None, round_no: int = 1, stage=STAGE_03) -> str:
+        return self.panel._build_member_prompt(
+            paths=self.paths, stage=stage, attempt_no=1, stage_markdown="# Stage\n",
+            suggestions=SUGGESTIONS, role=role or DEFAULT_PANEL[0], previous=previous,
+            round_no=round_no,
+        )
+
+    def chair_prompt(self, deliberation=None, *, stage=STAGE_03) -> str:
+        return self.panel._build_chair_prompt(
+            paths=self.paths, stage=stage, attempt_no=1, stage_markdown="# Stage\n",
+            suggestions=SUGGESTIONS,
+            deliberation=deliberation or PanelDeliberation(stage_slug=stage.slug, attempt_no=1, chair_key="pi"),
+        )
+
+    def solo_prompt(self, *, stage=STAGE_03) -> str:
+        solo = AutomatedReviewer("claude", model="sonnet", ui=self.ui)
+        return solo._build_review_prompt(
+            paths=self.paths, stage=stage, attempt_no=1, stage_markdown="# Stage\n",
+            suggestions=SUGGESTIONS,
+        )
+
+
+class ParityWithTheSoloReviewerTests(PromptTestBase):
+    """The dial must not lose a mechanism as it is turned up."""
+
+    def test_the_fixture_really_does_hold_a_rule_and_a_debt(self) -> None:
+        # Guards every assertion below: against an empty policy and an empty ledger the
+        # renderers return "", and "the panel prompt contains it" would pass on nothing.
+        self.assertTrue(self.rendered_rules())
+        self.assertTrue(format_for_review_prompt(load_ledger(self.paths), STAGE_03))
+
+    def test_the_fixture_holds_a_rule_the_stage_filter_has_to_reject(self) -> None:
+        """Otherwise the parity assertions below hold with the `stage` argument deleted."""
+        self.assertIn(OWN_STAGE_RULE, format_policy_for_prompt(load_policy(self.paths)))
+        self.assertNotIn(OWN_STAGE_RULE, self.rendered_rules())
+        self.assertIn(RULE, self.rendered_rules())
+
+    def test_a_seat_argues_from_the_same_standing_rules_as_the_solo_reviewer(self) -> None:
+        rendered = self.rendered_rules()
+        self.assertIn(rendered, self.solo_prompt())
+        self.assertIn(rendered, self.seat_prompt())
+
+    def test_neither_gate_judges_a_stage_against_a_rule_its_own_retries_invented(self) -> None:
+        """Parity is what the two gates *render*, not only which function they call.
+
+        `format_policy_for_prompt` withholds the rules a stage's own attempts produced,
+        because a review that demands anything records one and the bar would otherwise rise
+        by a requirement per attempt until the retry loop could not converge. Calling the
+        same renderer with a different argument list reintroduces exactly that, and under a
+        panel it is five seats reading the moving bar instead of one. `assertIs` on the
+        function objects cannot see it; this can.
+        """
+        for name, prompt in (("solo", self.solo_prompt()), ("seat", self.seat_prompt()),
+                             ("chair", self.chair_prompt())):
+            with self.subTest(prompt=name):
+                self.assertIn(RULE, prompt)
+                self.assertNotIn(OWN_STAGE_RULE, prompt)
+
+    def test_a_seat_is_asked_about_the_same_inherited_obligations(self) -> None:
+        rendered = format_for_review_prompt(load_ledger(self.paths), STAGE_03)
+        self.assertIn(rendered, self.solo_prompt())
+        self.assertIn(rendered, self.seat_prompt())
+
+    def test_the_chair_sees_both_as_well(self) -> None:
+        prompt = self.chair_prompt()
+        self.assertIn(self.rendered_rules(), prompt)
+        self.assertIn(format_for_review_prompt(load_ledger(self.paths), STAGE_03), prompt)
+
+    def test_every_seat_in_the_roster_sees_both(self) -> None:
+        rules = self.rendered_rules()
+        debts = format_for_review_prompt(load_ledger(self.paths), STAGE_03)
+        for role in DEFAULT_PANEL:
+            with self.subTest(role=role.key):
+                prompt = self.seat_prompt(role)
+                self.assertIn(rules, prompt)
+                self.assertIn(debts, prompt)
+
+    def test_the_seat_that_is_shown_nothing_of_the_room_is_still_shown_the_run(self) -> None:
+        """`exposure="none"` withholds the peers, not the run's own accumulated record."""
+        skeptic = next(role for role in DEFAULT_PANEL if role.exposure == "none")
+        previous = [
+            PanelVerdict(role_key="pi", role_title="Principal Investigator", backend="claude",
+                         model="sonnet", choice="5", decision_token="approve", blocking=False,
+                         reason="fine", feedback=""),
+        ]
+        prompt = self.seat_prompt(skeptic, previous=previous, round_no=2)
+        self.assertIn("hold or revise, independently", prompt)
+        self.assertIn(self.rendered_rules(), prompt)
+        self.assertIn(format_for_review_prompt(load_ledger(self.paths), STAGE_03), prompt)
+
+    def test_both_paths_ask_for_the_two_ledger_fields(self) -> None:
+        for name, prompt in (("seat", self.seat_prompt()), ("chair", self.chair_prompt()),
+                             ("solo", self.solo_prompt())):
+            with self.subTest(prompt=name):
+                self.assertIn('"carry_forward"', prompt)
+                self.assertIn('"discharged"', prompt)
+
+    def test_a_seat_is_told_that_only_the_chair_closes_a_debt(self) -> None:
+        self.assertIn("Only the chair's list closes a debt", self.seat_prompt())
+
+    def test_both_gates_call_the_same_two_renderers(self) -> None:
+        """Not "both prompts say something similar": both prompts call one function.
+
+        The prompt assertions above compare rendered strings, which would still pass if the
+        panel grew its own copy of the wording that happened to agree today. This is the
+        structural half of the same claim, and the reason `docs/review-panel.md` can say the
+        two gates argue from one copy of the rules.
+
+        Necessary and not sufficient: one renderer called with two different argument lists
+        passes this and diverges anyway, which is what
+        `test_neither_gate_judges_a_stage_against_a_rule_its_own_retries_invented` is for.
+        """
+        self.assertIs(review_panel.format_policy_for_prompt, review_policy_module.format_policy_for_prompt)
+        self.assertIs(review_panel.format_for_review_prompt, obligations_module.format_for_review_prompt)
+        self.assertIs(approval_agent.format_policy_for_prompt, review_policy_module.format_policy_for_prompt)
+        self.assertIs(approval_agent.format_for_review_prompt, obligations_module.format_for_review_prompt)
+
+    def test_the_doc_names_the_renderers_it_claims_are_shared(self) -> None:
+        doc = (Path(__file__).resolve().parent.parent / "docs" / "review-panel.md").read_text(encoding="utf-8")
+        for symbol in ("format_policy_for_prompt", "format_for_review_prompt", "_context_block"):
+            with self.subTest(symbol=symbol):
+                self.assertIn(symbol, doc)
+
+    def test_a_run_with_nothing_learned_yet_gets_no_empty_sections(self) -> None:
+        """An empty ledger is silence, not a heading over nothing."""
+        fresh = build_run_paths(Path(self._tmp.name) / "run_0002")
+        ensure_run_layout(fresh)
+        write_text(fresh.user_input, "Study the thing.")
+        write_text(fresh.memory, "# Approved Run Memory\n")
+        ensure_run_config(fresh, model="sonnet", venue="neurips_2025")
+        prompt = self.panel._build_member_prompt(
+            paths=fresh, stage=STAGE_03, attempt_no=1, stage_markdown="# Stage\n",
+            suggestions=SUGGESTIONS, role=DEFAULT_PANEL[0], previous=None, round_no=1,
+        )
+        self.assertNotIn("# Standing Review Rules", prompt)
+        self.assertNotIn("# Inherited Obligations", prompt)
+
+    def test_an_obligation_aimed_at_another_stage_does_not_reach_this_room(self) -> None:
+        """`open_for` decides, here as for the solo reviewer: the debt targets Stage 03."""
+        self.assertNotIn(DEBT, self.seat_prompt(stage=STAGE_01))
+
+
+class _StubOperator:
+    model = "opus"
+    backend_name = "claude"
+
+
+class AnySeatCanCreateADebtTests(unittest.TestCase):
+    """A panel run that cannot leave an obligation behind has nothing to inherit later."""
+
+    def _panel(self, script: dict) -> _ScriptedPanel:
+        return _ScriptedPanel(self, script)
+
+    def test_a_unanimous_approval_still_carries_what_a_seat_asked_for(self) -> None:
+        """The ordinary path. No chair call happens here at all."""
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("approve", carry_forward=[_debt()])],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+        }
+        panel = self._panel(script)
+        decision = panel.review()
+        self.assertEqual(decision.choice, "5")
+        self.assertEqual(len(decision.carry_forward), 1)
+        self.assertEqual(decision.carry_forward[0]["obligation"], DEBT)
+        self.assertNotIn("__chair__", [key for key, _label in panel.calls])
+
+    def test_a_debt_survives_the_chair_and_joins_the_chairs_own(self) -> None:
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("custom_feedback", feedback="fix the citation",
+                                   carry_forward=[_debt()])],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+            "__chair__": [_seat_json("custom_feedback", feedback="do the thing",
+                                     carry_forward=[_debt(OTHER_DEBT, "05_experiments")])],
+        }
+        # `--panel-rounds 1` keeps the script to one round per seat; the second round is
+        # tested elsewhere and would only lengthen the fixture.
+        panel = _ScriptedPanel(self, script, deliberation_rounds=1)
+        decision = panel.review()
+        carried = [entry["obligation"] for entry in decision.carry_forward]
+        self.assertEqual(carried, [DEBT, OTHER_DEBT])
+
+    def test_an_overridden_chair_does_not_drop_the_debts(self) -> None:
+        """`_enforce_blocking_objections` builds a fresh decision; the ledger rides through."""
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("approve", carry_forward=[_debt()])],
+            "method": [_seat_json("custom_feedback", blocking=True, feedback="blocked")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+            "__chair__": [_seat_json("approve")],
+        }
+        panel = _ScriptedPanel(self, script, deliberation_rounds=1)
+        decision = panel.review()
+        self.assertEqual(decision.choice, "4")
+        self.assertTrue(panel.record()["chair_overridden"])
+        self.assertEqual([entry["obligation"] for entry in decision.carry_forward], [DEBT])
+
+    def test_a_seat_that_could_not_be_reached_carries_nothing(self) -> None:
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": ["__FAIL__"],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+            "__chair__": [_seat_json("approve")],
+        }
+        panel = _ScriptedPanel(self, script, deliberation_rounds=1)
+        decision = panel.review()
+        self.assertEqual(decision.carry_forward, [])
+
+    def test_what_a_seat_writes_is_in_the_shape_the_ledger_accepts(self) -> None:
+        """End to end through the manager funnel: seat JSON in, obligation on disk out."""
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("approve", carry_forward=[_debt()])],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+        }
+        panel = self._panel(script)
+        decision = panel.review()
+
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=panel.paths.run_root.parent,
+            operator=_StubOperator(),
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        manager._settle_obligations(paths=panel.paths, stage=STAGE_01, attempt_no=1, decision=decision)
+
+        ledger = load_ledger(panel.paths)
+        self.assertEqual([o.text for o in ledger.obligations], [DEBT])
+        self.assertEqual(ledger.obligations[0].target_stage, "03_study_design")
+        self.assertIn("obligation_recorded", read_text(panel.paths.logs))
+
+
+class OnlyTheChairClosesADebtTests(unittest.TestCase):
+    """Creating a debt is the strict direction; closing one is not, so they differ."""
+
+    def _panel(self, script: dict, **kwargs) -> _ScriptedPanel:
+        panel = _ScriptedPanel(self, script, **kwargs)
+        record_obligations(panel.paths, stage=STAGE_01, entries=[_debt(target="01_literature_survey")])
+        return panel
+
+    def test_a_seat_alone_cannot_write_an_obligation_off(self) -> None:
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("approve", discharged=["O001"])],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+        }
+        panel = self._panel(script)
+        decision = panel.review()
+        self.assertEqual(decision.discharged, [])
+
+    def test_the_claim_the_chair_did_not_take_is_still_on_the_record(self) -> None:
+        """Refused in code, not hidden: the chair reads it, and so does an auditor."""
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("approve", discharged=["O001"])],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+        }
+        panel = self._panel(script)
+        panel.review()
+        record = panel.record()
+        seats = {v["role"]: v for v in record["rounds"][0]}
+        self.assertEqual(seats["domain"]["discharged"], ["O001"])
+        self.assertEqual(record["discharged"], [])
+
+    def test_the_chair_seat_closes_a_debt_when_the_room_never_split(self) -> None:
+        """No chair call is made on a unanimous approval, so its seat verdict is its word."""
+        script = {
+            "pi": [_seat_json("approve", discharged=["O001"])],
+            "domain": [_seat_json("approve")],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+        }
+        panel = self._panel(script)
+        decision = panel.review()
+        self.assertEqual(decision.discharged, ["O001"])
+
+    def test_the_chairs_synthesis_closes_a_debt(self) -> None:
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("custom_feedback", feedback="tighten it")],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+            "__chair__": [_seat_json("approve", discharged=["O001"])],
+        }
+        panel = self._panel(script, deliberation_rounds=1)
+        decision = panel.review()
+        self.assertEqual(decision.discharged, ["O001"])
+
+    def test_once_the_room_splits_the_chairs_earlier_seat_verdict_stops_counting(self) -> None:
+        """It was a position taken before the chair heard the objections."""
+        script = {
+            "pi": [_seat_json("approve", discharged=["O001"])],
+            "domain": [_seat_json("custom_feedback", feedback="tighten it")],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+            "__chair__": [_seat_json("custom_feedback", feedback="tighten it")],
+        }
+        panel = self._panel(script, deliberation_rounds=1)
+        decision = panel.review()
+        self.assertEqual(decision.discharged, [])
+
+    def test_nothing_is_discharged_while_a_blocking_objection_stands(self) -> None:
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("custom_feedback", blocking=True, feedback="blocked")],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+            "__chair__": [_seat_json("approve", discharged=["O001"])],
+        }
+        panel = self._panel(script, deliberation_rounds=1)
+        decision = panel.review()
+        self.assertEqual(decision.choice, "4")
+        self.assertEqual(decision.discharged, [])
+
+    def test_a_refusing_chair_cannot_close_a_debt_on_its_way_out(self) -> None:
+        """The blocking rule has to be written onto the decision, not onto the override.
+
+        A chair does not have to approve to claim a discharge. `_enforce_blocking_objections`
+        rebuilds the decision only when the chair *approved* — that is the whole of its job —
+        so on this script it returns the chair's own decision untouched, `chair_overridden`
+        stays false, and the chair's `discharged` list is still on it. The refusal therefore
+        has to come from `_attach_ledger_positions` writing the room's empty list over it
+        unconditionally. The sibling test above passes with an approving chair and cannot
+        reach this arm.
+        """
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("custom_feedback", blocking=True, feedback="blocked")],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+            "__chair__": [
+                _seat_json("custom_feedback", feedback="tighten it", discharged=["O001"])
+            ],
+        }
+        panel = self._panel(script, deliberation_rounds=1)
+        decision = panel.review()
+        record = panel.record()
+        self.assertEqual(decision.choice, "4")
+        # The override arm did not run, so nothing else rebuilt this decision.
+        self.assertFalse(record["chair_overridden"])
+        self.assertEqual(decision.discharged, [])
+        # The audit record and the channel the manager reads must not be able to disagree.
+        self.assertEqual(record["discharged"], [])
+
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=panel.paths.run_root.parent,
+            operator=_StubOperator(),
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        manager._settle_obligations(paths=panel.paths, stage=STAGE_01, attempt_no=1, decision=decision)
+        self.assertEqual(load_ledger(panel.paths).by_id("O001").status, OPEN)
+
+        # The control: `O001` is a real open id and this funnel does close it, so the
+        # assertion above is the panel's rule refusing rather than a typo in an id.
+        manager._settle_obligations(
+            paths=panel.paths, stage=STAGE_01, attempt_no=2,
+            decision=ReviewDecision(choice="5", decision_token="approve", reason="ok",
+                                    discharged=["O001"]),
+        )
+        self.assertEqual(load_ledger(panel.paths).by_id("O001").status, DISCHARGED)
+
+    def test_a_chair_that_could_not_be_reached_discharges_nothing(self) -> None:
+        script = {
+            "pi": [_seat_json("approve", discharged=["O001"])],
+            "domain": [_seat_json("custom_feedback", feedback="tighten it")],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+            "__chair__": ["__FAIL__"],
+        }
+        panel = self._panel(script, deliberation_rounds=1)
+        decision = panel.review()
+        self.assertEqual(decision.discharged, [])
+
+    def test_a_total_outage_settles_nothing_in_either_direction(self) -> None:
+        script = {key: ["__FAIL__"] for key in ("pi", "domain", "method", "repro", "skeptic")}
+        script["__chair__"] = ["__FAIL__"]
+        panel = self._panel(script, deliberation_rounds=1)
+        decision = panel.review()
+        self.assertEqual(decision.carry_forward, [])
+        self.assertEqual(decision.discharged, [])
+
+    def test_an_applied_discharge_reaches_the_ledger_and_a_refused_one_does_not(self) -> None:
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("approve", discharged=["O001"])],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+        }
+        panel = self._panel(script)
+        decision = panel.review()
+        manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=panel.paths.run_root.parent,
+            operator=_StubOperator(),
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        manager._settle_obligations(paths=panel.paths, stage=STAGE_01, attempt_no=1, decision=decision)
+        self.assertEqual(load_ledger(panel.paths).by_id("O001").status, OPEN)
+
+        # The control: the id is real and the funnel does close it, so the assertion above
+        # is the panel's rule refusing and not a typo in an obligation id.
+        manager._settle_obligations(
+            paths=panel.paths, stage=STAGE_01, attempt_no=2,
+            decision=ReviewDecision(choice="5", decision_token="approve", reason="ok",
+                                    discharged=["O001"]),
+        )
+        self.assertEqual(load_ledger(panel.paths).by_id("O001").status, DISCHARGED)
+
+
+class LedgerPositionsTests(unittest.TestCase):
+    """The aggregation rules, at the level where they are decidable.
+
+    Driving these through a scripted panel cannot reach them: a seat that abstains or fails
+    is constructed with empty ledger fields, so the filters below would look correct while
+    holding nothing. Built by hand, each filter has a case that dies without it.
+    """
+
+    def _verdict(self, key: str, **kwargs) -> PanelVerdict:
+        base = dict(
+            role_key=key, role_title=key.title(), backend="claude", model="sonnet",
+            choice="5", decision_token="approve", blocking=False, reason="", feedback="",
+        )
+        base.update(kwargs)
+        return PanelVerdict(**base)
+
+    def _deliberation(self, verdicts: list[PanelVerdict]) -> PanelDeliberation:
+        deliberation = PanelDeliberation(stage_slug=STAGE_01.slug, attempt_no=1, chair_key="pi")
+        deliberation.rounds.append(verdicts)
+        return deliberation
+
+    def test_a_seat_that_abstained_is_not_carrying_a_debt(self) -> None:
+        """Abstention is "nothing to add", and a debt is something to add."""
+        deliberation = self._deliberation(
+            [self._verdict("domain", abstained=True, choice="", decision_token="abstain",
+                           carry_forward=(_debt(),))]
+        )
+        self.assertEqual(deliberation.carried_obligations(), [])
+
+    def test_a_seat_that_could_not_be_reached_is_not_carrying_a_debt(self) -> None:
+        deliberation = self._deliberation(
+            [self._verdict("domain", failed=True, choice="4", decision_token="custom_feedback",
+                           carry_forward=(_debt(),))]
+        )
+        self.assertEqual(deliberation.carried_obligations(), [])
+
+    def test_two_seats_naming_one_debt_are_both_kept_for_the_record(self) -> None:
+        """`record_obligations` deduplicates; who raised it is information the record keeps."""
+        deliberation = self._deliberation(
+            [self._verdict("domain", carry_forward=(_debt(),)),
+             self._verdict("method", carry_forward=(_debt(),))]
+        )
+        self.assertEqual(len(deliberation.carried_obligations()), 2)
+
+    def test_only_the_final_round_carries(self) -> None:
+        """A debt a seat withdrew in cross-examination is not one the run inherits."""
+        deliberation = self._deliberation([self._verdict("domain", carry_forward=(_debt(),))])
+        deliberation.rounds.append([self._verdict("domain")])
+        self.assertEqual(deliberation.carried_obligations(), [])
+
+    def test_a_chair_that_abstained_closes_nothing(self) -> None:
+        deliberation = self._deliberation(
+            [self._verdict("pi", abstained=True, choice="", decision_token="abstain",
+                           discharged=("O001",))]
+        )
+        self.assertEqual(deliberation.settled_obligations(), [])
+
+    def test_a_roster_with_no_seated_chair_closes_nothing(self) -> None:
+        deliberation = self._deliberation([self._verdict("domain", discharged=("O001",))])
+        self.assertEqual(deliberation.settled_obligations(), [])
+
+
+class AVerdictIsNotHashableAtAllTests(unittest.TestCase):
+    """The ledger fields made `PanelVerdict` hashable only for seats that used neither.
+
+    `frozen=True` generates a `__hash__` over every field. `carry_forward` holds whatever
+    `record_obligations` accepts, and that includes dicts, so before the refusal a verdict
+    from a seat that carried nothing hashed and the identical verdict from a seat that
+    carried one raised `TypeError` from inside the tuple. A container that works until a
+    seat uses a feature is the worse of the two, so it is refused for every verdict.
+    """
+
+    def _verdict(self, **kwargs) -> PanelVerdict:
+        base = dict(
+            role_key="domain", role_title="Domain Expert", backend="claude", model="sonnet",
+            choice="5", decision_token="approve", blocking=False, reason="", feedback="",
+        )
+        base.update(kwargs)
+        return PanelVerdict(**base)
+
+    def test_neither_an_empty_verdict_nor_a_carrying_one_can_be_hashed(self) -> None:
+        for label, verdict in (
+            ("carries nothing", self._verdict()),
+            ("carries a debt", self._verdict(carry_forward=(_debt(),))),
+        ):
+            with self.subTest(seat=label):
+                with self.assertRaises(TypeError):
+                    hash(verdict)
+                with self.assertRaises(TypeError):
+                    {verdict}
+
+    def test_the_refusal_did_not_cost_equality(self) -> None:
+        """`__hash__ = None` on a dataclass can take `__eq__` with it if it is misdeclared."""
+        self.assertEqual(self._verdict(carry_forward=(_debt(),)), self._verdict(carry_forward=(_debt(),)))
+        self.assertNotEqual(self._verdict(), self._verdict(carry_forward=(_debt(),)))
+
+
+class NoStandInVerdictClaimsADischargeTests(unittest.TestCase):
+    """`chair_verdict` is read without asking who wrote it, and this is why that is safe.
+
+    When the chair cannot be read, `parse_with_retry` hands back a decision AutoR assembled
+    on its behalf. The panel records that as the chair's word for ledger purposes, which is
+    only harmless while every stand-in in the tree is empty in both fields — one that
+    inherited the seats' discharge claims would close a debt no chair ever agreed to. The
+    alternative was a "did the chair really write this" flag that no test could distinguish
+    from its absence, so the invariant is pinned here instead of guarded there.
+    """
+
+    def _panel(self) -> ReviewPanel:
+        return ReviewPanel(
+            DEFAULT_PANEL, backend_name="claude", model="sonnet",
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+
+    def _verdict(self, **kwargs) -> PanelVerdict:
+        base = dict(
+            role_key="domain", role_title="Domain Expert", backend="claude", model="sonnet",
+            choice="4", decision_token="custom_feedback", blocking=False, reason="no",
+            feedback="fix it", discharged=("O001",), carry_forward=(_debt(),),
+        )
+        base.update(kwargs)
+        return PanelVerdict(**base)
+
+    def test_no_verdict_autor_writes_in_a_reviewers_place_settles_the_ledger(self) -> None:
+        panel = self._panel()
+        reviewer = AutomatedReviewer(
+            "claude", model="sonnet",
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+        stand_ins = {
+            "dissent": panel._decision_from_dissent([self._verdict()], reason="chair gone"),
+            "total outage": panel._decision_from_dissent(
+                [self._verdict(failed=True)], reason="everyone gone"
+            ),
+            "unreadable": reviewer._unreadable_verdict("not json at all"),
+            "unsupported token": reviewer._parse_decision('{"decision":"maybe","discharged":["O001"]}'),
+        }
+        for label, decision in stand_ins.items():
+            with self.subTest(stand_in=label):
+                self.assertEqual(list(decision.carry_forward), [])
+                self.assertEqual(list(decision.discharged), [])
+
+
+class TheChairIsShownWhatTheRoomProposedTests(PromptTestBase):
+    def _deliberation(self) -> PanelDeliberation:
+        deliberation = PanelDeliberation(stage_slug=STAGE_03.slug, attempt_no=1, chair_key="pi")
+        deliberation.rounds.append(
+            [
+                PanelVerdict(
+                    role_key="domain", role_title="Domain Expert", backend="claude",
+                    model="sonnet", choice="5", decision_token="approve", blocking=False,
+                    reason="fine", feedback="", carry_forward=(_debt(),), discharged=("O001",),
+                )
+            ]
+        )
+        return deliberation
+
+    def test_the_transcript_names_the_debts_and_the_claims(self) -> None:
+        prompt = self.chair_prompt(self._deliberation())
+        self.assertIn(f"Carries forward: {DEBT} (target: 03_study_design)", prompt)
+        self.assertIn("Claims discharged: O001", prompt)
+
+    def test_the_chair_is_told_which_of_the_two_is_its_decision(self) -> None:
+        prompt = self.chair_prompt(self._deliberation())
+        self.assertIn("the discharges are yours alone", prompt)
+
+
+class TheRecordSaysWhatTheLedgerGotTests(unittest.TestCase):
+    def test_the_markdown_and_the_log_name_the_carried_debt(self) -> None:
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("approve", carry_forward=[_debt()])],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+        }
+        panel = _ScriptedPanel(self, script)
+        panel.review()
+        markdown = read_text(
+            panel.paths.reviews_dir / "panel" / f"{STAGE_01.slug}_attempt_01.md"
+        )
+        self.assertIn(f"Carried forward: {DEBT}", markdown)
+        self.assertIn("obligations: 1 carried forward, 0 discharged", read_text(panel.paths.logs))
+
+    def test_the_json_record_carries_both_lists(self) -> None:
+        script = {
+            "pi": [_seat_json("approve")],
+            "domain": [_seat_json("approve", carry_forward=[_debt()])],
+            "method": [_seat_json("approve")],
+            "repro": [_seat_json("approve")],
+            "skeptic": [_seat_json("approve")],
+        }
+        panel = _ScriptedPanel(self, script)
+        panel.review()
+        record = panel.record()
+        self.assertEqual(record["carry_forward"][0]["obligation"], DEBT)
+        self.assertEqual(record["discharged"], [])
+
+
+class ASingleSeatPanelStillHasAChairTests(unittest.TestCase):
+    def test_the_lone_seat_holds_the_gavel_and_can_close_a_debt(self) -> None:
+        """`resolve_roles` gives the first seat the gavel, so the rule still has a subject."""
+        roles = resolve_roles(["repro"])
+        panel = _ScriptedPanel(
+            self, {"repro": [_seat_json("approve", discharged=["O001"])]}, roles=roles
+        )
+        record_obligations(panel.paths, stage=STAGE_01, entries=[_debt(target="01_literature_survey")])
+        decision = panel.review()
+        self.assertEqual(decision.discharged, ["O001"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`--rigor max` had fewer live mechanisms than `--rigor standard`. The higher
setting swaps the solo reviewer for the panel -- `main.py`'s `create_reviewer`
returns a `ReviewPanel` *instead of* an `AutomatedReviewer`, and `review_panel`
is the one feature only `MAX` carries in `_LEVEL_FEATURES` -- and two mechanisms
that accumulate across a run reached only the reviewer being swapped out:

  standing rules      `_standing_rules_block` renders `review_policy.json` into
                      `AutomatedReviewer._build_review_prompt` and nowhere else
  obligations         `_obligations_block` does the same with the ledger

Measured on origin/main (fdded57), on a run with one rule and one obligation on
disk, over six probes -- the rendered rule, the rendered debt, `carry_forward`
and `discharged`, against the solo prompt, a seat prompt and the chair prompt:

  prompt   rule   debt   carry_forward  discharged
  solo     True   True   True           True
  seat     False  False  False          False
  chair    False  False  False          False

All three halves the item named were real. On this branch all twelve are True.

The third half is what makes the first two matter. Neither the seat prompt nor
the chair prompt asked for `carry_forward`, and `record_obligations` has one
caller -- `manager.py:_settle_obligations`, reading `ReviewDecision.carry_forward`
-- so a panel run essentially never created an obligation, and had nothing to
inherit at the next gate. Worse in one direction than a plain omission: a panel
refusal reaches `record_correction` by the same manager path a solo refusal does,
so the room was writing standing rules it would never be shown.

What changed:

  * `_context_block` -- the one builder the seat prompt and the chair prompt
    share -- renders both blocks, through `format_policy_for_prompt` and
    `format_for_review_prompt`, the same two functions the solo reviewer calls,
    with the same arguments. Two tests, because one is not enough:
    `test_both_gates_call_the_same_two_renderers` asserts the panel module and
    the approval agent hold the same function objects, and
    `test_neither_gate_judges_a_stage_against_a_rule_its_own_retries_invented`
    asserts the two gates render the same thing. The second exists because
    `format_policy_for_prompt` takes a `stage` that withholds the rules the
    stage under review produced in its own earlier attempts (#210); calling the
    shared renderer without it puts five seats behind a bar that rises by one
    requirement per attempt, and `assertIs` cannot see that. The fixture now
    holds a rule from the stage under review, so the filter has a row to reject.
  * Both return formats ask for `carry_forward` and `discharged`;
    `PanelVerdict` carries what a seat answered, off the parsed verdict rather
    than a second read of the raw payload. `PanelVerdict.__hash__` is refused
    outright: `frozen=True` had made it hashable for a seat that carried nothing
    and `TypeError` for a seat that carried a dict-shaped debt, and a container
    that works until a seat uses a feature is the worse of the two.
  * `_attach_ledger_positions` puts the room's positions on the decision the
    manager reads, unconditionally. It sits after `_enforce_blocking_objections`
    on the single path every outcome passes through, because four constructions
    produce that decision -- the unanimous early return, the chair's verdict, the
    dissent fallback and the override -- and only one of the four is the chair.
    Unconditional matters: `_enforce_blocking_objections` rebuilds the decision
    only when the chair *approved*, so a chair that refuses while claiming
    `discharged:["O001"]` keeps its own list, and skipping the rewrite when the
    room settled nothing is exactly the case where the two disagree.

Creating a debt and closing one are deliberately asymmetric, because they fail
asymmetrically. Any seat that spoke may record one and every entry is carried
whatever the room decides, so five seats make a run stricter than one. Discharge
is the lenient direction, and five seats must not become five chances to accept
a restatement as payment: only the chair's last word closes a debt -- its seat
verdict when the room never split, its synthesis once it has spoken -- a chair
that was asked and could not answer closes nothing, and nothing is discharged at
all while a blocking objection stands, whether the chair approved or refused.
Every claim the chair declined stays in the record next to its verdict.

One branch was removed rather than added. Tracking whether the chair's synthesis
was really written by the chair turned out to be a distinction no test could
draw, because every stand-in AutoR writes in a reviewer's place is empty in both
ledger fields. `NoStandInVerdictClaimsADischargeTests` pins that invariant
instead, over four stand-ins.

Mutation-checked: 29 mutations of `src/review_panel.py`, each applied to its own
copy of the tree and run against the whole suite, one survivor. Every count
below is the measured number of distinct failing tests, not an estimate.

  drop `+ self._standing_rules_block(paths, stage)`        5
  drop `+ self._obligations_block(paths, stage)`           4
  drop both fields from the seat return format             1
  drop both fields from the chair return format            1
  seat verdict discards what the seat wrote                9
  drop the `_attach_ledger_positions` call                 7
  apply it only when `chair_asked`                         4
  restore the `if not carried and not settled` early
    return                                                 1  (the new refusing-
                                                               chair test, and
                                                               only that)
  `blocking_verdicts()` no longer withholds discharge      2
  any seat, not the chair, closes a debt                   4
  never set `chair_asked`                                  3
  stand-in inherits the seats' claims                      1
  heading over an empty policy / an empty ledger           1 / 1
  `carried_obligations` drops the `counts` filter          2
  ... drops the chair's own entries                        1
  ... collapses two seats naming one debt                  1
  ... reads every round, not the final one                 1
  unreachable chair falls back to its seat verdict         1
  an abstaining chair closes a debt                        1
  the JSON record drops both lists                         3
  the panel renders the ledger with its own copy          21
  the outcome block stops naming the positions             1
  the chair transcript hides the seats' claims             1
  the status line drops the obligations count              1
  the panel stops filtering the stage's own rules          1
  a verdict becomes hashable again                         1

The survivor is honest and named: shortening the seat prompt's `discharged`
bullet from "put in front of the chair, so one seat cannot write off an
obligation the room did not agree was paid" to "put in front of the chair"
kills nothing. It removes the justification, not the rule. The control run for
that -- deleting "Only the chair's list closes a debt;" and keeping the
justification -- kills `test_a_seat_is_told_that_only_the_chair_closes_a_debt`,
so the rule-bearing clause is held and the elaboration is not.

`python -m py_compile main.py src/*.py tests/*.py` clean; `python -m unittest
discover -s tests -q` is 2297 tests OK (skipped=1). origin/main at fdded57 is
2254 OK (skipped=1), so +43, all in `tests/test_panel_inherits_the_ledger.py`,
which has 43 test methods.

Docs corrected in the same commit rather than deferred, because the change made
each sentence false: README.md's and docs/framework.md's "Standing rules and
obligations never reach a panel seat" Limits bullets, and two passages in
docs/run-artifacts.md ("a seated review panel never sees them, however it was
seated" and "a review panel's seats and chair are prompted elsewhere and are not
shown the rules"). Each is rewritten to what is now true, and the Limits bullets
keep the section's contract by naming what is still open: `CrossModelReviewer`
sees neither block, since `format_policy_for_prompt` and
`format_for_review_prompt` are imported by `src/approval_agent.py` and
`src/review_panel.py` and by no other module in `src/`.

`docs/development.md`'s coverage map gains this branch's test module. Its "Every
test module in `tests/` is listed" sentence is still false for 16 other modules
that predate this branch -- `ls tests/test_*.py` finds 99, the table names 83 --
which is a real gap and not this branch's to guess placements for.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)