### PR TITLE
Score the stages at the ends of the graph, and refuse a hypothesis nothing could refute

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ included.
 Every valid stage draft is measured against a rigour rubric read off disk — do the paths it names
 resolve, do the numbers it reports appear in a results file, did it produce artifacts during *this*
 execution, is the decision ledger four different things rather than one sentence four times. Eight
-weighted criteria, `RUBRIC_VERSION = "4"`:
+weighted criteria, `RUBRIC_VERSION = "5"`:
 
 | Criterion | Weight | From | What it measures |
 | --- | ---: | :---: | --- |
@@ -364,7 +364,7 @@ weighted criteria, `RUBRIC_VERSION = "4"`:
 | `numeric_fidelity` | 3.0 | 05 | Reported numbers trace to a results file |
 | `reproducibility` | 3.0 | 01 | The machine-readable validity chain is present and parses |
 | `contract` | 2.0 | 01 | Contract compliance in substance, not just in headings |
-| `artifact_breadth` | 2.0 | 03 | Artifacts produced *this* stage, across the classes the role calls for |
+| `artifact_breadth` | 2.0 | 01 | Artifacts produced *this* stage, in the directories this stage's prompt named |
 | `quantification` | 2.0 | 04 | Findings carrying numbers rather than adjectives |
 | `traceability` | 1.5 | 01 | The decision ledger is four different things, not one sentence four times |
 | `commitment` | 1.5 | 01 | Reports work, not intentions |
@@ -373,6 +373,18 @@ weighted criteria, `RUBRIC_VERSION = "4"`:
 manifest to produce, and grading it as if it failed to produce one would make every early stage look
 worse than every late one — which would make the ratchet prefer late drafts for a reason unconnected
 to quality.
+
+`artifact_breadth` is scored against `STAGE_ARTIFACT_KINDS`, the set of workspace directories *this*
+stage's prompt tells the agent to write — `literature/` at Stage 01, `artifacts/` + `reviews/` +
+`writing/` at Stage 08, and so on. A test refuses any expectation the stage's own prompt never
+asked for, so the criterion cannot drift into demanding work the run was never told to do. AutoR's
+own bookkeeping does not count towards it: neither the `RECORD_ARTIFACTS` the experiment manifest
+already excludes, nor the ideation pool, the writing and layout triage, the comment, crux and effort
+ledgers, the panel's transcripts, the run scorecard or the adversarial reviewer's findings, all of
+which the workflow manager writes into those same directories — six of them inside a stage's own
+window, before its draft is scored. `_harness_written_records` names them, each imported from the
+module that writes it, and a census over `src/` fails the suite on a path under one of those
+directories that nobody has said who owns.
 
 **Measuring is free and always on.** The rubric reads the run off disk and never calls a backend, so
 the property it buys costs nothing: the draft that gets promoted is the best one the run produced,
@@ -503,6 +515,7 @@ options, concrete file paths under `Files Produced`, and no `[In progress]`, `[P
 | Stage | Required non-toy output |
 | --- | --- |
 | Stage 01 | A cross-referenced evidence ledger: `sources.json` and `claims.json`, where every cited `source_id` resolves |
+| Stage 02+ | A `decision_rule` on every empirical hypothesis in `hypothesis_manifest.json` — held here, at the stage that writes them, rather than at the Stage 05 preregistration gate, where the set is already frozen and the only repair is a rollback |
 | Stage 03+ | Machine-readable data under `workspace/data/`, plus a `report_plan.json` committing to the figures and headline numbers the report will carry |
 | Stage 05+ | Machine-readable results under `workspace/results/`, plus a valid `experiment_manifest.json` |
 | Stage 06+ | Real figure files under `workspace/figures/`, and every planned figure's `source_artifact` resolving to a non-empty file |
@@ -520,11 +533,12 @@ an ordinary run and **3** for a ResearchClawBench run (`BENCHMARK_MIN_REPORT_FIG
 
 **Validity gates.** The same function — `validate_stage_artifacts` ([src/utils.py](src/utils.py)) —
 also runs the validators that ask whether a *claim* is warranted rather than whether output exists.
-Seventeen `validate_*` functions are reachable from it in all:
+Eighteen `validate_*` functions are reachable from it in all:
 
 | Fires at | Validator | Refuses when |
 | --- | --- | --- |
 | 01 | `validate_literature_evidence` | A claim cites a `source_id` that is not in `sources.json` |
+| 02+ | `validate_hypothesis_decision_rules` | An empirical hypothesis in `hypothesis_manifest.json` carries no `decision_rule`, or the manifest does not parse |
 | 03+ | `validate_report_plan` | The plan has no task outputs, non-contiguous slots, a slot with no supported claim, or headline numbers without a quantity, unit and source |
 | 05+ | `validate_preregistration` | Nothing is frozen, an empirical hypothesis has no decision rule, the frozen file disagrees with its own digest or with AutoR's stamped copy, or the manifest changed — or went missing — with no amendment on record |
 | 05+ | `validate_experimental_protocol` | No primary metric, `planned_seeds < 1`, or a baseline missing `why_competent` / `tuning_budget` |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ correctly — and then runs the validity-chain validators that ask whether a
 report-plan validators (`validate_report_plan`, `validate_report_plan_sources`,
 `validate_report_plan_coverage`) and the task-deliverables gate
 (`validate_deliverables_coverage`). Counting the two Stage 07 format branches,
