### PR TITLE
Close three ways to raise the new criterion without doing the work

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ naming them.
 | Required stage-summary headings | `REQUIRED_STAGE_HEADINGS` | 7 |
 | Rubric criteria (weighted, backend-free) | `CRITERIA`, [src/rubric.py](src/rubric.py) | 9 |
 | Flags on `main.py` / `rcb_agent.py` | `parse_args` | 61 / 37 |
-| Python modules / lines / tests | the tree | 183 / 82 k / 2497 |
+| Python modules / lines / tests | the tree | 178 / 81 k / 2558 |
 
-`python -m unittest discover -s tests -p "test_*.py"` runs **2497 tests** across 109 test
+`python -m unittest discover -s tests -p "test_*.py"` runs **2558 tests** across 111 test
 modules, with no third-party dependency.
 
 ## Quick start
@@ -355,8 +355,8 @@ included.
 
 Every valid stage draft is measured against a rigour rubric read off disk — do the paths it names
 resolve, do the numbers it reports appear in a results file, did it produce artifacts during *this*
-execution, is the decision ledger four different things rather than one sentence four times. Eight
-weighted criteria, `RUBRIC_VERSION = "6"`:
+execution, is the decision ledger four different things rather than one sentence four times. Nine
+weighted criteria, `RUBRIC_VERSION = "7"`:
 
 | Criterion | Weight | From | What it measures |
 | --- | ---: | :---: | --- |
@@ -855,7 +855,8 @@ comparators run GPT-5.4; and it is a `gpt-5.1` number.
 ### The re-run, and the control that matters more
 
 #180 and #181 closed the routes that produced the stubs. Re-running all forty tasks on the repaired
-code took the mean to **23.57** with no run scoring zero. The same batch made the obvious control
+code took the mean to **23.57** and removed six of the seven zeros; the seventh, `Information_002`,
+still scores 0.0 and is the case §2.4.1 dissects. The same batch made the obvious control
 cheap, and it had never been run: the same model, on the same machine, handed the same forty task
 statements with no AutoR at all.
 
@@ -865,9 +866,9 @@ statements with no AutoR at all.
 | AutoR (Opus), post-repair | 23.57 | 35 (23%) | 15 |
 
 Paired over the forty tasks that is **−5.67 ± 1.84**. The scaffold currently makes the model worse
