### PR TITLE
Make a rollback take the workspace back, not only the manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ naming them.
 | Required stage-summary headings | `REQUIRED_STAGE_HEADINGS` | 7 |
 | Rubric criteria (weighted, backend-free) | `CRITERIA`, [src/rubric.py](src/rubric.py) | 8 |
 | Flags on `main.py` / `rcb_agent.py` | `parse_args` | 61 / 37 |
-| Python modules / lines / tests | the tree | 170 / 75 k / 2282 |
+| Python modules / lines / tests | the tree | 183 / 82 k / 2497 |
 
-`python -m unittest discover -s tests -p "test_*.py"` runs **2282 tests** across 99 test
+`python -m unittest discover -s tests -p "test_*.py"` runs **2497 tests** across 109 test
 modules, with no third-party dependency.
 
 ## Quick start
@@ -725,6 +725,15 @@ cross-stage edge is a typed channel or a JSON artifact. `run_manifest.json` is t
 that resume, redo and rollback read; `prompt_cache/` holds the exact prompt of every attempt,
 repair, review, panel seat and crux voice.
 
+`evolution/artifact_provenance.json` records which stage wrote each workspace file and every
+version it has held; `evolution/effects/<slug>.jsonl` is that stage's accumulated inverses, moved
+to `<slug>.reverted.jsonl` once applied, and `evolution/effects/blobs/` is the content-addressed
+store the rewinds read from. A rollback is not only a manifest edit: it applies those inverses in
+reverse, deletes what the withdrawn stages created, rewinds what they amended back to the version
+the last surviving stage left, and drops the withheld emissions in
+`evolution/emissions.json`. Everything it moved is named in the run log under
+`rollback recovery`, and the preview says it before the operator confirms.
+
 Full file-by-file reference: **[docs/run-artifacts.md](docs/run-artifacts.md)**.
 
 ## Architecture
@@ -758,6 +767,9 @@ flowchart LR
 | [src/ideation_panel.py](src/ideation_panel.py) | Divergent Stage 02 proposers across five lenses, deduplicated into a candidate pool |
 | [src/evolution.py](src/evolution.py) | The champion ratchet: budgeted polish rounds, reverted when they do not improve, rejected on verdict drift |
 | [src/writing_manifest.py](src/writing_manifest.py) | The Stage 07 inventory plus the AutoR-owned triage artifact for each output format |
+| [src/provenance.py](src/provenance.py) | Which stage wrote each workspace file, every version it has held, and what a rollback withdraws or rewinds |
+| [src/effects.py](src/effects.py) | The inverse of each write, accumulated per stage and applied in reverse on a backward edge; commutative and ordered keys |
+| [src/emissions.py](src/emissions.py) | Acts that leave the run, withheld until the stage that asked for them is approved |
 | [src/approval_agent.py](src/approval_agent.py) | The solo approval gate, its six-choice vocabulary and its unreadable-verdict fallback |
 | [src/preregistration.py](src/preregistration.py) | Freeze, amend, adjudicate, trace |
 | [src/information_flow.py](src/information_flow.py) | Eighteen typed information channels, each with declared readers and a written rationale |

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -254,8 +254,8 @@ same credulity it is built to remove.
 ### 2.6 No runtime dependency outside the standard library
 
 AutoR's runtime imports nothing that is not in the Python standard library. The runtime under
-`src/` is 61 modules and ~37 k lines; counting the entry points, `tools/` and the suite, the tree is
-170 files and ~75 k lines, and 2282 tests run with no install step. The MCP web-search server
+`src/` is 64 modules and ~40 k lines; counting the entry points, `tools/` and the suite, the tree is
+183 files and ~82 k lines, and 2497 tests run with no install step. The MCP web-search server
 ([`mcp_web_search.py`](../src/mcp_web_search.py)) is a stdlib JSON-RPC 2.0 implementation over stdio
 rather than an SDK. `google-genai` is needed only by three optional paths (`--web-search gemini`,
 `--cross-review`, `--research-diagram`), and each degrades to a recorded *unavailable* rather than a
@@ -444,6 +444,9 @@ An explicit `--flag`/`--no-flag` always beats the level. The validity chain is n
 | [`deliverables.py`](../src/deliverables.py) | Did the run answer what the task statement actually demanded? |
 | [`evidence_ledger.py`](../src/evidence_ledger.py) | Stage 01's `sources.json`/`claims.json` cross-reference, and Stage 07's citation self-report. |
 | [`experiment_manifest.py`](../src/experiment_manifest.py) · [`artifact_index.py`](../src/artifact_index.py) · [`writing_manifest.py`](../src/writing_manifest.py) | The machine-readable inventories later stages read instead of guessing from filenames. |
+| [`provenance.py`](../src/provenance.py) | Which stage wrote each workspace file, every version it has held, and whether a rollback has withdrawn it. The counting guards read the live count from here, so an abandoned future cannot open the edge it was abandoned at. |
+| [`effects.py`](../src/effects.py) | The inverse of each write, accumulated per stage and applied in reverse when a backward edge is taken. Classifies each shared location as commutative or ordered, which is what decides whether one stage could have been withdrawn without the ones after it. |
+| [`emissions.py`](../src/emissions.py) | Actions that leave the run — a release package, a pull request, a spent quota — held until the stage that asked for them is approved, and dropped when it is rolled back. The one class of act no inverse takes back, so the only recovery is not having performed it. |
 
 ### Review — five kinds of critic, two of which are the gate
 

--- a/src/artifact_index.py
+++ b/src/artifact_index.py
@@ -18,6 +18,24 @@ class ArtifactRecord:
     size_bytes: int
     updated_at: str
     schema: dict[str, object] = field(default_factory=dict)
+    #: Which stage's execution window this file first appeared in, read off
+    #: :mod:`src.provenance`. Empty for a file no stage boundary has observed yet —
+    #: this index is written mid-stage as well as at the end of one, and a record
+    #: that guessed an attribution would be worse than one that declines to.
+    produced_by_stage: str = ""
+    #: Which stage last changed the bytes. Equal to ``produced_by_stage`` until
+    #: something rewrites the file.
+    last_written_by_stage: str = ""
+    #: A fresh name for this version, never reused. A consumer that recorded a uid
+    #: and reads a different one knows its input changed without comparing values —
+    #: which is what a stage re-run after a rollback produces, byte-identical output
+    #: and all.
+    version_uid: str = ""
+    content_hash: str = ""
+    #: False once a rollback has withdrawn the stage that produced this file. The
+    #: record stays in the index: a reader has to be able to see that the file is
+    #: still on disk and no longer counts.
+    live: bool = True
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -28,6 +46,11 @@ class ArtifactRecord:
             "size_bytes": self.size_bytes,
             "updated_at": self.updated_at,
             "schema": self.schema,
+            "produced_by_stage": self.produced_by_stage,
+            "last_written_by_stage": self.last_written_by_stage,
+            "version_uid": self.version_uid,
+            "content_hash": self.content_hash,
+            "live": self.live,
         }
 
     @classmethod
@@ -40,20 +63,38 @@ class ArtifactRecord:
             size_bytes=int(payload.get("size_bytes", 0)),
             updated_at=str(payload.get("updated_at", "")).strip(),
             schema=dict(payload.get("schema", {})),
+            produced_by_stage=str(payload.get("produced_by_stage", "")).strip(),
+            last_written_by_stage=str(payload.get("last_written_by_stage", "")).strip(),
+            version_uid=str(payload.get("version_uid", "")).strip(),
+            content_hash=str(payload.get("content_hash", "")).strip(),
+            live=bool(payload.get("live", True)),
         )
 
 
 @dataclass(frozen=True)
 class ArtifactIndex:
     generated_at: str
+    #: Live artifacts only. What a consumer means by "how much has this run produced"
+    #: is what still counts, and a withdrawn file counts for nothing — it is on disk
+    #: because AutoR could not always restore what preceded it, not because the run
+    #: stands behind it.
     artifact_count: int
     counts_by_category: dict[str, int]
+    #: Every file found, withdrawn ones included and marked. The count above says what
+    #: the run has; this list says what is on the disk, and after a rollback those are
+    #: two different questions.
     artifacts: list[ArtifactRecord]
+    withdrawn_count: int = 0
+
+    @property
+    def live_artifacts(self) -> list[ArtifactRecord]:
+        return [artifact for artifact in self.artifacts if artifact.live]
 
     def to_dict(self) -> dict[str, object]:
         return {
             "generated_at": self.generated_at,
             "artifact_count": self.artifact_count,
+            "withdrawn_count": self.withdrawn_count,
             "counts_by_category": dict(self.counts_by_category),
             "artifacts": [artifact.to_dict() for artifact in self.artifacts],
         }
@@ -65,14 +106,16 @@ class ArtifactIndex:
             for item in payload.get("artifacts", [])
             if isinstance(item, dict)
         ]
+        live = [artifact for artifact in artifacts if artifact.live]
         return cls(
             generated_at=str(payload.get("generated_at", "")).strip(),
-            artifact_count=int(payload.get("artifact_count", len(artifacts))),
+            artifact_count=int(payload.get("artifact_count", len(live))),
             counts_by_category={
                 str(key): int(value)
                 for key, value in dict(payload.get("counts_by_category", {})).items()
             },
             artifacts=artifacts,
+            withdrawn_count=int(payload.get("withdrawn_count", len(artifacts) - len(live))),
         )
 
 
@@ -106,15 +149,17 @@ def is_autor_own_record(paths: RunPaths, path: Path) -> bool:
 
 def write_artifact_index(paths: RunPaths) -> ArtifactIndex:
     artifacts = _scan_artifacts(paths)
