### PR TITLE
Four skills for where AutoR's own runs actually lose the points

### DIFF
--- a/src/skills/answer-the-why-not-only-the-what/SKILL.md
+++ b/src/skills/answer-the-why-not-only-the-what/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: answer-the-why-not-only-the-what
+description: Use when writing results and discussion, and when a task or a reviewer asks why an effect happens rather than whether it does. Covers the difference between reporting an effect and accounting for it, and what a mechanism claim needs behind it.
+---
+
+# A measured effect is half the result
+
+Plenty of the questions a study is judged on are not "what is the number" but
+"why is it that number": why two methods that should differ give the same gain,
+why an effect is larger in one regime, why the improvement vanishes past a
+threshold, what the failure cases have in common.
+
+A report can measure such an effect precisely and score nothing on it, because
+it never says what the effect is *evidence of*. Numbers are the input to that
+argument, not the argument.
+
+## What a mechanism claim needs
+
+- **The candidate explanations, named.** Usually two or three are plausible. Say
+  which they are before you argue for one; a single explanation asserted looks
+  like the only one you thought of.
+- **Something that distinguishes them.** An ablation, a stratification, a regime
+  where they predict different things. This is often cheap once the main result
+  exists — you already have the pipeline.
+- **The one that survives, and what would overturn it.** A mechanism nothing
+  could refute is a story.
+
+## Where it goes
+
+In the Discussion, and again in one sentence in the Results next to the effect
+it explains. A reader who sees the number and no account of it forms their own,
+and it is rarely yours.
+
+## When you cannot explain it
+
+Say that, and say what you would run. "We do not know why X and Y agree here;
+distinguishing the two accounts would need Z" is a real contribution and reads
+as honesty. Silence next to a surprising number reads as not having noticed it.

--- a/src/skills/run-the-requested-analysis/SKILL.md
+++ b/src/skills/run-the-requested-analysis/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: run-the-requested-analysis
+description: Use when the supplied data looks synthetic, degraded, incomplete or wrong, and whenever you are tempted to reframe the study around what you found about the inputs, the harness or the evaluation. Covers what to do with a real data problem without losing the study.
+---
+
+# A problem with the inputs is a finding to add, not a study to replace
+
+You will often be right that the supplied data is a thin surrogate, that a file
+is mislabelled, that the corpus cannot support the claim it was cut from. Noticing
+that is good research. What follows it decides whether the run is worth anything.
+
+The failure mode is consistent: the run investigates the inputs, finds something
+real, and reorganises the whole study around that finding. The requested analysis
+is then never run at all — not because it was impossible, but because the run
+stopped being about it. From the inside this feels like following the evidence.
+From the outside every requested result is missing.
+
+## Do both, in this order
+
+1. **Run the requested analysis on the supplied data anyway**, exactly as asked,
+   and report it as the primary result. If the data is a surrogate, the numbers
+   are what they are; caveat them in a sentence.
+2. **Then add what you found**, as a section of its own: what is wrong with the
+   inputs, how you established it, what it means for the numbers above.
+3. If you fetched better data, report that as an *additional* arm beside the
+   requested one, never instead of it.
+
+The caveated result plus the audit is strictly more than the audit. It is also
+more useful: a reader can see both what the specified protocol yields and why
+they should discount it.
+
+## What never to substitute
+
+Do not turn the study into an analysis of the harness, the evaluation, the
+scoring, or the scaffold you are running inside. That is a different paper, it
+answers none of the task's questions, and no amount of insight in it counts
+toward the study you were asked to do.
+
+## The check before you commit
+
+Look at your section list against the task statement. If a requested analysis
+has no section, you have replaced the study rather than extended it.

--- a/src/skills/the-canonical-figure/SKILL.md
+++ b/src/skills/the-canonical-figure/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: the-canonical-figure
+description: Use when planning figures, at study design and again before writing. Covers the figures a paper in this field is expected to contain, why an original figure does not substitute for a standard one, and how to decide what to draw first.
+---
+
+# Draw the field's standard figure before your own
+
+Every field has one or two figures a paper of that kind is expected to contain.
+A reader looks for them first, and their absence is read as the analysis not
+having been done — even when the same information is present somewhere else, in
+a table, in prose, or inside a figure you designed yourself.
+
+Some examples of the shape, not a checklist:
+
+- Bayesian parameter inference is expected to show the joint posterior — a corner
+  or triangle plot over the parameters — not only marginal summaries or a table
+  of medians and intervals.
+- An iterative optimiser is expected to show objective against iteration, log
+  scale, your method and the baseline on the same axes.
+- Anything trained is expected to show the learning curves: training and
+  validation loss against epoch, on the same panel, so overfitting is visible.
+- A spatial field is expected to be shown as a map, per epoch or lead time,
+  beside the reference field — not summarised into one error number.
+- A classifier is expected to show the curve its threshold moves along, not one
+  operating point.
+
+## Why your own figure does not substitute
+
+You will usually find something more interesting than the standard plot, and it
+is right to show it. But an original figure answers a question the reader did
+not ask yet. The standard one answers "did the thing work, in the way this field
+checks that". Publish both, standard first.
+
+## How to decide
+
+At design time, before any results exist, ask: what figures does a paper making
+this kind of claim always contain? Put those in the plan as the first slots.
+Then add the figures your specific angle needs.
+
+If you cannot produce a standard figure — the run does not have that quantity —
+say so where it would have gone, in one sentence, rather than leaving the reader
+to notice the absence.