-at the benchmark than not having it, and it does so while writing 39% more prose — it covers less,
+at the benchmark than not having it, and it does so while writing 36% more prose — it covers less,
 not less well. [§6.8](docs/framework.md#68-the-scaffold-is-currently-worth-less-than-no-scaffold) is
-the account of why, and `RUBRIC_VERSION` 6 is the first change aimed at it.
+the account of why, and `RUBRIC_VERSION` 7 is the first change aimed at it.
 
 [The framework document's §6](docs/framework.md#6-the-system-measured-against-itself) is the full
 account, including the part that is worse than the mean: the two highest scores came from runs that

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -193,11 +193,12 @@ exists to prevent, reached by a route the design did not consider. Declining to 
 fabrication is not the same as declining to *pay* for it. `_cap_quantification_by_fidelity` now caps
 the first criterion at the second wherever both apply, which makes the middle row 0.0; the cap is
 recorded in `observed` so a stage can still tell which half to fix, and Stage 04 is exempt because
-fidelity does not apply before there are results. `RUBRIC_VERSION` is `6` — it went to 3 when
+fidelity does not apply before there are results. `RUBRIC_VERSION` is `7` — it went to 3 when
 that cap landed, to 4 when the length gradient came out of `commitment`, to 5 when
 `artifact_breadth` learned to read the four workspace directories Stages 01, 02, 07 and 08 are
-told to write and `reproducibility` gained its Stage 02-03 link, and to 6 when
-`deliverable_coverage` was added (§2.4.1) — and the archive
+told to write and `reproducibility` gained its Stage 02-03 link, to 6 when
+`deliverable_coverage` was added (§2.4.1), and to 7 when three ways to raise that criterion
+without doing any work were closed — and the archive
 ranks no score from before a bump against one after it, so each bump is a clean break rather
 than a silent drift.
 
@@ -279,21 +280,39 @@ Three things it deliberately does not do.
 Replayed over the 263 stage drafts of that pass: the existing eight read mean 0.964 / sd 0.043,
 with 20% at exactly 1.000 — a fitness function with almost no gradient left, which turns the polish
 loop off at `evolution.py`'s `champion.total >= 1.0` short-circuit. The new criterion reads mean
-0.746 / sd 0.329 and **falls monotonically with stage number**, 0.95 at Stage 01 to 0.51 at Stage
-07, because a late stage owes more of the task than an early one. On the 0.0 run it reads 0.00 from
-Stage 05 on, which is the stage at which that run stopped producing the object the task named.
+0.657 / sd 0.326 and **generally falls with stage number** — 0.74 / 0.94 / 0.65 / 0.55 / 0.61 /
+0.54 / 0.51 across Stages 01 to 07 — because a late stage owes more of the task than an early one.
+It is not monotone: Stage 02 is the high point, and an earlier version of this paragraph claimed
+monotonicity from the two endpoints alone. On the 0.0 run it reads 0.00 from Stage 05 on, which is
+the stage at which that run stopped producing the object the task named.
 
-*Cost:* it is the first criterion prose can move at all, so keyword-stuffing is the attack it has
-to survive; the on-disk match is the whole defence and must not be relaxed. It also gives 125 of
-those drafts headroom where they had none, which buys polish rounds and therefore tokens.
+*Cost:* it is the first criterion prose can move at all, so gaming it is the attack it has to
+survive; the on-disk match is the whole defence and must not be relaxed. Of the 263 drafts, 52 sat
+at exactly 1.000 on the existing eight — the ones the ratchet's `total >= 1.0` short-circuit turns
+off — and 27 of those now have headroom, which buys polish rounds and therefore tokens.
 *Why anyway:* a ratchet climbing a surface that does not include the question is a machine for
 polishing the wrong answer, and it had been running.
+
+**How far prose can move it, and the three routes that were open when it landed.** The first
+version of this criterion shipped with the attack surface unmeasured, and an adversarial replay
+found three ways to raise it without doing any work: restating a demand in its own words scored
+**1.000** at every stage below 05 on 40 of 40 tasks; quoting the task statement counted as
+answering it; and — worst — pasting back the shortfall the ratchet had just printed raised the
+*total* on **89 of 89** drafts, median **+0.069**, every one past `DEFAULT_MIN_GAIN`. A fitness
+function whose own feedback is a recipe for beating it is the failure §2.4 exists to prevent,
+reached from a direction the design did not consider for the second time. All three are closed in
+`RUBRIC_VERSION` 7: the on-disk half now applies at every stage rather than from Stage 05, a
+sentence made only of the demand's own vocabulary is not engagement, an eight-word span of the task
+statement is not engagement, and the shortfall's own phrases are filtered. Measured after: pure
+restatement scores **0.504** — not zero, because a report that names what was asked does beat one
+silent about it, and never more than half, because nothing it says is checkable — pasting the task
+statement moves the total by a median of **−0.008**, and pasting the shortfall moves **0 of 55**.
 
 The same version bump fixes a smaller thing pointing the same way. `numeric_fidelity` admitted any
 token containing a dot as a reported measurement, so an arXiv id, a DOI and a `Fig. 3` all became
 numbers the draft had to justify against a results file. Measured on a controlled pair at Stage 06
 with everything else held fixed, a draft ending *"on the 2111.01152 system"* totals 0.7587 and the
-same draft ending *"on the target system"* totals 0.8063 — a gain of 0.0476, nearly ten times
+same draft ending *"on the target system"* totals 0.8063 — a gain of 0.0476, 9.5 times
 `DEFAULT_MIN_GAIN`, which means the ratchet recorded **deleting the subject paper's name** as a new
 champion.
 
@@ -1015,8 +1034,13 @@ this document is:
 ### 6.8 The scaffold is currently worth less than no scaffold
 
 The repairs of §6.5 worked, in the sense that they were aimed at: the floor came up from 14.16 to
-**23.57**, and the seven zeros became zero — every one of the forty runs now ships a report with
-methodology, results and figures in it. That is the last piece of good news in this section.
+**23.57**, and six of the seven zeros went away — every one of the forty runs now ships a report
+with methodology, results and figures in it. **One zero survived**, and it is `Information_002`:
+0.0 on all three of its criteria, `gpt-5.1`, no judge failure. It is the run §2.4.1 is about — the
+one with 71,671 bytes of derivation on disk and no equation in its report — so the surviving zero
+is not an artefact of the repair, it is the defect the repair did not touch. An earlier version of
+this section said "the seven zeros became zero", which was wrong and contradicted §2.4.1 in the
+same commit. That is the last piece of good news in this section.
 
 Because the obvious control had never been run, and the batch above made it cheap to run. Same
 model, same machine, same forty tasks, same `gpt-5.1` judge, no AutoR at all — just Claude Code
@@ -1033,16 +1057,18 @@ reviewer gates, a rigour rubric and a champion ratchet make the same model, on t
 measurably **worse** at the task than being handed the task.
 
 The composition of that deficit is not where the design's story predicted. AutoR is not shipping
-less: its median report is 37,068 bytes against bare Claude Code's 26,668, 39% *more* prose. It is
+less: its median report is 36,330 bytes against bare Claude Code's 26,669, 36% *more* prose. It is
 not shipping fewer figures: both arms have ~5 images in front of the judge. It covers **less** —
-23% of criteria score zero against 16% — which means the extra 39% of prose is spent on criteria the
+23% of criteria score zero against 16% — which means the extra 36% of prose is spent on criteria the
 task never asked about, and the missing 7 points are things the task did ask about and the report
 never mentioned.
 
 That is the diagnosis this whole document has been circling, and §2.4.1 is the first fix aimed
 directly at it: every surface allocating AutoR's attention was defined over the run's own record
-rather than over the task statement. Across the seven stage prompts, instructions that produce a
-*record about the work* outnumber instructions that *advance the work* 254 to 147. Two of the
+rather than over the task statement. A hand classification of the seven stage prompts put
+instructions that produce a *record about the work* ahead of those that *advance the work* by
+roughly 254 to 147 — that split is a judgement, no rule in the tree reproduces it, and it is quoted
+here as an impression rather than a measurement. What is mechanical, and enough on its own: two of the
 prompts that decide what gets written — Stage 05, which produces the numbers, and Stage 07, which
 publishes them — contained the word "task" zero times each. The demand list every stage was held to
 was 59.3% delivery contract: over the forty tasks, 200 of 337 "demands" were the same five lines
@@ -1137,8 +1163,8 @@ any.
   choice has been measured to move a score by up to 16.2. The landscape study's first conclusion
   stands and now has a local instance: model choice dominates harness choice.
 - **The §6.5 repairs are measured; the §2.4.1 change is not.** The repairs took the mean from 14.16
-  to 23.57 and removed all seven zeros, and that was still 5.67 points short of no scaffold at all.
-  `RUBRIC_VERSION` 6 and the Stage 01/05/07 prompt changes are aimed at the composition of that
+  to 23.57 and removed six of seven zeros, and that was still 5.67 points short of no scaffold at
+  all. `RUBRIC_VERSION` 7 and the Stage 01/05/07 prompt changes are aimed at the composition of that
   remaining deficit and **have not been run on the benchmark**. Nothing in §2.4.1's numbers is a
   benchmark result: they are replays of a new criterion over archived drafts, which say the
   criterion has a gradient, not that following the gradient scores better.

--- a/src/approval_agent.py
+++ b/src/approval_agent.py
@@ -637,20 +637,8 @@ class AutomatedReviewer:
             f"{self._read_excerpt(paths.artifact_index, max_chars=6000)}\n\n"
             "# Experiment Manifest Excerpt\n\n"
             f"{self._read_excerpt(paths.experiment_manifest, max_chars=6000)}\n\n"
-            # The one machine-readable artifact in which the stage states, item by item,
-            # which of the task's demands it did not meet and why -- and the substitution
-            # check above was run without it. On the run that scored 0.0 externally, this
-            # file marked the task's first named output addressed with four PNG filenames
-            # as its evidence, and marked the only named data file unmet with a reason.
-            "# Task Coverage Record (self-reported by the stage)\n\n"
-            "The stage wrote this about itself. It is not evidence; it is the claim the "
-            "substitution check is about. Read each `addressed: true` and ask what in the "
-            "report or the artifacts actually discharges it -- an entry whose `where` is "
-            "only a figure filename has published a picture about the deliverable, not the "
-            "deliverable. Read each `addressed: false` and apply the discriminating "
-            "question above: was the named work runnable from what is in this workspace?\n\n"
-            f"{self._read_excerpt(paths.artifacts_dir / COVERAGE_FILENAME, max_chars=4000)}\n\n"
-            "# Recent Log Excerpt\n\n"
+            + self._coverage_record_block(paths)
+            + "# Recent Log Excerpt\n\n"
             f"{self._read_excerpt(paths.logs, max_chars=5000, tail=True)}\n"
             + CLOSING_VERDICT_INSTRUCTION
         )
@@ -677,6 +665,34 @@ class AutomatedReviewer:
         if not rendered:
             return ""
         return "# Standing Review Rules (learned earlier in this run)\n\n" + rendered + "\n\n"
+
+    def _coverage_record_block(self, paths: RunPaths) -> str:
+        """The stage's own item-by-item claim about what the task asked for.
+
+        The one machine-readable artifact in which a stage states which of the task's
+        demands it did not meet and why -- and the substitution check above was run
+        without it. On the run an external judge scored 0.0, this file marked the task's
+        first named output addressed with four PNG filenames as its evidence, and marked
+        the only named data file unmet with a reason; the reviewer saw neither.
+
+        Emitted only when the file exists. Stage 07 is where it is written on 38 of 40
+        archived runs, so an unconditional block would have spent 700 characters telling
+        six reviewers out of seven to read a record that says ``(missing)`` -- which is
+        how a prompt teaches a reader to skip a section.
+        """
+        path = paths.artifacts_dir / COVERAGE_FILENAME
+        if not path.exists():
+            return ""
+        return (
+            "# Task Coverage Record (self-reported by the stage)\n\n"
+            "The stage wrote this about itself. It is not evidence; it is the claim the "
+            "substitution check is about. Read each `addressed: true` and ask what in the "
+            "report or the artifacts actually discharges it -- an entry whose `where` is "
+            "only a figure filename has published a picture about the deliverable, not the "
+            "deliverable. Read each `addressed: false` and apply the discriminating "
+            "question above: was the named work runnable from what is in this workspace?\n\n"
+            f"{self._read_excerpt(path, max_chars=4000)}\n\n"
+        )
 
     def _read_excerpt(self, path: Path, *, max_chars: int, tail: bool = False) -> str:
         if not path.exists():

--- a/src/deliverables.py
+++ b/src/deliverables.py
@@ -85,11 +85,14 @@ def demanding_sentences(task_statement: str) -> list[str]:
 #: figures are mandatory, that `report.md` is the deliverable. Measured over the 40
 #: archived ResearchClawBench tasks: reading the whole fenced statement returns 337
 #: demanding sentences of which 200 (59.3%) are the same five contract lines present in
-#: all 40 tasks. Scoping to these headings returns 137. :func:`task_statement` already
+#: all 40 tasks. Scoping to these headings returns 59, and 75 once they are split into
+#: clauses. (An earlier version of this note said 137: that is the count with
+#: `Available Data Files` admitted, which the next comment says is deliberately out.)
+#: :func:`task_statement` already
 #: strips AutoR's own wrapper; this strips the benchmark's inner one.
 #: `Available Data Files` is deliberately not here. A file description says what the run
-#: has, not what it owes, and admitting the block made 45 of 147 demands across the 40
-#: archived tasks a dataset blurb -- the same dilution in miniature.
+#: has, not what it owes, and admitting the block took the 40 archived tasks from 75
+#: demands to 147, the 72 added being dataset blurbs -- the same dilution in miniature.
 _BRIEF_HEADINGS = re.compile(
     r"^#{1,6}\s*(?:Task Description|Scientific Objective|Research Objective)\s*:?\s*$",
     re.IGNORECASE | re.MULTILINE,
@@ -229,8 +232,13 @@ def validate_deliverables_coverage(paths: RunPaths, task_statement: str) -> list
 
 #: Fragments that locate nothing. A `where` of "images/foo.png" splits to "images", which
 #: is in every report that has a figure, so the pointer resolves without pointing
-#: anywhere. Information_002's entire physics deliverable -- the entry carrying all three
-#: criteria the external judge scored 0 -- was validated by that six-character substring.
+#: anywhere. Honest about its reach: replayed over the 603 coverage entries of the 40
+#: archived runs this changes **no** verdict, and it does not save the case that
+#: motivated it -- Information_002's entry 4 also names `derived_hamiltonians.png`, 24
+#: characters and genuinely in the report, and the fragment loop is a disjunction. It
+#: closes the class for the next corpus, not this one. The measured refusal that *would*
+#: have caught entry 4 -- rejecting an entry discharged by figure filenames alone -- was
+#: rejected instead: it fails 148 of 575 addressed entries across 38 of the 40 runs.
 _GENERIC_LOCATORS = frozenset({
     "images", "figure", "figures", "section", "results", "report", "appendix",
     "table", "tables", "method", "methods", "data", "abstract", "discussion",

--- a/src/evolution.py
+++ b/src/evolution.py
@@ -534,11 +534,15 @@ class EvolutionController:
             "",
             "- Do not lengthen a section to raise a score. Eight of these criteria are ratios or "
             "counts over artifacts on disk and prose cannot move any of them. "
-            "`deliverable_coverage` is the exception and it is not moved by prose either: a "
-            "sentence stuffed with the task's nouns scores nothing unless it also carries a "
-            "number that appears in a file under `workspace/results`. Raise it by doing the work "
-            "the task named and reporting the result, or by stating in that demand's own section "
-            "that it could not be produced and why.",
+            "`deliverable_coverage` is the exception, and it is honest about how far prose can "
+            "move it: **half**. Mentioning a thing the task asked for earns half its share, "
+            "because a report that names it beats one that is silent about it. The other half is "
+            "only paid when the sentence that mentions it also carries a number that appears in "
+            "a file under `workspace/results`, or names a file the run actually wrote. Restating "
+            "the task, or pasting back the shortfall printed above, earns nothing at all -- both "
+            "are filtered. So the way to raise this is to do the work the task named and report "
+            "the result, or to state in that demand's own section that it could not be produced "
+            "and why.",
             "- Do not restate an unverified number more confidently. If a value is not in a file "
             "under `workspace/results`, either measure it and write it there or remove the claim.",
             "- Do not delete a weak part of the draft to raise an average. A dropped file "

--- a/src/prompts/07_writing.md
+++ b/src/prompts/07_writing.md
@@ -3,12 +3,36 @@ verdict in ten minutes. The failure here is arguing from prose: unhedged superla
 nobody would accept. The skills `paper-writing`, `latex-repair` and `venue-checklist` are installed
 for this stage — use them.
 
+## What This Paper Must Answer
+
+Read `# What the Task Asks For` in your context — the numbered list of what the task statement
+demanded — together with the `task_outputs` block of the injected `# Report Plan`. Before drafting,
+write down, for each numbered demand, which section answers it and which number, equation, table or
+figure that section carries.
+
+- **Answer in the task's own terms.** If the task says "construct the Hamiltonian", the paper
+  contains a Hamiltonian, under a heading a reader scanning for one will find. Do not translate a
+  demand into the adjacent thing this run happened to do well.
+- **If the task names an object as an output — a derivation, an equation, a table, a sequence, a
+  structure — the paper shows that object at least once.** A rate computed over it, or a figure
+  about it, is a summary of the deliverable and not the deliverable; put the full working in an
+  appendix if it is long.
+- **A demand the run cannot answer from its evidence is still owed its place**, in the section a
+  reader looks in for the answer, with what is missing named. Do not compute, estimate or narrate a
+  number the run did not produce.
+- **Never open with what the run did not do.** An absence belongs in its own section and in
+  Limitations, never in the title, the abstract or the first paragraph.
+
 ## Mission
 
-Turn the approved problem framing, method, evidence, and analysis into a submission-ready paper package. You are responsible for the full writing loop: drafting LaTeX, improving clarity, checking evidence-to-claim alignment, compiling to PDF, and packaging the paper artifacts.
+Answer the task's questions in a submission-ready paper package, grounded in what this run actually
+established. You are responsible for the full writing loop: mapping the task's demands onto
+sections, drafting LaTeX, improving clarity, checking evidence-to-claim alignment, compiling to PDF,
+and packaging the paper artifacts.
 
 ## Your Responsibilities
 
+- Cover every numbered demand in `# What the Task Asks For`, each in its own place in the paper.
 - Draft paper-ready LaTeX grounded in the actual approved outputs and real workspace artifacts.
 - Distinguish verified empirical findings from provisional Stage 02 paper claims. Do not present provisional claims as confirmed results.
 - Use the strongest validated narrative from prior stages instead of writing generic background-heavy prose.

--- a/src/report_plan.py
+++ b/src/report_plan.py
@@ -1195,4 +1195,22 @@ def format_report_plan_for_prompt(plan: ReportPlan) -> str:
             lines.append(
                 f"- {number.quantity} ({number.unit}), from `{number.source_artifact}`"
             )
+
+    # `task_outputs` was the one block this renderer never emitted, which made the whole
+    # field invisible to the stage that has to publish it: Stage 07's prompt tells the
+    # writer to read `task_outputs`, and the `# Report Plan` channel it reads is where
+    # `task_outputs` was guaranteed not to be. An `artifact:` coverage kind that no
+    # prompt ever shows anyone is a field the gate checks and nobody answers.
+    if plan.task_outputs:
+        lines.append("")
+        lines.append("What the task asked for, and what in this plan produces it:")
+        for output in plan.task_outputs:
+            answer = {
+                "figure": lambda o: f"figure slot {o.target}",
+                "number": lambda o: f"headline number {o.target}",
+                "artifact": lambda o: f"the object in `{o.target}` — show it in the report",
+                "prose": lambda o: "prose in the report",
+                "not_attempted": lambda o: f"NOT ATTEMPTED: {o.why_not}",
+            }.get(output.kind, lambda o: o.covered_by)(output)
+            lines.append(f"- {output.stated} → {answer}")
     return "\n".join(lines)

--- a/src/rubric.py
+++ b/src/rubric.py
@@ -90,16 +90,29 @@ if TYPE_CHECKING:  # pragma: no cover - import cycle at runtime, type-only here
 #: did not write -- the task statement -- and asks whether the draft speaks to what was
 #: asked, with a number an artifact holds. Every criterion before it measured the run
 #: against its own record. Replayed over the 263 stage drafts of a 40-task benchmark
-#: pass, the existing eight read mean 0.964 / sd 0.043; the new one reads mean 0.746 /
-#: sd 0.329 and falls monotonically with stage number, 0.95 at Stage 01 to 0.51 at
-#: Stage 07, because a late stage owes more of the task than an early one. On the run
-#: that pass scored 0.0 externally the eight read 0.97 at Stage 06 and the new criterion
-#: reads 0.00 from Stage 05 on, which is the stage the run stopped producing the object
-#: the task named. ``6`` also stops ``numeric_fidelity`` treating an arXiv id or a "Fig. 3"
-#: as a reported measurement, which had made deleting the subject paper's name from a
-#: draft worth five times ``DEFAULT_MIN_GAIN``. Both change what an existing score means,
-#: so a v5 total and a v6 total are not two measurements of one thing.
-RUBRIC_VERSION = "6"
+#: pass, the existing eight read mean 0.964 / sd 0.043; the new one reads mean 0.657 /
+#: sd 0.326 and generally falls with stage number -- 0.74 / 0.94 / 0.65 / 0.55 / 0.61 /
+#: 0.54 / 0.51 for Stages 01 to 07 -- because a late stage owes more of the task than an
+#: early one. It is *not* monotone: Stage 02 is the high point, and an earlier version of
+#: this note claimed monotonicity from the two endpoints alone. On the run that pass
+#: scored 0.0 externally the eight read 0.97 at Stage 06 and the new criterion reads 0.00
+#: from Stage 05 on, which is the stage the run stopped producing the object the task
+#: named. ``6`` also stops ``numeric_fidelity`` treating an arXiv id or a "Fig. 3" as a
+#: reported measurement, which had made deleting the subject paper's name from a draft
+#: worth 9.5x ``DEFAULT_MIN_GAIN``. Both change what an existing score means, so a v5
+#: total and a v6 total are not two measurements of one thing.
+#:
+#: ``7`` is a correction, not a feature, and it is a version bump because it moves every
+#: ``deliverable_coverage`` score. Three ways to raise the criterion without doing any
+#: work were open in v6 and are closed here -- restating a demand in its own words,
+#: quoting the task statement, and pasting back the shortfall the ratchet had just
+#: printed (the last raised the total on 89 of 89 drafts). The on-disk half now applies
+#: at every stage rather than from Stage 05, so a v6 early-stage score and a v7 one are
+#: not comparable either. ``_IDENTIFIER_PREFIX`` also gains the left word boundary it
+#: shipped without: ``v`` was matching the tail of CV, HIV, dev and MeV, so writing
+#: "CV 0.821" hid an invented number from ``numeric_fidelity`` for a gain of +0.0476 --
+#: the same size as the gradient v6 added the filter to remove.
+RUBRIC_VERSION = "7"
 
 #: The keys the rubric refuses to read out of an adjudication artifact.
 #:
@@ -803,10 +816,20 @@ def _artifact_numbers(paths: RunPaths) -> set[float]:
 #: controlled pair at Stage 06, everything else held fixed: a draft ending "on the
 #: 2111.01152 system" totals 0.7587, with ``numeric_fidelity`` 0.67 and the shortfall
 #: "These reported values appear in no results artifact: 2111.01152"; the same draft
-#: ending "on the target system" totals 0.8063. That +0.0476 is nearly ten times
+#: ending "on the target system" totals 0.8063. That +0.0476 is 9.5x
 #: ``DEFAULT_MIN_GAIN``, so the ratchet records the deletion of the paper's identity as a
 #: new champion.
+#: The left boundary is load-bearing and was missing when this landed. Without it the
+#: alternative ``v`` matched the *tail* of CV, PV, HIV, dev, MeV and .csv, ``table``
+#: matched stable and suitable, ``section`` matched cross-section. Measured over the 263
+#: archived stage drafts, 29 numeric tokens across 11 of the 40 runs were silently
+#: dropped that way -- and it cut both ways: an invented number written "CV 0.821"
+#: escaped ``numeric_fidelity`` entirely, worth +0.0476 of total for one word, which is
+#: the same size as the gradient this filter was added to remove; and an honest on-disk
+#: "CV 0.0230" stopped counting as an answer for ``deliverable_coverage``.
 _IDENTIFIER_PREFIX = re.compile(
+    # The hyphen is in the boundary class too, or `section` matches `cross-section`.
+    r"(?<![A-Za-z0-9_-])"
     r"(?:arxiv|doi|fig|figure|eq|eqn|equation|table|section|sec|ref|v|#)\s*[.:]?\s*$",
     re.IGNORECASE,
 )
@@ -977,9 +1000,29 @@ def _score_deliverable_coverage(
 
     So this criterion, alone among them, reads a document the run did not write: the
     task statement. For each demand in it, the draft must have a sentence *about* that
-    demand, and from Stage 05 on that sentence must carry a number an artifact on disk
-    holds. Both halves matter -- without the second, the criterion is moved by
-    keyword-stuffing; without the first, it is `numeric_fidelity` again.
+    demand, and that sentence must also land on disk -- a number an artifact holds, or a
+    file the run wrote. Both halves matter, and each is worth half: without the second,
+    the criterion is moved by keyword-stuffing; without the first, it is
+    `numeric_fidelity` again.
+
+    **How far prose can move it, measured rather than asserted.** A draft of one restated
+    demand per line, no numbers, no files, no work, scores **0.504** over the 40 archived
+    tasks -- not zero, because a report that names what was asked does beat one silent
+    about it, and not more than half, because nothing it says is checkable. That is the
+    designed ceiling for talk. Three cheaper routes are closed outright and each was open
+    when this criterion first landed:
+
+    * a sentence made of nothing but the demand's own vocabulary is not engagement (it
+      scored **1.000** at every stage below 05, on 40 of 40 tasks, before this);
+    * a sentence that is an eight-word span of the task statement does not count (pasting
+      the whole task statement now moves the total by a median of **-0.008**);
+    * a sentence carrying this criterion's own shortfall text does not count. That one
+      was the worst: the ratchet prints the shortfall into the next polish prompt, so
+      pasting it back raised the *total* on **89 of 89** drafts, median **+0.069**, every
+      one past ``DEFAULT_MIN_GAIN``. A fitness function whose feedback is a recipe for
+      beating it is the failure this module exists to prevent, reached from a direction
+      the design did not consider -- for the second time, after
+      :func:`_cap_quantification_by_fidelity`. It now moves **0 of 55**.
 
     Verdict-blind, and structurally so: nothing here opens
     ``paths.hypothesis_outcomes`` or reads an :data:`OUTCOME_BLIND_FIELDS` key. A
@@ -1012,9 +1055,13 @@ def _score_deliverable_coverage(
     # Backticked spans are kept, unlike in `numeric_fidelity`: a demand whose answer is
     # an *object* rather than a statistic is answered by the file holding the object, and
     # that reference is written in backticks.
-    sentences = [s for s in re.split(r"(?<=[.!?])\s+|\n+", body) if s.strip()]
-    known = _artifact_numbers(paths) if stage.number >= 5 else set()
-    want_number = stage.number >= 5
+    normalized_task = " ".join(read_text(paths.user_input).split()).casefold()
+    sentences = [
+        sentence
+        for sentence in re.split(r"(?<=[.!?])\s+|\n+", body)
+        if sentence.strip() and not _is_quoted_from(sentence, normalized_task)
+    ]
+    known = _artifact_numbers(paths)
 
     from .deliverables import _content_words
 
@@ -1027,48 +1074,102 @@ def _score_deliverable_coverage(
             continue
         need = min(2, len(terms))
         hit = False
-        with_number = False
+        landed = False
         for sentence in sentences:
-            if len(_content_words(sentence) & terms) < need:
+            words = _content_words(sentence)
+            if len(words & terms) < need:
                 continue
-            hit = True
-            if not want_number:
-                break
             if _sentence_lands_on_disk(sentence, known, paths, artifact_roots):
-                with_number = True
+                # Evidence needs no vocabulary test. "The quasiparticle gap is 41.7 meV"
+                # is made of nothing but the demand's own nouns and a number, and it is
+                # the answer.
+                hit = landed = True
                 break
+            # An *unsupported* sentence made of nothing but the demand's own vocabulary
+            # says the demand back. The free half is for having something of the run's
+            # own to say, so at least one content word has to come from somewhere other
+            # than the ask. Without this, a draft of one restated demand per line scored
+            # 1.000 at every stage below 05, on 40 of 40 archived tasks, with no work.
+            if words - terms - _PROCESS_WORDS:
+                hit = True
         if hit:
             engaged.append(demand)
-        if with_number:
+        if landed:
             answered.append(demand)
 
     total = len(demands)
-    if want_number:
-        score = _clamp((len(engaged) + len(answered)) / (2 * total))
-    else:
-        score = _clamp(len(engaged) / total)
+    score = _clamp((len(engaged) + len(answered)) / (2 * total))
 
     missing = [demand for demand in demands if demand not in engaged]
     unanswered = [demand for demand in engaged if demand not in answered]
     observed = (
-        f"{len(engaged)}/{total} of the task's demands are spoken to"
-        + (f", {len(answered)}/{total} with a number from a results artifact" if want_number else "")
+        f"{len(engaged)}/{total} of the task's demands are spoken to, "
+        f"{len(answered)}/{total} by something on disk"
     )
     if score >= 1.0:
         shortfall = ""
     elif missing:
+        # Deliberately paraphrased rather than quoted. The shortfall used to carry the
+        # demand verbatim, and pasting it back into Key Results raised the *total* on
+        # every draft it was tried on -- median +0.069, all of them past
+        # ``DEFAULT_MIN_GAIN`` -- so the ratchet's own feedback was a recipe for a new
+        # champion that did no work. Naming the demand's subject is enough to act on.
         shortfall = (
-            f"Key Results does not speak to what the task asked: {missing[0][:110]!r}. "
-            "State the result for it, with its number, or state that it could not be "
-            "produced and why."
+            "Key Results does not speak to one of the things the task asked for -- the one "
+            f"about {_demand_subject(missing[0])}. State the result for it, with the number "
+            "or the file that carries it, or state that it could not be produced and why."
         )
     else:
         shortfall = (
-            f"The task's demand {unanswered[0][:110]!r} is discussed without a measured "
-            "value. Give it the number the run produced for it, and write that number to "
-            "a file under workspace/results so it can be checked."
+            f"What the report says about {_demand_subject(unanswered[0])} carries nothing "
+            "checkable. Give it the number the run produced, or name the file under "
+            "workspace/results that holds the answer."
         )
     return CriterionScore(key, title, weight, score, observed, shortfall)
+
+
+def _demand_subject(demand: str) -> str:
+    """A demand's subject, short enough to act on and not long enough to paste back."""
+    from .deliverables import _content_words
+
+    words = [word for word in _content_words(demand) if word not in _PROCESS_WORDS]
+    return ", ".join(sorted(words)[:4]) or demand[:40]
+
+
+#: How much of a sentence has to be a contiguous span of the task statement before it
+#: stops counting as the run's own words.
+_QUOTE_RUN_WORDS = 8
+
+#: Fixed spans of this criterion's own shortfall templates. The ratchet prints the
+#: shortfall into the polish prompt, so anything the shortfall says is text the next
+#: draft has in front of it -- and pasting it back used to raise the *total* on every
+#: draft it was tried on, median +0.069, all of them past ``DEFAULT_MIN_GAIN``. A fitness
+#: function whose own feedback is a recipe for beating it is the failure this module's
+#: docstring exists to prevent, arrived at from a direction the design did not consider.
+_SHORTFALL_MARKERS = (
+    "does not speak to one of the things the task asked for",
+    "carries nothing checkable",
+    "or state that it could not be produced and why",
+    "name the file under workspace/results that holds the answer",
+)
+
+
+def _is_quoted_from(sentence: str, normalized_task: str) -> bool:
+    """Whether a sentence is the task statement, or this criterion's own complaint, handed back.
+
+    Quoting the ask is not answering it, and quoting the grader is not answering it
+    either.
+    """
+    normalized = " ".join(sentence.split()).casefold()
+    if any(marker in normalized for marker in _SHORTFALL_MARKERS):
+        return True
+    words = normalized.split()
+    if len(words) < _QUOTE_RUN_WORDS:
+        return False
+    for start in range(len(words) - _QUOTE_RUN_WORDS + 1):
+        if " ".join(words[start : start + _QUOTE_RUN_WORDS]) in normalized_task:
+            return True
+    return False
 
 
 def _sentence_lands_on_disk(

--- a/tests/test_report_plan.py
+++ b/tests/test_report_plan.py
@@ -1019,6 +1019,33 @@ class TaskOutputCoverageTest(ReportPlanTestCase):
         )
         self.assertTrue(any("which does not exist" in p for p in self.problems()))
 
+    def test_the_task_outputs_reach_the_stage_that_has_to_publish_them(self) -> None:
+        """The field the gate checks has to be the field the writer is shown.
+
+        `format_report_plan_for_prompt` rendered `figures` and `headline_numbers` and
+        never `task_outputs`, while the Stage 07 prompt told the writer to read
+        `task_outputs` from the injected `# Report Plan` — the one place it was
+        guaranteed not to be. An `artifact:` coverage kind nobody is shown is a field the
+        gate checks and no one answers.
+        """
+        write_text(self.paths.results_dir / "hamiltonians.md", "H_HF = ...\n" * 20)
+        self.write_plan(
+            task_outputs=[
+                {"stated": "correctly derived Hartree-Fock Hamiltonians",
+                 "covered_by": "artifact:results/hamiltonians.md"},
+                {"stated": "the accuracy comparison", "covered_by": "figure:1"},
+                {"stated": "posterior chains", "covered_by": "not_attempted",
+                 "why_not": "the supplied data carries only best-fit values"},
+            ]
+        )
+        plan = load_report_plan(self.paths)
+        assert plan is not None
+        rendered = format_report_plan_for_prompt(plan)
+        self.assertIn("correctly derived Hartree-Fock Hamiltonians", rendered)
+        self.assertIn("results/hamiltonians.md", rendered)
+        self.assertIn("show it in the report", rendered)
+        self.assertIn("NOT ATTEMPTED", rendered)
+
     def test_an_unknown_coverage_kind_is_refused(self) -> None:
         self.write_plan(task_outputs=[{"stated": "constraints", "covered_by": "somehow"}])
         self.assertTrue(any("expected one of" in p for p in self.problems()))

--- a/tests/test_reviewer_sees_the_task.py
+++ b/tests/test_reviewer_sees_the_task.py
@@ -146,8 +146,19 @@ class ReviewerSeesTheCoverageRecordTest(unittest.TestCase):
         self.assertIn("It is not evidence; it is the claim", prompt)
         self.assertIn("runnable from what is in this workspace", prompt)
 
-    def test_a_stage_that_has_not_written_one_yet_still_gets_a_review(self) -> None:
-        self.assertIn("Task Coverage Record", self._prompt())
+    def test_a_stage_that_has_not_written_one_yet_gets_no_block_at_all(self) -> None:
+        """Absent means absent, not a heading over the word "(missing)".
+
+        The record is written at Stage 07 on 38 of 40 archived runs. Emitted
+        unconditionally, the block spent 700 characters telling six reviewers out of
+        seven — 1,340 of 1,600 archived review prompts — to read each `addressed: true`
+        of a file that says `(missing)`. That is how a prompt teaches a reader to skip a
+        section, and the section it teaches them to skip is the one that matters at 07.
+        """
+        prompt = self._prompt()
+        self.assertNotIn("Task Coverage Record", prompt)
+        self.assertIn("# Recent Log Excerpt", prompt)
+        self.assertIn("## The substitution check", prompt)
 
 
 class PanelSeatsSeeItTooTest(unittest.TestCase):

--- a/tests/test_rubric_deliverable_coverage.py
+++ b/tests/test_rubric_deliverable_coverage.py
@@ -135,14 +135,23 @@ class DeliverableCoverageTest(unittest.TestCase):
         )
         self.assertEqual(self.score(markdown), 0.75)
 
-    def test_the_shortfall_names_the_demand_that_was_dropped(self) -> None:
+    def test_the_shortfall_names_the_dropped_demand_without_quoting_it(self) -> None:
+        """Actionable, and not pasteable.
+
+        The shortfall used to carry the demand verbatim. The ratchet prints it into the
+        next polish prompt, so pasting it back raised the *total* on 89 of 89 archived
+        drafts — median +0.069, every one past `DEFAULT_MIN_GAIN`. It now names the
+        subject instead, and `_SHORTFALL_MARKERS` filters the text itself.
+        """
         markdown = draft(
             objective="Answer half the task.",
             what_i_did="Computed the gap.",
             key_results="The quasiparticle gap is 41.7 meV against the published 43.2 meV.",
         )
+        shortfall = self.shortfall(markdown)
         self.assertLess(self.score(markdown), 1.0)
-        self.assertIn("Hartree-Fock", self.shortfall(markdown))
+        self.assertIn("hamiltonian", shortfall)
+        self.assertNotIn("Derive the Hartree-Fock Hamiltonian for the target", shortfall)
 
     # -- what it must not reward ---------------------------------------------------
 
@@ -161,7 +170,7 @@ class DeliverableCoverageTest(unittest.TestCase):
             ),
         )
         self.assertEqual(self.score(markdown), 0.5)
-        self.assertIn("without a measured value", self.shortfall(markdown))
+        self.assertIn("carries nothing checkable", self.shortfall(markdown))
 
     def test_a_number_no_artifact_holds_does_not_answer_a_demand(self) -> None:
         """Catching the invented number is `numeric_fidelity`'s job; not counting it
@@ -187,9 +196,15 @@ class DeliverableCoverageTest(unittest.TestCase):
 
     # -- shape ---------------------------------------------------------------------
 
-    def test_before_stage_05_only_the_engagement_half_is_scored(self) -> None:
-        """A survey has no results to carry a number and must not be failed for it."""
-        markdown = draft(
+    def test_an_early_stage_is_held_to_the_same_contract(self) -> None:
+        """The on-disk half applies at every stage, and it is reachable at every stage.
+
+        v6 scored only the engagement half below Stage 05, on the theory that an early
+        stage has no results to point at. It has: Stage 01 writes `literature/`. What the
+        exemption actually bought was a draft of restated demands scoring 1.000 at Stages
+        01, 03 and 04 on 40 of 40 archived tasks.
+        """
+        talk = draft(
             objective="Survey.",
             what_i_did="Reviewed prior derivations.",
             key_results=(
@@ -198,8 +213,72 @@ class DeliverableCoverageTest(unittest.TestCase):
                 "against a computed one."
             ),
         )
-        self.assertEqual(self.score(markdown, stage=STAGE_03), 1.0)
-        self.assertLess(self.score(markdown, stage=STAGE_06), 1.0)
+        self.assertEqual(self.score(talk, stage=STAGE_03), 0.5)
+
+        write_text(self.paths.literature_dir / "prior_derivations.md", "notes\n" * 40)
+        grounded = draft(
+            objective="Survey.",
+            what_i_did="Reviewed prior derivations.",
+            key_results=(
+                "Prior work derives the Hartree-Fock Hamiltonian for related target "
+                "bilayers, collected in `workspace/literature/prior_derivations.md`. Two "
+                "papers compare a published quasiparticle gap against a computed one, "
+                "also in `workspace/literature/prior_derivations.md`."
+            ),
+        )
+        self.assertEqual(self.score(grounded, stage=STAGE_03), 1.0)
+
+    # -- the three free routes to a higher score, all measured open in v6 ---------------
+
+    def test_restating_a_demand_in_its_own_words_is_not_engagement(self) -> None:
+        """Scored 1.000 at Stages 01/03/04 on 40 of 40 archived tasks before this."""
+        markdown = draft(
+            objective="x",
+            what_i_did="y",
+            key_results=(
+                "Hartree-Fock Hamiltonian target bilayer derive.\n"
+                "Quasiparticle compare published value compute against."
+            ),
+        )
+        self.assertEqual(self.score(markdown), 0.0)
+
+    def test_quoting_the_task_statement_back_is_not_engagement(self) -> None:
+        markdown = draft(
+            objective="x",
+            what_i_did="y",
+            key_results=(
+                "Derive the Hartree-Fock Hamiltonian for the target bilayer; compute the "
+                "quasiparticle gap in meV and compare it against the published value."
+            ),
+        )
+        self.assertEqual(self.score(markdown), 0.0)
+
+    def test_pasting_the_shortfall_back_earns_nothing(self) -> None:
+        """The ratchet prints the shortfall into the next polish prompt.
+
+        Before the filter this was the cheapest new champion in the system: +0.069 median
+        on the total across 89 archived drafts, all past `DEFAULT_MIN_GAIN`, for a paste.
+        """
+        markdown = draft(objective="x", what_i_did="y", key_results="Nothing yet.")
+        before = self.score(markdown)
+        pasted = draft(
+            objective="x",
+            what_i_did="y",
+            key_results="Nothing yet. " + self.shortfall(markdown),
+        )
+        self.assertEqual(self.score(pasted), before)
+
+    def test_talking_about_everything_and_grounding_nothing_caps_at_half(self) -> None:
+        markdown = draft(
+            objective="Discuss.",
+            what_i_did="Considered both parts of the brief at length.",
+            key_results=(
+                "Our treatment of the derived Hartree-Fock Hamiltonian across the target "
+                "bilayer remains qualitative throughout. Similarly we compare the "
+                "quasiparticle gap against published expectations only in narrative form."
+            ),
+        )
+        self.assertEqual(self.score(markdown), 0.5)
 
     def test_a_task_stating_no_demand_does_not_penalise_the_draft(self) -> None:
         write_text(self.paths.user_input, "Some background prose about bilayers.")
@@ -265,6 +344,30 @@ class IdentifiersAreNotMeasurementsTest(unittest.TestCase):
         self.assertTrue(_is_measurement_like("41.7", 41.7, prefix="the gap is "))
         self.assertTrue(_is_measurement_like("0.741", 0.741, prefix="accuracy of "))
         self.assertTrue(_is_measurement_like("2048", 2048.0, prefix="context of "))
+
+    def test_the_prefix_needs_a_word_boundary_on_its_left(self) -> None:
+        """Shipped without one, and it opened a hole bigger than the one it closed.
+
+        `v` matched the *tail* of CV, HIV, dev, MeV and .csv; `table` matched stable;
+        `section` matched cross-section. Measured over the 263 archived stage drafts, 29
+        numeric tokens across 11 of the 40 runs were silently dropped. It cut both ways:
+        an invented number written "CV 0.821" escaped `numeric_fidelity` for +0.0476 of
+        total — the same size as the gradient the filter was added to remove — and an
+        honest on-disk "CV 0.0230" stopped counting as an answer for
+        `deliverable_coverage`.
+        """
+        from src.rubric import _is_measurement_like
+
+        for prefix in (
+            "AUROC on HIV ", "the CV ", "mean dev ", "a stable ", "cross-section ",
+            "measured in mSv ", "the ratio D_DV ", "sub-section width ",
+        ):
+            with self.subTest(prefix=prefix):
+                self.assertTrue(_is_measurement_like("0.821", 0.821, prefix=prefix))
+
+        for prefix in ("see arXiv:", "Fig. ", "in equation ", "Table ", "see Section ", "ref. "):
+            with self.subTest(prefix=prefix):
+                self.assertFalse(_is_measurement_like("3.5", 3.5, prefix=prefix))
 
 
 if __name__ == "__main__":

--- a/tests/test_task_deliverables_contract.py
+++ b/tests/test_task_deliverables_contract.py
@@ -162,6 +162,37 @@ class TheDeliveryContractIsNotTheResearchQuestionTest(unittest.TestCase):
         self.assertEqual(task_demands(TASK), demanding_sentences(TASK))
         self.assertEqual(task_demands("Some background prose about black holes."), [])
 
+    def test_the_gate_holds_the_narrowed_population_and_not_the_wide_one(self) -> None:
+        """The one line that gives the coverage gate any teeth, pinned.
+
+        `_uncovered_demands` reads `task_demands`, not `demanding_sentences`. Reverting
+        that single call left the whole suite green while taking the gate from firing on
+        3 of 40 archived runs back to 0 of 40 — its entire measurable effect, uncovered.
+        Asserted behaviourally rather than by reading the source: a record that accounts
+        only for the delivery contract must not satisfy a brief that asks for something
+        else.
+        """
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, self.BENCHMARK_SHAPED)
+        write_text(paths.report_file, "# Report\n\n## Findings\n\nSee images/f.png\n")
+        write_text(
+            paths.artifacts_dir / COVERAGE_FILENAME,
+            json.dumps({"deliverables": [{
+                "task_quote": "Figures are mandatory",
+                "addressed": True,
+                "where": "## Findings",
+            }]}),
+        )
+        problems = validate_deliverables_coverage(paths, self.BENCHMARK_SHAPED)
+        self.assertTrue(
+            any("does not account for what the task asked" in p for p in problems),
+            problems,
+        )
+        self.assertTrue(any("coupling strengths" in p or "ULB" in p for p in problems), problems)
+
     def test_the_brief_is_the_headed_part_only(self) -> None:
         brief = research_brief(self.BENCHMARK_SHAPED)
         self.assertIn("coupling strengths", brief)


### PR DESCRIPTION
A 10-agent adversarial audit of #220 against the merged tree. It found that the criterion added to stop AutoR auditing itself **could be raised by prose alone**, and that the cheapest route was printed into the polish prompt by the ratchet itself.

## The three routes, measured on the 40 archived runs

| route | before | after |
|:---|---:|---:|
| one restated demand per line, no numbers, no files, no work | **1.000** at every stage below 05, on 40/40 tasks | 0.504 |
| paste the whole task statement | counted as answering it | median **−0.008** on the total |
| paste back the shortfall this criterion just printed | **+0.069** median on the *total*, **89/89** past `DEFAULT_MIN_GAIN` | **0/55** |

The third is the one that matters. `EvolutionController.consider` would have recorded every one of those 89 as a new champion, and the text being pasted is text the ratchet itself puts in front of the operator. A fitness function shipping the recipe for beating it is the failure `src/rubric.py`'s docstring exists to prevent — reached from a direction the design did not consider, for the second time after `_cap_quantification_by_fidelity`.

Closed by: the on-disk half now applies at every stage rather than from Stage 05 (the exemption assumed an early stage has nothing to point at — Stage 01 writes `literature/`); a sentence made only of the demand's own vocabulary is not engagement *unless it lands on disk*, so `The quasiparticle gap is 41.7 meV` — the demand's nouns plus a number — still counts; an eight-word span of the task statement is not engagement; and `_SHORTFALL_MARKERS` filters the criterion's own complaint.

0.504 rather than 0 for pure restatement is deliberate and stated: a report that names what was asked beats one silent about it, and it can never exceed half because nothing it says is checkable. `src/evolution.py`'s prohibition block claimed prose could move this criterion by *nothing*, which was false at four stages of seven; it now states the half-credit rule exactly.

## `_IDENTIFIER_PREFIX` shipped without a left word boundary

`v` matched the tail of **CV, HIV, dev, MeV, .csv**; `table` matched *stable*; `section` matched *cross-section*. 29 numeric tokens across 11 of the 40 runs were silently dropped, and it cut both ways:

- an invented number written `CV 0.821` escaped `numeric_fidelity` entirely, worth **+0.0476** of total for one word — the same size as the gradient v6 added this filter to *remove*. The fix had installed a cheaper version of the bug it fixed.
- an honest, on-disk `CV 0.0230` stopped counting as an answer for `deliverable_coverage` — a 0.214 total swing decided by an abbreviation.

## Two things #220 added that nobody could reach

- **`task_outputs` was never rendered into a prompt.** `format_report_plan_for_prompt` emits `figures` and `headline_numbers` only, while #220's new Stage 07 head tells the writer to read `task_outputs` from the injected `# Report Plan` — the one place it was guaranteed not to be. So the `artifact:` coverage kind was a field the gate checked and no one was shown.
- **The coverage record is written at Stage 07 on 38 of 40 runs.** Emitted unconditionally to the reviewer, the block spent 700 characters telling **1,340 of 1,600** archived review prompts to read each `addressed: true` of a file that says `(missing)`.

`07_writing.md`, the LaTeX sibling, never got #220's task framing and still contained the word "task" zero times.

## Numbers #220 published that do not re-derive

Corrected in place rather than quietly dropped:

- **"the seven zeros became zero" is false.** Six went. `Information_002` still scores **0.0** — `gpt-5.1`, no judge failure, 3 of 3 criteria at zero — and it is the run §2.4.1 is entirely about. README and §6.8 contradicted §2.4.1 inside the same commit.
- **"39% more prose / median 37,068 bytes"** → measured **36%** and **36,330**. 37,068 is nothing on this machine; the nearest statistic is AutoR's *mean*.
- **"falls monotonically with stage number"** → it *rises* 0.948 → 0.979 from Stage 01 to 02, then falls. The claim came from quoting the two endpoints.
- **"125 of those drafts headroom where they had none"** → **27**, of the 52 that sat at exactly 1.000 on the existing eight.
- `deliverables.py`'s **"scoping to these headings returns 137"** was the *rejected* four-heading variant's number; the shipped set returns 59, and 75 after clause splitting.
- The **254:147** instruction ratio has no rule anywhere in the tree that reproduces it. Now quoted as a hand classification and an impression, not a measurement.
- `_locator_appears`'s comment claimed it stopped the `Information_002` case. It does not — the fragment loop is a disjunction and `derived_hamiltonians.png` is 24 characters and genuinely in the report. Replayed over 603 coverage entries it changes **no** verdict. The comment says so now.

## Tests

New tests pin each of the three routes, the word boundary in both directions, the `task_outputs` rendering, and the mutation #220 left uncovered: reverting `_uncovered_demands` to the wide population takes the gate from firing on 3 of 40 runs to 0 of 40 — its entire measurable effect — and the suite stayed green without it.

`RUBRIC_VERSION` 6 → 7: every `deliverable_coverage` score moves.

2558 tests pass, 1 skipped.

**Still unmeasured on the benchmark.** Everything here is a replay over archived artifacts. It says the criterion is harder to game, not that a run following it scores better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)