+    live = [artifact for artifact in artifacts if artifact.live]
     counts_by_category = {
-        category: len([artifact for artifact in artifacts if artifact.category == category])
+        category: len([artifact for artifact in live if artifact.category == category])
         for category in ("data", "results", "figures")
     }
     index = ArtifactIndex(
         generated_at=datetime.now().isoformat(timespec="seconds"),
-        artifact_count=len(artifacts),
+        artifact_count=len(live),
         counts_by_category=counts_by_category,
         artifacts=artifacts,
+        withdrawn_count=len(artifacts) - len(live),
     )
     paths.artifact_index.write_text(
         json.dumps(index.to_dict(), indent=2, ensure_ascii=True) + "\n",
@@ -138,15 +183,27 @@ def load_artifact_index(path: Path) -> ArtifactIndex | None:
 
 
 def format_artifact_index_for_prompt(index: ArtifactIndex, max_entries_per_category: int = 5) -> str:
-    if not index.artifacts:
+    if not index.live_artifacts:
         return "No structured data, result, or figure artifacts have been indexed yet."
 
     lines = [
         f"Artifact index generated at: {index.generated_at}",
         f"Indexed artifacts: {index.artifact_count}",
     ]
+    if index.withdrawn_count:
+        # Said out loud rather than left as a silent subtraction. A stage that sees
+        # files under `workspace/data` and an index reporting fewer is owed the reason,
+        # and the reason is that a rollback withdrew the stage that wrote them.
+        lines.append(
+            f"Withdrawn by a rollback and not counted: {index.withdrawn_count} "
+            "(still on disk; do not build on them)"
+        )
     for category in ("data", "results", "figures"):
-        entries = [artifact for artifact in index.artifacts if artifact.category == category]
+        entries = [
+            artifact
+            for artifact in index.artifacts
+            if artifact.category == category and artifact.live
+        ]
         if not entries:
             continue
         lines.append(f"\n### {category.title()}")
@@ -165,14 +222,29 @@ def format_artifact_index_for_prompt(index: ArtifactIndex, max_entries_per_categ
 
 
 def indexed_artifacts_for_category(index: ArtifactIndex, category: str) -> list[dict[str, object]]:
+    """The live artifacts of one category.
+
+    Withdrawn ones are dropped here rather than marked, because the two callers —
+    ``experiment_manifest`` and ``writing_manifest`` — are building the run's statement
+    of what it produced. A manifest that indexed a withdrawn result would hand Stage 07
+    a result file to write about that the run had already taken back, which is the
+    failure ``_skip_stage`` patched by hand at one path and this closes at all of them.
+    """
+
     return [
         artifact.to_dict()
         for artifact in index.artifacts
-        if artifact.category == category
+        if artifact.category == category and artifact.live
     ]
 
 
 def _scan_artifacts(paths: RunPaths) -> list[ArtifactRecord]:
+    from .provenance import load_ledger
+
+    # Read once. The index is rewritten on every stage boundary and by three other
+    # callers, and re-reading the ledger per file would make the scan quadratic in a
+    # run's own artifact count.
+    ledger = load_ledger(paths)
     records: list[ArtifactRecord] = []
     for category, directory, suffixes in (
         ("data", paths.data_dir, MACHINE_DATA_SUFFIXES),
@@ -191,15 +263,26 @@ def _scan_artifacts(paths: RunPaths) -> list[ArtifactRecord]:
             if is_autor_own_record(paths, path):
                 continue
             stat = path.stat()
+            rel_path = str(path.relative_to(paths.workspace_root))
+            attribution = ledger.entries.get(Path(rel_path).as_posix())
             records.append(
                 ArtifactRecord(
                     category=category,
-                    rel_path=str(path.relative_to(paths.workspace_root)),
+                    rel_path=rel_path,
                     filename=path.name,
                     suffix=path.suffix.lower(),
                     size_bytes=stat.st_size,
                     updated_at=datetime.fromtimestamp(stat.st_mtime).isoformat(timespec="seconds"),
                     schema=_infer_schema(path, category, paths.workspace_root),
+                    produced_by_stage=attribution.produced_by_stage if attribution else "",
+                    last_written_by_stage=(
+                        attribution.last_written_by_stage if attribution else ""
+                    ),
+                    version_uid=attribution.version_uid if attribution else "",
+                    content_hash=attribution.content_hash if attribution else "",
+                    # Unattributed files count. Only an explicit withdrawal takes one
+                    # out, for the same reason `provenance.is_live` fails open.
+                    live=attribution.live if attribution else True,
                 )
             )
     return records

--- a/src/effects.py
+++ b/src/effects.py
@@ -1,0 +1,604 @@
+"""Every write a stage makes carries the inverse that withdraws it.
+
+:mod:`src.provenance` makes attribution exist — which stage wrote which file. This module
+is what attribution is for: a stage's writes go through a primitive that returns, with the
+write, the operation that undoes it, and the run keeps those inverses per stage. Rolling
+back to Stage 03 stops being a manifest edit and becomes the application of Stage 04's,
+Stage 05's and Stage 06's accumulated inverses, in reverse.
+
+**Why an inverse per write rather than a snapshot of the run.** A snapshot is all or
+nothing. It can restore the state before Stage 04 and it cannot withdraw Stage 04 while
+Stage 06 stands, because it has no representation of one stage's contribution separately
+from the run's. That distinction is the whole reason AutoR's topology is a graph: a late
+finding invalidates *a* decision, not every decision that followed it in wall-clock order,
+and a rollback that discards Stage 05's honest measurement along with Stage 04's wrong
+design has thrown away the evidence that justified the move. Inverses composed per stage
+support both: the reverse-order withdrawal, which needs no hypothesis at all and is what
+:func:`recover_to_stage` performs, and the selective one, whose precondition
+:func:`independence_obstruction` decides and which the rollback preview reports on.
+
+**Inverses are data, not closures.** A run resumes in a new process — ``--resume-run`` is
+routine, and a stage timeout is 14400 seconds — so an inverse held as a Python closure is
+an inverse that does not survive the thing most likely to need it. Each is an
+:class:`Inverse`: a kind naming one of the handlers in :data:`INVERSE_HANDLERS`, and a JSON
+payload. The accumulator is a JSONL file under ``evolution/effects/``, appended to as the
+stage runs, so a crash mid-stage leaves a partial accumulator that still withdraws
+everything the stage had done up to the crash.
+
+**Undo is unconditional.** No inverse here has a precondition it can fail: deleting a path
+that is already gone succeeds, and restoring bytes creates the parent directories it needs.
+An undo that can refuse is not an undo — it turns a rollback into a state the run has no
+rule for, and the recovery it was supposed to perform into a partial one nobody records.
+
+**What the primitives cover, and what they do not.** A stage's real work is done by an
+agent CLI writing files directly, and those writes do not come through here; they are
+picked up by :func:`src.provenance.observe` at the stage boundary, which stores the bytes
+it can and marks the rest ``restorable=False``. So the recovery this module offers is
+layered: writes made through a primitive are withdrawn exactly, observed writes are
+withdrawn to the previous bytes when the ledger holds them and deleted when it does not,
+and a file too large for the ledger is deleted with the fact recorded rather than silently
+half-restored.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from . import provenance
+from .provenance import Withdrawal, load_blob, store_blob
+from .utils import RunPaths, StageSpec, STAGES
+
+
+# ----------------------------------------------------------------------------
+# Keys and commutativity
+# ----------------------------------------------------------------------------
+
+
+#: A key names the shared location an effect writes, at the granularity at which two
+#: effects can be asked whether they interfere. Not the file and not the row: the *table*.
+#: Two appends to ``literature.sources`` are two entries in one table, and the question
+#: "can one be withdrawn while the other stands" is answered once for the table.
+#:
+#: A key is commutative when its value is a collection whose entries are added and removed
+#: independently — a set of sources, a set of hypotheses, a directory of result files. Two
+#: writes to it in either order leave a collection that answers every read alike, and
+#: either can be withdrawn while the other stands.
+#:
+#: A key is ordered when its value is a sequence whose entries see each other — a
+#: narrative, an append-only log. A paragraph written after another reads differently
+#: without it, and neither order can be withdrawn without disturbing the rest. Ordered keys
+#: are not a defect to be fixed; they are where the order-sensitive part of the run lives,
+#: and naming them is what lets everything else be reordered safely.
+COMMUTATIVE_KEYS = frozenset(
+    {
+        "literature.sources",
+        "literature.claims",
+        "hypotheses",
+        "data",
+        "code",
+        "results",
+        "figures",
+        "notes",
+    }
+)
+
+ORDERED_KEYS = frozenset(
+    {
+        "report.draft",
+        "run.log",
+        "research.rounds",
+    }
+)
+
+
+def is_commutative(key: str) -> bool:
+    """Whether two effects on this key are independent.
+
+    Unknown keys are ordered. A key nobody has classified is a key nobody has checked
+    the two registrations of, and reading it as commutative would license exactly the
+    reordering the classification exists to authorise.
+    """
+
+    return str(key).strip() in COMMUTATIVE_KEYS
+
+
+def key_for_workspace_path(paths: RunPaths, rel_path: str) -> str:
+    """The key a workspace path belongs to, from the directory it sits in."""
+
+    head = str(rel_path).strip().replace("\\", "/").split("/", 1)[0]
+    mapping = {
+        "data": "data",
+        "code": "code",
+        "results": "results",
+        "figures": "figures",
+        "notes": "notes",
+        "literature": "literature.sources",
+        "writing": "report.draft",
+        "report": "report.draft",
+    }
+    return mapping.get(head, "notes")
+
+
+# ----------------------------------------------------------------------------
+# Inverses
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Inverse:
+    kind: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {"kind": self.kind, "payload": dict(self.payload)}
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "Inverse":
+        raw = payload.get("payload", {})
+        return cls(
+            kind=str(payload.get("kind", "noop")).strip() or "noop",
+            payload=dict(raw) if isinstance(raw, dict) else {},
+        )
+
+
+@dataclass(frozen=True)
+class EffectRecord:
+    """One write, the key it landed on, and how to take it back."""
+
+    stage: str
+    key: str
+    action: str
+    rel_path: str
+    inverse: Inverse
+    at: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "stage": self.stage,
+            "key": self.key,
+            "action": self.action,
+            "rel_path": self.rel_path,
+            "inverse": self.inverse.to_dict(),
+            "at": self.at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "EffectRecord":
+        raw_inverse = payload.get("inverse", {})
+        return cls(
+            stage=str(payload.get("stage", "")).strip(),
+            key=str(payload.get("key", "")).strip(),
+            action=str(payload.get("action", "")).strip(),
+            rel_path=str(payload.get("rel_path", "")).strip(),
+            inverse=Inverse.from_dict(raw_inverse if isinstance(raw_inverse, dict) else {}),
+            at=str(payload.get("at", "")).strip(),
+        )
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _resolve(paths: RunPaths, rel_path: str) -> Path:
+    return paths.workspace_root / rel_path
+
+
+def _invert_delete_path(paths: RunPaths, payload: Mapping[str, Any]) -> str:
+    rel_path = str(payload.get("rel_path", "")).strip()
+    if not rel_path:
+        return "no path to delete"
+    target = _resolve(paths, rel_path)
+    if not target.exists():
+        return f"{rel_path} was already gone"
+    target.unlink()
+    provenance.drop_entries(paths, [rel_path])
+    return f"deleted {rel_path}"
+
+
+def _invert_restore_blob(paths: RunPaths, payload: Mapping[str, Any]) -> str:
+    rel_path = str(payload.get("rel_path", "")).strip()
+    blob_hash = str(payload.get("blob_hash", "")).strip()
+    if not rel_path:
+        return "no path to restore"
+    blob = load_blob(paths, blob_hash)
+    if blob is None:
+        # The bytes were never held — the file was over the restorable limit, or the
+        # blob store was pruned. Deleting is the honest fallback: leaving the current
+        # bytes in place would present a withdrawn stage's output as the restored state.
+        return _invert_delete_path(paths, {"rel_path": rel_path}) + " (no stored bytes to restore)"
+    target = _resolve(paths, rel_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(blob)
+    return f"restored {rel_path}"
+
+
+def _invert_noop(paths: RunPaths, payload: Mapping[str, Any]) -> str:
+    return str(payload.get("note", "")).strip() or "nothing to undo"
+
+
+#: Every inverse the accumulator can hold. A record naming a kind that is not here is
+#: reported and skipped rather than raised on: one unreadable row must not stop the
+#: rest of a rollback, because the rows after it are the ones nearest the current state.
+INVERSE_HANDLERS: dict[str, Callable[[RunPaths, Mapping[str, Any]], str]] = {
+    "delete_path": _invert_delete_path,
+    "restore_blob": _invert_restore_blob,
+    "noop": _invert_noop,
+}
+
+
+# ----------------------------------------------------------------------------
+# The accumulator
+# ----------------------------------------------------------------------------
+
+
+def effects_dir(paths: RunPaths) -> Path:
+    return paths.evolution_dir / "effects"
+
+
+def accumulator_path(paths: RunPaths, stage: StageSpec | str) -> Path:
+    slug = stage.slug if isinstance(stage, StageSpec) else str(stage).strip()
+    return effects_dir(paths) / f"{slug}.jsonl"
+
+
+def reverted_path(paths: RunPaths, stage: StageSpec | str) -> Path:
+    slug = stage.slug if isinstance(stage, StageSpec) else str(stage).strip()
+    return effects_dir(paths) / f"{slug}.reverted.jsonl"
+
+
+def record_effect(paths: RunPaths, record: EffectRecord) -> EffectRecord:
+    """Append one inverse to its stage's accumulator.
+
+    Appended as the effect happens rather than gathered at the end, so the accumulator
+    of a stage killed by its 14400-second timeout still withdraws what it managed to do.
+    """
+
+    path = accumulator_path(paths, record.stage)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record.to_dict(), ensure_ascii=True) + "\n")
+    return record
+
+
+def load_accumulator(paths: RunPaths, stage: StageSpec | str) -> list[EffectRecord]:
+    path = accumulator_path(paths, stage)
+    if not path.exists():
+        return []
+    records: list[EffectRecord] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            records.append(EffectRecord.from_dict(payload))
+    return records
+
+
+def keys_touched(records: Sequence[EffectRecord]) -> set[str]:
+    return {record.key for record in records if record.key}
+
+
+def independence_obstruction(
+    target: Sequence[EffectRecord],
+    later: Sequence[EffectRecord],
+) -> str | None:
+    """Why ``target`` cannot be withdrawn while ``later`` stands, or ``None`` if it can.
+
+    Two effects at distinct keys never interfere: each reads and writes its own
+    collection, so either order leaves the same state and either can be withdrawn while
+    the other stands. Two effects at one key interfere unless the key is commutative.
+    So the obstruction is exactly the ordered keys both sides touch.
+
+    Withdrawing in reverse order — the target stage and everything after it — needs none
+    of this and never consults it: each inverse then meets the state its own application
+    produced. This function is asked only when a caller wants to withdraw a stage out of
+    order and keep the work that followed.
+    """
+
+    shared = keys_touched(target) & keys_touched(later)
+    blocking = sorted(key for key in shared if not is_commutative(key))
+    if not blocking:
+        return None
+
+    # Two ways to be blocking, and they call for different repairs. A key in
+    # `ORDERED_KEYS` is a genuine finding about the research: a narrative or a log was
+    # written by both sides, and no reordering of those is sound. A key in neither set is
+    # a finding about this file: somebody added a shared location and did not classify
+    # it, and it is being treated as ordered because that is the safe default, not
+    # because anyone checked. Reporting them alike would hide the second behind the
+    # first, and the second is the one with a fix.
+    declared = [key for key in blocking if key in ORDERED_KEYS]
+    unclassified = [key for key in blocking if key not in ORDERED_KEYS]
+    parts: list[str] = []
+    if declared:
+        parts.append(
+            "these keys are ordered and both sides wrote them: " + ", ".join(declared)
+        )
+    if unclassified:
+        parts.append(
+            "these keys are in neither COMMUTATIVE_KEYS nor ORDERED_KEYS, so they are "
+            "treated as ordered until someone classifies them: " + ", ".join(unclassified)
+        )
+    return "; ".join(parts)
+
+
+@dataclass(frozen=True)
+class RevertReport:
+    stages: list[str] = field(default_factory=list)
+    applied: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+
+    @property
+    def count(self) -> int:
+        return len(self.applied)
+
+    def render(self) -> str:
+        if not self.stages:
+            return "No accumulated effect needed withdrawing."
+        lines = [f"Withdrew {len(self.applied)} effect(s) from {', '.join(self.stages)}."]
+        lines.extend(f"- {note}" for note in self.applied)
+        if self.skipped:
+            lines.append("Could not withdraw:")
+            lines.extend(f"- {note}" for note in self.skipped)
+        return "\n".join(lines)
+
+
+def _apply_records(paths: RunPaths, records: Sequence[EffectRecord]) -> tuple[list[str], list[str]]:
+    applied: list[str] = []
+    skipped: list[str] = []
+    for record in reversed(records):
+        handler = INVERSE_HANDLERS.get(record.inverse.kind)
+        if handler is None:
+            skipped.append(f"{record.rel_path}: no handler for inverse {record.inverse.kind!r}")
+            continue
+        try:
+            applied.append(handler(paths, record.inverse.payload))
+        except OSError as error:
+            skipped.append(f"{record.rel_path}: {error}")
+    return applied, skipped
+
+
+def _retire_accumulator(paths: RunPaths, stage: StageSpec | str, records: Sequence[EffectRecord]) -> None:
+    """Move a spent accumulator aside rather than deleting it.
+
+    The run's record of how it reached its answer includes what it took back. A
+    rollback that leaves no trace of what it withdrew is a claim about a rollback.
+    """
+
+    source = accumulator_path(paths, stage)
+    if not source.exists():
+        return
+    archive = reverted_path(paths, stage)
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    with archive.open("a", encoding="utf-8") as handle:
+        for record in records:
+            payload = record.to_dict()
+            payload["reverted_at"] = _now()
+            handle.write(json.dumps(payload, ensure_ascii=True) + "\n")
+    source.unlink()
+
+
+def revert_from(paths: RunPaths, stage: StageSpec, stages: Iterable[StageSpec]) -> RevertReport:
+    """Withdraw every stage at or after ``stage``, latest first, each in reverse.
+
+    The order needs no justification: reverting in the reverse of the order applied hands
+    each inverse the state its own application produced, whatever the effects were. This
+    is the rollback a backward edge takes.
+    """
+
+    ordered = sorted(
+        (item for item in stages if item.number >= stage.number),
+        key=lambda item: item.number,
+        reverse=True,
+    )
+    touched: list[str] = []
+    applied: list[str] = []
+    skipped: list[str] = []
+    for item in ordered:
+        records = load_accumulator(paths, item)
+        if not records:
+            continue
+        touched.append(item.slug)
+        stage_applied, stage_skipped = _apply_records(paths, records)
+        applied.extend(stage_applied)
+        skipped.extend(stage_skipped)
+        _retire_accumulator(paths, item, records)
+    return RevertReport(stages=touched, applied=applied, skipped=skipped)
+
+
+def apply_withdrawal(paths: RunPaths, plan: Sequence[Withdrawal]) -> RevertReport:
+    """Move the files a withdrawal plan names, for writes the primitives never saw.
+
+    The stage's own agent writes most of what a run produces, and those writes never pass
+    through :func:`record_effect`. :mod:`src.provenance` observes them instead, keeping a
+    version chain per file, so a withdrawal is still exact wherever the bytes were held:
+    a file created inside the withdrawn range is deleted, and one that existed before it
+    is rewound to what the last stage outside the range left.
+
+    A version whose bytes were never held — over
+    :data:`src.provenance.RESTORABLE_BYTE_LIMIT` — cannot be rewound to. Deleting is the
+    fallback and it is said out loud, because leaving the current bytes would present a
+    withdrawn stage's output as the restored state, which is the failure this whole path
+    exists to prevent.
+    """
+
+    applied: list[str] = []
+    skipped: list[str] = []
+    dropped: list[str] = []
+
+    for item in plan:
+        target = paths.workspace_root / item.rel_path
+        if item.deletes:
+            if not target.exists():
+                dropped.append(item.rel_path)
+                continue
+            try:
+                target.unlink()
+                applied.append(f"deleted {item.rel_path}")
+                dropped.append(item.rel_path)
+            except OSError as error:
+                skipped.append(f"{item.rel_path}: {error}")
+            continue
+
+        version = item.restore_to
+        assert version is not None
+        blob = load_blob(paths, version.blob_hash) if version.restorable else None
+        if blob is None:
+            if not target.exists():
+                continue
+            try:
+                target.unlink()
+                applied.append(
+                    f"deleted {item.rel_path} (no stored bytes for {version.version_uid})"
+                )
+                dropped.append(item.rel_path)
+            except OSError as error:
+                skipped.append(f"{item.rel_path}: {error}")
+            continue
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(blob)
+            applied.append(f"rewound {item.rel_path} to {version.version_uid}")
+        except OSError as error:
+            skipped.append(f"{item.rel_path}: {error}")
+
+    if dropped:
+        provenance.drop_entries(paths, dropped)
+
+    return RevertReport(
+        stages=["observed"] if applied or skipped else [],
+        applied=applied,
+        skipped=skipped,
+    )
+
+
+@dataclass(frozen=True)
+class RecoveryReport:
+    """What a rollback did to the workspace, as opposed to what it did to the manifest."""
+
+    stage: str
+    accumulated: RevertReport = field(default_factory=RevertReport)
+    observed: RevertReport = field(default_factory=RevertReport)
+    emissions_discarded: int = 0
+
+    @property
+    def touched(self) -> bool:
+        return bool(
+            self.accumulated.applied
+            or self.accumulated.skipped
+            or self.observed.applied
+            or self.observed.skipped
+            or self.emissions_discarded
+        )
+
+    def render(self) -> str:
+        if not self.touched:
+            return f"Rollback to {self.stage} withdrew nothing: the workspace held no attributed change."
+        lines = [f"Rollback to {self.stage} withdrew the workspace, not only the manifest."]
+        if self.accumulated.applied or self.accumulated.skipped:
+            lines.append(self.accumulated.render())
+        if self.observed.applied or self.observed.skipped:
+            lines.append(self.observed.render())
+        if self.emissions_discarded:
+            lines.append(
+                f"Discarded {self.emissions_discarded} withheld emission intent(s); "
+                "none had been performed."
+            )
+        return "\n".join(lines)
+
+
+def recover_to_stage(paths: RunPaths, stage: StageSpec, reason: str = "") -> RecoveryReport:
+    """Put the workspace back to what it was before ``stage`` ran, and say what moved.
+
+    The seam a backward edge goes through. Four things happen and the order is load
+    bearing.
+
+    The plan is read off the ledger first, while nothing has moved, because it is the
+    only reading of "what the workspace looked like before this range" that is still
+    available once the range starts being taken back.
+
+    Accumulated inverses run next, latest stage first and each stage in reverse. These are
+    the writes that came through a primitive, so their withdrawal is exact and needs no
+    stored bytes.
+
+    The plan is applied to whatever is left — the writes the agent made directly, which no
+    inverse describes.
+
+    The ledger is committed last, so a crash between the file moves and the ledger write
+    leaves rows claiming versions that are gone, which the next :func:`observe` corrects,
+    rather than a ledger claiming a clean state over a workspace that still holds the
+    withdrawn one.
+
+    Withheld emissions of the withdrawn range are dropped. They were never performed, so
+    there is nothing to compensate; the record of having declined to perform them stays.
+    """
+
+    from . import emissions
+
+    note = reason.strip() or f"Rolled back to {stage.stage_title}"
+    plan = provenance.plan_withdrawal(paths, stage)
+    accumulated = revert_from(paths, stage, STAGES)
+    observed = apply_withdrawal(paths, plan)
+    provenance.invalidate_from(paths, stage, note)
+    discarded = emissions.discard_from(paths, stage, note)
+
+    return RecoveryReport(
+        stage=stage.stage_title,
+        accumulated=accumulated,
+        observed=observed,
+        emissions_discarded=len(discarded),
+    )
+
+
+# ----------------------------------------------------------------------------
+# Primitives
+# ----------------------------------------------------------------------------
+
+
+def set_artifact(
+    paths: RunPaths,
+    stage: StageSpec,
+    rel_path: str,
+    content: str | bytes,
+    key: str | None = None,
+) -> EffectRecord:
+    """Write a workspace file and accumulate the inverse that takes it back.
+
+    Creating a file inverts to deleting it. Overwriting one inverts to restoring the
+    bytes that were there, which are put in the blob store before the write — after it,
+    they are gone and the inverse would be a guess.
+    """
+
+    target = _resolve(paths, rel_path)
+    payload = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+    existed = target.exists()
+    inverse: Inverse
+    if existed:
+        inverse = Inverse(
+            "restore_blob",
+            {"rel_path": rel_path, "blob_hash": store_blob(paths, target.read_bytes())},
+        )
+    else:
+        inverse = Inverse("delete_path", {"rel_path": rel_path})
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(payload)
+
+    return record_effect(
+        paths,
+        EffectRecord(
+            stage=stage.slug,
+            key=key or key_for_workspace_path(paths, rel_path),
+            action="overwrite" if existed else "create",
+            rel_path=rel_path,
+            inverse=inverse,
+            at=_now(),
+        ),
+    )

--- a/src/emissions.py
+++ b/src/emissions.py
@@ -1,0 +1,225 @@
+"""Actions that leave the run are held until the stage that asked for them is approved.
+
+:mod:`src.effects` can withdraw a write because the run owns the file: it can change the
+bytes exclusively and it can put the previous bytes back. Not everything a stage does is
+like that. Opening a pull request, spending a model-API quota, writing a row into a shared
+leaderboard, sending mail — each of those puts data somewhere other parties can already
+read, and no inverse the run holds takes it back.
+
+So the run's actions divide, and the division is per action rather than per medium. An
+*acquisition* installs a record the run owns — a file it created, a handle it holds, a
+directory it made — and is withdrawable. An *emission* pushes data across the boundary and
+is not. Writing a draft into ``workspace/`` is an acquisition; pushing that draft to a
+remote is an emission, and the second is not the first done harder.
+
+There are two ways to be able to recover from an emission and this module implements the
+first: **withhold it** until the state that produced it is settled. A stage that wants to
+emit registers the intent here; the intent is released when the stage is approved and
+discarded when the stage is rolled back. The alternative — emit now, compensate later — is
+available to a caller that needs it and is not free: a compensating action restores the
+world only up to an equivalence the application supplies, coarser than the one the rest of
+this system reasons in, and nothing here can check it.
+
+The kinds a run is known to cross by are ``pull_request``, ``quota``, ``leaderboard``,
+``network``, ``message`` and ``outside_run_write``. The kind is a label rather than a
+filter: an intent whose kind is not one of those is still held, because refusing an
+unclassified intent would push its caller back to emitting directly, which is the
+behaviour this module exists to replace.
+
+**This module does not perform emissions.** It holds intents and says which are released.
+The caller performs the released ones, which keeps the decision about what crosses the
+boundary in one place and the knowledge of how to cross it with whoever owns the channel.
+A withheld intent that is never released is not a failure to emit; it is the run declining
+to act on a stage whose work it took back.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from .utils import RunPaths, StageSpec
+
+STATUS_WITHHELD = "withheld"
+STATUS_RELEASED = "released"
+STATUS_DISCARDED = "discarded"
+
+
+@dataclass(frozen=True)
+class Emission:
+    emission_id: str
+    stage: str
+    kind: str
+    summary: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    status: str = STATUS_WITHHELD
+    created_at: str = ""
+    settled_at: str = ""
+    settled_reason: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "emission_id": self.emission_id,
+            "stage": self.stage,
+            "kind": self.kind,
+            "summary": self.summary,
+            "payload": dict(self.payload),
+            "status": self.status,
+            "created_at": self.created_at,
+            "settled_at": self.settled_at,
+            "settled_reason": self.settled_reason,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "Emission":
+        raw = payload.get("payload", {})
+        return cls(
+            emission_id=str(payload.get("emission_id", "")).strip(),
+            stage=str(payload.get("stage", "")).strip(),
+            kind=str(payload.get("kind", "")).strip(),
+            summary=str(payload.get("summary", "")).strip(),
+            payload=dict(raw) if isinstance(raw, dict) else {},
+            status=str(payload.get("status", STATUS_WITHHELD)).strip() or STATUS_WITHHELD,
+            created_at=str(payload.get("created_at", "")).strip(),
+            settled_at=str(payload.get("settled_at", "")).strip(),
+            settled_reason=str(payload.get("settled_reason", "")).strip(),
+        )
+
+    @property
+    def withheld(self) -> bool:
+        return self.status == STATUS_WITHHELD
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def emissions_path(paths: RunPaths) -> Path:
+    return paths.evolution_dir / "emissions.json"
+
+
+def load_emissions(paths: RunPaths) -> list[Emission]:
+    path = emissions_path(paths)
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return []
+    entries = payload.get("emissions") if isinstance(payload, dict) else payload
+    if not isinstance(entries, list):
+        return []
+    return [Emission.from_dict(item) for item in entries if isinstance(item, dict)]
+
+
+def save_emissions(paths: RunPaths, emissions: Sequence[Emission]) -> None:
+    path = emissions_path(paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"emissions": [item.to_dict() for item in emissions]}, indent=2, ensure_ascii=True
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def withhold(
+    paths: RunPaths,
+    stage: StageSpec | str,
+    kind: str,
+    summary: str,
+    payload: Mapping[str, Any] | None = None,
+) -> Emission:
+    """Register an intent to cross the boundary. Nothing crosses until it is released."""
+
+    slug = stage.slug if isinstance(stage, StageSpec) else str(stage).strip()
+    existing = load_emissions(paths)
+    emission = Emission(
+        emission_id=f"e{len(existing) + 1:04d}",
+        stage=slug,
+        kind=str(kind).strip(),
+        summary=str(summary).strip(),
+        payload=dict(payload or {}),
+        status=STATUS_WITHHELD,
+        created_at=_now(),
+    )
+    save_emissions(paths, [*existing, emission])
+    return emission
+
+
+def pending(paths: RunPaths, stage: StageSpec | str | None = None) -> list[Emission]:
+    slug = None
+    if stage is not None:
+        slug = stage.slug if isinstance(stage, StageSpec) else str(stage).strip()
+    return [
+        emission
+        for emission in load_emissions(paths)
+        if emission.withheld and (slug is None or emission.stage == slug)
+    ]
+
+
+def _settle(
+    paths: RunPaths,
+    stage: StageSpec | str | None,
+    status: str,
+    reason: str,
+    stage_numbers_at_or_after: int | None = None,
+) -> list[Emission]:
+    from .provenance import stage_number_for_slug
+
+    slug = None
+    if stage is not None:
+        slug = stage.slug if isinstance(stage, StageSpec) else str(stage).strip()
+
+    settled: list[Emission] = []
+    updated: list[Emission] = []
+    now = _now()
+    for emission in load_emissions(paths):
+        if not emission.withheld:
+            updated.append(emission)
+            continue
+        matches = True
+        if slug is not None:
+            matches = emission.stage == slug
+        if stage_numbers_at_or_after is not None:
+            number = stage_number_for_slug(emission.stage)
+            matches = number is not None and number >= stage_numbers_at_or_after
+        if not matches:
+            updated.append(emission)
+            continue
+        moved = replace(emission, status=status, settled_at=now, settled_reason=reason.strip())
+        updated.append(moved)
+        settled.append(moved)
+
+    if settled:
+        save_emissions(paths, updated)
+    return settled
+
+
+def release(paths: RunPaths, stage: StageSpec | str, reason: str = "stage approved") -> list[Emission]:
+    """Mark a stage's withheld intents releasable and hand them back to the caller.
+
+    The caller performs them. Marking happens first: an intent recorded as released and
+    then not performed is a visible discrepancy, and one performed and then not recorded
+    is an emission the run cannot account for.
+    """
+
+    return _settle(paths, stage, STATUS_RELEASED, reason)
+
+
+def discard_from(
+    paths: RunPaths, stage: StageSpec, reason: str = ""
+) -> list[Emission]:
+    """Drop every withheld intent registered by ``stage`` or any stage after it.
+
+    What a rollback does with the emissions of the future it withdrew. They were never
+    performed, so there is nothing to compensate; the record of having declined to
+    perform them stays.
+    """
+
+    note = reason.strip() or f"withdrawn by rollback to {stage.stage_title}"
+    return _settle(paths, None, STATUS_DISCARDED, note, stage_numbers_at_or_after=stage.number)

--- a/src/hypothesis_manifest.py
+++ b/src/hypothesis_manifest.py
@@ -6,7 +6,12 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Sequence
 
-from .utils import RunPaths, TYPED_HYPOTHESIS_HEADINGS, extract_typed_hypothesis_sections
+from .utils import (
+    RunPaths,
+    StageSpec,
+    TYPED_HYPOTHESIS_HEADINGS,
+    extract_typed_hypothesis_sections,
+)
 
 
 @dataclass(frozen=True)
@@ -106,15 +111,35 @@ def build_hypothesis_manifest(stage_markdown: str) -> HypothesisManifest | None:
     )
 
 
-def write_hypothesis_manifest(paths: RunPaths, stage_markdown: str) -> HypothesisManifest | None:
+def write_hypothesis_manifest(
+    paths: RunPaths, stage_markdown: str, stage: StageSpec | None = None
+) -> HypothesisManifest | None:
+    """Derive the manifest from the stage's markdown and write it.
+
+    ``stage`` is what makes the write revertible. AutoR owns this file — it is derived
+    here rather than written by the agent — so the write can go through
+    :func:`src.effects.set_artifact`, which stores the previous bytes and accumulates the
+    inverse against the stage. A rollback past the stage that wrote it then rewinds this
+    file exactly, rather than depending on the next :func:`src.provenance.observe` having
+    happened to catch it at a boundary.
+
+    Omitting ``stage`` writes directly, which is what the tests and any caller with no
+    stage in hand do. The file is still attributed at the next stage boundary, so it is
+    still withdrawable; it is the exactness that needs the stage, not the coverage.
+    """
+
     manifest = build_hypothesis_manifest(stage_markdown)
     if manifest is None:
         return None
+    body = json.dumps(manifest.to_dict(), indent=2, ensure_ascii=True) + "\n"
+    if stage is not None:
+        from .effects import set_artifact
+
+        rel_path = paths.hypothesis_manifest.relative_to(paths.workspace_root).as_posix()
+        set_artifact(paths, stage, rel_path, body, key="hypotheses")
+        return manifest
     paths.hypothesis_manifest.parent.mkdir(parents=True, exist_ok=True)
-    paths.hypothesis_manifest.write_text(
-        json.dumps(manifest.to_dict(), indent=2, ensure_ascii=True) + "\n",
-        encoding="utf-8",
-    )
+    paths.hypothesis_manifest.write_text(body, encoding="utf-8")
     return manifest
 
 

--- a/src/manager.py
+++ b/src/manager.py
@@ -52,6 +52,13 @@ from .intake import (
     save_intake_context
 )
 from .artifact_index import write_artifact_index
+from .effects import independence_obstruction, load_accumulator
+from .emissions import (
+    pending as pending_emissions,
+    release as release_emissions,
+    withhold as withhold_emission,
+)
+from .provenance import format_withdrawal_plan, observe as observe_artifacts, plan_withdrawal
 from .experiment_manifest import write_experiment_manifest
 from .hypothesis_manifest import write_hypothesis_manifest
 from .information_flow import CHANNELS, ChannelContext, render_inbound
@@ -1287,6 +1294,10 @@ class ResearchManager:
             min_report_figures=self.min_report_figures,
         )
         initialize_run_manifest(paths)
+        # Whatever bootstrap has already put in the workspace belongs to intake, not to
+        # Stage 01. Attributing it at the first stage boundary instead would make a
+        # rollback to Stage 01 delete the run's own starting material.
+        observe_artifacts(paths, INTAKE_STAGE)
         write_artifact_index(paths)
         write_experiment_manifest(paths)
         append_log_entry(paths.logs, "run_start", f"Run root: {paths.run_root}")
@@ -2287,7 +2298,7 @@ class ResearchManager:
             stage_markdown = strip_revision_delta(stage_markdown)
             write_text(result.stage_file_path, stage_markdown)
             if stage.slug == "02_hypothesis_generation":
-                write_hypothesis_manifest(paths, stage_markdown)
+                write_hypothesis_manifest(paths, stage_markdown, stage)
                 self._amend_preregistration(
                     paths, "Stage 02 was re-run and rewrote the hypothesis manifest."
                 )
@@ -2344,7 +2355,7 @@ class ResearchManager:
                 stage_markdown = strip_revision_delta(stage_markdown)
                 write_text(repair_result.stage_file_path, stage_markdown)
                 if stage.slug == "02_hypothesis_generation":
-                    write_hypothesis_manifest(paths, stage_markdown)
+                    write_hypothesis_manifest(paths, stage_markdown, stage)
                     self._amend_preregistration(
                         paths, "Stage 02 was re-run and rewrote the hypothesis manifest."
                     )
@@ -2380,7 +2391,7 @@ class ResearchManager:
 
                     stage_markdown = read_text(repair_result.stage_file_path)
                     if stage.slug == "02_hypothesis_generation":
-                        write_hypothesis_manifest(paths, stage_markdown)
+                        write_hypothesis_manifest(paths, stage_markdown, stage)
                         self._amend_preregistration(
                             paths, "Stage 02 was re-run and rewrote the hypothesis manifest."
                         )
@@ -2627,13 +2638,34 @@ class ResearchManager:
                             ),
                         )
                 elif stage.slug == "08_dissemination":