-seventeen `validate_*` functions are reachable from it; the full table, with the
+eighteen `validate_*` functions are reachable from it; the full table, with the
 condition each one refuses on, is in the
 [README](../README.md#the-stage-contract-and-what-gets-validated). The code
 labels the split itself: *"the scientific-validity chain, distinct from the

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -193,10 +193,36 @@ exists to prevent, reached by a route the design did not consider. Declining to 
 fabrication is not the same as declining to *pay* for it. `_cap_quantification_by_fidelity` now caps
 the first criterion at the second wherever both apply, which makes the middle row 0.0; the cap is
 recorded in `observed` so a stage can still tell which half to fix, and Stage 04 is exempt because
-fidelity does not apply before there are results. `RUBRIC_VERSION` is `4` — it went to 3 when
-that cap landed and to 4 when the length gradient came out of `commitment` — and the archive
+fidelity does not apply before there are results. `RUBRIC_VERSION` is `5` — it went to 3 when
+that cap landed, to 4 when the length gradient came out of `commitment`, and to 5 when
+`artifact_breadth` learned to read the four workspace directories Stages 01, 02, 07 and 08 are
+told to write and `reproducibility` gained its Stage 02-03 link — and the archive
 ranks no score from before a bump against one after it, so each bump is a clean break rather
 than a silent drift.
+
+**A criterion that cannot see a stage's output is not measuring that stage.** `artifact_breadth`
+read five directories — `data/`, `results/`, `figures/`, `code/`, `writing/` — and Stages 01 and 02
+write to none of them, while Stage 08 writes to exactly one of the five. A Stage 08 that produced
+its entire release bundle was therefore graded on the third of it that fell under `writing/`, and a
+Stage 08 whose summary went into `artifacts/` instead scored `0.0` on a criterion worth 2.0 and was
+handed the shortfall *"every artifact in the run predates this stage's execution"* — false, because
+the bundle had been written minutes earlier into `artifacts/` and `reviews/`, where nothing was
+looking. Stages 01 and 02 escaped the number and not the consequence: `min_stage` was 3, so their
+drafts were ranked on five criteria worth 11 while Stage 03's were ranked on six worth 13, and
+`StageScore.comparable_to` guards the rubric version and the stage slug, not the criterion set. That
+exclusion had no justification of the kind `min_stage` exists for — `quantification` cannot apply to
+a stage with nothing to quantify, but Stage 01 does produce `literature/`. The expectation is now
+the set of directories the stage's *own prompt* names (`STAGE_ARTIFACT_KINDS`), which is also why
+Stage 03 is not asked for `code/`.
+
+Widening what the criterion reads reopens, in four directories, the hole `is_autor_own_record`
+exists for: AutoR writes the ideation pool, the writing triage, the comment ledger, the crux
+ledger, the effort ledger, the panel transcripts, the run scorecard and the adversarial reviewer's
+findings into `notes/`, `artifacts/` and `reviews/`, and six of those land inside a stage's own
+window before its draft is scored. `_harness_written_records` excludes them, tests drive each
+shipped writer rather than placing a file by hand, and a census reads `src/` for a name addressed
+under a graded directory that nobody has classified — because the failure this criterion keeps
+having is a writer no one remembered.
 
 1,842 tests passed before the fix and none of them failed after it: the hole was in a composition
 nothing asserted over. The four tests added with it are mutation-checked — they fail when the cap is
@@ -301,7 +327,7 @@ The control loop, per step:
    conversation. A skill pack is installed into the operator's working directory so the agent can
    *pull* long-form craft guidance instead of being pushed it.
 3. **Validate.** `validate_stage_markdown` checks the seven-heading contract; `validate_stage_artifacts`
-   runs the cumulative artifact gates and the seventeen `validate_*` functions. A failure triggers a
+   runs the cumulative artifact gates and the eighteen `validate_*` functions. A failure triggers a
    repair attempt, then local normalisation, then a full re-run, bounded by `--max-attempts` (5).
 4. **Measure and improve.** Every *valid* draft is scored by the rubric. Up to two polish rounds per
    stage are budgeted, skipped entirely when no criterion has a shortfall worth acting on. Losing
@@ -333,6 +359,7 @@ The chain that runs unconditionally at every rigor level, `fast` included:
 | Point | What happens | Enforced by |
 | --- | --- | --- |
 | Stage 02 | Markdown is parsed into typed `T*`/`H*`/`C*` entries with `decision_rule` | `write_hypothesis_manifest` |
+| Stage 02+ | Every parsed empirical hypothesis carries a non-empty `decision_rule`, and the manifest parses at all | `validate_hypothesis_decision_rules` |
 | Stage 04 approval | The hypothesis set is copied, hashed and frozen; never overwritten | `freeze_preregistration` |
 | Stage 02 re-run | The freeze is re-derived and an amendment row records `previous_digest` | `amend_preregistration` |
 | Stage 05+ | A prereg exists, has an empirical hypothesis, every one has a decision rule, the manifest has not silently changed or vanished | `validate_preregistration` |
@@ -349,6 +376,16 @@ The chain that runs unconditionally at every rigor level, `fast` included:
 Every one of these can be traced from `validate_stage_artifacts` in [`utils.py`](../src/utils.py),
 whose own comment names the split: *"the scientific-validity chain, distinct from the artifact gates
 around it"*.
+
+The second row is new, and the gap it closes was three stages wide. Stage 02 *parsed* a
+`decision_rule` and nothing read it until `validate_preregistration` at Stage 05 — by which point
+Stage 04's approval had frozen the set, so the only repair was a rollback across three stages of
+work. The Stage 03 call site of `validate_report_plan` already carried the argument, written about
+the experimental protocol: *"the Stage 03 prompt asks for it and the gate first fires at Stage 05,
+so a Stage 03 that skipped it is approved and the failure surfaces two stages later, where the only
+repair is a rollback."* The same sentence was true of the decision rule, one stage earlier.
+`derived_from` is deliberately not required with it: the Stage 02 prompt lists that field under
+"when relevant".
 
 ### 3.4 Rounds, not just stages
 

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -281,7 +281,8 @@ manifest is a view of the index, not an entry in it, and counting the
 preregistration would make a stage that declared its hypotheses look like a
 stage that produced results — measurably: the manifest is rewritten on the way
 *into* every stage from 05 on, so counted as output, a Stage 05 that produced
-literally nothing scored a third of `artifact_breadth` off a file whose own body
+literally nothing scored a third of `artifact_breadth`, as the criterion was
+denominated then, off a file whose own body
 reads `result_artifact_count: 0`. `is_autor_own_record` is the single rule, read
 by both this module and the rubric, so the two cannot drift.
 

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -200,7 +200,7 @@ when the work moves and not when the wording does.
 | --- | --- | --- | --- |
 | `contract` | 2.0 | stage markdown contract errors | all stages |
 | `grounding` | 3.0 | every path the draft names resolves, and how much of the narrative is anchored in one | all stages |
-| `artifact_breadth` | 2.0 | artifact kinds written *during this stage's execution* | 03 |
+| `artifact_breadth` | 2.0 | the artifact kinds *this stage's prompt named*, written during its own execution | 01 |
 | `quantification` | 2.0 | findings in Key Results carrying numbers | 04 |
 | `numeric_fidelity` | 3.0 | **every reported number appears in a results artifact** | 05 |
 | `traceability` | 1.5 | the four decision-ledger buckets, filled and distinct | all stages |
@@ -342,9 +342,9 @@ the estimator underneath is worth acting on.
 ### The composition of a run is not allowed to be the improvement
 
 A stage's score is a weighted mean over the criteria that apply to it, and the late
-stages face more of them — Stage 02 is scored on five criteria worth 11, Stage 06 on
+stages face more of them — Stage 02 is scored on six criteria worth 13, Stage 06 on
 eight worth 18, including `numeric_fidelity`, the hardest. (Not *strictly* more at
-every step: 01 and 02 face the same set, and so do 05 through 08. The count is
+every step: 01, 02 and 03 face the same set, and so do 05 through 08. The count is
 non-decreasing and it rises twice.) So the *set of stages a run reached* is a free
 parameter of the objective.
 
@@ -520,8 +520,8 @@ a capability that changes how far runs get has done something, and it is not a
 score.
 
 **It does not report a total without the criterion decomposition.** A capability
-that writes more files raises `artifact_breadth` whether or not the research
-improved. The report prints the per-criterion difference and a concentration figure;
+that writes more of the artifact kinds a stage was asked for raises
+`artifact_breadth` whether or not the research improved. The report prints the per-criterion difference and a concentration figure;
 above 60% in one criterion it says so. A win concentrated in a single criterion is a
 flag, not a result.
 
@@ -624,8 +624,9 @@ run, the goal a retrieval-augmented-generation leakage question, taken to Stage 
 
 Two things follow, and both change how a number in this document should be read.
 
-**The rubric has no resolution at Stages 01 and 02 against a competent backend.**
-Every criterion scored exactly 1.0 — 8/8 referenced paths resolving, 4/4 decision
+**The rubric had no resolution at Stages 01 and 02 against a competent backend.**
+Measured at `RUBRIC_VERSION` 4, where five criteria reached Stage 01. Every one of
+them scored exactly 1.0 — 8/8 referenced paths resolving, 4/4 decision
 ledger buckets distinct, 0 forward-looking phrases in 1,611 words — and the
 improvement ledger records `rounds_spent: 0`, because the controller found no
 headroom to spend. The composition figure quoted above for stages 01–02, 0.973, is a
@@ -634,11 +635,17 @@ property of the `--fake-operator` *script*, not of the rubric: a real run scores
 worse than the table implies. Stopping early is not worth "nearly eight times what a
 promotion needs"; on a real run it buys a perfect score.
 
-**A trial cut at `--final-stage 02` therefore cannot resolve anything.** Both arms
+**A trial cut at `--final-stage 02` therefore could not resolve anything.** Both arms
 would score 1.0, every within-pair difference would be 0, and the report would say
-"no effect" when it means "no instrument". Resolution starts at Stage 03, where
-`artifact_breadth` enters, and the first two stages cost about 35 minutes each on
+"no effect" when it means "no instrument". Resolution started at Stage 03, where
+`artifact_breadth` entered, and the first two stages cost about 35 minutes each on
 opus before reaching it.
+
+`RUBRIC_VERSION` 5 moves `artifact_breadth` to Stage 01 and this ceiling has not been
+re-measured under it. Whether that opus Stage 01 would still score 1.0 turns on
+whether it wrote `literature/` inside its own execution window, which the v4 run was
+not graded on — so this document cannot say, and the run would have to be repeated
+before a `--final-stage 02` trial is called uninformative again.
 
 So when this document says a capability *is* better, it is describing an argument.
 When it says a capability *measures* better, it means the rubric, and now on one real

--- a/src/archive.py
+++ b/src/archive.py
@@ -106,7 +106,7 @@ def comparability_basis(
     """The key two runs must share before their fitness may be compared at all.
 
     A stage's score is a weighted mean over the criteria that apply to it, and the
-    late stages face more of them: Stage 02 is scored on five criteria worth 11,
+    late stages face more of them: Stage 02 is scored on six criteria worth 13,
     Stage 06 on eight worth 18, including `numeric_fidelity`, which is the hardest.
     So the *set of stages a run reached* is a free parameter of the objective. On a
     scripted `--fake-operator` run the difference is not subtle — mean fitness over

--- a/src/hypothesis_manifest.py
+++ b/src/hypothesis_manifest.py
@@ -4,6 +4,7 @@ import json
 import re
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Sequence
 
 from .utils import RunPaths, TYPED_HYPOTHESIS_HEADINGS, extract_typed_hypothesis_sections
 
@@ -115,6 +116,72 @@ def write_hypothesis_manifest(paths: RunPaths, stage_markdown: str) -> Hypothesi
         encoding="utf-8",
     )
     return manifest
+
+
+def hypotheses_without_decision_rule(entries: Sequence[HypothesisEntry]) -> list[str]:
+    """Which empirical hypotheses carry no decision rule, by identifier.
+
+    One spelling of one rule, two readers: :func:`validate_hypothesis_decision_rules`,
+    which refuses the stage, and ``src.rubric``, which grades the same condition on the
+    draft. Written here rather than in either of them because a gate and its graded
+    twin disagreeing about what "has a decision rule" means is the failure that makes a
+    score and a gate tell a run two different things.
+
+    ``derived_from`` is deliberately not required alongside it. The Stage 02 prompt
+    lists that field under "Add supporting lines under each entry **when relevant**",
+    and the repo's own Stage 02 fixtures omit it, so demanding it here would refuse a
+    draft that did exactly what it was told.
+    """
+    return [
+        entry.identifier or "(unnamed hypothesis)"
+        for entry in entries
+        if not entry.decision_rule.strip()
+    ]
+
+
+def validate_hypothesis_decision_rules(paths: RunPaths) -> list[str]:
+    """Refuse a hypothesis set that cannot come out negative, at the stage that wrote it.
+
+    The Stage 02 prompt requires a ``- Decision rule: ...`` line on every empirical
+    hypothesis. Until this existed, the first gate that read one was
+    :func:`src.preregistration.validate_preregistration` at Stage 05 — three stages
+    downstream of the mistake, after the set was frozen at Stage 04, where the only
+    repair is a rollback. That is the same shape as the experimental-protocol
+    counter-example already written at the ``validate_report_plan`` call site in
+    :func:`src.utils.validate_stage_artifacts`, and the fix is the same one: hold the
+    check at the stage that can still make the change cheaply.
+
+    A missing manifest is deliberately **not** refused here. At Stage 02
+    :func:`src.utils.validate_stage_markdown` already requires the typed hypothesis
+    subsections and ``write_hypothesis_manifest`` derives the file from them moments
+    before this runs; from Stage 03 on, absence is ``validate_preregistration``'s to
+    report, and it says something more useful about it than this could.
+    """
+    if not paths.hypothesis_manifest.exists():
+        return []
+    try:
+        payload = json.loads(paths.hypothesis_manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return [
+            "cannot read workspace/notes/hypothesis_manifest.json as JSON "
+            f"({exc}). Rewrite it in the Stage 02 format; a hypothesis set nothing can "
+            "parse cannot be frozen, adjudicated, or reported."
+        ]
+
+    section = payload.get("empirical_hypotheses") if isinstance(payload, dict) else None
+    if not isinstance(section, list):
+        return []
+    entries = [HypothesisEntry.from_dict(item) for item in section if isinstance(item, dict)]
+    missing = hypotheses_without_decision_rule(entries)
+    if not missing:
+        return []
+    return [
+        "has empirical hypotheses with no decision rule in "
+        f"workspace/notes/hypothesis_manifest.json: {', '.join(missing)}. State, as "
+        "`- Decision rule: ...` under each one in Stage 02, what result would count as "
+        "support and what would count as refutation. A hypothesis with no decision rule "
+        "cannot come out negative, and Stage 04 freezes this set as it stands."
+    ]
 
 
 def load_hypothesis_manifest(path) -> HypothesisManifest | None:

--- a/src/ideation_panel.py
+++ b/src/ideation_panel.py
@@ -56,6 +56,11 @@ DUPLICATE_THRESHOLD = 0.5
 #: Where the pool lands. Stage 02's own artifacts live under workspace/notes.
 IDEA_POOL_FILENAME = "idea_pool.json"
 
+#: The same pool rendered for the prompt. Named rather than inlined because
+#: `rubric._harness_written_records` has to exclude it from Stage 02's `notes` kind,
+#: and a name that exists in one place cannot drift out of the other.
+IDEA_POOL_MARKDOWN_FILENAME = "idea_pool.md"
+
 
 @dataclass(frozen=True)
 class ProposerLens:
@@ -681,7 +686,7 @@ def record_idea_pool(paths: RunPaths, pool: IdeaPool, stage: StageSpec, attempt_
     payload = {"stage": stage.slug, "attempt": attempt_no, **pool.to_dict()}
     paths.notes_dir.mkdir(parents=True, exist_ok=True)
     write_text(paths.notes_dir / IDEA_POOL_FILENAME, json.dumps(payload, indent=2, ensure_ascii=False))
-    write_text(paths.notes_dir / "idea_pool.md", format_pool_for_prompt(pool))
+    write_text(paths.notes_dir / IDEA_POOL_MARKDOWN_FILENAME, format_pool_for_prompt(pool))
     append_log_entry(
         paths.logs,
         f"{stage.slug} attempt {attempt_no} idea_pool",

--- a/src/review_panel.py
+++ b/src/review_panel.py
@@ -82,6 +82,15 @@ from .utils import (
 #: Choices that leave the stage unapproved. Used to decide whether a panel actually converged.
 _REFINEMENT_CHOICES = {"1", "2", "3", "4"}
 
+#: The subdirectory of ``workspace/reviews/`` that belongs to the panel, and to nothing
+#: else. Named because four modules address it — this one writes the transcripts and the
+#: effect ledger, :mod:`src.scorecard` locates the ledger, :mod:`src.validity_review`
+#: reads the transcripts for the obligations they impose on the next stage, and
+#: :func:`src.rubric._harness_written_records` excludes the whole subtree from Stage 08's
+#: ``reviews`` kind. A literal repeated in four places is one rename away from three of
+#: them being wrong.
+PANEL_DIRNAME = "panel"
+
 
 @dataclass(frozen=True)
 class PanelRole:
@@ -1382,7 +1391,7 @@ class ReviewPanel:
         claim. A panel that reported only its verdict would be less inspectable than the single
         reviewer it replaced.
         """
-        panel_dir = paths.reviews_dir / "panel"
+        panel_dir = paths.reviews_dir / PANEL_DIRNAME
         panel_dir.mkdir(parents=True, exist_ok=True)
         stem = f"{deliberation.stage_slug}_attempt_{deliberation.attempt_no:02d}"
 
@@ -1489,7 +1498,7 @@ def record_panel_effect(paths: RunPaths, deliberation: PanelDeliberation) -> dic
     file exists to let a run say, in its own artifacts, that the panel did not earn its cost.
     It is the least flattering thing the feature writes about itself, which is why it writes it.
     """
-    path = paths.reviews_dir / "panel" / PANEL_EFFECT_FILENAME
+    path = paths.reviews_dir / PANEL_DIRNAME / PANEL_EFFECT_FILENAME
     path.parent.mkdir(parents=True, exist_ok=True)
 
     history: list[dict[str, Any]] = []

--- a/src/rubric.py
+++ b/src/rubric.py
@@ -41,13 +41,14 @@ import json
 import re
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, NamedTuple, Sequence
 
 from .artifact_index import is_autor_own_record
 from .utils import (
     FIGURE_SUFFIXES,
     MACHINE_DATA_SUFFIXES,
     RESULT_SUFFIXES,
+    STAGES,
     RunPaths,
     StageSpec,
     _existing_files,
@@ -57,6 +58,9 @@ from .utils import (
     stage_execution_started_at,
     validate_stage_markdown,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle at runtime, type-only here
+    from .hypothesis_manifest import HypothesisEntry
 
 
 #: Bump when a criterion is added, removed, reweighted, or has its measurement
@@ -72,7 +76,16 @@ from .utils import (
 #: :func:`_cap_quantification_by_fidelity`. Every stage draft scored before the cap
 #: over-credits any Key Results section carrying unverifiable numbers, which is why
 #: this is a version bump and not a patch.
-RUBRIC_VERSION = "4"
+#: ``5`` moves two things at once. ``artifact_breadth`` now reads the four workspace
+#: directories Stages 01, 02, 07 and 08 are told to write — ``literature/``,
+#: ``notes/``, ``artifacts/`` and ``reviews/`` — and scores against
+#: :data:`STAGE_ARTIFACT_KINDS`, the kinds *this* stage's prompt asks for, instead of
+#: a bare count of any two or three; and ``reproducibility`` gains a Stage 02-03 link
+#: for the decision rule on every empirical hypothesis. Both change what an existing
+#: score means: replayed against v4, a Stage 08 that produced its whole release bundle
+#: measures 0.333 on breadth, and 0.0 if none of that bundle went under ``writing/``.
+#: So a v4 total and a v5 total are not two measurements of one thing.
+RUBRIC_VERSION = "5"
 
 #: The keys the rubric refuses to read out of an adjudication artifact.
 #:
@@ -145,7 +158,7 @@ class Criterion:
 CRITERIA: tuple[Criterion, ...] = (
     Criterion("contract", "Contract compliance", weight=2.0),
     Criterion("grounding", "References that resolve", weight=3.0),
-    Criterion("artifact_breadth", "Artifacts produced this stage", weight=2.0, min_stage=3),
+    Criterion("artifact_breadth", "Artifacts produced this stage", weight=2.0, min_stage=1),
     Criterion("quantification", "Findings carrying numbers", weight=2.0, min_stage=4),
     Criterion("numeric_fidelity", "Reported numbers trace to results", weight=3.0, min_stage=5),
     Criterion("traceability", "Decision ledger", weight=1.5),
@@ -424,6 +437,170 @@ def _score_grounding(
     return CriterionScore("grounding", CRITERIA_BY_KEY["grounding"].title, weight, score, observed, shortfall)
 
 
+def _artifact_kind_dirs(
+    paths: RunPaths, artifact_dirs: Mapping[str, Sequence[Path]] | None
+) -> dict[str, tuple[Path, ...]]:
+    """Which workspace directory each artifact kind is read from.
+
+    A kind is named after the directory it comes from, so "this stage wrote
+    ``literature``" is a claim a reader can check with ``ls``. ``writing`` is the one
+    exception: a run's manuscript lives under ``writing/`` in LaTeX mode and under
+    ``report/`` in markdown mode, and the two are one kind of work.
+
+    ``artifact_dirs`` is the operator's declaration of where a benchmark harness puts
+    its outputs, and only the three categories a benchmark contract can redirect —
+    ``data``, ``results``, ``figures`` — accept one.
+    """
+    extra = artifact_dirs or {}
+    return {
+        "data": (paths.data_dir, *extra.get("data", ())),
+        "results": (paths.results_dir, *extra.get("results", ())),
+        "figures": (paths.figures_dir, *extra.get("figures", ())),
+        "code": (paths.code_dir,),
+        "writing": (paths.writing_dir, paths.report_dir),
+        "literature": (paths.literature_dir,),
+        "notes": (paths.notes_dir,),
+        "artifacts": (paths.artifacts_dir,),
+        "reviews": (paths.reviews_dir,),
+    }
+
+
+#: What counts as a file of each kind. The four kinds added here accept ``.md``,
+#: because a reading note, an assumption map, a readiness checklist and a release note
+#: are markdown and the prompts ask for them in those words. That is not a way in for
+#: prose: ``MIN_ARTIFACT_BYTES`` still applies, the file has to be under the directory
+#: its stage was pointed at, and the criterion is a set of *kinds* — a second paragraph
+#: in a second file moves nothing.
+_ARTIFACT_KIND_SUFFIXES: dict[str, set[str]] = {
+    "data": MACHINE_DATA_SUFFIXES,
+    "results": RESULT_SUFFIXES,
+    "figures": FIGURE_SUFFIXES,
+    "code": {".py", ".sh", ".r", ".jl", ".ipynb", ".cpp", ".rs", ".go", ".ts", ".js"},
+    "writing": {".md", ".tex", ".bib"},
+    "literature": {".md", ".json", ".jsonl", ".bib", ".csv", ".tsv", ".yaml", ".yml"},
+    "notes": {".md", ".json", ".jsonl", ".csv", ".tsv", ".yaml", ".yml"},
+    "artifacts": {".md", ".json", ".jsonl", ".pdf", ".tex", ".zip", ".tar", ".gz"},
+    "reviews": {".md", ".json", ".jsonl", ".yaml", ".yml"},
+}
+
+
+#: What each stage is expected to leave behind, by stage number.
+#:
+#: Every kind named here is a directory that stage's own prompt tells the agent to
+#: write to — ``tests/test_rubric_artifact_kinds.py`` reads the ``{{WORKSPACE_*_DIR}}``
+#: placeholders out of ``src/prompts/`` and refuses any expectation the prompt never
+#: asked for. That is why Stage 03 expects ``data`` and ``notes`` and not ``code``:
+#: implementation is Stage 04's job and ``03_study_design.md`` never names the code
+#: directory. Scored as a set rather than as a count so that a stage cannot climb by
+#: emitting more of the one kind it already had, and so that the shortfall can name
+#: the directory that is missing instead of listing every directory in the run.
+STAGE_ARTIFACT_KINDS: dict[int, frozenset[str]] = {
+    1: frozenset({"literature"}),
+    2: frozenset({"literature", "notes"}),
+    3: frozenset({"data", "notes"}),
+    4: frozenset({"code", "data", "notes"}),
+    5: frozenset({"code", "results"}),
+    6: frozenset({"figures", "results"}),
+    7: frozenset({"artifacts", "writing"}),
+    8: frozenset({"artifacts", "reviews", "writing"}),
+}
+
+
+def expected_artifact_kinds(stage: StageSpec) -> frozenset[str]:
+    """The kinds this stage is graded on producing. Empty for a stage nobody declared."""
+    return STAGE_ARTIFACT_KINDS.get(stage.number, frozenset())
+
+
+class HarnessWrites(NamedTuple):
+    """The files and whole subtrees AutoR itself puts inside a graded directory.
+
+    Two members rather than one set because ``reviews/panel/`` is a *directory* AutoR
+    owns — the panel writes one transcript pair per stage per attempt, so the names are
+    not enumerable in advance and matching them one by one would leak every second file.
+    """
+
+    files: frozenset[Path]
+    trees: frozenset[Path]
+
+    def covers(self, path: Path) -> bool:
+        return path in self.files or any(tree in path.parents for tree in self.trees)
+
+
+def _harness_written_records(paths: RunPaths) -> HarnessWrites:
+    """Everything AutoR writes for the stage, into directories this criterion now reads.
+
+    :func:`is_autor_own_record` covers the scientific bookkeeping — the six files under
+    ``notes/`` and two under ``results/`` that ``RECORD_ARTIFACTS`` lists — and that list
+    is about the *experiment bundle*, so these do not belong in it. They are the same
+    hazard by a different route: each is written by AutoR's own machinery into a
+    directory the stage is graded on, so a stage that produced nothing would collect the
+    kind anyway. ``tests/test_rubric_artifact_kinds.py`` drives each writer and censuses
+    ``src/`` for a path under a graded directory that this list has not classified.
+
+    Written **before the draft is scored, inside the stage's own window**, so each one
+    is a live free kind rather than a hazard in principle:
+
+    - ``notes/idea_pool.{json,md}``: :func:`record_idea_pool` runs while the Stage 02
+      prompt is being built, and Stage 02 is graded on ``notes``.
+    - ``artifacts/report_review.json`` and ``artifacts/layout_review.json``: the manager
+      generates one — which one depends on the output format — after every Stage 07
+      attempt, and Stage 07 is graded on ``artifacts``. ``07_writing.md`` says so to the
+      agent in as many words: "generated for you by the workflow manager after each
+      attempt — read it, do not write it".
+    - ``reviews/comment_ledger.json``: ``_close_comment_round`` writes it when an
+      anchored-revision round closes, one call above ``consider``.
+    - ``reviews/deliberations.json``: ``_settle_cruxes`` writes it in the statement after
+      that, still above ``consider``.
+    - ``reviews/panel/``: ``ReviewPanel._record`` writes a transcript pair and the effect
+      ledger from ``_collect_review_decision``, which runs *after* attempt N is scored
+      and therefore before attempt N+1 is.
+    - ``reviews/effort.json``: ``_note_effort_failure`` writes it in the same window, on
+      the branch where the panel refused.
+
+    And two AutoR records in ``reviews/`` whose current call sites happen to sit after
+    the last score of the run. They are excluded on ownership, not on ordering, because
+    the ordering is not theirs to keep: ``_report_optional_machinery`` is called from
+    ``_complete_run``, and a resumed or revisited walk re-opens a stage window after it.
+
+    - ``reviews/scorecard.{json,md}``: :func:`write_scorecard`.
+    - ``reviews/validity_review_<stage>.json``: the adversarial reviewer's own findings,
+      about the stage rather than by it.
+
+    Every name is imported from the module that writes it, so a rename cannot leave this
+    list pointing at nothing — that is why ``idea_pool.md``, ``report_review.json``,
+    ``layout_review.json`` and ``panel/`` gained constants at their writers.
+    """
+    from .deliberation import LEDGER_FILENAME as DELIBERATION_LEDGER_FILENAME
+    from .effort import LEDGER_FILENAME as EFFORT_LEDGER_FILENAME
+    from .ideation_panel import IDEA_POOL_FILENAME, IDEA_POOL_MARKDOWN_FILENAME
+    from .review_panel import PANEL_DIRNAME
+    from .scorecard import SCORECARD_JSON, SCORECARD_MD
+    from .stage_comments import COMMENT_LEDGER_FILENAME
+    from .validity_review import validity_review_path
+    from .writing_manifest import LAYOUT_REVIEW_FILENAME, REPORT_REVIEW_FILENAME
+
+    return HarnessWrites(
+        files=frozenset(
+            {
+                paths.notes_dir / IDEA_POOL_FILENAME,
+                paths.notes_dir / IDEA_POOL_MARKDOWN_FILENAME,
+                paths.artifacts_dir / REPORT_REVIEW_FILENAME,
+                paths.artifacts_dir / LAYOUT_REVIEW_FILENAME,
+                paths.reviews_dir / COMMENT_LEDGER_FILENAME,
+                paths.reviews_dir / DELIBERATION_LEDGER_FILENAME,
+                paths.reviews_dir / EFFORT_LEDGER_FILENAME,
+                paths.reviews_dir / SCORECARD_JSON,
+                paths.reviews_dir / SCORECARD_MD,
+                # One per stage: the reviewer names the file after the stage it read, so
+                # the set is derived from `STAGES` rather than from a glob, which would
+                # also swallow the *response* the stage itself writes beside it.
+                *(validity_review_path(paths, stage.slug) for stage in STAGES),
+            }
+        ),
+        trees=frozenset({paths.reviews_dir / PANEL_DIRNAME}),
+    )
+
+
 def _fresh_artifact_kinds(
     paths: RunPaths,
     stage: StageSpec,
@@ -436,25 +613,13 @@ def _fresh_artifact_kinds(
     nothing at all would be indistinguishable from one that did.
     """
     cutoff = stage_execution_started_at(paths, stage)
-    kinds: dict[str, tuple[Path, ...]] = {
-        "data": (paths.data_dir, *(artifact_dirs or {}).get("data", ())),
-        "results": (paths.results_dir, *(artifact_dirs or {}).get("results", ())),
-        "figures": (paths.figures_dir, *(artifact_dirs or {}).get("figures", ())),
-        "code": (paths.code_dir,),
-        "writing": (paths.writing_dir, paths.report_dir),
-    }
-    suffixes = {
-        "data": MACHINE_DATA_SUFFIXES,
-        "results": RESULT_SUFFIXES,
-        "figures": FIGURE_SUFFIXES,
-        "code": {".py", ".sh", ".r", ".jl", ".ipynb", ".cpp", ".rs", ".go", ".ts", ".js"},
-        "writing": {".md", ".tex", ".bib"},
-    }
+    kinds = _artifact_kind_dirs(paths, artifact_dirs)
+    harness_written = _harness_written_records(paths)
 
     present: set[str] = set()
     fresh: set[str] = set()
     for kind, directories in kinds.items():
-        allowed = suffixes[kind]
+        allowed = _ARTIFACT_KIND_SUFFIXES[kind]
         for directory in directories:
             for path in _existing_files(directory):
                 if path.suffix.lower() not in allowed:
@@ -462,7 +627,7 @@ def _fresh_artifact_kinds(
                 # AutoR's own bookkeeping is not the stage's output. Per-file rather
                 # than by pruning the directory, because `artifact_dirs` are
                 # operator-declared and may point anywhere.
-                if is_autor_own_record(paths, path):
+                if is_autor_own_record(paths, path) or harness_written.covers(path):
                     continue
                 try:
                     stat = path.stat()
@@ -483,29 +648,54 @@ def _score_artifact_breadth(
     stage: StageSpec,
     artifact_dirs: Mapping[str, Sequence[Path]] | None,
 ) -> CriterionScore:
+    """The kinds this stage's own prompt asked for, written inside its own window.
+
+    Scored against :data:`STAGE_ARTIFACT_KINDS` rather than against a count of any
+    two or three kinds. The count was wrong in both directions at the ends of the
+    graph. It could not see ``literature/``, ``notes/``, ``artifacts/`` or
+    ``reviews/`` at all, so a Stage 08 was graded on whichever part of its release
+    bundle happened to land in ``writing/`` — one kind of the three it owes, or none
+    at all, in which case it was told "every artifact in the run predates this
+    stage's execution" while the bundle sat on disk seconds old. And it credited a
+    Stage 06 that wrote ``code/`` and ``notes/`` and no figures with one of its
+    three, because any three kinds were worth the same as the three the analysis
+    stage owes. Both numbers are replays against ``origin/main@fdded57``;
+    ``tests/test_rubric_artifact_kinds.py`` carries the trees they were taken on.
+    """
     weight = CRITERIA_BY_KEY["artifact_breadth"].weight
     present, fresh = _fresh_artifact_kinds(paths, stage, artifact_dirs)
-    # What a stage is reasonably expected to touch. Scored against an expectation
-    # rather than a raw count so a stage cannot climb by emitting more of the one
-    # kind it already had.
-    expected = 2 if stage.number < 5 else 3
-    score = _clamp(len(fresh) / expected)
+    expected = expected_artifact_kinds(stage)
+    if not expected:
+        return CriterionScore(
+            "artifact_breadth",
+            CRITERIA_BY_KEY["artifact_breadth"].title,
+            weight,
+            1.0,
+            "no artifact kinds are declared for this stage",
+        )
+
+    earned = fresh & expected
+    missing = expected - fresh
+    score = _clamp(len(earned) / len(expected))
     observed = (
-        f"{len(fresh)} artifact kind(s) written during this stage "
-        f"({', '.join(sorted(fresh)) or 'none'}); {len(present)} present overall"
+        f"{len(earned)}/{len(expected)} expected artifact kind(s) written during this stage "
+        f"({', '.join(sorted(earned)) or 'none'}); {len(present)} kind(s) present overall"
     )
     if score >= 1.0:
         shortfall = ""
     elif not fresh and present:
         shortfall = (
             "Every artifact in the run predates this stage's execution. Produce or "
-            "update the files this stage is responsible for."
+            "update the files this stage is responsible for: "
+            + ", ".join(f"`workspace/{kind}/`" for kind in sorted(missing))
+            + "."
         )
     else:
         shortfall = (
-            f"Only {len(fresh)} of an expected {expected} artifact kinds were written here. "
-            "Add the missing machine-readable outputs (data, results, figures, code) rather "
-            "than describing them in prose."
+            f"{len(earned)} of the {len(expected)} artifact kinds this stage is responsible "
+            "for were written here. Write the missing ones — "
+            + ", ".join(f"`workspace/{kind}/`" for kind in sorted(missing))
+            + " — as files, rather than describing them in prose."
         )
     return CriterionScore(
         "artifact_breadth", CRITERIA_BY_KEY["artifact_breadth"].title, weight, score, observed, shortfall
@@ -807,7 +997,36 @@ def _score_commitment(markdown: str) -> CriterionScore:
     )
 
 
-def _score_reproducibility(paths: RunPaths, stage: StageSpec) -> CriterionScore:
+def _empirical_hypotheses(
+    paths: RunPaths, stage: StageSpec, markdown: str
+) -> list["HypothesisEntry"]:
+    """The empirical hypotheses this draft is answerable for.
+
+    At Stage 02 they are read out of **the draft being scored**, not out of
+    ``notes/hypothesis_manifest.json``. ``score_stage`` runs once per candidate, and
+    a polish round that gets reverted leaves the loser's manifest on disk — scoring
+    the new draft against the old file would grade a document nobody wrote. From
+    Stage 03 the draft carries no hypothesis sections at all, so the manifest Stage 02
+    left behind is the only copy, and it is the one Stage 04 will freeze.
+
+    Every read is defensive by construction. ``score_stage`` has no ``try`` around it
+    and a hand-edited manifest is a file the agent can write, so a corrupt one has to
+    cost the criterion rather than end the run.
+    """
+    from .hypothesis_manifest import HypothesisEntry, build_hypothesis_manifest
+
+    if stage.number == 2:
+        manifest = build_hypothesis_manifest(markdown)
+        return list(manifest.empirical_hypotheses) if manifest is not None else []
+
+    payload = _load_json(paths.hypothesis_manifest)
+    section = payload.get("empirical_hypotheses") if isinstance(payload, dict) else None
+    if not isinstance(section, list):
+        return []
+    return [HypothesisEntry.from_dict(item) for item in section if isinstance(item, dict)]
+
+
+def _score_reproducibility(paths: RunPaths, stage: StageSpec, markdown: str) -> CriterionScore:
     """The machine-readable validity chain that applies at this stage.
 
     Each check is a boolean over an artifact that either exists and parses or does
@@ -832,6 +1051,27 @@ def _score_reproducibility(paths: RunPaths, stage: StageSpec) -> CriterionScore:
                 not validate_literature_evidence(paths),
                 "Write workspace/literature/sources.json and claims.json so each claim names the "
                 "source_ids behind it.",
+            )
+        )
+    if 2 <= stage.number <= 3:
+        # The graded twin of the Stage 02+ gate in `validate_stage_artifacts`. Stages
+        # 2-3 only, and not `>= 2`: from Stage 04 the same hypothesis set is measured
+        # by the frozen-preregistration link below, and scoring both would spend two
+        # of this criterion's links on one artifact — the run would look more
+        # reproducible for having declared its hypotheses twice.
+        from .hypothesis_manifest import hypotheses_without_decision_rule
+
+        entries = _empirical_hypotheses(paths, stage, markdown)
+        undecided = hypotheses_without_decision_rule(entries)
+        named = f" ({', '.join(undecided)})" if undecided else ""
+        checks.append(
+            (
+                "falsifiable hypothesis set",
+                bool(entries) and not undecided,
+                f"Give every empirical hypothesis{named} a `- Decision rule: ...` line saying "
+                "what result would count as support and what would count as refutation. A "
+                "hypothesis with no decision rule cannot come out negative, and Stage 04 "
+                "freezes the set as it stands.",
             )
         )
     if stage.number >= 3:
@@ -999,7 +1239,7 @@ def score_stage(
         elif criterion.key == "commitment":
             scores.append(_score_commitment(markdown))
         elif criterion.key == "reproducibility":
-            scores.append(_score_reproducibility(paths, stage))
+            scores.append(_score_reproducibility(paths, stage, markdown))
 
     scores = _cap_quantification_by_fidelity(scores)
 

--- a/src/scorecard.py
+++ b/src/scorecard.py
@@ -45,7 +45,7 @@ from typing import Any, Callable
 from .deliberation import LEDGER_FILENAME as DELIBERATIONS_FILENAME
 from .effort import LEDGER_FILENAME as EFFORT_FILENAME
 from .ideation_panel import IDEA_POOL_FILENAME
-from .review_panel import PANEL_EFFECT_FILENAME
+from .review_panel import PANEL_DIRNAME, PANEL_EFFECT_FILENAME
 from .stage_comments import COMMENT_LEDGER_FILENAME
 from .utils import RunPaths, read_text, write_text
 
@@ -261,7 +261,7 @@ FEATURES: tuple[dict[str, Any], ...] = (
      "filename": PANEL_EFFECT_FILENAME, "assess": _assess_review_panel,
      # `record_panel_effect` writes beside the per-gate transcripts, one directory down.
      # This is the one that was being looked for a level too high.
-     "locate": lambda p: p.reviews_dir / "panel" / PANEL_EFFECT_FILENAME},
+     "locate": lambda p: p.reviews_dir / PANEL_DIRNAME / PANEL_EFFECT_FILENAME},
     {"key": "ideation_panel", "name": "Ideation panel", "flag": "--ideation-panel",
      "filename": IDEA_POOL_FILENAME, "assess": _assess_ideation,
      "locate": lambda p: p.notes_dir / IDEA_POOL_FILENAME},

--- a/src/utils.py
+++ b/src/utils.py
@@ -1544,6 +1544,17 @@ def validate_stage_artifacts(
     for problem in validate_round_decision(paths, stage):
         problems.append(f"{stage.stage_title} {problem}")
 
+    if stage.number >= 2:
+        # Held at the stage that writes the hypotheses, for the reason the report-plan
+        # comment below spells out: the Stage 02 prompt requires a decision rule on
+        # every empirical hypothesis, and the first gate that read one was
+        # `validate_preregistration` at Stage 05 — three stages later, after Stage 04
+        # froze the set, where the only repair is a rollback.
+        from .hypothesis_manifest import validate_hypothesis_decision_rules
+
+        for problem in validate_hypothesis_decision_rules(paths):
+            problems.append(f"{stage.stage_title} {problem}")
+
     if stage.number >= 3:
         if count_in("data", paths.data_dir, MACHINE_DATA_SUFFIXES) == 0:
             problems.append(

--- a/src/validity_review.py
+++ b/src/validity_review.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from .approval_agent import extract_json_payload
+from .review_panel import PANEL_DIRNAME
 from .terminal_ui import TerminalUI
 from .utils import (
     RunPaths,
@@ -315,7 +316,7 @@ def findings_from_panel(paths: RunPaths, stage: StageSpec) -> list[ValidityFindi
     deliberation was answered inside the panel, and re-raising it would punish
     the deliberation for working.
     """
-    panel_dir = paths.reviews_dir / "panel"
+    panel_dir = paths.reviews_dir / PANEL_DIRNAME
     if not panel_dir.is_dir():
         return []
 

--- a/src/writing_manifest.py
+++ b/src/writing_manifest.py
@@ -26,6 +26,15 @@ RESULT_SUFFIXES = {".json", ".jsonl", ".csv", ".tsv", ".parquet", ".npz", ".npy"
 _LATEX_WARNING_SAMPLE_LIMIT = 5
 _REPORT_ISSUE_SAMPLE_LIMIT = 5
 
+#: The two triage files the *workflow manager* drops into `workspace/artifacts/` after a
+#: Stage 07 attempt — one per output format. `07_writing.md` tells the agent it is
+#: "generated for you by the workflow manager after each attempt — read it, do not write
+#: it", so `rubric._harness_written_records` must not let it earn Stage 07 the
+#: `artifacts` kind. Named here, at the writer, so the exclusion cannot point at a file
+#: this module has since renamed.
+REPORT_REVIEW_FILENAME = "report_review.json"
+LAYOUT_REVIEW_FILENAME = "layout_review.json"
+
 
 def build_writing_manifest(paths: RunPaths) -> dict[str, object]:
     artifact_index = write_artifact_index(paths)
@@ -281,7 +290,7 @@ def generate_layout_review(paths: RunPaths) -> dict[str, object]:
         "issues": issues,
         "priority_fixes": priority_fixes,
     }
-    output_path = paths.artifacts_dir / "layout_review.json"
+    output_path = paths.artifacts_dir / LAYOUT_REVIEW_FILENAME
     output_path.write_text(json.dumps(review, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
     return review
 
@@ -490,7 +499,7 @@ def generate_report_review(paths: RunPaths) -> dict[str, object]:
         ),
     }
     paths.artifacts_dir.mkdir(parents=True, exist_ok=True)
-    output_path = paths.artifacts_dir / "report_review.json"
+    output_path = paths.artifacts_dir / REPORT_REVIEW_FILENAME
     output_path.write_text(json.dumps(review, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
     return review
 

--- a/tests/test_doc_counts.py
+++ b/tests/test_doc_counts.py
@@ -46,6 +46,7 @@ a pinned artifact rather than at moving code.
 
 from __future__ import annotations
 
+import ast
 import re
 import unittest
 from pathlib import Path
@@ -96,6 +97,45 @@ def _channels_that_narrow() -> int:
     """
     return sum(1 for channel in CHANNELS if set(channel.consumed_by) != set(ALL_STAGES))
 
+def _criteria_reaching(stage_number: int) -> int:
+    return sum(1 for criterion in CRITERIA if criterion.min_stage <= stage_number)
+
+
+def _weight_reaching(stage_number: int) -> str:
+    """The weight a stage is graded out of, spelled the way prose spells it.
+
+    ``13.0`` reads as "13" in a sentence and the docs write it that way, so the trailing
+    zero comes off rather than the documents being made to carry it.
+    """
+    total = sum(c.weight for c in CRITERIA if c.min_stage <= stage_number)
+    return f"{total:g}"
+
+
+def _reachable_validators() -> int:
+    """How many distinct ``validate_*`` functions ``validate_stage_artifacts`` calls.
+
+    Three documents quote this number and they had already drifted apart: adding one
+    validator moved `README.md` and `docs/framework.md` to eighteen and left
+    `docs/architecture.md` saying seventeen, so a reader comparing two pages of the same
+    repo got two answers. Counted off the syntax rather than off a hand-list, because
+    the failure being prevented is a validator someone added and did not count.
+    """
+    tree = ast.parse((REPO / "src" / "utils.py").read_text(encoding="utf-8"))
+    gate = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "validate_stage_artifacts"
+    )
+    return len(
+        {
+            node.func.id
+            for node in ast.walk(gate)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id.startswith("validate_")
+        }
+    )
+
 
 #: ``(noun, live value)``. Every spelled-out numeral immediately before *noun* in a
 #: tracked document must equal *value*. The noun is matched case-insensitively and
@@ -113,6 +153,7 @@ COUNTED_NOUNS: tuple[tuple[str, int], ...] = (
     ("edges in the adaptive graph", _adaptive_edges()),
     ("forward edges", _forward_edges() - 1),  # the abandonment terminal aside
     ("guarded forward edges", len(_ADVANCE_GUARDS)),
+    ("`validate_*` functions", _reachable_validators()),
 )
 
 #: Three documents state the channel count and ``docs/framework.md`` states it
@@ -341,6 +382,43 @@ class CountsInProseMatchTheSymbolTests(unittest.TestCase):
     def test_the_criteria_count_is_stated_correctly(self) -> None:
         text = (REPO / "docs/self-improvement.md").read_text(encoding="utf-8")
         self.assertIn(f"{spelled(len(CRITERIA)).capitalize()} criteria", text)
+
+    def test_the_early_and_late_criterion_counts_are_stated_correctly(self) -> None:
+        """One sentence, written twice, about the number the objective turns on.
+
+        `docs/self-improvement.md` and `comparability_basis`'s own docstring both argue
+        that the *set of stages a run reached* is a free parameter of the objective, and
+        both make the argument by contrasting how many criteria Stage 02 faces with how
+        many Stage 06 faces. A `min_stage` change moves those counts and neither copy is
+        near the code that moved: raising `artifact_breadth` to Stage 01 made both read
+        "five criteria worth 11" against a live 6 and 13.0.
+
+        Pinned as a pair, in prose and in a docstring, because the divergence being
+        prevented is the two copies disagreeing as much as either one being stale.
+        """
+        # Every space matches a run of whitespace: the sentence wraps in both copies,
+        # and it wraps at a different word in each.
+        pattern = re.compile(
+            r"\s+".join(
+                r"Stage 02 is scored on (\w+) criteria worth ([\d.]+), "
+                r"Stage 06 on (\w+) worth ([\d.]+)".split(" ")
+            )
+        )
+        for name in ("docs/self-improvement.md", "src/archive.py"):
+            with self.subTest(document=name):
+                match = pattern.search((REPO / name).read_text(encoding="utf-8"))
+                self.assertIsNotNone(match, f"{name} stopped making the comparison")
+                assert match is not None  # for the type checker
+                self.assertEqual(
+                    [match.group(1), match.group(2), match.group(3), match.group(4)],
+                    [
+                        spelled(_criteria_reaching(2)),
+                        _weight_reaching(2),
+                        spelled(_criteria_reaching(6)),
+                        _weight_reaching(6),
+                    ],
+                    f"{name} states criterion counts the rubric no longer has",
+                )
 
     def test_the_stage_count_is_stated_correctly(self) -> None:
         text = (REPO / "README.md").read_text(encoding="utf-8")

--- a/tests/test_hypothesis_decision_rule_link.py
+++ b/tests/test_hypothesis_decision_rule_link.py
@@ -1,0 +1,283 @@
+"""The Stage 02 link in the validity chain, as a gate and as a graded criterion.
+
+`02_hypothesis_generation.md` tells the agent that every empirical hypothesis **must**
+carry a `- Decision rule: ...` line. `write_hypothesis_manifest` parsed the field and
+nothing read it: measured on this tree before the change, `validate_stage_artifacts`
+returned **no problem** at Stages 02, 03 and 04 for a manifest whose one empirical
+hypothesis carried an empty `decision_rule`, and the first refusal came from
+`validate_preregistration` at Stage 05 — after Stage 04's approval had frozen that set,
+where the only repair is a rollback across three stages of work.
+
+That is the shape the `validate_report_plan` call site already names, one stage
+earlier: *"the Stage 03 prompt asks for it and the gate first fires at Stage 05, so a
+Stage 03 that skipped it is approved and the failure surfaces two stages later, where
+the only repair is a rollback."*
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.hypothesis_manifest import (
+    build_hypothesis_manifest,
+    hypotheses_without_decision_rule,
+    validate_hypothesis_decision_rules,
+    write_hypothesis_manifest,
+)
+from src.preregistration import freeze_preregistration, validate_preregistration
+from src.rubric import score_stage
+from src.utils import (
+    STAGES,
+    build_run_paths,
+    ensure_run_layout,
+    validate_stage_artifacts,
+    validate_stage_markdown,
+    write_text,
+)
+
+STAGE = {stage.number: stage for stage in STAGES}
+
+RULE = (
+    "supported if retrieval-on exceeds retrieval-off by more than 8 accuracy points on "
+    "the held-out split across >=5 seeds; refuted if the gap is <=0."
+)
+
+
+def typed_stage_02(*, rule: str | None = RULE, derived_from: bool = False) -> str:
+    """A Stage 02 draft in the shape the prompt asks for.
+
+    `derived_from` defaults off because the prompt lists that field under "Add
+    supporting lines under each entry **when relevant**" — a draft that omits it
+    followed the prompt, and a gate that refuses it would be inventing a requirement.
+    """
+    lines = ["- **H1**: Retrieval augmentation raises long-context accuracy."]
+    if derived_from:
+        lines.append("  - Derived from: the Stage 01 survey of retrieval baselines.")
+    lines.append("  - Depends on: T1")
+    if rule is not None:
+        lines.append(f"  - Decision rule: {rule}")
+    hypothesis = "\n".join(lines)
+    return (
+        "# Stage 02: Hypothesis Generation\n\n"
+        "## Objective\n\nDerive testable hypotheses from the survey.\n\n"
+        "## Previously Approved Stage Summaries\n\nNone yet.\n\n"
+        "## What I Did\n\nTurned `workspace/literature/claims.json` into typed claims.\n\n"
+        "## Key Results\n\n"
+        "### Theoretical Propositions\n"
+        "- **T1**: Attention bottlenecks cause long-context degradation.\n\n"
+        "### Empirical Hypotheses\n"
+        f"{hypothesis}\n\n"
+        "### Paper Claims (Provisional)\n"
+        "- **C1**: Retrieval is a practical long-context fix.\n\n"
+        "## Files Produced\n\n- `workspace/notes/hypothesis_manifest.json`\n\n"
+        "## Decision Ledger\n\n"
+        "- Open Questions: whether retrieval costs too much latency.\n"
+        "- Locked Decisions: long-context QA is the evaluation target.\n"
+        "- Assumptions: the base model is held fixed across arms.\n"
+        "- Rejected Alternatives: full retraining, which the budget cannot cover.\n"
+        "## Suggestions for Refinement\n\n1. a\n2. b\n3. c\n\n"
+        "## Your Options\n\n"
+        "1. Use suggestion 1\n2. Use suggestion 2\n3. Use suggestion 3\n"
+        "4. Refine with your own feedback\n5. Approve and continue\n6. Abort\n"
+    )
+
+
+def manifest_payload(*, rule: str) -> dict:
+    return {
+        "generated_at": "2026-08-13T00:00:00",
+        "theoretical_propositions": [
+            {"id": "T1", "type": "theoretical", "statement": "A mechanism exists.", "decision_rule": ""}
+        ],
+        "empirical_hypotheses": [
+            {
+                "id": "H1",
+                "type": "empirical",
+                "statement": "Retrieval raises accuracy.",
+                "decision_rule": rule,
+            }
+        ],
+        "paper_claims": [
+            {"id": "C1", "type": "paper_claim", "statement": "Retrieval is practical."}
+        ],
+    }
+
+
+class DecisionRuleLinkTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    def write_manifest(self, *, rule: str) -> None:
+        write_text(self.paths.hypothesis_manifest, json.dumps(manifest_payload(rule=rule), indent=2))
+
+    def problems(self, number: int) -> list[str]:
+        return validate_stage_artifacts(STAGE[number], self.paths)
+
+    def rule_problems(self, number: int) -> list[str]:
+        return [item for item in self.problems(number) if "decision rule" in item.lower()]
+
+
+class TheGateRefusesAtTheStageThatWroteThemTests(DecisionRuleLinkTestCase):
+    def test_stage_02_refuses_an_empirical_hypothesis_with_no_decision_rule(self) -> None:
+        self.write_manifest(rule="")
+        found = self.rule_problems(2)
+        self.assertEqual(len(found), 1, self.problems(2))
+        self.assertIn("H1", found[0])
+
+    def test_stage_02_accepts_the_same_manifest_once_the_rule_is_there(self) -> None:
+        self.write_manifest(rule=RULE)
+        self.assertEqual(self.rule_problems(2), [])
+
+    def test_the_refusal_lands_three_stages_before_the_gate_that_used_to_be_first(self) -> None:
+        """What the fix buys, stated as a comparison rather than as an adjective.
+
+        `validate_preregistration` is the gate that caught this, and it is wired from
+        Stage 05. It reads the *frozen* record — which Stage 04's approval writes from
+        this very manifest, empty rule and all — so the run carried the defect through
+        design and implementation, froze it, and only then heard about it, at the one
+        point where the repair is a rollback across three stages.
+        """
+        self.write_manifest(rule="")
+        frozen = freeze_preregistration(self.paths)
+        assert frozen is not None
+        self.assertEqual(
+            [item.decision_rule for item in frozen.hypotheses if item.claim_type == "empirical"],
+            [""],
+            "Stage 04 froze the defect, which is what makes Stage 05 too late",
+        )
+
+        late = "has no decision rule"
+        self.assertTrue(any(late in item for item in validate_preregistration(self.paths)))
+        self.assertFalse(any(late in item for item in self.problems(4)))
+        self.assertTrue(any(late in item for item in self.problems(5)))
+        self.assertTrue(self.rule_problems(2))
+
+    def test_the_requirement_is_cumulative_like_every_other_artifact_gate(self) -> None:
+        self.write_manifest(rule="")
+        for number in (2, 3, 4, 5, 6, 7, 8):
+            self.assertTrue(self.rule_problems(number), msg=f"stage {number:02d} let it through")
+
+    def test_stage_01_is_not_asked_for_hypotheses_it_has_not_generated_yet(self) -> None:
+        self.write_manifest(rule="")
+        self.assertEqual(self.rule_problems(1), [])
+
+    def test_a_theoretical_proposition_carries_no_decision_rule_and_that_is_correct(self) -> None:
+        """Only `empirical_hypotheses` are adjudicated. A proposition and a paper claim
+        are not things a result can refute, and demanding a rule for them would push
+        the agent to write one that no outcome could fail."""
+        self.write_manifest(rule=RULE)
+        payload = json.loads(self.paths.hypothesis_manifest.read_text(encoding="utf-8"))
+        self.assertEqual(payload["theoretical_propositions"][0]["decision_rule"], "")
+        self.assertEqual(payload["paper_claims"][0].get("decision_rule", ""), "")
+        self.assertEqual(self.rule_problems(2), [])
+
+    def test_derived_from_is_not_required_with_it(self) -> None:
+        """The prompt lists `Derived from` under "when relevant", and the repo's own
+        Stage 02 fixtures omit it. A gate that required it would refuse a draft that
+        did what it was told."""
+        markdown = typed_stage_02(derived_from=False)
+        manifest = write_hypothesis_manifest(self.paths, markdown)
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest.empirical_hypotheses[0].derived_from, "")
+        self.assertEqual(validate_stage_markdown(markdown, stage=STAGE[2], paths=self.paths), [])
+        self.assertEqual(self.rule_problems(2), [])
+
+    def test_a_manifest_nobody_can_parse_is_a_problem_and_not_a_crash(self) -> None:
+        """`workspace/` is written by the party this gate constrains."""
+        write_text(self.paths.hypothesis_manifest, "{not json at all")
+        problems = validate_hypothesis_decision_rules(self.paths)
+        self.assertEqual(len(problems), 1, problems)
+        self.assertIn("hypothesis_manifest.json", problems[0])
+
+    def test_an_absent_manifest_is_not_this_gates_business(self) -> None:
+        """Stage 02's markdown contract already requires the typed subsections, and
+        `validate_preregistration` says something better about a missing manifest than
+        this could. Two gates reporting one absence is noise, not defence."""
+        self.assertFalse(self.paths.hypothesis_manifest.exists())
+        self.assertEqual(validate_hypothesis_decision_rules(self.paths), [])
+
+    def test_the_gate_and_the_rubric_share_one_spelling_of_the_rule(self) -> None:
+        manifest = build_hypothesis_manifest(typed_stage_02(rule=None))
+        assert manifest is not None
+        self.assertEqual(
+            hypotheses_without_decision_rule(manifest.empirical_hypotheses), ["H1"]
+        )
+        self.assertEqual(
+            hypotheses_without_decision_rule(
+                build_hypothesis_manifest(typed_stage_02()).empirical_hypotheses  # type: ignore[union-attr]
+            ),
+            [],
+        )
+
+
+class TheGradedTwinReadsTheDraftTests(DecisionRuleLinkTestCase):
+    def link(self, number: int, markdown: str):
+        score = score_stage(paths=self.paths, stage=STAGE[number], markdown=markdown)
+        return score.by_key["reproducibility"]
+
+    def test_stage_02_is_graded_on_the_draft_and_not_on_the_file_on_disk(self) -> None:
+        """A reverted polish round leaves the loser's manifest at
+        `notes/hypothesis_manifest.json`. Reading it would grade the wrong document —
+        in whichever direction the loser happened to differ."""
+        self.write_manifest(rule=RULE)
+        weak = self.link(2, typed_stage_02(rule=None))
+        self.assertIn("falsifiable hypothesis set", weak.shortfall)
+        self.assertIn("H1", weak.shortfall)
+
+    def test_a_good_draft_is_not_docked_for_the_manifest_a_lost_round_left_behind(self) -> None:
+        """The mirror. Both directions matter: one grades a draft for work it did not
+        do, the other refuses a draft the work it did."""
+        self.write_manifest(rule="")
+        strong = self.link(2, typed_stage_02())
+        self.assertNotIn("falsifiable hypothesis set", strong.shortfall)
+
+    def test_a_stage_02_draft_with_no_hypotheses_at_all_does_not_borrow_the_old_ones(self) -> None:
+        self.write_manifest(rule=RULE)
+        empty = self.link(2, typed_stage_02().replace("### Empirical Hypotheses", "### Nothing"))
+        self.assertIn("falsifiable hypothesis set", empty.shortfall)
+
+    def test_stage_03_reads_the_manifest_because_its_draft_carries_none(self) -> None:
+        markdown = typed_stage_02().replace("Stage 02: Hypothesis Generation", "Stage 03: Study Design")
+        self.write_manifest(rule="")
+        self.assertIn("falsifiable hypothesis set", self.link(3, markdown).shortfall)
+        self.write_manifest(rule=RULE)
+        self.assertNotIn("falsifiable hypothesis set", self.link(3, markdown).shortfall)
+
+    def test_the_hypothesis_set_is_not_graded_twice_from_stage_04(self) -> None:
+        """`>= 2` would spend two of this criterion's links on one artifact.
+
+        From Stage 04 the same set is measured by the frozen-preregistration link, and
+        `validate_preregistration` — the gate — checks the rules there. A run would
+        otherwise look more reproducible for having declared its hypotheses twice.
+        """
+        markdown = typed_stage_02().replace("Stage 02: Hypothesis Generation", "Stage 04: Implementation")
+        self.write_manifest(rule="")
+        without = self.link(4, markdown)
+        self.write_manifest(rule=RULE)
+        self.assertEqual(self.link(4, markdown).score, without.score)
+        self.assertNotIn("falsifiable hypothesis set", without.shortfall)
+
+    def test_a_hand_corrupted_manifest_costs_the_criterion_and_does_not_end_the_run(self) -> None:
+        """`score_stage` has no `try` around it, and the operator runs with
+        `bypassPermissions` at `cwd=run_root`: `workspace/notes/` is written by the
+        party this criterion measures. A `json.loads` here would turn a malformed file
+        into a crash that loses the run rather than a score that loses points."""
+        write_text(self.paths.hypothesis_manifest, '{"empirical_hypotheses": [')
+        markdown = typed_stage_02().replace("Stage 02: Hypothesis Generation", "Stage 03: Study Design")
+        self.assertIn("falsifiable hypothesis set", self.link(3, markdown).shortfall)
+
+    def test_a_manifest_whose_hypothesis_list_is_not_a_list_is_survivable(self) -> None:
+        write_text(self.paths.hypothesis_manifest, json.dumps({"empirical_hypotheses": "H1"}))
+        markdown = typed_stage_02().replace("Stage 02: Hypothesis Generation", "Stage 03: Study Design")
+        self.assertIn("falsifiable hypothesis set", self.link(3, markdown).shortfall)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rubric.py
+++ b/tests/test_rubric.py
@@ -299,10 +299,15 @@ class RubricTestCase(unittest.TestCase):
     def test_criteria_that_cannot_apply_are_not_scored_as_failures(self) -> None:
         """Stage 01 has no experiment manifest to produce and must not be graded as
         if it failed to produce one, or the ratchet would prefer late stages for a
-        reason with nothing to do with their quality."""
+        reason with nothing to do with their quality.
+
+        `artifact_breadth` used to be on this list and is not any more: Stage 01 does
+        have artifacts to produce — `workspace/literature/` is the first line of its
+        prompt's filesystem requirements — and the criterion could not see them.
+        """
         score = score_stage(paths=self.paths, stage=STAGE_01, markdown=stage_markdown(STAGE_01))
         self.assertNotIn("numeric_fidelity", score.by_key)
-        self.assertNotIn("artifact_breadth", score.by_key)
+        self.assertNotIn("quantification", score.by_key)
         self.assertIn("grounding", score.by_key)
 
     def test_weakest_orders_by_recoverable_weight_not_raw_score(self) -> None:

--- a/tests/test_rubric_artifact_kinds.py
+++ b/tests/test_rubric_artifact_kinds.py
@@ -6,10 +6,12 @@ exactly one: `08_dissemination.md` names `{{WORKSPACE_WRITING_DIR}}` alongside t
 `artifacts/` and `reviews/` directories nothing was looking at. So a Stage 08 carrying
 its whole release bundle was measured on the one third of it the criterion could see.
 Replayed against `origin/main@fdded57` with only the bundle written inside the stage
-window, that stage scored **0.333** — *"1 artifact kind(s) written during this stage
-(writing); 3 present overall"* — and drop the summary under `writing/` and it scores
+window, that stage scored **0.333**, and dropping the summary under `writing/` scored
 **0.0** with the shortfall *"Every artifact in the run predates this stage's
-execution"*, which is false: the bundle had been written seconds earlier.
+execution"* — which is false: the bundle had been written seconds earlier. Only the two
+scores are quoted, because this module does not import on main, so the exact `observed`
+transcript cannot be re-derived by anyone reading this later and a quoted one would be
+a claim with no instrument behind it.
 
 Stages 01 and 02 escaped the number and not the consequence. `min_stage` was 3, so
 their drafts were ranked on five criteria worth 11.0 while Stage 03's were ranked on
@@ -124,7 +126,13 @@ class WhatTheCriterionCanSeeTests(ArtifactKindTestCase):
         written *before* the window and left stale: they are the run accumulating,
         not this stage working.
         """
-        write_text(self.paths.results_dir / "metrics.json", json.dumps({"accuracy": 0.5, "f1": 0.6}))
+        # Padded past MIN_ARTIFACT_BYTES on purpose. The obvious two-key payload is 28
+        # bytes, so `results` was never visible at any mtime and the "written before the
+        # window and left stale" half of the docstring described an inert line.
+        write_text(
+            self.paths.results_dir / "metrics.json",
+            json.dumps({"accuracy": 0.5, "f1": 0.6, "seeds": [1, 2, 3], "n": 240}),
+        )
         write_text(self.paths.figures_dir / "effect.png", "x" * 200)
         time.sleep(0.05)
         stage = self.start(8)
@@ -336,14 +344,28 @@ class TheHarnessMustNotEarnTheStageItsScoreTests(ArtifactKindTestCase):
         self.assert_the_harness_earned_nothing(stage, "artifacts", before)
 
     def test_the_comment_ledger_is_not_stage_08s_reviews(self) -> None:
-        """`record_comment_round` closes an anchored-revision round before scoring."""
-        from src.stage_comments import COMMENT_LEDGER_FILENAME
+        """`record_comment_round` closes an anchored-revision round before scoring.
+
+        Driven through the shipped writer, like every other case in this class. It used
+        to hand-place the file, which meant renaming what `record_round` emits would have
+        left this green while quietly reopening the hole the class exists to close.
+        """
+        from src.stage_comments import StageComment, record_round
 
         stage = self.start(8)
         before = self.files_of_kind("reviews")
-        write_text(
-            self.paths.reviews_dir / COMMENT_LEDGER_FILENAME,
-            json.dumps({"rounds": [{"stage": stage.slug, "comments": [{"quote": "x" * 40}]}]}),
+        record_round(
+            self.paths,
+            stage,
+            1,
+            [
+                StageComment(
+                    comment_id="C001",
+                    quote="x" * 40,
+                    comment="The readiness checklist does not name the venue." + "y" * 40,
+                    required_change="Name it." + "z" * 40,
+                )
+            ],
         )
         self.assert_the_harness_earned_nothing(stage, "reviews", before)
 

--- a/tests/test_rubric_artifact_kinds.py
+++ b/tests/test_rubric_artifact_kinds.py
@@ -1,0 +1,806 @@
+"""What `artifact_breadth` can see, and what it must refuse to be paid for.
+
+The criterion read five workspace directories — `data/`, `results/`, `figures/`,
+`code/`, `writing/`. Stages 01 and 02 write to none of them, and Stage 08 writes to
+exactly one: `08_dissemination.md` names `{{WORKSPACE_WRITING_DIR}}` alongside the
+`artifacts/` and `reviews/` directories nothing was looking at. So a Stage 08 carrying
+its whole release bundle was measured on the one third of it the criterion could see.
+Replayed against `origin/main@fdded57` with only the bundle written inside the stage
+window, that stage scored **0.333** — *"1 artifact kind(s) written during this stage
+(writing); 3 present overall"* — and drop the summary under `writing/` and it scores
+**0.0** with the shortfall *"Every artifact in the run predates this stage's
+execution"*, which is false: the bundle had been written seconds earlier.
+
+Stages 01 and 02 escaped the number and not the consequence. `min_stage` was 3, so
+their drafts were ranked on five criteria worth 11.0 while Stage 03's were ranked on
+six worth 13.0, and `StageScore.comparable_to` guards the rubric version and the stage
+slug, not the criterion set. `min_stage` exists for a criterion that *cannot* apply;
+Stage 01 and 02 do produce artifacts, so this was not one.
+
+Widening what the criterion reads opens the failure `is_autor_own_record` was written
+for, in four new directories: AutoR itself writes into `notes/`, `artifacts/` and
+`reviews/` inside a stage's own execution window and *before* the draft is scored. A
+criterion that pays a stage for the harness's files measures the harness. Each writer
+below is driven for real, and `TheCensusOfWhoWritesUnderAGradedDirectoryTests` refuses
+a path in `src/` that nobody has classified.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from src.rubric import (
+    CRITERIA,
+    MIN_ARTIFACT_BYTES,
+    STAGE_ARTIFACT_KINDS,
+    _ARTIFACT_KIND_SUFFIXES,
+    _artifact_kind_dirs,
+    _fresh_artifact_kinds,
+    _harness_written_records,
+    _score_artifact_breadth,
+    expected_artifact_kinds,
+    score_stage,
+)
+from src.utils import (
+    STAGES,
+    StageSpec,
+    build_run_paths,
+    ensure_run_config,
+    ensure_run_layout,
+    format_stage_template,
+    load_prompt_template,
+    mark_stage_execution_started,
+    write_text,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+PROMPT_DIR = REPO / "src" / "prompts"
+STAGE = {stage.number: stage for stage in STAGES}
+
+
+def stage_markdown(stage: StageSpec, *, files: str = "- `workspace/notes/plan.md`") -> str:
+    return (
+        f"# {stage.stage_title}\n\n"
+        "## Objective\n\nPrepare the outputs this stage owes.\n\n"
+        "## Previously Approved Stage Summaries\n\nNone yet.\n\n"
+        "## What I Did\n\nWrote the files listed below.\n\n"
+        "## Key Results\n\nThe bundle is complete.\n\n"
+        f"## Files Produced\n\n{files}\n\n"
+        "## Decision Ledger\n\n"
+        "- Open Questions: whether the poster needs a second figure.\n"
+        "- Locked Decisions: the release notes name the refuted hypothesis.\n"
+        "- Assumptions: the manuscript is final at this revision.\n"
+        "- Rejected Alternatives: a press release, which overstates one run.\n"
+        "## Suggestions for Refinement\n\n1. a\n2. b\n3. c\n\n"
+        "## Your Options\n\n"
+        "1. Use suggestion 1\n2. Use suggestion 2\n3. Use suggestion 3\n"
+        "4. Refine with your own feedback\n5. Approve and continue\n6. Abort\n"
+    )
+
+
+class ArtifactKindTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    def start(self, number: int) -> StageSpec:
+        """Open a stage's execution window, so what follows is written inside it."""
+        stage = STAGE[number]
+        mark_stage_execution_started(self.paths, stage)
+        # The freshness cutoff is a marker file's mtime, at whatever resolution the
+        # filesystem keeps. Without this, a file written in the same tick as the
+        # marker is fresh or stale by luck.
+        time.sleep(0.02)
+        return stage
+
+    def breadth(self, stage: StageSpec):
+        return _score_artifact_breadth(self.paths, stage, None)
+
+    def files_of_kind(self, kind: str) -> set[Path]:
+        return {
+            path
+            for directory in _artifact_kind_dirs(self.paths, None)[kind]
+            for path in directory.rglob("*")
+            if path.is_file()
+        }
+
+
+class WhatTheCriterionCanSeeTests(ArtifactKindTestCase):
+    def test_stage_08_is_measured_on_the_bundle_it_actually_wrote(self) -> None:
+        """The regression, end to end.
+
+        Replayed against `origin/main@fdded57`, this exact tree scores **0.333** —
+        `artifacts/` and `reviews/` were invisible, so two thirds of the bundle did
+        not exist as far as the criterion was concerned, and only the summary under
+        `writing/` counted. The `results/` and `figures/` files are deliberately
+        written *before* the window and left stale: they are the run accumulating,
+        not this stage working.
+        """
+        write_text(self.paths.results_dir / "metrics.json", json.dumps({"accuracy": 0.5, "f1": 0.6}))
+        write_text(self.paths.figures_dir / "effect.png", "x" * 200)
+        time.sleep(0.05)
+        stage = self.start(8)
+        write_text(self.paths.reviews_dir / "readiness_checklist.md", "# Readiness\n" + "x" * 200)
+        write_text(self.paths.artifacts_dir / "release_notes.md", "# Release\n" + "x" * 200)
+        write_text(self.paths.writing_dir / "external_summary.md", "# Summary\n" + "x" * 200)
+
+        score = self.breadth(stage)
+        self.assertEqual(score.score, 1.0)
+        self.assertEqual(score.shortfall, "")
+        self.assertIn("artifacts", score.observed)
+        self.assertIn("reviews", score.observed)
+
+    def test_a_stage_that_produced_something_is_not_told_it_produced_nothing(self) -> None:
+        """The false shortfall, on its own.
+
+        `predates this stage's execution` is a claim about the run, and it was being
+        made to a stage whose output was on disk with a fresh mtime.
+        """
+        write_text(self.paths.results_dir / "metrics.json", json.dumps({"a": 0.5}))
+        stage = self.start(8)
+        write_text(self.paths.reviews_dir / "readiness_checklist.md", "# Readiness\n" + "x" * 200)
+
+        score = self.breadth(stage)
+        self.assertGreater(score.score, 0.0)
+        self.assertNotIn("predates", score.shortfall)
+        self.assertIn("workspace/artifacts/", score.shortfall)
+        self.assertIn("workspace/writing/", score.shortfall)
+
+    def test_the_predates_shortfall_survives_for_the_stage_it_is_true_of(self) -> None:
+        """The control. It was the *wrong* diagnosis, not a wrong message."""
+        write_text(self.paths.artifacts_dir / "release_notes.md", "# Release\n" + "x" * 200)
+        time.sleep(0.02)
+        stage = self.start(8)
+
+        score = self.breadth(stage)
+        self.assertEqual(score.score, 0.0)
+        self.assertIn("predates", score.shortfall)
+
+    def test_stage_01_is_scored_on_its_literature_directory(self) -> None:
+        stage = self.start(1)
+        write_text(
+            self.paths.literature_dir / "sources.json",
+            json.dumps({"sources": [{"source_id": "s1", "title": "A long enough title"}]}),
+        )
+        score = self.breadth(stage)
+        self.assertEqual(score.score, 1.0)
+
+    def test_stage_01_and_02_face_the_same_criteria_as_the_first_stage_that_did(self) -> None:
+        """`min_stage=3` made an early draft's total a different measurement.
+
+        Asserted as a relation between the three stages rather than as a count, so it
+        stays true when a criterion is added. `quantification` and `numeric_fidelity`
+        still do not reach Stage 01 — those are the two `min_stage` exists for, since
+        Stage 01 has no Key Results to quantify and no results file to trace to.
+        `artifact_breadth` was never in that category: Stage 01 writes `literature/`.
+        """
+        applicable = {
+            number: frozenset(c.key for c in CRITERIA if c.applies_to(STAGE[number]))
+            for number in (1, 2, 3)
+        }
+        self.assertEqual(applicable[1], applicable[3], "Stage 01 is graded on a different set")
+        self.assertEqual(applicable[2], applicable[3], "Stage 02 is graded on a different set")
+        self.assertIn("artifact_breadth", applicable[1])
+
+        for number in (1, 2):
+            score = score_stage(
+                paths=self.paths, stage=STAGE[number], markdown=stage_markdown(STAGE[number])
+            )
+            self.assertIn("artifact_breadth", score.by_key, msg=f"stage {number:02d}")
+
+    def test_a_stage_cannot_climb_by_writing_more_of_the_kind_it_already_had(self) -> None:
+        stage = self.start(6)
+        write_text(self.paths.figures_dir / "one.png", "x" * 200)
+        one = self.breadth(stage).score
+        for index in range(2, 8):
+            write_text(self.paths.figures_dir / f"more_{index}.png", "x" * 200)
+        self.assertEqual(self.breadth(stage).score, one)
+
+    def test_a_kind_the_stage_was_never_asked_for_earns_nothing(self) -> None:
+        """Scored against the expected set, not against a count of any kinds at all.
+
+        Measured against `origin/main@fdded57`: this tree — a Stage 06 that wrote code
+        and notes and no figures — scored 0.333, collecting one of its three for
+        `code/`, which the analysis stage does not owe. `notes/` was invisible then.
+        The analysis stage owes figures and results, so it now earns neither.
+        """
+        stage = self.start(6)
+        write_text(self.paths.code_dir / "plot.py", "print('x')\n" * 5)
+        write_text(self.paths.notes_dir / "analysis.md", "# Analysis\n" + "x" * 200)
+        score = self.breadth(stage)
+        self.assertEqual(score.score, 0.0)
+        self.assertIn("workspace/figures/", score.shortfall)
+        self.assertIn("workspace/results/", score.shortfall)
+
+    def test_a_stage_nobody_declared_kinds_for_is_not_scored_as_a_failure(self) -> None:
+        """The same rule as `min_stage`: an expectation nobody wrote is not a failure."""
+        invented = StageSpec(9, "09_invented", "Invented Stage")
+        self.assertEqual(expected_artifact_kinds(invented), frozenset())
+        self.assertEqual(self.breadth(invented).score, 1.0)
+
+
+class TheHarnessMustNotEarnTheStageItsScoreTests(ArtifactKindTestCase):
+    """AutoR's own writes into the four directories this criterion now reads.
+
+    Each case drives the shipped writer rather than hand-placing a file, so renaming
+    what a writer emits breaks the test instead of silently reopening the hole. Each
+    also asserts, *before* looking at the score, that the writer left behind a file the
+    criterion would otherwise have paid for — right directory, readable suffix, over
+    `MIN_ARTIFACT_BYTES`. Without that the exclusion could be doing nothing and every
+    test here would still pass, on a writer that wrote nothing.
+    """
+
+    def assert_the_harness_earned_nothing(self, stage: StageSpec, kind: str, before: set[Path]):
+        """Something countable was written, and the stage was not credited for it."""
+        allowed = _ARTIFACT_KIND_SUFFIXES[kind]
+        produced = sorted(self.files_of_kind(kind) - before)
+        countable = [
+            path
+            for path in produced
+            if path.suffix.lower() in allowed and path.stat().st_size >= MIN_ARTIFACT_BYTES
+        ]
+        self.assertTrue(
+            countable,
+            f"the writer left nothing this criterion could have paid for: {produced}",
+        )
+        _, fresh = _fresh_artifact_kinds(self.paths, stage, None)
+        self.assertNotIn(
+            kind,
+            fresh,
+            f"{kind} was earned by {[p.name for p in countable]}, which AutoR wrote",
+        )
+        self.assertEqual(self.breadth(stage).score, 0.0)
+        return countable
+
+    def panel_deliberation(self, stage: StageSpec, attempt_no: int):
+        from src.review_panel import PanelDeliberation, PanelVerdict
+
+        verdict = PanelVerdict(
+            role_key="pi",
+            role_title="Principal Investigator",
+            backend="claude",
+            model="sonnet",
+            choice="5",
+            decision_token="approve",
+            blocking=False,
+            reason="The release bundle matches what the stage committed to.",
+            feedback="",
+            concerns=("the second figure may be redundant",),
+        )
+        return PanelDeliberation(
+            stage_slug=stage.slug, attempt_no=attempt_no, rounds=[[verdict]], chair_key="pi"
+        )
+
+    def test_a_record_artifact_under_notes_is_still_not_the_stages_output(self) -> None:
+        """`RECORD_ARTIFACTS` puts six files under `notes/` and two under `results/`.
+
+        Stage 02's own `hypothesis_manifest.json` is one of them, and `reproducibility`
+        already grades the hypothesis set — paying `artifact_breadth` for the same file
+        would credit one artifact twice.
+        """
+        from src.experiment_manifest import RECORD_ARTIFACTS
+
+        self.assertEqual(
+            sorted(str(item).split("/")[0] for item in RECORD_ARTIFACTS).count("notes"), 6
+        )
+        stage = self.start(2)
+        write_text(
+            self.paths.hypothesis_manifest,
+            json.dumps({"empirical_hypotheses": [{"id": "H1", "decision_rule": "r"}]}),
+        )
+        write_text(self.paths.report_plan, json.dumps({"slots": []}))
+        write_text(self.paths.experimental_protocol, json.dumps({"baselines": []}))
+        _, fresh = _fresh_artifact_kinds(self.paths, stage, None)
+        self.assertNotIn("notes", fresh)
+        self.assertEqual(self.breadth(stage).score, 0.0)
+
+    def test_the_ideation_pool_the_panel_writes_is_not_stage_02s_notes(self) -> None:
+        """`record_idea_pool` runs while the Stage 02 *prompt* is being built."""
+        from src.ideation_panel import IdeaPool, record_idea_pool
+
+        stage = self.start(2)
+        before = self.files_of_kind("notes")
+        record_idea_pool(self.paths, IdeaPool(candidates=[]), stage, 1)
+        self.assert_the_harness_earned_nothing(stage, "notes", before)
+
+    def test_the_writing_triage_the_manager_generates_is_not_stage_07s_artifacts(self) -> None:
+        """`07_writing.md` tells the agent this file is "generated for you ... read it,
+        do not write it". A criterion that pays for it pays the workflow manager."""
+        from src.writing_manifest import generate_report_review
+
+        stage = self.start(7)
+        before = self.files_of_kind("artifacts")
+        generate_report_review(self.paths)
+        self.assert_the_harness_earned_nothing(stage, "artifacts", before)
+
+    def test_the_layout_triage_the_manager_generates_is_not_stage_07s_artifacts(self) -> None:
+        """The LaTeX half of the same pair, and the live path for a LaTeX run.
+
+        `generate_report_review` covers markdown output and `generate_layout_review`
+        covers LaTeX; the manager calls whichever the run's format selects, so pinning
+        only one leaves the other exclusion held by nothing at all.
+        """
+        from src.writing_manifest import generate_layout_review
+
+        stage = self.start(7)
+        before = self.files_of_kind("artifacts")
+        generate_layout_review(self.paths)
+        self.assert_the_harness_earned_nothing(stage, "artifacts", before)
+
+    def test_the_comment_ledger_is_not_stage_08s_reviews(self) -> None:
+        """`record_comment_round` closes an anchored-revision round before scoring."""
+        from src.stage_comments import COMMENT_LEDGER_FILENAME
+
+        stage = self.start(8)
+        before = self.files_of_kind("reviews")
+        write_text(
+            self.paths.reviews_dir / COMMENT_LEDGER_FILENAME,
+            json.dumps({"rounds": [{"stage": stage.slug, "comments": [{"quote": "x" * 40}]}]}),
+        )
+        self.assert_the_harness_earned_nothing(stage, "reviews", before)
+
+    def test_the_panel_transcripts_are_not_stage_08s_reviews(self) -> None:
+        """`ReviewPanel._record` writes one transcript pair per stage per attempt.
+
+        It runs from `_collect_review_decision`, which is *after* attempt N is scored
+        and therefore before attempt N+1 is. Excluded as a subtree rather than by name
+        because the names carry the attempt number, so listing them would leak every
+        attempt after the one that was listed.
+        """
+        from src.review_panel import ReviewPanel
+
+        stage = self.start(8)
+        before = self.files_of_kind("reviews")
+        panel = ReviewPanel(backend_name="claude", model="sonnet", fake_mode=True)
+        panel._record(self.paths, self.panel_deliberation(stage, 2))
+        written = self.assert_the_harness_earned_nothing(stage, "reviews", before)
+        self.assertTrue(
+            any(path.name.endswith("_attempt_02.json") for path in written),
+            f"the panel wrote no per-attempt transcript: {[p.name for p in written]}",
+        )
+
+    def test_the_panel_effect_ledger_is_not_stage_08s_reviews(self) -> None:
+        """The least flattering file the panel writes about itself is still its own."""
+        from src.review_panel import record_panel_effect
+
+        stage = self.start(8)
+        before = self.files_of_kind("reviews")
+        record_panel_effect(self.paths, self.panel_deliberation(stage, 1))
+        self.assert_the_harness_earned_nothing(stage, "reviews", before)
+
+    def test_the_effort_ledger_is_not_stage_08s_reviews(self) -> None:
+        """`_note_effort_failure` writes it on the branch where the panel refused."""
+        from src.effort import EffortPlan, record_plan
+
+        stage = self.start(8)
+        before = self.files_of_kind("reviews")
+        record_plan(self.paths, EffortPlan(enabled=True))
+        self.assert_the_harness_earned_nothing(stage, "reviews", before)
+
+    def test_the_deliberation_ledger_is_not_stage_08s_reviews(self) -> None:
+        """`_settle_cruxes` writes it one statement above the call that scores."""
+        from src.deliberation import Position, Resolution, parse_requests, record_resolution
+
+        stage = self.start(8)
+        before = self.files_of_kind("reviews")
+        request = parse_requests(
+            {
+                "question": "Should the control arm be matched on age?",
+                "why_it_matters": "Every downstream estimate is conditioned on it.",
+                "already_considered": ["stratifying instead"],
+                "working_answer": "match on age",
+                "help_wanted": "both",
+            },
+            stage=stage,
+        )[0]
+        record_resolution(
+            self.paths,
+            stage,
+            Resolution(
+                request=request,
+                positions=[
+                    Position(
+                        voice="theorist",
+                        title="Theorist",
+                        backend="claude",
+                        model="sonnet",
+                        answer="Match, and report the unmatched estimate beside it.",
+                    )
+                ],
+                answer="Match, and report the unmatched estimate beside it.",
+                reason="The unmatched estimate is the sensitivity check.",
+                falsifier="A matched and an unmatched estimate that disagree in sign.",
+                dissent="",
+                voice_calls=3,
+                changed_the_answer=True,
+            ),
+        )
+        self.assert_the_harness_earned_nothing(stage, "reviews", before)
+
+    def test_the_scorecard_is_not_stage_08s_reviews(self) -> None:
+        """Excluded on ownership rather than on ordering.
+
+        `_report_optional_machinery` currently runs from `_complete_run`, after the
+        last score of the walk. That ordering is not the scorecard's to keep — a
+        resumed run re-opens a stage window with this file already on disk — and the
+        run's summary of its own optional features was never Stage 08's output.
+        """
+        from src.scorecard import write_scorecard
+
+        stage = self.start(8)
+        before = self.files_of_kind("reviews")
+        write_scorecard(self.paths, "standard")
+        self.assert_the_harness_earned_nothing(stage, "reviews", before)
+
+    def test_the_validity_review_is_not_the_reviewed_stages_reviews(self) -> None:
+        """The adversarial reviewer's findings are *about* the stage, not by it."""
+        from src.validity_review import ValidityFinding, ValidityReviewer
+
+        stage = self.start(8)
+        before = self.files_of_kind("reviews")
+        ValidityReviewer(operator=None)._write_review(
+            self.paths,
+            stage,
+            [
+                ValidityFinding(
+                    identifier="V1",
+                    category="confounding",
+                    severity="major",
+                    finding="The control arm is not matched on age.",
+                    why_it_matters="Every downstream estimate is conditioned on it.",
+                    what_would_settle_it="A matched and an unmatched estimate, side by side.",
+                )
+            ],
+            note="one finding",
+        )
+        self.assert_the_harness_earned_nothing(stage, "reviews", before)
+
+    def test_the_stages_own_review_asset_beside_the_ledger_still_counts(self) -> None:
+        """The control, so the exclusion cannot over-broaden into dropping output.
+
+        Every AutoR write the class above drives is in this tree at once, and the one
+        file the *stage* wrote still earns the kind on its own.
+        """
+        from src.effort import EffortPlan, record_plan
+        from src.review_panel import record_panel_effect
+        from src.scorecard import write_scorecard
+        from src.stage_comments import COMMENT_LEDGER_FILENAME
+
+        stage = self.start(8)
+        write_text(self.paths.reviews_dir / COMMENT_LEDGER_FILENAME, json.dumps({"rounds": []}))
+        record_plan(self.paths, EffortPlan(enabled=True))
+        record_panel_effect(self.paths, self.panel_deliberation(stage, 1))
+        write_scorecard(self.paths, "standard")
+        _, without = _fresh_artifact_kinds(self.paths, stage, None)
+        self.assertNotIn("reviews", without)
+
+        write_text(self.paths.reviews_dir / "readiness_checklist.md", "# Readiness\n" + "x" * 200)
+        _, fresh = _fresh_artifact_kinds(self.paths, stage, None)
+        self.assertIn("reviews", fresh)
+
+    def test_the_agents_answer_to_the_review_is_the_agents(self) -> None:
+        """`validity_response_<stage>.json` sits beside `validity_review_<stage>.json`.
+
+        One is written by the reviewer and one by the stage answering it. An exclusion
+        that globbed `validity_*` would take both and silently drop real output.
+        """
+        from src.validity_review import validity_response_path
+
+        stage = self.start(6)
+        write_text(
+            validity_response_path(self.paths, "05_experimentation"),
+            json.dumps({"responses": [{"id": "V1", "answer": "Matched; both estimates shipped."}]}),
+        )
+        self.assertFalse(_harness_written_records(self.paths).covers(
+            validity_response_path(self.paths, "05_experimentation")
+        ))
+
+
+# ---------------------------------------------------------------------------
+# The census
+# ---------------------------------------------------------------------------
+
+#: Directory attributes on ``RunPaths`` that ``artifact_breadth`` now reads and that
+#: ``RECORD_ARTIFACTS`` does not already cover. ``data``/``results``/``figures``/
+#: ``code``/``writing`` are excluded: the criterion read them before this change and
+#: the experiment bundle's own exclusion list is what guards them.
+GRADED_DIR_ATTRS = {
+    "literature_dir": "literature",
+    "notes_dir": "notes",
+    "artifacts_dir": "artifacts",
+    "reviews_dir": "reviews",
+}
+
+#: What the scan prints where a path segment is built at runtime.
+DYNAMIC = "{*}"
+
+#: Who owns every ``<paths>.<graded>_dir / <name>`` expression in ``src/``.
+#:
+#: ``harness`` — AutoR's own machinery writes it, so ``_harness_written_records`` must
+#: hide it from ``artifact_breadth``. ``agent`` — the run produced it, or nothing in
+#: ``src/`` writes it at all, and the criterion is supposed to see it if it appears.
+#: The third column is a concrete relative path to assert against, needed only where
+#: the scan found a name assembled at runtime.
+#:
+#: This table is the point of the census. A new file under a graded directory forces
+#: the ownership call in the same commit that adds it, instead of arriving as a free
+#: artifact kind nobody noticed — which is exactly how five of the entries below were
+#: missing when this criterion first learned to read ``reviews/``.
+PATH_OWNERS: tuple[tuple[str, str, str], ...] = (
+    # -- the harness's own bookkeeping ------------------------------------------
+    ("artifacts/layout_review.json", "harness", ""),
+    ("artifacts/report_review.json", "harness", ""),
+    # `_load_review_summary(paths, filename)` reads one of the two above.
+    ("artifacts/{*}", "harness", "artifacts/report_review.json"),
+    ("notes/idea_pool.json", "harness", ""),
+    ("notes/idea_pool.md", "harness", ""),
+    ("reviews/comment_ledger.json", "harness", ""),
+    ("reviews/deliberations.json", "harness", ""),
+    ("reviews/effort.json", "harness", ""),
+    ("reviews/panel", "harness", "reviews/panel/08_dissemination_attempt_02.json"),
+    ("reviews/panel/panel_effect.json", "harness", ""),
+    ("reviews/scorecard.json", "harness", ""),
+    ("reviews/scorecard.md", "harness", ""),
+    ("reviews/validity_review_{*}.json", "harness", "reviews/validity_review_06_analysis.json"),
+    # -- the run's own output ----------------------------------------------------
+    ("artifacts/build.log", "agent", ""),
+    ("artifacts/build_log.txt", "agent", ""),
+    ("artifacts/citation_verification.json", "agent", ""),
+    ("artifacts/deliverables_coverage.json", "agent", ""),
+    ("artifacts/paper.pdf", "agent", ""),
+    ("artifacts/paper_package", "agent", ""),
+    ("artifacts/paper_package/build.log", "agent", ""),
+    ("artifacts/paper_package/paper.pdf", "agent", ""),
+    ("artifacts/release_package", "agent", ""),
+    ("artifacts/self_review.json", "agent", ""),
+    ("literature/claims.json", "agent", ""),
+    ("literature/sources.json", "agent", ""),
+    # Written by `--fake-operator`, which stands in for the agent. Excluding these
+    # would make a scripted run score differently from the real one it simulates.
+    ("notes/autor_intro.md", "agent", ""),
+    ("notes/{*}_fake_operator_note.md", "agent", "notes/03_study_design_fake_operator_note.md"),
+    ("notes/deliberation_request.json", "agent", ""),
+    ("notes/hypotheses.md", "agent", ""),
+    ("reviews/readiness_review.json", "agent", ""),
+    ("reviews/release_package", "agent", ""),
+    ("reviews/validity_response_{*}.json", "agent", "reviews/validity_response_05_experimentation.json"),
+    # `settled_reasoning.rejected_candidates` reads the ideation pool from `reviews/`
+    # while `record_idea_pool` writes it to `notes/`, so nothing in the tree produces
+    # this path. Recorded rather than repaired: the reader is a separate defect and
+    # this census says where a name is addressed, not whether the address is right.
+    ("reviews/idea_pool.json", "agent", ""),
+)
+
+
+def _string_constants(tree: ast.Module) -> dict[str, str]:
+    """Module-level ``NAME = "literal"`` bindings, which is how filenames are declared."""
+    constants: dict[str, str] = {}
+    for node in tree.body:
+        target: ast.expr | None = None
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign):
+            target, value = node.target, node.value
+        if (
+            isinstance(target, ast.Name)
+            and isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+        ):
+            constants[target.id] = value.value
+    return constants
+
+
+def _imported_constants(tree: ast.Module) -> dict[str, str]:
+    """Follow ``from .effort import LEDGER_FILENAME as EFFORT_FILENAME`` one hop.
+
+    One hop is enough because every filename in this repo is declared at the module
+    that writes it, and an alias that resolves to nothing simply reads as dynamic —
+    which the table then has to declare explicitly rather than silently skip.
+    """
+    resolved: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.level == 0 or not node.module:
+            continue
+        source = REPO / "src" / (node.module.replace(".", "/") + ".py")
+        if not source.is_file():
+            continue
+        origin = _string_constants(ast.parse(source.read_text(encoding="utf-8")))
+        for alias in node.names:
+            if alias.name in origin:
+                resolved[alias.asname or alias.name] = origin[alias.name]
+    return resolved
+
+
+def _segment(node: ast.expr, names: dict[str, str]) -> str:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return names.get(node.id, DYNAMIC)
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            part.value if isinstance(part, ast.Constant) else DYNAMIC for part in node.values
+        )
+    return DYNAMIC
+
+
+def census_of_graded_paths() -> dict[str, list[str]]:
+    """Every path expression in ``src/`` rooted at a graded directory, and where it is.
+
+    Read off the syntax rather than off a list of writers, because the thing that goes
+    wrong is a writer nobody remembered. Reads are included as well as writes: telling
+    them apart statically is unreliable, and a read is the cheapest evidence that a
+    name exists at all.
+    """
+    found: dict[str, list[str]] = {}
+    for path in sorted((REPO / "src").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        names = {**_imported_constants(tree), **_string_constants(tree)}
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div)):
+                continue
+            segments = [node.right]
+            base = node.left
+            while isinstance(base, ast.BinOp) and isinstance(base.op, ast.Div):
+                segments.insert(0, base.right)
+                base = base.left
+            if not (isinstance(base, ast.Attribute) and base.attr in GRADED_DIR_ATTRS):
+                continue
+            key = "/".join(
+                [GRADED_DIR_ATTRS[base.attr]] + [_segment(item, names) for item in segments]
+            )
+            found.setdefault(key, []).append(f"{path.relative_to(REPO)}:{node.lineno}")
+    return found
+
+
+class TheCensusOfWhoWritesUnderAGradedDirectoryTests(unittest.TestCase):
+    """The exclusion list was incomplete, and nothing could have said so.
+
+    `_harness_written_records` is a list someone has to remember to extend. This class
+    is the thing that remembers: it re-derives, from `src/` itself, every name addressed
+    under a directory `artifact_breadth` grades, and refuses one that `PATH_OWNERS` has
+    not classified — in either direction, so an over-broad exclusion that swallows the
+    run's own output fails here too.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run_0001")
+
+    def sample_path(self, key: str, sample: str) -> Path:
+        return self.paths.run_root / "workspace" / (sample or key)
+
+    def test_every_path_under_a_graded_directory_has_a_declared_owner(self) -> None:
+        found = census_of_graded_paths()
+        declared = {key for key, _, _ in PATH_OWNERS}
+
+        undeclared = sorted(set(found) - declared)
+        self.assertEqual(
+            undeclared,
+            [],
+            "\n".join(
+                f"{key} is addressed at {', '.join(sorted(set(found[key])))} and PATH_OWNERS "
+                "does not say whether AutoR or the run writes it"
+                for key in undeclared
+            ),
+        )
+        stale = sorted(declared - set(found))
+        self.assertEqual(stale, [], f"PATH_OWNERS names paths nothing addresses: {stale}")
+
+    def test_every_harness_path_is_hidden_and_every_agent_path_is_not(self) -> None:
+        harness = _harness_written_records(self.paths)
+        for key, owner, sample in PATH_OWNERS:
+            with self.subTest(path=key):
+                covered = harness.covers(self.sample_path(key, sample))
+                if owner == "harness":
+                    self.assertTrue(
+                        covered,
+                        f"{key} is AutoR's own record and artifact_breadth would pay a stage "
+                        "for it",
+                    )
+                else:
+                    self.assertFalse(
+                        covered,
+                        f"{key} is the run's output and the exclusion has swallowed it",
+                    )
+
+    def test_the_census_finds_the_writers_this_class_exists_for(self) -> None:
+        """A scan that resolved nothing would pass every assertion above vacuously."""
+        found = census_of_graded_paths()
+        for key in (
+            "reviews/effort.json",
+            "reviews/deliberations.json",
+            "reviews/scorecard.json",
+            "reviews/panel",
+            "notes/idea_pool.json",
+            "artifacts/layout_review.json",
+        ):
+            self.assertIn(key, found, "the scan stopped resolving module constants")
+        self.assertIn(
+            "src/effort.py",
+            " ".join(found["reviews/effort.json"]),
+            "the scan no longer reaches the module that writes the effort ledger",
+        )
+        self.assertLess(
+            sum(1 for key in found if DYNAMIC in key),
+            len(found) / 2,
+            "over half the scan is unresolved; the resolver has stopped working",
+        )
+
+
+class TheExpectationComesFromTheStagesOwnPromptTests(ArtifactKindTestCase):
+    """A rubric may not ask for work the run was never told to do.
+
+    Re-derived rather than reviewed: the prompt is rendered with this run's real paths
+    and a kind counts as "asked for" when the directory it reads appears in the
+    rendered text. No hand-written map of placeholders to kinds sits between the two,
+    so a prompt that stops naming a directory fails here.
+    """
+
+    def rendered_prompt(self, stage: StageSpec) -> str:
+        ensure_run_config(self.paths)
+        texts = []
+        for output_format in (None, "markdown", "latex"):
+            template = load_prompt_template(PROMPT_DIR, stage, output_format)
+            texts.append(format_stage_template(template, stage, self.paths))
+        return "\n".join(texts)
+
+    def kinds_named_by(self, stage: StageSpec) -> set[str]:
+        text = self.rendered_prompt(stage)
+        return {
+            kind
+            for kind, directories in _artifact_kind_dirs(self.paths, None).items()
+            if any(str(directory.resolve()) in text for directory in directories)
+        }
+
+    def test_every_expected_kind_is_a_directory_the_stages_prompt_names(self) -> None:
+        for number, expected in sorted(STAGE_ARTIFACT_KINDS.items()):
+            named = self.kinds_named_by(STAGE[number])
+            self.assertLessEqual(
+                expected,
+                named,
+                msg=(
+                    f"stage {number:02d} is graded on {sorted(expected - named)}, which its "
+                    f"prompt never asks for; it names {sorted(named)}"
+                ),
+            )
+
+    def test_stage_08_was_always_writing_to_one_of_the_five_old_directories(self) -> None:
+        """The premise, stated precisely: 08 was half-visible, not invisible.
+
+        `08_dissemination.md` names the writing directory as well as `artifacts/` and
+        `reviews/`, so the criterion could see one third of what the stage produces.
+        The module docstring says so, and this is the assertion behind that sentence.
+        """
+        named = self.kinds_named_by(STAGE[8])
+        self.assertEqual(named & {"data", "results", "figures", "code", "writing"}, {"writing"})
+        self.assertEqual(self.kinds_named_by(STAGE[1]) & {"data", "results", "figures", "code", "writing"}, set())
+        self.assertEqual(self.kinds_named_by(STAGE[2]) & {"data", "results", "figures", "code", "writing"}, set())
+
+    def test_study_design_is_not_asked_for_code(self) -> None:
+        """The one place the obvious grouping is wrong.
+
+        `03_study_design.md` names the data and notes directories and never the code
+        directory — implementation is Stage 04's job — so expecting `code` at 03 would
+        dock a compliant design stage a third of the criterion and send its polish
+        round after code it should not write.
+        """
+        self.assertNotIn("code", expected_artifact_kinds(STAGE[3]))
+        self.assertNotIn("code", self.kinds_named_by(STAGE[3]))
+        self.assertIn("code", expected_artifact_kinds(STAGE[4]))
+
+    def test_every_stage_of_the_graph_declares_an_expectation(self) -> None:
+        self.assertEqual(sorted(STAGE_ARTIFACT_KINDS), [stage.number for stage in STAGES])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Both are the defect this branch exists to prevent, committed by the branch itself.

**A fixture line that did nothing.** `results/metrics.json` was
`json.dumps({"accuracy": 0.5, "f1": 0.6})` — 28 bytes, under `MIN_ARTIFACT_BYTES = 32`,
so `results` was invisible at any mtime. The docstring's "the `results/` and `figures/`
files are deliberately written *before* the window and left stale" was therefore half a
description of an inert line, and the quoted transcript said "3 present overall" where
the shipped fixture produced two. Padded to 58 bytes, measured.

**A transcript nobody can re-derive.** The module quoted main's exact `observed` string.
This module does not import on main — it needs `STAGE_ARTIFACT_KINDS` and
`_harness_written_records`, neither of which exists there — so no reader can reproduce
that string. The two scores survive, because those were reproduced; the transcript is
gone rather than restated.

**A class docstring that was false of one of its ten cases.**
`TheHarnessMustNotEarnTheStageItsScoreTests` promises "each case drives the shipped
writer rather than hand-placing a file, so renaming what a writer emits breaks the test
instead of silently reopening the hole".
`test_the_comment_ledger_is_not_stage_08s_reviews` hand-placed the file and never called
`stage_comments.record_round`. It drives the writer now.

Mutation, on the promise rather than on the code: renaming `COMMENT_LEDGER_FILENAME`
fails two tests. Before this commit that rename left the comment-ledger case green,
which is exactly the silent reopening the docstring claimed was impossible.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Two defects in the rubric, one version bump, because either one alone changes
what an archived total means.

**`artifact_breadth` was grading Stages 01, 02 and 08 on a fraction of what they
produce.** Its kind map read five directories — `data/`, `results/`, `figures/`,
`code/`, `writing/`. Stages 01 and 02 write to none of them and Stage 08 writes to
exactly one: `08_dissemination.md` names `{{WORKSPACE_WRITING_DIR}}` alongside the
`artifacts/` and `reviews/` directories nothing was looking at. Replayed against
`origin/main@fdded57`, a Stage 08 that wrote `reviews/readiness_checklist.md`,
`artifacts/release_notes.md` and `writing/external_summary.md` inside its own window,
over a run whose earlier `results/` and `figures/` were already stale:

    present=['figures', 'results', 'writing'] fresh=['writing'] score=0.3333
      observed : 1 artifact kind(s) written during this stage (writing); 3 present overall
      shortfall: Only 1 of an expected 3 artifact kinds were written here. Add the
                 missing machine-readable outputs (data, results, figures, code) ...

Drop the one file that happened to land under `writing/` and the same tree scores
`0.0` and is told *"Every artifact in the run predates this stage's execution"* —
false, the bundle was seconds old. Both trees are the fixtures in
`tests/test_rubric_artifact_kinds.py`, and the criterion is worth 2.0 of the 18 the
champion ratchet promotes on.

Stages 01 and 02 escaped the number and not the consequence. `min_stage` was 3, so
their drafts were ranked on five criteria worth 11.0 while Stage 03's were ranked on
six worth 13.0, and `StageScore.comparable_to` guards the rubric version and the
stage slug, not the criterion set. Measured off `CRITERIA`, both trees:

    origin/main@fdded57   stage 1: 5 criteria, 11    stage 3: 6 criteria, 13
    this branch           stage 1: 6 criteria, 13    stage 3: 6 criteria, 13

`min_stage` exists for a criterion that *cannot* apply — Stage 01 has no Key Results
to quantify and no results file to trace to, which is why `quantification` and
`numeric_fidelity` still do not reach it. Stage 01 does produce `literature/`, so
`artifact_breadth` was never in that category.

`literature`, `notes`, `artifacts` and `reviews` are now kinds, `min_stage` is 1, and
the expectation is per-stage (`STAGE_ARTIFACT_KINDS`) instead of "any two, or any
three from 05". Every kind a stage is graded on is a directory that stage's own prompt
tells the agent to write: the test renders each prompt with a real run's paths and
refuses an expectation the prompt never asked for. That is why Stage 03 expects `data`
and `notes` and not `code` — `03_study_design.md` names the data and notes directories
and never the code one, and expecting `code` there would dock a compliant design stage
a third of the criterion and send its polish round after code Stage 04 is to write.

The old count was wrong in the other direction too. Replayed against
`origin/main@fdded57`, a Stage 06 that wrote `code/` and `notes/` and no figures
scored `0.333` — `present=['code'] fresh=['code']` — collecting one of its three for a
kind the analysis stage does not owe. It now earns neither of the two it does.

**AutoR's own writes into those directories.** Widening what the criterion reads
reopens the hole `is_autor_own_record` exists for, in four new directories.
`RECORD_ARTIFACTS` covers the experiment bundle — measured, `len()` is 8: six files
under `notes/` and two under `results/` — and these are not in it. Each was driven for
real against the branch as first written, one at a time, into an otherwise empty tree
with nothing the agent produced:

    stage 08 reviews  0.333 -> 0.000   ReviewPanel._record        reviews/panel/<slug>_attempt_NN.{json,md}
    stage 08 reviews  0.333 -> 0.000   record_panel_effect        reviews/panel/panel_effect.json
    stage 08 reviews  0.333 -> 0.000   effort.record_plan         reviews/effort.json
    stage 08 reviews  0.333 -> 0.000   deliberation.record_...    reviews/deliberations.json
    stage 08 reviews  0.333 -> 0.000   scorecard.write_scorecard  reviews/scorecard.{json,md}
    stage 08 reviews  0.333 -> 0.000   ValidityReviewer._write..  reviews/validity_review_<slug>.json
    stage 07 artifacts 0.000           generate_layout_review     artifacts/layout_review.json
    stage 07 artifacts 0.000           generate_report_review     artifacts/report_review.json
    stage 02 notes     0.000           record_idea_pool           notes/idea_pool.{json,md}

Four of the six run before the draft is scored inside the stage's own window —
`_close_comment_round` and `_settle_cruxes` one and two statements above `consider`,
`ReviewPanel._record` and `_note_effort_failure` from `_collect_review_decision`,
which is after attempt N is scored and therefore before attempt N+1 is. The scorecard
and the validity review are excluded on ownership rather than ordering: their call
sites happen to sit after the last score of the walk, and that is not theirs to keep.

Each name is imported from the module that writes it, which is why `idea_pool.md`,
`report_review.json`, `layout_review.json` and the `panel/` subdirectory gained
constants at their writers — `PANEL_DIRNAME` replaces a literal `"panel"` that four
modules were spelling independently. `reviews/panel/` is excluded as a subtree because
its filenames carry the attempt number; `validity_response_<stage>.json`, which the
*stage* writes beside `validity_review_<stage>.json`, is deliberately not, and a test
holds that boundary.

A hand-maintained exclusion list is a thing someone has to remember, and the first
version of this one was missing five entries. So `tests/test_rubric_artifact_kinds.py`
now censuses `src/` for it: every `paths.<graded>_dir / <name>` expression is read off
the syntax tree, module constants and one-hop `from x import Y as Z` aliases resolved,
and each of the 33 distinct paths it finds must be declared `harness` or `agent` in
`PATH_OWNERS` — 13 and 20 today. Harness rows must be covered by
`_harness_written_records` and agent rows must not, so an over-broad exclusion that
swallows the run's own output fails the same test.

**The validity chain had no Stage 02 link.** `02_hypothesis_generation.md` says every
empirical hypothesis **must** carry a `- Decision rule: ...` line;
`write_hypothesis_manifest` parsed the field and nothing read it. Measured before the
change, on a manifest whose one empirical hypothesis carried `decision_rule: ""`:

    stage 2: 0 problem(s); decision-rule mentions: []
    stage 3: 2 problem(s); decision-rule mentions: []
    stage 4: 2 problem(s); decision-rule mentions: []

`freeze_preregistration` then froze that set at Stage 04 approval, empty rule and all,
and `validate_preregistration` first objected at Stage 05 — where the only repair is a
rollback across three stages. The argument was already written at the
`validate_report_plan` call site, about the experimental protocol, one stage later:
"the gate first fires at Stage 05, so a Stage 03 that skipped it is approved and the
failure surfaces two stages later". `validate_hypothesis_decision_rules` now runs from
`stage.number >= 2`, and `reproducibility` grades the same condition at Stages 2-3
only — `>= 2` would spend two of the criterion's links on one artifact, because the
frozen-preregistration link starts at 4.

Three traps an earlier review named, all avoided and all tested: `derived_from` is not
required with it (the prompt lists it "when relevant" and the repo's own fixtures omit
it); the graded twin reads the manifest out of the **draft** via
`build_hypothesis_manifest`, because a reverted polish round leaves the loser's
manifest on disk; and both readers parse defensively — `score_stage` has no `try`
around it and `workspace/notes/` is written by the party being measured.

**Counts that had drifted, now held by a symbol.** Counted off the syntax tree,
`validate_stage_artifacts` reaches 17 distinct `validate_*` functions on
`origin/main@fdded57` and 18 with this one. `README.md` and `docs/framework.md` said
eighteen and `docs/architecture.md` said seventeen, so two pages of one repo gave a
reader two answers; `tests/test_doc_counts.py` now derives the number and pins the
phrase in all three, and `docs/framework.md` joins `TRACKED_DOCS`. The sentence
"Stage 02 is scored on N criteria worth W, Stage 06 on M worth V" appears twice — in
`docs/self-improvement.md` and in `comparability_basis`'s docstring — and both said
five and 11 against a live 6 and 13.0; both are now pinned against `CRITERIA` in prose
and in the docstring at once, because the divergence matters as much as the staleness.
`docs/self-improvement.md`'s criterion table said `artifact_breadth` starts at 03.

The 2026-08-11 real-backend measurement in `docs/self-improvement.md` is now labelled
as taken at `RUBRIC_VERSION` 4, and its conclusion — that a `--final-stage 02` trial
cannot resolve anything because resolution starts where `artifact_breadth` enters — is
marked as not re-measured under v5, where the criterion enters at Stage 01. Whether
that opus Stage 01 would still score 1.0 turns on whether it wrote `literature/` in
its own window, which the v4 run was not graded on, so the document says it does not
know rather than guessing.

`RUBRIC_VERSION` 4 -> 5. The archive splits at the bump: `RunRecord.usable` requires
`rubric_version == RUBRIC_VERSION`, so every earlier record leaves the comparison pool.
On this machine's `~/.autor/archive/runs.jsonl`, **0** records carry
`provenance: live` — 354 predate the field and the rest are `fake` — so no live run's
fitness is lost to the split. The total is deliberately not quoted: the suite appends

🤖 Generated with [Claude Code](https://claude.com/claude-code)