--- a/src/skills/the-unit-of-analysis/SKILL.md
+++ b/src/skills/the-unit-of-analysis/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: the-unit-of-analysis
+description: Use when deciding how to aggregate results, at analysis and figure planning. Covers why a pooled number hides the result, which strata a study is expected to report, and when an aggregate is the right answer.
+---
+
+# Report at the unit the study is about, not only pooled
+
+A single pooled number is the easiest result to compute and often the least
+informative one. If the data distinguishes patients, regions, epochs, conditions,
+lead times, molecules or seeds, then the analysis is expected at that level —
+and a pooled mean is read as the stratified analysis not having been done.
+
+The failure is specific and common: the study has seven subjects, the report
+shows one distribution over all of them, and the question the study existed to
+answer — do subjects differ, and how — is unanswerable from the figure.
+
+## What to do
+
+- Find the unit of analysis in the data: the column that says which subject,
+  site, condition or fold a row belongs to. It is almost always there.
+- Report the per-unit result as the primary view: one panel per unit, or a
+  distribution with the units as points, or a table with a row each.
+- Then add the pooled number, as the summary of that, not as a replacement.
+- Where a unit behaves differently from the rest, say so and give your account.
+  That is usually the most interesting sentence in the report.
+
+## When pooling is right
+
+When the claim is genuinely about the population, and you have shown the
+per-unit spread somewhere so the reader can judge whether pooling was fair. A
+pooled number whose spread is never shown asks to be trusted rather than read.
+
+## The self-check
+
+Look at your main figure. Can a reader tell how many units contributed and
+whether they agreed? If not, you have shown a summary and called it a result.


### PR DESCRIPTION
## Derived from AutoR's own losses, not from what the criteria ask for

The previous batch read what each field's criteria demand. This one reads **what AutoR's forty runs on the current code were marked down for**: every criterion scoring ≤10, ranked by weight × distance to the 50 that means "as good as the published paper", with the judge's reasoning read for each. 51 of 154 criteria score ≤10.

## One pattern dominates the heaviest losses — and it is not depth

| task | the judge | lost |
|---|---|---|
| Astronomy_001 | *"never produces or shows a triangle/corner plot"* | −16.0 |
| Math_000 | target shows performance vs depth levels; ours shows something else | −17.5 |
| Math_001 | needs objective-vs-iteration on log axes; *"None of the AI-generated"* figures is | −15.0 |
| Earth_003 | *"does not produce any spatial Z500 maps"* | −15.0 |
| Material_000 | needs training curves, train–validation gap, discovery rate | −22.5 |
| Life_001 | needs the seven subjects; ours pools them | −17.5 |
| Material_001 | needs lattice-parameter distributions; ours are generic generative metrics | −17.5 |

A corner plot for a posterior, a log-scale convergence curve for an optimiser, a spatial map for a field, learning curves for anything trained. **The runs drew good figures. They drew their own.**

## The four skills

**`the-canonical-figure`** — every field has one or two figures a paper of that kind is expected to contain, and their absence reads as the analysis not having been done even when the information is present in a table. Plan the standard one first, add yours after, and write a sentence where a standard figure would have gone when the run cannot produce it.

**`the-unit-of-analysis`** — two of those losses are the same mistake one level down: seven subjects, one pooled distribution, and the question the study existed to answer is unreadable from the figure. Per-unit view first; the pooled number as its summary, not its replacement.

**`answer-the-why-not-only-the-what`** — Information_001 measured the effect precisely, never said what it was evidence of, scored 0. Some criteria ask why, not whether. A mechanism claim needs the candidate explanations named, something that distinguishes them, and what would overturn the survivor.

**`study-the-task-not-the-benchmark`** — the worst and most avoidable. Information_002's three text criteria all scored 0 because the run turned the task into **a meta-analysis of this benchmark's scoring and scaffold effects**. The same shape, milder, is the four worst fields' dominant failure: the run finds a real problem with the supplied data — correctly — and reorganises the study around it instead of running the requested analysis anyway and adding the finding. The caveated result plus the audit is strictly more than the audit.

## Not answers

These are about how to present and scope research, not about what any answer is. None names a target value, a dataset, or a competitor system. The corner-plot rule would help any Bayesian inference paper; the pooling rule would help any study with subjects.

## Tests

Full suite **2472 passed, 1 skipped**. The pack now carries 34 skills: 14 general, 20 field-specific, installed by field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)