+                    # The one place the run assembles something meant to leave it. The
+                    # intent is registered before the package is built and released
+                    # after, so the boundary crossing is in the record either way: an
+                    # intent marked released with no package is a visible discrepancy,
+                    # and a package with no intent is an emission the run cannot
+                    # account for. A rollback past Stage 08 discards the intent, which
+                    # is the whole reason it is registered rather than assumed.
+                    intent = withhold_emission(
+                        paths,
+                        stage,
+                        "outside_run_write",
+                        "release package assembled from the run's deliverables",
+                        {"run_root": str(paths.run_root)},
+                    )
                     package = generate_release_package(paths.run_root)
+                    release_emissions(paths, stage, f"{stage.slug} approved")
                     append_log_entry(
                         paths.logs,
                         f"{stage.slug} release_package",
-                        package.summary,
+                        f"{package.summary}\nEmission intent {intent.emission_id} released.",
                     )
                 write_stage_handoff(paths, stage, stage_markdown)
+                # Attribution happens at the boundary, before the index reads it. The
+                # stage's agent wrote these files directly, so this comparison against
+                # the previous observation is the only record of who produced them —
+                # and the only thing that lets a later rollback withdraw this stage's
+                # contribution without touching anyone else's.
+                observe_artifacts(paths, stage)
                 write_artifact_index(paths)
                 write_experiment_manifest(paths)
                 append_log_entry(
@@ -3555,6 +3587,10 @@ class ResearchManager:
             kind=kind,
         )
         write_stage_handoff(paths, stage, stage_markdown)
+        # A skipped stage is still a stage that may have written before it gave up, and
+        # what it wrote is what `_skip_stage` was patched by hand to deal with at one
+        # path. Attributing here covers the rest of them.
+        observe_artifacts(paths, stage)
         write_artifact_index(paths)
         write_experiment_manifest(paths)
         append_log_entry(
@@ -3664,6 +3700,43 @@ class ResearchManager:
             lines.extend(f"- {slug}" for slug in stale_candidates)
         else:
             lines.append("No downstream stages currently need invalidation.")
+        # What the rollback does to the workspace, shown before it does it. The manifest
+        # half of this preview was the whole of it while the workspace half did not
+        # happen; an operator reading "three stages will be marked stale" had no way to
+        # tell that the files those stages wrote would still be there afterwards.
+        lines.append(format_withdrawal_plan(plan_withdrawal(paths, rollback_stage)))
+
+        # What the rollback costs beyond the stage being withdrawn. Reverse-order
+        # withdrawal takes the later stages with it whatever they wrote; withdrawing this
+        # stage alone would need them to be independent of it, and they are exactly when
+        # no ordered key was written by both. Reported rather than acted on: the action
+        # is the operator's, and knowing that Stage 04 could have gone on its own — or
+        # that it could not, and why — is what a backward edge in a graph is worth.
+        later = [
+            record
+            for spec in STAGES
+            if spec.number > rollback_stage.number
+            for record in load_accumulator(paths, spec)
+        ]
+        own = load_accumulator(paths, rollback_stage)
+        if own and later:
+            obstruction = independence_obstruction(own, later)
+            lines.append(
+                f"Withdrawing {rollback_stage.slug} alone was not available: {obstruction}"
+                if obstruction is not None
+                else (
+                    f"The stages after {rollback_stage.slug} are independent of it; their "
+                    "accumulated work is being withdrawn because the rollback is in "
+                    "reverse order, not because it had to be."
+                )
+            )
+
+        withheld = pending_emissions(paths)
+        if withheld:
+            lines.append(
+                f"{len(withheld)} withheld emission intent(s) will be discarded; "
+                "none of them was performed."
+            )
         return "\n".join(lines)
 
     def describe_run_status(self, run_root: Path) -> str:

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -446,8 +446,33 @@ def sync_stage_session_id(paths: RunPaths, stage: StageSpec, session_id: str | N
 
 
 def rollback_to_stage(paths: RunPaths, rollback_stage: StageSpec, reason: str | None = None) -> RunManifest:
+    """Mark the manifest back to ``rollback_stage`` **and** take the workspace back with it.
+
+    This function used to do only the first half. It set ``status``, ``approved``,
+    ``dirty``, ``stale`` and ``invalidated_by_stage`` on the entries at and after the
+    target and left ``workspace/`` untouched, so the artifacts of the future being
+    abandoned stayed on disk and stayed countable. Six of the graph's forward guards count
+    files; a run that rolled back from Stage 06 to Stage 03 found the edge out of Stage 03
+    already open, satisfied by the data Stage 04 and Stage 05 had written under the design
+    being abandoned.
+
+    The recovery is wired here rather than at the three call sites so that no caller can
+    reach a rollback without it. ``/back`` from the operator, a research round that
+    redirected itself, and a review that withdrew an approval all go through this seam,
+    and a rollback that recovered the workspace on two of the three paths would be worse
+    than one that recovered on none: the difference between the paths is invisible in the
+    run record.
+    """
+
+    from .effects import recover_to_stage
+    from .utils import append_log_entry
+
     manifest = ensure_run_manifest(paths)
     invalidated_reason = reason or f"Rolled back to {rollback_stage.stage_title}"
+
+    recovery = recover_to_stage(paths, rollback_stage, invalidated_reason)
+    if recovery.touched:
+        append_log_entry(paths.logs, "rollback recovery", recovery.render())
     updated_stages: list[StageManifestEntry] = []
 
     for entry in manifest.stages:

--- a/src/provenance.py
+++ b/src/provenance.py
@@ -1,0 +1,713 @@
+"""Which stage wrote each artifact, which version of it, and whether it still counts.
+
+A rollback in AutoR was bookkeeping. :func:`src.manifest.rollback_to_stage` set
+``stale``/``dirty``/``invalidated_by_stage`` on the manifest entries at and after the
+target, and :meth:`src.manager.AutoRManager._rollback_and_jump` added a correction and a
+log line. Nothing under ``workspace/`` moved. Every file the abandoned future wrote was
+still on disk, and nothing on disk said which stage had written it.
+
+Two consequences, and the second is the one that decided a run.
+
+**A forward gate could be fed by the future it had just invalidated.** Six of the graph's
+forward edges are guarded by counting files: ``_guard_design_artifacts`` counts
+``workspace/data``, ``_guard_runnable_code`` counts ``workspace/code``,
+``_guard_results_exist`` counts ``workspace/results``, ``_guard_validity_chain`` counts
+``workspace/figures``, ``_guard_report_exists`` counts ``workspace/writing``. A run that
+reached Stage 06, discovered the design was wrong and rolled back to Stage 03 then found
+the edge out of Stage 03 already open — satisfied by the data files Stage 04 and Stage 05
+had written under the design being abandoned. The gate meant to prove *this* visit did the
+work was answering for the previous one.
+
+``_guard_round_abandoned`` states the invariant the others were relying on: "Every other
+guard here reads stage artifacts, which a rollback invalidates." That sentence was the
+reason given for scoping one guard to the visit and leaving the rest global. It was not
+true. A rollback invalidated manifest rows; the artifacts those guards read were untouched.
+
+**The same defect had already been patched once, by hand.** ``_skip_stage`` carries the
+note that a skipped Stage 06's round declaration is "never consumed and never unlinked.
+Left on disk, the *next* Stage 06 closes its round from the previous visit's file —
+inheriting a conclusion drawn from results it did not produce." One instance, one patch,
+at one path. The general shape — a stage's output outliving the stage's approval — had no
+mechanism behind it.
+
+This module is that mechanism's first half: it makes *attribution* exist. Without a record
+of which stage produced a file, "withdraw Stage 04's contribution" has no referent, and a
+guard cannot tell an artifact it should count from one it should not. :mod:`src.effects`
+is the second half, and turns attribution into recovery.
+
+**Attribution is observed, not declared.** The stage's work is done by an agent CLI writing
+files directly, so AutoR cannot intercept the writes. It can only compare: each row keeps a
+content hash per version, and :func:`observe` re-scans the workspace at a stage boundary and
+attributes whatever is new or changed to the stage that just ran. That is weaker than
+instrumentation in one specific way, recorded per version as ``restorable``: a version whose
+bytes AutoR never held can be withdrawn from the guards and deleted, but not rewound to. The
+limit is the system boundary of a revertible-effect model drawn where it actually falls —
+per file, by whether the previous state can be restored, rather than per medium.
+
+**A row is a version chain, not a single state.** A file created at Stage 02 and rewritten
+at Stage 05 has two versions, and rolling back to Stage 04 does not withdraw it: it rewinds
+it to what Stage 02 left. Withdrawal is for files whose *creator* is being withdrawn. Keeping
+only the latest version would collapse the two cases into "delete", which would take Stage
+02's honest work with Stage 05's — which is precisely the loss a graph topology exists to
+avoid.
+
+**Version identity is a fresh name, never a value.** ``version_uid`` is drawn from a counter
+that only ever increases, and a uid retired by a rewind is not reissued. A consumer that
+recorded ``a000007`` and finds ``a000019`` knows its input changed, without comparing values
+— two stages can write byte-identical content and still be distinguishable, which is what a
+re-run after a rollback produces and what a value comparison would silently miss.
+
+The ledger lives under ``evolution/`` beside the other records of how a run reached its
+answer, not under ``workspace/``, so a benchmark export of the workspace does not ship it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from .utils import INTAKE_STAGE, RunPaths, StageSpec, STAGES
+
+#: Directory names never walked when attributing artifacts. Caches and version-control
+#: metadata are not research output, and a ``.git`` under the workspace would make the
+#: scan quadratic in the run's own history.
+SKIP_DIR_NAMES = frozenset(
+    {"__pycache__", ".git", ".ipynb_checkpoints", "node_modules", ".venv", ".pytest_cache"}
+)
+
+#: Workspace files a rollback must not touch, by path relative to ``workspace/``.
+#:
+#: The distinction is the one ``_guard_round_abandoned`` already draws: "Every other guard
+#: here reads stage artifacts, which a rollback invalidates. This one reads a *ledger*." An
+#: artifact is a stage's claim about the research and is withdrawn with the stage. A ledger
+#: is the run's record of how it got here, and survives the stages it describes — otherwise
+#: a rollback launders it. ``research_rounds.json`` is the case with a test on it already:
+#: a round that concluded the question cannot be answered must not become answerable again
+#: by rolling back to Stage 03 and resuming, and it would if the rollback rewound the file
+#: recording the abandonment.
+#:
+#: ``preregistration.json`` is here for a different reason. It has its own invalidation
+#: path in :mod:`src.preregistration`, stamped outside the workspace and checked for
+#: tampering, and two mechanisms deciding whether one frozen document still counts is how
+#: they drift apart.
+#:
+#: Excluded at :func:`observe` rather than at withdrawal, so these files carry no
+#: attribution at all and the fail-open rule in :func:`is_live` keeps them countable.
+LEDGER_PATHS = frozenset(
+    {
+        "notes/research_rounds.json",
+        "notes/round_decision.json",
+        "notes/preregistration.json",
+    }
+)
+
+#: Where the boundary falls. Under it, ``observe`` keeps a copy of the bytes so a later
+#: rollback can restore that version; over it, the version records ``restorable=False``
+#: and a rollback can only withdraw and delete. A cap rather than a medium: the same
+#: directory holds a 2 KB results table AutoR can rewind and a 4 GB checkpoint it cannot,
+#: and the honest record says so per version.
+RESTORABLE_BYTE_LIMIT = 8 * 1024 * 1024
+
+#: Intake is in here at number 0 on purpose. Whatever bootstrap puts in the workspace
+#: before Stage 01 runs is attributed to intake, and no rollback targets a stage below
+#: 01, so those files are never withdrawn. Leaving intake out would reach the same
+#: behaviour through an unattributed row, which is the same answer for the wrong reason
+#: and would change the day someone rolls back to Stage 00.
+_STAGE_NUMBER_BY_SLUG: dict[str, int] = {
+    stage.slug: stage.number for stage in (INTAKE_STAGE, *STAGES)
+}
+
+
+def stage_number_for_slug(slug: str) -> int | None:
+    """The stage number a slug names, or ``None`` when it names no stage.
+
+    Rows written by an earlier AutoR, or by a caller passing a label that is not a
+    stage, resolve to ``None`` and are treated as unattributed everywhere below.
+    """
+
+    return _STAGE_NUMBER_BY_SLUG.get(str(slug).strip())
+
+
+@dataclass(frozen=True)
+class ArtifactVersion:
+    """One set of bytes a file held, and which stage's window left it that way."""
+
+    stage: str
+    version_uid: str
+    content_hash: str
+    size_bytes: int
+    at: str
+    #: Whether ``blob_hash`` holds the bytes, so a rollback can rewind to this version
+    #: rather than only delete past it. False above :data:`RESTORABLE_BYTE_LIMIT`.
+    restorable: bool = True
+    blob_hash: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "stage": self.stage,
+            "version_uid": self.version_uid,
+            "content_hash": self.content_hash,
+            "size_bytes": self.size_bytes,
+            "at": self.at,
+            "restorable": self.restorable,
+            "blob_hash": self.blob_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "ArtifactVersion":
+        return cls(
+            stage=str(payload.get("stage", "")).strip(),
+            version_uid=str(payload.get("version_uid", "")).strip(),
+            content_hash=str(payload.get("content_hash", "")).strip(),
+            size_bytes=int(payload.get("size_bytes", 0) or 0),
+            at=str(payload.get("at", "")).strip(),
+            restorable=bool(payload.get("restorable", True)),
+            blob_hash=str(payload.get("blob_hash", "")).strip(),
+        )
+
+
+@dataclass(frozen=True)
+class ArtifactProvenance:
+    """One workspace file: every version it has held, and whether it still counts."""
+
+    rel_path: str
+    versions: tuple[ArtifactVersion, ...] = ()
+    #: Set when a rollback withdrew the stage that *created* this file. The row is kept
+    #: rather than dropped: a reader has to be able to tell a withdrawn artifact from
+    #: one that was never seen, and the fail-open rule in :func:`is_live` reads an unseen
+    #: file as countable — so dropping the row would hand the withdrawn artifact straight
+    #: back to the gate it was withdrawn from.
+    invalidated_by_stage: str | None = None
+    invalidated_reason: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "rel_path": self.rel_path,
+            "produced_by_stage": self.produced_by_stage,
+            "last_written_by_stage": self.last_written_by_stage,
+            "version_uid": self.version_uid,
+            "content_hash": self.content_hash,
+            "size_bytes": self.size_bytes,
+            "first_seen_at": self.first_seen_at,
+            "updated_at": self.updated_at,
+            "invalidated_by_stage": self.invalidated_by_stage,
+            "invalidated_reason": self.invalidated_reason,
+            "restorable": self.restorable,
+            "blob_hash": self.blob_hash,
+            "versions": [version.to_dict() for version in self.versions],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "ArtifactProvenance":
+        raw_versions = payload.get("versions")
+        versions: list[ArtifactVersion] = []
+        if isinstance(raw_versions, list):
+            versions = [
+                ArtifactVersion.from_dict(item) for item in raw_versions if isinstance(item, dict)
+            ]
+        if not versions:
+            # A row written before version chains existed carries one flat state. Read
+            # as a single version so the chain-aware readers below need no second shape.
+            stage = str(payload.get("produced_by_stage", "")).strip()
+            if stage or payload.get("content_hash"):
+                versions = [
+                    ArtifactVersion(
+                        stage=stage,
+                        version_uid=str(payload.get("version_uid", "")).strip(),
+                        content_hash=str(payload.get("content_hash", "")).strip(),
+                        size_bytes=int(payload.get("size_bytes", 0) or 0),
+                        at=str(payload.get("updated_at", "")).strip(),
+                        restorable=bool(payload.get("restorable", True)),
+                        blob_hash=str(payload.get("blob_hash", "")).strip(),
+                    )
+                ]
+        invalidated = payload.get("invalidated_by_stage")
+        return cls(
+            rel_path=str(payload.get("rel_path", "")).strip(),
+            versions=tuple(versions),
+            invalidated_by_stage=(
+                str(invalidated).strip()
+                if isinstance(invalidated, str) and invalidated.strip()
+                else None
+            ),
+            invalidated_reason=str(payload.get("invalidated_reason", "")).strip(),
+        )
+
+    @property
+    def live(self) -> bool:
+        return self.invalidated_by_stage is None
+
+    @property
+    def produced_by_stage(self) -> str:
+        return self.versions[0].stage if self.versions else ""
+
+    @property
+    def last_written_by_stage(self) -> str:
+        return self.versions[-1].stage if self.versions else ""
+
+    @property
+    def version_uid(self) -> str:
+        return self.versions[-1].version_uid if self.versions else ""
+
+    @property
+    def content_hash(self) -> str:
+        return self.versions[-1].content_hash if self.versions else ""
+
+    @property
+    def size_bytes(self) -> int:
+        return self.versions[-1].size_bytes if self.versions else 0
+
+    @property
+    def restorable(self) -> bool:
+        return self.versions[-1].restorable if self.versions else False
+
+    @property
+    def blob_hash(self) -> str:
+        return self.versions[-1].blob_hash if self.versions else ""
+
+    @property
+    def first_seen_at(self) -> str:
+        return self.versions[0].at if self.versions else ""
+
+    @property
+    def updated_at(self) -> str:
+        return self.versions[-1].at if self.versions else ""
+
+    def restore_point(self, before_stage_number: int) -> ArtifactVersion | None:
+        """The latest version written by a stage strictly before ``before_stage_number``.
+
+        What the file should say once every stage at or after that number is withdrawn.
+        ``None`` when the file has no such version, which means it did not exist before
+        the withdrawn range and withdrawing the range deletes it.
+        """
+
+        candidate: ArtifactVersion | None = None
+        for version in self.versions:
+            number = stage_number_for_slug(version.stage)
+            if number is None or number >= before_stage_number:
+                continue
+            candidate = version
+        return candidate
+
+    def trimmed_to(self, before_stage_number: int) -> "ArtifactProvenance":
+        """This row with every version written at or after ``before_stage_number`` dropped."""
+
+        kept = tuple(
+            version
+            for version in self.versions
+            if (stage_number_for_slug(version.stage) or -1) < before_stage_number
+        )
+        return replace(self, versions=kept)
+
+
+@dataclass(frozen=True)
+class ProvenanceLedger:
+    #: Monotone. The next uid to hand out, never decreased and never rewound by a
+    #: withdrawal, so a uid names one version of one file for the life of the run.
+    next_uid: int
+    entries: dict[str, ArtifactProvenance] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "next_uid": self.next_uid,
+            "entries": [
+                entry.to_dict() for entry in sorted(self.entries.values(), key=lambda e: e.rel_path)
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "ProvenanceLedger":
+        entries: dict[str, ArtifactProvenance] = {}
+        raw_entries = payload.get("entries", [])
+        if isinstance(raw_entries, list):
+            for item in raw_entries:
+                if not isinstance(item, dict):
+                    continue
+                record = ArtifactProvenance.from_dict(item)
+                if record.rel_path:
+                    entries[record.rel_path] = record
+        return cls(next_uid=int(payload.get("next_uid", 1) or 1), entries=entries)
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def ledger_path(paths: RunPaths) -> Path:
+    return paths.evolution_dir / "artifact_provenance.json"
+
+
+def blob_dir(paths: RunPaths) -> Path:
+    return paths.evolution_dir / "effects" / "blobs"
+
+
+def load_ledger(paths: RunPaths) -> ProvenanceLedger:
+    path = ledger_path(paths)
+    if not path.exists():
+        return ProvenanceLedger(next_uid=1)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        # A ledger that cannot be read is not a reason to refuse every gate. The
+        # fail-open rule in `is_live` covers an empty ledger, so a corrupt one degrades
+        # to the pre-provenance behaviour rather than to a stuck run.
+        return ProvenanceLedger(next_uid=1)
+    if not isinstance(payload, dict):
+        return ProvenanceLedger(next_uid=1)
+    return ProvenanceLedger.from_dict(payload)
+
+
+def save_ledger(paths: RunPaths, ledger: ProvenanceLedger) -> None:
+    path = ledger_path(paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(ledger.to_dict(), indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def hash_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def content_identity(path: Path, size_bytes: int) -> str:
+    """A value that changes when the file's contents change.
+
+    A digest below :data:`RESTORABLE_BYTE_LIMIT`, and size-and-mtime above it.
+
+    :func:`observe` runs at every stage boundary and walks the whole workspace, so the
+    cost of this call is paid eight times a run over everything the run has produced. A
+    training checkpoint is the case that matters: hashing four gigabytes eight times to
+    learn something the run cannot act on is the wrong trade, because a version over the
+    limit is recorded ``restorable=False`` and a rollback can only delete it. What is
+    needed above the limit is *change detection*, not content addressing, and size with
+    mtime is the standard cheap detector for that.
+
+    What it costs is the case where a large file is rewritten within the same second at
+    exactly its previous length. Such a rewrite is read as no change, so the version chain
+    misses it and a rollback deletes the file rather than rewinding — which is what it
+    would have done anyway, the bytes never having been held.
+    """
+
+    if size_bytes > RESTORABLE_BYTE_LIMIT:
+        return f"size-mtime:{size_bytes}:{path.stat().st_mtime_ns}"
+    return hash_file(path)
+
+
+def store_blob(paths: RunPaths, payload: bytes) -> str:
+    """Put bytes in the content-addressed store and return their hash.
+
+    Write-once: two versions with the same bytes share one blob, and re-storing an
+    existing one is a no-op rather than a rewrite, so a restore cannot race a store.
+    """
+
+    digest = hash_bytes(payload)
+    target = blob_dir(paths) / digest
+    if target.exists():
+        return digest
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(".tmp")
+    tmp.write_bytes(payload)
+    tmp.replace(target)
+    return digest
+
+
+def load_blob(paths: RunPaths, digest: str) -> bytes | None:
+    if not digest:
+        return None
+    target = blob_dir(paths) / digest
+    if not target.exists():
+        return None
+    return target.read_bytes()
+
+
+def _walk_workspace(paths: RunPaths) -> list[Path]:
+    root = paths.workspace_root
+    if not root.exists():
+        return []
+    found: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if any(part in SKIP_DIR_NAMES for part in relative.parts[:-1]):
+            continue
+        if relative.as_posix() in LEDGER_PATHS:
+            continue
+        found.append(path)
+    return found
+
+
+def observe(paths: RunPaths, stage: StageSpec | str) -> ProvenanceLedger:
+    """Attribute everything new or changed under ``workspace/`` to the stage that ran.
+
+    Called at a stage boundary. A path whose bytes match the newest version on record is
+    untouched work and gets no new version. Anything else — a path the ledger has never
+    seen, or one whose bytes moved — gets a version appended, naming this stage and a
+    fresh uid.
+
+    A row carrying a withdrawal is revived only if its bytes changed. A rollback that
+    could not delete a file leaves it on disk withdrawn, and a re-run that genuinely
+    rewrote it clears the withdrawal. A re-run that did not touch it leaves it withdrawn,
+    which is the point: the file is still the abandoned future's, and the gate that counts
+    it should still not count it.
+    """
+
+    slug = stage.slug if isinstance(stage, StageSpec) else str(stage).strip()
+    ledger = load_ledger(paths)
+    entries = dict(ledger.entries)
+    next_uid = ledger.next_uid
+    now = _now()
+
+    for path in _walk_workspace(paths):
+        rel_path = path.relative_to(paths.workspace_root).as_posix()
+        try:
+            stat = path.stat()
+            digest = content_identity(path, stat.st_size)
+        except OSError:
+            continue
+
+        existing = entries.get(rel_path)
+        if existing is not None and existing.content_hash == digest:
+            continue
+
+        restorable = stat.st_size <= RESTORABLE_BYTE_LIMIT
+        blob_hash = ""
+        if restorable:
+            try:
+                blob_hash = store_blob(paths, path.read_bytes())
+            except OSError:
+                restorable = False
+                blob_hash = ""
+
+        version = ArtifactVersion(
+            stage=slug,
+            version_uid=f"a{next_uid:06d}",
+            content_hash=digest,
+            size_bytes=stat.st_size,
+            at=now,
+            restorable=restorable,
+            blob_hash=blob_hash,
+        )
+        next_uid += 1
+
+        if existing is None:
+            entries[rel_path] = ArtifactProvenance(rel_path=rel_path, versions=(version,))
+            continue
+
+        entries[rel_path] = replace(
+            existing,
+            versions=(*existing.versions, version),
+            # The bytes moved, so whatever withdrew this path no longer describes it.
+            invalidated_by_stage=None,
+            invalidated_reason="",
+        )
+
+    updated = ProvenanceLedger(next_uid=next_uid, entries=entries)
+    save_ledger(paths, updated)
+    return updated
+
+
+@dataclass(frozen=True)
+class Withdrawal:
+    """What a rollback determined about one file, before anything on disk moved."""
+
+    entry: ArtifactProvenance
+    #: The version to put back, or ``None`` when the file did not exist before the
+    #: withdrawn range and should be deleted.
+    restore_to: ArtifactVersion | None
+
+    @property
+    def rel_path(self) -> str:
+        return self.entry.rel_path
+
+    @property
+    def deletes(self) -> bool:
+        return self.restore_to is None
+
+
+def plan_withdrawal(paths: RunPaths, stage: StageSpec) -> list[Withdrawal]:
+    """What withdrawing every stage at or after ``stage`` implies for each file.
+
+    Read-only. Two cases per file, and separating them is the point of keeping version
+    chains: a file created inside the withdrawn range has no earlier version and goes
+    away, while a file created before it and amended inside it rewinds to what the last
+    stage outside the range left. Collapsing both into "delete" would discard the work of
+    stages the rollback never touched.
+    """
+
+    ledger = load_ledger(paths)
+    plan: list[Withdrawal] = []
+    for entry in sorted(ledger.entries.values(), key=lambda item: item.rel_path):
+        if not entry.versions:
+            continue
+        touched = any(
+            (stage_number_for_slug(version.stage) or -1) >= stage.number
+            for version in entry.versions
+        )
+        if not touched:
+            continue
+        plan.append(Withdrawal(entry=entry, restore_to=entry.restore_point(stage.number)))
+    return plan
+
+
+def invalidate_from(
+    paths: RunPaths,
+    stage: StageSpec,
+    reason: str = "",
+) -> list[Withdrawal]:
+    """Withdraw every version written at or after ``stage``. Returns what was withdrawn.
+
+    Only the ledger moves here; :func:`src.effects.apply_withdrawal` is what moves the
+    files. Rows whose creator is inside the withdrawn range are marked invalidated and
+    kept; rows that merely have versions inside it are trimmed back to their restore
+    point and stay live.
+    """
+
+    ledger = load_ledger(paths)
+    plan = plan_withdrawal(paths, stage)
+    if not plan:
+        return []
+
+    note = reason.strip() or f"Rolled back to {stage.stage_title}"
+    entries = dict(ledger.entries)
+    for item in plan:
+        if item.deletes:
+            # Marked, not trimmed. Trimming a row whose every version is inside the
+            # withdrawn range empties its chain, and an empty chain reports no content
+            # hash — so the next `observe` compares the file on disk against nothing,
+            # reads it as changed, and revives the withdrawal. A file the rollback could
+            # not delete would count again at the next boundary, which is the whole
+            # defect this module exists to close. The history stays: it is the record of
+            # what the abandoned future did, and the row is dropped outright by
+            # `drop_entries` once the file is actually gone.
+            entries[item.rel_path] = replace(
+                item.entry, invalidated_by_stage=stage.slug, invalidated_reason=note
+            )
+        else:
+            # Trimmed, because the chain now has to describe the file as the rewind
+            # leaves it: the restore point is the newest version, and its hash is what
+            # the next `observe` will find on disk.
+            entries[item.rel_path] = replace(
+                item.entry.trimmed_to(stage.number),
+                invalidated_by_stage=None,
+                invalidated_reason="",
+            )
+
+    save_ledger(paths, ProvenanceLedger(next_uid=ledger.next_uid, entries=entries))
+    return plan
+
+
+def drop_entries(paths: RunPaths, rel_paths: Iterable[str]) -> None:
+    """Forget the named rows entirely, for paths whose files no longer exist.
+
+    Only :mod:`src.effects` calls this, and only after it has deleted the file. A row for
+    a path that is not on disk would make :func:`observe` treat the next creation as a
+    rewrite of something that was never there.
+    """
+
+    targets = {str(item).strip() for item in rel_paths if str(item).strip()}
+    if not targets:
+        return
+    ledger = load_ledger(paths)
+    entries = {key: value for key, value in ledger.entries.items() if key not in targets}
+    if len(entries) != len(ledger.entries):
+        save_ledger(paths, ProvenanceLedger(next_uid=ledger.next_uid, entries=entries))
+
+
+def is_live(ledger: ProvenanceLedger, rel_path: str) -> bool:
+    """Whether a path counts. Unknown paths count.
+
+    Fail-open, deliberately. A run started before this ledger existed, a resumed run whose
+    ledger did not survive, and a file written outside any stage's window all reach here
+    with no row. Reading those as withdrawn would close every counting gate in the graph
+    at once, and a precondition no real run can meet is not a strict gate, it is a broken
+    one — which this repo has already shipped once, in ``_guard_results_exist``. Only an
+    explicit withdrawal takes a file out of a count.
+    """
+
+    entry = ledger.entries.get(rel_path)
+    if entry is None:
+        return True
+    return entry.live
+
+
+def path_is_live(paths: RunPaths, path: Path) -> bool:
+    """Whether one named file counts, for a guard that checks existence rather than count.
+
+    Same fail-open rule as :func:`is_live`, and the same reason: a gate that reads a single
+    well-known path must not close because no stage boundary has attributed it.
+    """
+
+    if not path.exists():
+        return False
+    try:
+        rel_path = path.relative_to(paths.workspace_root).as_posix()
+    except ValueError:
+        return True
+    return is_live(load_ledger(paths), rel_path)
+
+
+def live_files(paths: RunPaths, directory: Path, suffixes: set[str]) -> list[Path]:
+    """Files under ``directory`` with one of ``suffixes`` that a withdrawal has not taken.
+
+    The guard-facing query. Walks the directory as the pre-provenance counter did and then
+    subtracts what the ledger has withdrawn, so a gate reads the work of the visit it is
+    gating rather than of the visit that was abandoned.
+    """
+
+    if not directory.exists():
+        return []
+    ledger = load_ledger(paths)
+    root = paths.workspace_root
+    found: list[Path] = []
+    for path in sorted(directory.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in suffixes:
+            continue
+        if any(part in SKIP_DIR_NAMES for part in path.parts):
+            continue
+        try:
+            rel_path = path.relative_to(root).as_posix()
+        except ValueError:
+            # Outside the workspace, so no ledger row can describe it and no rollback
+            # reaches it. Counted, as it was before.
+            found.append(path)
+            continue
+        if is_live(ledger, rel_path):
+            found.append(path)
+    return found
+
+
+def count_live_files(paths: RunPaths, directory: Path, suffixes: set[str]) -> int:
+    return len(live_files(paths, directory, suffixes))
+
+
+def format_withdrawal_plan(plan: Sequence[Withdrawal]) -> str:
+    """What a rollback is about to do to the workspace, before it does it."""
+
+    if not plan:
+        return "No artifact needs withdrawing."
+    deletes = [item for item in plan if item.deletes]
+    rewinds = [item for item in plan if not item.deletes]
+    lines = [f"{len(plan)} artifact(s) affected: {len(deletes)} deleted, {len(rewinds)} rewound."]
+    for item in deletes:
+        lines.append(f"- delete {item.rel_path} (created by {item.entry.produced_by_stage})")
+    for item in rewinds:
+        assert item.restore_to is not None
+        lines.append(
+            f"- rewind {item.rel_path} to {item.restore_to.version_uid} "
+            f"({item.restore_to.stage})"
+        )
+    return "\n".join(lines)

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -58,7 +58,6 @@ from .utils import (
     RunPaths,
     StageSpec,
     STAGES,
-    _count_files_with_suffixes,
     read_text,
     write_text,
 )
@@ -102,12 +101,50 @@ def _load_json(path: Path) -> Any:
         return None
 
 
+def _load_json_if_live(paths: RunPaths, path: Path) -> Any:
+    """``_load_json``, except a file a rollback withdrew reads as absent.
+
+    For the gates that read one named document rather than counting a directory. The
+    ``preregistration`` is deliberately not read through this: it has its own
+    invalidation path in :mod:`src.preregistration`, stamped outside the workspace, and
+    two mechanisms deciding whether one frozen document counts is how they drift apart.
+    """
+
+    from .provenance import path_is_live
+
+    if not path_is_live(paths, path):
+        return None
+    return _load_json(path)
+
+
 def _guard_always(paths: RunPaths, state: "GraphState") -> GuardResult:
     return GuardResult(True, "no precondition")
 
 
+def _count_live(paths: RunPaths, directory: Path, suffixes: set[str]) -> int:
+    """Count the files in ``directory`` that a rollback has not withdrawn.
+
+    Every counting guard below reads this rather than ``_count_files_with_suffixes``,
+    and the difference is the one that decided runs. A rollback used to be a manifest
+    edit: ``workspace/`` was untouched, so the files the abandoned future had written
+    stayed on disk and stayed countable. A run that reached Stage 06, found the design
+    wrong and went back to Stage 03 met an already-open forward edge — opened by the
+    data files Stage 04 and Stage 05 had written under the design being abandoned. The
+    gate that exists to prove *this* visit did the work was answering for the visit the
+    run had just repudiated.
+
+    :func:`src.provenance.count_live_files` subtracts what
+    :func:`src.provenance.invalidate_from` withdrew, and counts anything unattributed,
+    so a run with no ledger behaves exactly as it did before.
+    """
+
+    from .provenance import count_live_files
+
+    return count_live_files(paths, directory, suffixes)
+
+
 def _guard_design_artifacts(paths: RunPaths, state: "GraphState") -> GuardResult:
-    count = _count_files_with_suffixes(paths.data_dir, MACHINE_DATA_SUFFIXES)
+    count = _count_live(paths, paths.data_dir, MACHINE_DATA_SUFFIXES)
     protocol = _load_json(paths.experimental_protocol)
     has_protocol = isinstance(protocol, dict) and bool(protocol.get("baselines"))
     if count and has_protocol:
@@ -121,8 +158,8 @@ def _guard_design_artifacts(paths: RunPaths, state: "GraphState") -> GuardResult
 
 
 def _guard_runnable_code(paths: RunPaths, state: "GraphState") -> GuardResult:
-    count = _count_files_with_suffixes(
-        paths.code_dir, {".py", ".sh", ".r", ".jl", ".ipynb", ".cpp", ".rs", ".go"}
+    count = _count_live(
+        paths, paths.code_dir, {".py", ".sh", ".r", ".jl", ".ipynb", ".cpp", ".rs", ".go"}
     )
     if count:
         return GuardResult(True, f"{count} executable file(s) under workspace/code")
@@ -138,7 +175,7 @@ def _guard_results_exist(paths: RunPaths, state: "GraphState") -> GuardResult:
     the forward move out of Stage 05 was permanently closed. A precondition no real
     run can meet is not a strict gate, it is a broken one.
     """
-    count = _count_files_with_suffixes(paths.results_dir, RESULT_SUFFIXES)
+    count = _count_live(paths, paths.results_dir, RESULT_SUFFIXES)
     manifest = _load_json(paths.experiment_manifest)
     indexed = manifest.get("result_artifacts") if isinstance(manifest, dict) else None
     if count and indexed:
@@ -187,7 +224,7 @@ def _guard_validity_chain(paths: RunPaths, state: "GraphState") -> GuardResult:
         for item in hypotheses
         if isinstance(item, dict) and str(item.get("type") or "") == "empirical"
     }
-    outcomes = _load_json(paths.hypothesis_outcomes)
+    outcomes = _load_json_if_live(paths, paths.hypothesis_outcomes)
     recorded = {
         str(item.get("id") or "").strip()
         for item in (outcomes.get("outcomes", []) if isinstance(outcomes, dict) else [])
@@ -199,14 +236,18 @@ def _guard_validity_chain(paths: RunPaths, state: "GraphState") -> GuardResult:
             False,
             "these preregistered hypotheses have no verdict yet: " + ", ".join(unadjudicated),
         )
-    figures = _count_files_with_suffixes(paths.figures_dir, FIGURE_SUFFIXES)
+    figures = _count_live(paths, paths.figures_dir, FIGURE_SUFFIXES)
     if not figures:
         return GuardResult(False, "the analysis produced no figure under workspace/figures")
     return GuardResult(True, f"every hypothesis is adjudicated and {figures} figure(s) exist")
 
 
 def _guard_report_exists(paths: RunPaths, state: "GraphState") -> GuardResult:
-    if paths.report_file.exists() or _count_files_with_suffixes(paths.writing_dir, {".tex", ".md"}):
+    from .provenance import path_is_live
+
+    if path_is_live(paths, paths.report_file) or _count_live(
+        paths, paths.writing_dir, {".tex", ".md"}
+    ):
         return GuardResult(True, "a written deliverable exists")
     return GuardResult(False, "no report or manuscript source has been written")
 
@@ -240,6 +281,13 @@ def _guard_round_abandoned(paths: RunPaths, state: "GraphState") -> GuardResult:
     # This one reads a ledger, so the scoping has to be explicit: the closing round
     # is stamped on the `Visit`, and the guard asks whether *this* traversal closed
     # a round that concluded abandon.
+    #
+    # That first sentence was the reason given for scoping this guard and leaving the
+    # others global, and until `src.provenance` existed it was false: a rollback edited
+    # manifest rows and left `workspace/` alone, so every artifact the other guards
+    # counted survived the rollback that was supposed to invalidate it. The distinction
+    # this comment draws — artifacts a rollback withdraws, ledgers it does not — is now
+    # the distinction the code makes, via `_count_live` and `_load_json_if_live`.
     visit = state.path[-1] if state.path else None
     closed = visit.closed_round if visit is not None else 0
     if not closed:
@@ -267,7 +315,7 @@ def _guard_round_abandoned(paths: RunPaths, state: "GraphState") -> GuardResult:
 
 
 def _guard_has_hypotheses(paths: RunPaths, state: "GraphState") -> GuardResult:
-    manifest = _load_json(paths.hypothesis_manifest)
+    manifest = _load_json_if_live(paths, paths.hypothesis_manifest)
     if isinstance(manifest, dict) and manifest.get("empirical_hypotheses"):
         return GuardResult(True, "typed hypotheses are on record")
     return GuardResult(False, "no empirical hypothesis has been stated yet")

--- a/tests/test_a_rollback_closes_the_gate_it_opened.py
+++ b/tests/test_a_rollback_closes_the_gate_it_opened.py
@@ -1,0 +1,173 @@
+"""A forward gate must not be satisfied by the future the run has just repudiated.
+
+Six of the graph's forward edges are guarded by counting files under ``workspace/``. A
+rollback set flags on the manifest and left ``workspace/`` alone, so the count those guards
+read still included everything the abandoned stages had written. A run that reached Stage
+06, found the study design wrong and rolled back to Stage 03 met an already-open edge out
+of Stage 03 — opened by the data Stage 04 and Stage 05 had produced under the design being
+abandoned. The gate that exists to prove *this* visit did the work was answering for the
+visit the run had just repudiated.
+
+``_guard_round_abandoned`` states the invariant the rest were relying on: "Every other
+guard here reads stage artifacts, which a rollback invalidates." It was not true. This
+module is where it becomes true, and the first test is the one that failed before
+:mod:`src.provenance` and :mod:`src.effects` existed.
+
+The same class of defect had already been patched once by hand, at one path, in
+``_skip_stage``: a skipped Stage 06's round declaration was "never consumed and never
+unlinked", so the next Stage 06 closed its round from the previous visit's file. One
+instance, one patch. The general shape is what these tests hold.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.manifest import ensure_run_manifest, rollback_to_stage, update_stage_entry
+from src.provenance import observe
+from src.stage_graph import GUARDS, GraphState
+from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+
+STAGE_03, STAGE_04, STAGE_05, STAGE_06 = STAGES[2], STAGES[3], STAGES[4], STAGES[5]
+
+
+class RollbackClosesTheGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+        ensure_run_manifest(self.paths)
+
+    def _guard(self, name: str) -> bool:
+        return GUARDS[name](self.paths, GraphState()).ok
+
+    def test_the_design_gate_closes_when_the_design_it_counted_is_withdrawn(self) -> None:
+        write_text(
+            self.paths.experimental_protocol,
+            '{"baselines": [{"name": "control"}]}\n',
+        )
+        write_text(self.paths.data_dir / "design_matrix.csv", "arm,n\ncontrol,30\n")
+        observe(self.paths, STAGE_04)
+        self.assertTrue(self._guard("design_artifacts"), "precondition: the gate is open")
+
+        rollback_to_stage(self.paths, STAGE_03, "the design answered a different question")
+
+        self.assertFalse(
+            self._guard("design_artifacts"),
+            "the edge out of Stage 03 was open on the strength of Stage 04's own output",
+        )
+
+    def test_the_results_gate_closes_when_the_experiment_is_withdrawn(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"accuracy": 0.9}\n')
+        write_text(
+            self.paths.experiment_manifest,
+            '{"result_artifacts": [{"rel_path": "results/metrics.json"}]}\n',
+        )
+        observe(self.paths, STAGE_05)
+        self.assertTrue(self._guard("results_exist"))
+
+        rollback_to_stage(self.paths, STAGE_04, "the implementation was wrong")
+
+        self.assertFalse(self._guard("results_exist"))
+
+    def test_the_code_gate_closes_when_the_implementation_is_withdrawn(self) -> None:
+        write_text(self.paths.code_dir / "run.py", "print('hi')\n")
+        observe(self.paths, STAGE_04)
+        self.assertTrue(self._guard("runnable_code"))
+
+        rollback_to_stage(self.paths, STAGE_04, "wrong implementation")
+
+        self.assertFalse(self._guard("runnable_code"))
+
+    def test_the_report_gate_closes_when_the_manuscript_is_withdrawn(self) -> None:
+        write_text(self.paths.writing_dir / "paper.md", "# Findings\n")
+        observe(self.paths, STAGE_06)
+        self.assertTrue(self._guard("report_exists"))
+
+        rollback_to_stage(self.paths, STAGE_05, "the analysis was wrong")
+
+        self.assertFalse(self._guard("report_exists"))
+
+    def test_the_hypothesis_gate_closes_when_the_manifest_is_withdrawn(self) -> None:
+        write_text(
+            self.paths.hypothesis_manifest,
+            '{"empirical_hypotheses": [{"id": "H1", "type": "empirical"}]}\n',
+        )
+        observe(self.paths, STAGE_04)
+        self.assertTrue(self._guard("has_hypotheses"))
+
+        rollback_to_stage(self.paths, STAGE_03, "the hypotheses were not falsifiable")
+
+        self.assertFalse(self._guard("has_hypotheses"))
+
+    def test_a_gate_reopens_once_the_re_run_actually_redoes_the_work(self) -> None:
+        """The withdrawal is not a permanent closure. It is a demand for this visit's work.
+
+        A run that rolls back and then genuinely re-does the stage must get its edge back,
+        or the mechanism has replaced one broken gate with another.
+        """
+
+        write_text(self.paths.experimental_protocol, '{"baselines": [{"name": "control"}]}\n')
+        write_text(self.paths.data_dir / "design_matrix.csv", "arm,n\ncontrol,30\n")
+        observe(self.paths, STAGE_04)
+        rollback_to_stage(self.paths, STAGE_03, "wrong design")
+        self.assertFalse(self._guard("design_artifacts"))
+
+        # Both halves have to be redone, and the gate is right to want both. The protocol
+        # was Stage 04's too, so the rollback withdrew it; a re-run that rewrote only the
+        # data matrix would be declaring a design against baselines it had disowned.
+        write_text(self.paths.data_dir / "design_matrix.csv", "arm,n\ncontrol,60\ntreatment,60\n")
+        self.assertFalse(self._guard("design_artifacts"))
+        write_text(
+            self.paths.experimental_protocol,
+            '{"baselines": [{"name": "control"}, {"name": "treatment"}]}\n',
+        )
+        observe(self.paths, STAGE_03)
+
+        self.assertTrue(self._guard("design_artifacts"))
+
+    def test_work_from_before_the_rollback_target_still_counts(self) -> None:
+        """A rollback withdraws a range, not a directory.
+
+        Stage 03's own data must survive a rollback to Stage 04, or the graph's backward
+        edge costs more than the pipeline it replaced.
+        """
+
+        write_text(self.paths.experimental_protocol, '{"baselines": [{"name": "control"}]}\n')
+        write_text(self.paths.data_dir / "design_matrix.csv", "arm,n\ncontrol,30\n")
+        observe(self.paths, STAGE_03)
+        write_text(self.paths.data_dir / "run_log.csv", "step,loss\n1,0.5\n")
+        observe(self.paths, STAGE_05)
+
+        rollback_to_stage(self.paths, STAGE_04, "the implementation was wrong")
+
+        self.assertTrue((self.paths.data_dir / "design_matrix.csv").exists())
+        self.assertFalse((self.paths.data_dir / "run_log.csv").exists())
+        self.assertTrue(self._guard("design_artifacts"))
+
+    def test_a_run_with_no_ledger_behaves_as_it_did_before_one_existed(self) -> None:
+        """Fail-open, checked. Every counting gate would close at once if it did not."""
+
+        write_text(self.paths.experimental_protocol, '{"baselines": [{"name": "control"}]}\n')
+        write_text(self.paths.data_dir / "design_matrix.csv", "arm,n\ncontrol,30\n")
+
+        self.assertTrue(self._guard("design_artifacts"))
+        rollback_to_stage(self.paths, STAGE_03, "no attribution exists for any of this")
+        self.assertTrue(self._guard("design_artifacts"))
+
+    def test_the_manifest_half_of_the_rollback_still_happens(self) -> None:
+        update_stage_entry(self.paths, STAGE_05, status="approved", approved=True)
+        rollback_to_stage(self.paths, STAGE_03, "reason")
+
+        manifest = ensure_run_manifest(self.paths)
+        by_number = {entry.number: entry for entry in manifest.stages}
+        self.assertEqual(by_number[STAGE_03.number].status, "pending")
+        self.assertTrue(by_number[STAGE_05.number].stale)
+        self.assertEqual(manifest.current_stage_slug, STAGE_03.slug)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,0 +1,247 @@
+"""The recovery half: inverses, the accumulator, and what a rollback does to the disk.
+
+The end-to-end assertion is :class:`RecoverToStageTests`. Everything above it is a
+property that one depends on.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.effects import (
+    COMMUTATIVE_KEYS,
+    EffectRecord,
+    Inverse,
+    ORDERED_KEYS,
+    accumulator_path,
+    apply_withdrawal,
+    independence_obstruction,
+    is_commutative,
+    key_for_workspace_path,
+    load_accumulator,
+    record_effect,
+    recover_to_stage,
+    reverted_path,
+    revert_from,
+    set_artifact,
+)
+from src.emissions import pending as pending_emissions, withhold
+from src.provenance import load_ledger, observe, plan_withdrawal
+from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+
+STAGE_02, STAGE_03, STAGE_04, STAGE_05, STAGE_06 = (
+    STAGES[1],
+    STAGES[2],
+    STAGES[3],
+    STAGES[4],
+    STAGES[5],
+)
+
+
+class EffectsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+
+
+class KeyClassificationTests(unittest.TestCase):
+    def test_the_two_sets_are_disjoint(self) -> None:
+        self.assertEqual(COMMUTATIVE_KEYS & ORDERED_KEYS, frozenset())
+
+    def test_an_unclassified_key_is_treated_as_ordered(self) -> None:
+        """Safe default. Reading it as commutative would license the reordering the
+        classification exists to authorise, on a location nobody has checked."""
+
+        self.assertFalse(is_commutative("something.nobody.classified"))
+
+    def test_a_table_shaped_key_is_commutative_and_a_narrative_is_not(self) -> None:
+        self.assertTrue(is_commutative("literature.sources"))
+        self.assertTrue(is_commutative("results"))
+        self.assertFalse(is_commutative("report.draft"))
+
+
+class KeyForPathTests(EffectsTestCase):
+    def test_a_workspace_path_maps_to_the_table_it_belongs_to(self) -> None:
+        self.assertEqual(key_for_workspace_path(self.paths, "data/counts.csv"), "data")
+        self.assertEqual(key_for_workspace_path(self.paths, "writing/paper.tex"), "report.draft")
+        self.assertEqual(key_for_workspace_path(self.paths, "results/a/b.json"), "results")
+
+
+class SetArtifactTests(EffectsTestCase):
+    def test_creating_a_file_accumulates_an_inverse_that_deletes_it(self) -> None:
+        record = set_artifact(self.paths, STAGE_04, "data/counts.csv", "id\n1\n")
+        target = self.paths.workspace_root / "data/counts.csv"
+
+        self.assertTrue(target.exists())
+        self.assertEqual(record.inverse.kind, "delete_path")
+        revert_from(self.paths, STAGE_04, STAGES)
+        self.assertFalse(target.exists())
+
+    def test_overwriting_a_file_accumulates_an_inverse_that_restores_the_bytes(self) -> None:
+        set_artifact(self.paths, STAGE_03, "data/counts.csv", "first\n")
+        record = set_artifact(self.paths, STAGE_04, "data/counts.csv", "second\n")
+        target = self.paths.workspace_root / "data/counts.csv"
+
+        self.assertEqual(record.inverse.kind, "restore_blob")
+        self.assertEqual(target.read_text(encoding="utf-8"), "second\n")
+        revert_from(self.paths, STAGE_04, STAGES)
+        self.assertEqual(target.read_text(encoding="utf-8"), "first\n")
+
+    def test_the_accumulator_survives_being_read_back_from_disk(self) -> None:
+        """Inverses are data, not closures. A run resumes in a new process."""
+
+        set_artifact(self.paths, STAGE_04, "data/counts.csv", "id\n1\n")
+        reloaded = load_accumulator(self.paths, STAGE_04)
+
+        self.assertEqual(len(reloaded), 1)
+        self.assertEqual(reloaded[0].inverse.payload["rel_path"], "data/counts.csv")
+
+
+class AccumulatorOrderTests(EffectsTestCase):
+    def test_inverses_are_applied_last_in_first_out(self) -> None:
+        target = self.paths.workspace_root / "data/counts.csv"
+        set_artifact(self.paths, STAGE_04, "data/counts.csv", "one\n")
+        set_artifact(self.paths, STAGE_04, "data/counts.csv", "two\n")
+        set_artifact(self.paths, STAGE_04, "data/counts.csv", "three\n")
+
+        revert_from(self.paths, STAGE_04, STAGES)
+        self.assertFalse(target.exists())
+
+    def test_later_stages_are_withdrawn_before_earlier_ones(self) -> None:
+        target = self.paths.workspace_root / "data/counts.csv"
+        set_artifact(self.paths, STAGE_03, "data/counts.csv", "design\n")
+        set_artifact(self.paths, STAGE_05, "data/counts.csv", "experiment\n")
+
+        report = revert_from(self.paths, STAGE_03, STAGES)
+        self.assertEqual(report.stages, [STAGE_05.slug, STAGE_03.slug])
+        self.assertFalse(target.exists())
+
+    def test_a_spent_accumulator_is_archived_rather_than_deleted(self) -> None:
+        set_artifact(self.paths, STAGE_04, "data/counts.csv", "id\n1\n")
+        revert_from(self.paths, STAGE_04, STAGES)
+
+        self.assertFalse(accumulator_path(self.paths, STAGE_04).exists())
+        archive = reverted_path(self.paths, STAGE_04)
+        self.assertTrue(archive.exists())
+        self.assertIn("reverted_at", json.loads(archive.read_text(encoding="utf-8").splitlines()[0]))
+
+    def test_an_unrecognised_inverse_is_skipped_rather_than_raised_on(self) -> None:
+        """One unreadable row must not stop the rest of a rollback: the rows after it are
+        the ones nearest the current state."""
+
+        set_artifact(self.paths, STAGE_04, "data/counts.csv", "id\n1\n")
+        record_effect(
+            self.paths,
+            EffectRecord(
+                stage=STAGE_04.slug,
+                key="data",
+                action="mystery",
+                rel_path="data/counts.csv",
+                inverse=Inverse("from_a_future_autor", {}),
+                at="",
+            ),
+        )
+
+        report = revert_from(self.paths, STAGE_04, STAGES)
+        self.assertEqual(len(report.skipped), 1)
+        self.assertFalse((self.paths.workspace_root / "data/counts.csv").exists())
+
+
+class IndependenceTests(EffectsTestCase):
+    def _record(self, stage, key: str) -> EffectRecord:
+        return EffectRecord(
+            stage=stage.slug, key=key, action="create", rel_path="x", inverse=Inverse("noop"), at=""
+        )
+
+    def test_effects_at_distinct_keys_never_obstruct_each_other(self) -> None:
+        obstruction = independence_obstruction(
+            [self._record(STAGE_04, "data")], [self._record(STAGE_06, "figures")]
+        )
+        self.assertIsNone(obstruction)
+
+    def test_effects_sharing_a_commutative_key_do_not_obstruct_each_other(self) -> None:
+        obstruction = independence_obstruction(
+            [self._record(STAGE_04, "results")], [self._record(STAGE_06, "results")]
+        )
+        self.assertIsNone(obstruction)
+
+    def test_effects_sharing_an_ordered_key_obstruct_a_selective_withdrawal(self) -> None:
+        obstruction = independence_obstruction(
+            [self._record(STAGE_04, "report.draft")], [self._record(STAGE_06, "report.draft")]
+        )
+        self.assertIsNotNone(obstruction)
+        assert obstruction is not None
+        self.assertIn("report.draft", obstruction)
+        self.assertIn("ordered", obstruction)
+
+    def test_an_unclassified_shared_key_says_so_rather_than_reading_as_ordered(self) -> None:
+        obstruction = independence_obstruction(
+            [self._record(STAGE_04, "brand.new")], [self._record(STAGE_06, "brand.new")]
+        )
+        assert obstruction is not None
+        self.assertIn("neither COMMUTATIVE_KEYS nor ORDERED_KEYS", obstruction)
+
+
+class ApplyWithdrawalTests(EffectsTestCase):
+    def test_an_observed_file_created_inside_the_range_is_deleted(self) -> None:
+        write_text(self.paths.data_dir / "late.csv", "id\n1\n")
+        observe(self.paths, STAGE_05)
+
+        apply_withdrawal(self.paths, plan_withdrawal(self.paths, STAGE_03))
+        self.assertFalse((self.paths.data_dir / "late.csv").exists())
+        self.assertNotIn("data/late.csv", load_ledger(self.paths).entries)
+
+    def test_an_observed_file_amended_inside_the_range_is_rewound(self) -> None:
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "early\n")
+        observe(self.paths, STAGE_02)
+        write_text(target, "late\n")
+        observe(self.paths, STAGE_05)
+
+        apply_withdrawal(self.paths, plan_withdrawal(self.paths, STAGE_04))
+        self.assertEqual(target.read_text(encoding="utf-8"), "early\n")
+
+
+class RecoverToStageTests(EffectsTestCase):
+    def test_a_rollback_takes_the_workspace_back_and_leaves_the_earlier_work(self) -> None:
+        kept = self.paths.data_dir / "design.csv"
+        amended = self.paths.data_dir / "shared.csv"
+        abandoned = self.paths.results_dir / "measurement.json"
+
+        write_text(kept, "the design\n")
+        write_text(amended, "as designed\n")
+        observe(self.paths, STAGE_03)
+
+        write_text(amended, "as measured\n")
+        write_text(abandoned, '{"value": 1}\n')
+        observe(self.paths, STAGE_05)
+
+        report = recover_to_stage(self.paths, STAGE_04, "the design was wrong")
+
+        self.assertTrue(report.touched)
+        self.assertTrue(kept.exists(), "Stage 03's own work is not Stage 05's to take with it")
+        self.assertEqual(amended.read_text(encoding="utf-8"), "as designed\n")
+        self.assertFalse(abandoned.exists())
+
+    def test_a_rollback_discards_the_withheld_emissions_of_the_range(self) -> None:
+        withhold(self.paths, STAGE_05, "pull_request", "publish the result")
+        withhold(self.paths, STAGE_02, "network", "fetch a corpus")
+
+        report = recover_to_stage(self.paths, STAGE_04)
+
+        self.assertEqual(report.emissions_discarded, 1)
+        self.assertEqual([item.stage for item in pending_emissions(self.paths)], [STAGE_02.slug])
+
+    def test_a_rollback_over_an_untouched_workspace_reports_that_it_did_nothing(self) -> None:
+        report = recover_to_stage(self.paths, STAGE_04)
+        self.assertFalse(report.touched)
+        self.assertIn("withdrew nothing", report.render())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -1,0 +1,92 @@
+"""An action that leaves the run is held until the stage that asked for it is approved.
+
+The division these tests hold is between an *acquisition*, which installs a record the run
+owns and can withdraw, and an *emission*, which puts data where other parties can read it
+and no inverse takes back. :mod:`src.effects` can undo the first. The only thing that makes
+the second recoverable is not having performed it yet.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.emissions import (
+    STATUS_DISCARDED,
+    STATUS_RELEASED,
+    STATUS_WITHHELD,
+    discard_from,
+    load_emissions,
+    pending,
+    release,
+    withhold,
+)
+from src.utils import STAGES, build_run_paths, ensure_run_layout
+
+STAGE_02, STAGE_04, STAGE_05, STAGE_08 = STAGES[1], STAGES[3], STAGES[4], STAGES[7]
+
+
+class EmissionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+
+    def test_a_registered_intent_is_withheld_and_nothing_says_otherwise(self) -> None:
+        emission = withhold(self.paths, STAGE_08, "pull_request", "open a PR with the report")
+
+        self.assertEqual(emission.status, STATUS_WITHHELD)
+        self.assertTrue(emission.withheld)
+        self.assertEqual([item.emission_id for item in pending(self.paths)], [emission.emission_id])
+
+    def test_intents_survive_a_reload_from_disk(self) -> None:
+        withhold(self.paths, STAGE_08, "quota", "spend the judge budget", {"calls": 40})
+
+        reloaded = load_emissions(self.paths)
+        self.assertEqual(len(reloaded), 1)
+        self.assertEqual(reloaded[0].payload["calls"], 40)
+
+    def test_releasing_a_stage_settles_only_that_stage(self) -> None:
+        withhold(self.paths, STAGE_04, "network", "fetch a corpus")
+        withhold(self.paths, STAGE_08, "pull_request", "open a PR")
+
+        released = release(self.paths, STAGE_08, "stage approved")
+
+        self.assertEqual([item.stage for item in released], [STAGE_08.slug])
+        self.assertEqual(released[0].status, STATUS_RELEASED)
+        self.assertEqual([item.stage for item in pending(self.paths)], [STAGE_04.slug])
+
+    def test_a_rollback_discards_the_range_and_leaves_earlier_intents_standing(self) -> None:
+        withhold(self.paths, STAGE_02, "network", "fetch a corpus")
+        withhold(self.paths, STAGE_05, "leaderboard", "post the score")
+
+        discarded = discard_from(self.paths, STAGE_04, "rolled back")
+
+        self.assertEqual([item.stage for item in discarded], [STAGE_05.slug])
+        self.assertEqual(discarded[0].status, STATUS_DISCARDED)
+        self.assertEqual([item.stage for item in pending(self.paths)], [STAGE_02.slug])
+
+    def test_a_settled_intent_is_not_settled_twice(self) -> None:
+        """The record of having released something must not be overwritten by a later
+        rollback claiming it was discarded. It was performed; that is history now."""
+
+        withhold(self.paths, STAGE_05, "leaderboard", "post the score")
+        release(self.paths, STAGE_05)
+
+        discard_from(self.paths, STAGE_04, "rolled back")
+
+        self.assertEqual([item.status for item in load_emissions(self.paths)], [STATUS_RELEASED])
+
+    def test_an_unclassified_kind_is_still_held(self) -> None:
+        """Refusing it would push the caller back to emitting directly, which is the
+        behaviour this module exists to replace."""
+
+        emission = withhold(self.paths, STAGE_05, "carrier_pigeon", "send the draft")
+        self.assertTrue(emission.withheld)
+        self.assertEqual(len(pending(self.paths)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,230 @@
+"""What the ledger has to get right for a rollback to mean anything.
+
+Every assertion here is a property :func:`src.manifest.rollback_to_stage` depends on. The
+two that matter most are the ones a single-state ledger would get wrong: a file created
+inside the withdrawn range goes away, and a file created before it and amended inside it
+goes *back*, rather than going away with it.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.provenance import (
+    LEDGER_PATHS,
+    RESTORABLE_BYTE_LIMIT,
+    count_live_files,
+    format_withdrawal_plan,
+    invalidate_from,
+    is_live,
+    load_ledger,
+    observe,
+    path_is_live,
+    plan_withdrawal,
+    stage_number_for_slug,
+)
+from src.utils import INTAKE_STAGE, STAGES, build_run_paths, ensure_run_layout, write_text
+
+STAGE_01, STAGE_02, STAGE_03, STAGE_04, STAGE_05 = STAGES[0], STAGES[1], STAGES[2], STAGES[3], STAGES[4]
+
+
+class ProvenanceTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+
+    def rel(self, path: Path) -> str:
+        return path.relative_to(self.paths.workspace_root).as_posix()
+
+
+class AttributionTests(ProvenanceTestCase):
+    def test_a_new_file_is_attributed_to_the_stage_whose_boundary_saw_it(self) -> None:
+        write_text(self.paths.data_dir / "counts.csv", "id,n\n1,2\n")
+        ledger = observe(self.paths, STAGE_03)
+
+        entry = ledger.entries[self.rel(self.paths.data_dir / "counts.csv")]
+        self.assertEqual(entry.produced_by_stage, STAGE_03.slug)
+        self.assertEqual(entry.last_written_by_stage, STAGE_03.slug)
+        self.assertTrue(entry.live)
+        self.assertEqual(len(entry.versions), 1)
+
+    def test_a_rewrite_appends_a_version_and_leaves_the_creator_alone(self) -> None:
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "id,n\n1,2\n")
+        observe(self.paths, STAGE_03)
+        write_text(target, "id,n\n1,2\n3,4\n")
+        ledger = observe(self.paths, STAGE_05)
+
+        entry = ledger.entries[self.rel(target)]
+        self.assertEqual(entry.produced_by_stage, STAGE_03.slug)
+        self.assertEqual(entry.last_written_by_stage, STAGE_05.slug)
+        self.assertEqual([version.stage for version in entry.versions], [STAGE_03.slug, STAGE_05.slug])
+
+    def test_an_unchanged_file_gets_no_second_version(self) -> None:
+        write_text(self.paths.data_dir / "counts.csv", "id,n\n1,2\n")
+        observe(self.paths, STAGE_03)
+        ledger = observe(self.paths, STAGE_04)
+
+        entry = ledger.entries[self.rel(self.paths.data_dir / "counts.csv")]
+        self.assertEqual(len(entry.versions), 1)
+        self.assertEqual(entry.last_written_by_stage, STAGE_03.slug)
+
+    def test_a_uid_is_never_reissued_even_for_identical_bytes(self) -> None:
+        """A re-run after a rollback writes the same bytes. It must still be a new version.
+
+        This is why the target view records a provider rather than a value: two stages can
+        produce byte-identical output, and a consumer comparing values could not tell the
+        re-run from the original.
+        """
+
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "same\n")
+        first = observe(self.paths, STAGE_03).entries[self.rel(target)].version_uid
+
+        write_text(target, "different\n")
+        observe(self.paths, STAGE_04)
+        write_text(target, "same\n")
+        third = observe(self.paths, STAGE_05).entries[self.rel(target)].version_uid
+
+        self.assertNotEqual(first, third)
+        self.assertEqual(load_ledger(self.paths).next_uid, 4)
+
+    def test_bootstrap_material_belongs_to_intake_and_no_rollback_reaches_it(self) -> None:
+        write_text(self.paths.notes_dir / "brief.md", "the question\n")
+        observe(self.paths, INTAKE_STAGE)
+
+        self.assertEqual(plan_withdrawal(self.paths, STAGE_01), [])
+
+    def test_a_run_level_ledger_is_never_attributed(self) -> None:
+        """A rollback that rewound ``research_rounds.json`` would launder an abandonment."""
+
+        write_text(self.paths.research_rounds, '{"rounds": []}\n')
+        ledger = observe(self.paths, STAGE_05)
+
+        self.assertNotIn("notes/research_rounds.json", ledger.entries)
+        self.assertIn("notes/research_rounds.json", LEDGER_PATHS)
+        self.assertEqual(plan_withdrawal(self.paths, STAGE_01), [])
+
+    def test_a_file_over_the_restorable_limit_is_recorded_as_delete_only(self) -> None:
+        target = self.paths.data_dir / "checkpoint.npy"
+        target.write_bytes(b"x" * (RESTORABLE_BYTE_LIMIT + 1))
+        ledger = observe(self.paths, STAGE_04)
+
+        entry = ledger.entries[self.rel(target)]
+        self.assertFalse(entry.restorable)
+        self.assertEqual(entry.blob_hash, "")
+
+    def test_intake_and_every_stage_resolve_to_a_number(self) -> None:
+        self.assertEqual(stage_number_for_slug(INTAKE_STAGE.slug), 0)
+        self.assertEqual(stage_number_for_slug(STAGE_05.slug), 5)
+        self.assertIsNone(stage_number_for_slug("not_a_stage"))
+
+
+class WithdrawalPlanTests(ProvenanceTestCase):
+    def test_a_file_created_inside_the_range_is_planned_for_deletion(self) -> None:
+        write_text(self.paths.data_dir / "late.csv", "id\n1\n")
+        observe(self.paths, STAGE_05)
+
+        plan = plan_withdrawal(self.paths, STAGE_03)
+        self.assertEqual([item.rel_path for item in plan], ["data/late.csv"])
+        self.assertTrue(plan[0].deletes)
+
+    def test_a_file_created_before_the_range_is_planned_for_a_rewind(self) -> None:
+        """The case a single-state ledger gets wrong, and the reason the graph exists.
+
+        Stage 02 wrote an honest hypothesis set and Stage 05 amended it. Rolling back to
+        Stage 04 withdraws Stage 05, and Stage 02's work is not Stage 05's to take with it.
+        """
+
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "early\n")
+        observe(self.paths, STAGE_02)
+        write_text(target, "late\n")
+        observe(self.paths, STAGE_05)
+
+        plan = plan_withdrawal(self.paths, STAGE_04)
+        self.assertEqual(len(plan), 1)
+        self.assertFalse(plan[0].deletes)
+        assert plan[0].restore_to is not None
+        self.assertEqual(plan[0].restore_to.stage, STAGE_02.slug)
+
+    def test_a_file_untouched_by_the_range_is_not_in_the_plan(self) -> None:
+        write_text(self.paths.data_dir / "early.csv", "early\n")
+        observe(self.paths, STAGE_02)
+
+        self.assertEqual(plan_withdrawal(self.paths, STAGE_04), [])
+
+    def test_the_plan_renders_both_kinds_separately(self) -> None:
+        write_text(self.paths.data_dir / "kept.csv", "early\n")
+        observe(self.paths, STAGE_02)
+        write_text(self.paths.data_dir / "kept.csv", "late\n")
+        write_text(self.paths.data_dir / "new.csv", "new\n")
+        observe(self.paths, STAGE_05)
+
+        rendered = format_withdrawal_plan(plan_withdrawal(self.paths, STAGE_04))
+        self.assertIn("1 deleted", rendered)
+        self.assertIn("1 rewound", rendered)
+        self.assertIn("delete data/new.csv", rendered)
+
+
+class LivenessTests(ProvenanceTestCase):
+    def test_an_unattributed_file_counts(self) -> None:
+        """Fail-open. A run with no ledger must behave as it did before one existed."""
+
+        write_text(self.paths.data_dir / "counts.csv", "id\n1\n")
+        self.assertTrue(is_live(load_ledger(self.paths), "data/counts.csv"))
+        self.assertEqual(count_live_files(self.paths, self.paths.data_dir, {".csv"}), 1)
+
+    def test_a_withdrawn_file_stops_counting_while_staying_on_disk(self) -> None:
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "id\n1\n")
+        observe(self.paths, STAGE_05)
+        invalidate_from(self.paths, STAGE_03, "design was wrong")
+
+        self.assertTrue(target.exists())
+        self.assertEqual(count_live_files(self.paths, self.paths.data_dir, {".csv"}), 0)
+        self.assertFalse(path_is_live(self.paths, target))
+
+    def test_a_withdrawn_row_is_kept_rather_than_dropped(self) -> None:
+        """Dropping it would make the file unattributed, and unattributed files count."""
+
+        write_text(self.paths.data_dir / "counts.csv", "id\n1\n")
+        observe(self.paths, STAGE_05)
+        invalidate_from(self.paths, STAGE_03)
+
+        entry = load_ledger(self.paths).entries["data/counts.csv"]
+        self.assertFalse(entry.live)
+        self.assertEqual(entry.invalidated_by_stage, STAGE_03.slug)
+
+    def test_a_rewrite_after_a_withdrawal_revives_the_row(self) -> None:
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "abandoned\n")
+        observe(self.paths, STAGE_05)
+        invalidate_from(self.paths, STAGE_03)
+
+        write_text(target, "redone\n")
+        ledger = observe(self.paths, STAGE_03)
+        self.assertTrue(ledger.entries["data/counts.csv"].live)
+        self.assertEqual(count_live_files(self.paths, self.paths.data_dir, {".csv"}), 1)
+
+    def test_a_withdrawal_that_is_not_rewritten_stays_withdrawn(self) -> None:
+        """The point of the whole mechanism, stated as one assertion.
+
+        A rollback that could not delete the file leaves it on disk and withdrawn. A later
+        visit that does not touch it must not have it counted back in.
+        """
+
+        write_text(self.paths.data_dir / "counts.csv", "abandoned\n")
+        observe(self.paths, STAGE_05)
+        invalidate_from(self.paths, STAGE_03)
+        observe(self.paths, STAGE_03)
+
+        self.assertEqual(count_live_files(self.paths, self.paths.data_dir, {".csv"}), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect, measured

`rollback_to_stage` was bookkeeping. It set `status`/`approved`/`dirty`/`stale`/`invalidated_by_stage` on the manifest entries at and after the target; `workspace/` was untouched. Six forward edges are guarded by counting files under `workspace/`, so the artifacts of the abandoned future stayed on disk and stayed countable.

Run against `origin/main`:

```
BASELINE  gate before rollback: True | 1 machine-readable design artifact(s) and a declared protocol
BASELINE  gate after  rollback: True | 1 machine-readable design artifact(s) and a declared protocol
BASELINE  files still on disk: ['design_matrix.csv']
```

A run that reached Stage 06, found the design wrong and went back to Stage 03 met an edge out of Stage 03 that was already open — opened by the data Stage 04 and Stage 05 had written under the design being abandoned. The gate that exists to prove *this* visit did the work was answering for the visit the run had just repudiated.

`_guard_round_abandoned` states the invariant the other five relied on — *"Every other guard here reads stage artifacts, which a rollback invalidates"* — and gives it as the reason for scoping itself to the visit while they stay global. The sentence was false. It is true as of this PR.

The same defect had been patched once by hand, at one path: `_skip_stage` notes that a skipped Stage 06's round declaration was *"never consumed and never unlinked. Left on disk, the next Stage 06 closes its round from the previous visit's file — inheriting a conclusion drawn from results it did not produce."* One instance, one patch, no general mechanism.

## What lands

| Module | Owns |
| --- | --- |
| `src/provenance.py` | Which stage wrote each workspace file, every version it has held, and what a rollback withdraws or rewinds |
| `src/effects.py` | The inverse of each write, accumulated per stage and applied in reverse; commutative vs ordered keys |
| `src/emissions.py` | Acts that leave the run, withheld until the stage that asked for them is approved |

**Attribution is observed, not declared.** The stage's work is an agent CLI writing files directly, so AutoR compares rather than intercepts: `observe` re-scans at a stage boundary and attributes whatever moved.

**A row is a version chain, not a state.** This is what keeps the two cases apart — a file created inside the withdrawn range is deleted, a file created before it and amended inside it is *rewound* to what the last surviving stage left. Collapsing both into "delete" would discard work the rollback never touched, which is the loss a graph topology exists to avoid.

**Inverses are data, not closures.** A run resumes in a new process and a stage timeout is 14400s. Each inverse is a kind plus a JSON payload in a per-stage JSONL, appended as the stage runs, so a crash mid-stage still leaves an accumulator that withdraws what had been done. No inverse has a precondition it can fail.

**Commutativity is classified, and reported.** A table of independently added entries is commutative; a narrative or a log is ordered. Whether Stage 04 could have been withdrawn without Stage 06 is exactly whether they share an ordered key, and the rollback preview says which. An unclassified key is named as unclassified rather than hidden among the ordered ones — the first is a finding about the research, the second is a finding about `effects.py`.

**Wired at the seam.** Recovery happens inside `rollback_to_stage`, so `/back`, a round that redirected itself, and a review that withdrew an approval all get it. Recovering on two of three paths would be worse than on none: the difference is invisible in the run record.

## Two limits, recorded rather than papered over

- A version over 8 MiB has its bytes unheld, so it can be deleted but not rewound to, and the row says `restorable=False`. The boundary is drawn per file by whether the previous state can be restored, not per medium. Above the limit, change detection uses size+mtime rather than a digest — hashing a 4 GB checkpoint eight times a run to learn something the run cannot act on is the wrong trade.
- Run-level ledgers (`research_rounds.json`, `round_decision.json`, `preregistration.json`) are excluded from attribution entirely. Rewinding the first would let a rollback launder a standing abandonment, which two existing tests refuse; the third has its own externally-stamped invalidation path, and two mechanisms deciding whether one frozen document counts is how they drift apart.

## Fail-open

Anything unknown to the ledger still counts — a run started before this existed, a resumed run whose ledger did not survive, a file written outside any stage's window. Reading those as withdrawn would close every counting gate at once, and a precondition no real run can meet is not a strict gate; this repo has shipped that once, in `_guard_results_exist`. `test_a_run_with_no_ledger_behaves_as_it_did_before_one_existed` holds it.

## Testing

- **52 new tests** across four modules. Nine of them fail on `origin/main`.
- Suite **2445 → 2497, green**. Baseline verified clean on `origin/main` before branching.
- Three failures surfaced during development and all three were real: the wiring gate caught three unwired symbols (deleted), and two existing tests caught that rewinding `research_rounds.json` launders an abandonment (`LEDGER_PATHS`). A fourth was found by the new tests themselves — trimming a delete-bound row to zero versions made `observe` read the file as changed and revive the withdrawal.

## Not in this PR

The agent-facing table primitives (`append_source`, `register_hypothesis`, `record_result`) and intra-stage checkpointing need a tool surface for the stage agent to write through; without one they would be symbols nothing calls, which `test_declared_symbols_are_wired` is right to refuse. Selective withdrawal (`revert_only`) is the action whose precondition this PR computes and reports — the action itself lands with that surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)