### PR TITLE
Ask when the file was written, and stop calling the on-disk half a defence

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -320,12 +320,38 @@ eight-word span of the task statement is not engagement, the shortfall names dem
 there is nothing in it to paste, and `_result_file_cited` asks who wrote the file instead of whether
 the path resolves.
 
-**What is left, published rather than denied.** Adding one sentence per demand that merely
-*mentions* it still gains up to **+0.094** of the stage total, on 88 of 263 drafts. That is the free
-half doing its job, and it is the largest gradient remaining. It is not closed and should not be: a
-criterion where mentioning earned nothing would also refuse the honest report that names a
-requirement it could not meet and says why, which §2.7 and the deliverables contract both require to
-stay valid.
+**What is left — and the previous version of this paragraph was wrong about it.** It said the free
+half, +0.094 on 88 of 263 drafts, was the largest gradient remaining. A third round found two
+larger, both inside the on-disk half the same paragraph had called "the whole defence":
+
+| route | measured | status |
+|:---|---:|:---|
+| cite a file the run did not earn: the benchmark's own reference PDFs, copied into `workspace/literature/` before the agent starts, or AutoR's `results/experiment_manifest.json` | median **+0.0625**, coverage 1.000 on 263/263 | closed — the resolver now asks *when* and *by whom*, not *which directory* |
+| **invent a number** | median **+0.0625**, max **+0.3810**, past the archive's gate on **173/263** | *partly* closed |
+| mention a demand and ground nothing | +0.094 max, 88/263 | open by design |
+
+The invented number is the one that matters and it is not fully fixed. It moves three criteria at
+once — this one, then `quantification`, then `numeric_fidelity` through the cap. One cause was a
+one-line tolerance bug: the percentage branch of `_matches_artifact_number` collapsed to the integer
+tolerance, so `74.1%` was satisfied by a results file holding `0.700` — five percentage points, not
+half of the last decimal. That is fixed. The other cause is not fixable in this criterion:
+`_artifact_numbers` pools **every** number in every result and data file, a median of **5,400** per
+archived run and **126,413** on one of them, most in [0, 1]. Against a bag that size an invented
+three-significant-figure metric matches by coincidence. That oracle predates this work — it is
+`numeric_fidelity`'s too — but adding a second consumer of it made the weakness worth more, and that
+is this criterion's doing.
+
+The free half stays open on purpose: a criterion where mentioning earned nothing would also refuse
+the honest report that names a requirement it could not meet and says why, which §2.7 and the
+deliverables contract both require to stay valid.
+
+**Three rounds, three corrections, and the pattern is the finding.** Each round of adversarial
+replay found a way to buy score that the previous round's fix had left open or introduced, and each
+round found published numbers that did not re-derive. That is worth more to a reader of this
+document than the criterion is: a mechanically-scored self-improvement loop is a target, the author
+of the target is the worst person to estimate its attack surface, and the only thing that worked was
+handing the artifact to something adversarial and rerunning it after every fix.
+`tools/rubric_replay.py` exists so the next round starts from prices rather than from prose.
 
 The same version bump fixes a smaller thing pointing the same way. `numeric_fidelity` admitted any
 token containing a dot as a reported measurement, so an arXiv id, a DOI and a `Fig. 3` all became

--- a/src/archive.py
+++ b/src/archive.py
@@ -84,9 +84,13 @@ ARCHIVE_VERSION = "1"
 DEFAULT_MIN_OBSERVATIONS = minimum_arms_for(ALPHA, family=len(REVISIT_EDGES) + len(STAGES))
 
 #: Mean fitness a challenger must beat the incumbent by. Roughly the size of one
-#: criterion moving a quarter of its range on the eight-criterion rubric: the lightest
-#: criterion carries 1.5 of 18, so a quarter of its range is 0.25 * 1.5/18 = 0.021.
-#: Below that the archive would promote noise.
+#: criterion moving a quarter of its range: the lightest criterion carries 1.5 of the
+#: nine-criterion rubric's 21 at Stage 05 and above, so a quarter of its range is
+#: 0.25 * 1.5/21 = 0.018, and 0.25 * 1.5/16 = 0.023 at the early stages where two
+#: criteria do not yet apply. The constant predates the ninth criterion and was derived
+#: against 1.5/18 = 0.021; it sits between the two live figures, so it is left where it
+#: is rather than moved for a third significant figure. Below it the archive would
+#: promote noise.
 DEFAULT_MIN_GAIN = 0.02
 
 #: Weight on an unproven variant when sampling a parent. Pure fitness-proportional

--- a/src/rubric.py
+++ b/src/rubric.py
@@ -110,7 +110,8 @@ if TYPE_CHECKING:  # pragma: no cover - import cycle at runtime, type-only here
 #: ``deliverable_coverage`` score. Three ways to raise the criterion without doing any
 #: work were open in v6 and are closed here -- restating a demand in its own words,
 #: quoting the task statement, and pasting back the shortfall the ratchet had just
-#: printed (the last raised the total on 89 of 89 drafts). The on-disk half now applies
+#: printed (the last raised the total on 88 of the 118 drafts that carried one). The
+#: on-disk half now applies
 #: at every stage rather than from Stage 05, so a v6 early-stage score and a v7 one are
 #: not comparable either. ``_IDENTIFIER_PREFIX`` also gains the left word boundary it
 #: shipped without: ``v`` was matching the tail of CV, HIV, dev and MeV, so writing
@@ -869,14 +870,34 @@ def _matches_artifact_number(value: float, raw: str, percent: bool, known: set[f
     :func:`_score_numeric_fidelity` about every number in the draft, and
     :func:`_score_deliverable_coverage` about the one number a demand's answer carries --
     and two encodings of one rule drift.
+
+    The fraction branch had that backwards for as long as it existed:
+    ``max(0.5 * 10**-decimals / 100, tolerance)`` is ``tolerance``, always, because the
+    first term is a hundredth of the second. So `74.1%` was matched against every
+    artifact value within **+/-0.05** rather than +/-0.0005 -- five percentage points --
+    and `74.1%` was satisfied by a file holding `0.700`. Verified before and after: it
+    now accepts `0.741` and refuses `0.700` and `0.79`.
+
+    What this does not fix, and what the docstring should not pretend it fixes: the
+    *population* is large. ``_artifact_numbers`` pools every number in every JSON, CSV
+    and text file under ``results/`` and ``data/`` -- a median of 5,400 per archived run
+    and 126,413 on one of them, most of them in [0, 1]. Against a bag that size a
+    plausible three-significant-figure metric matches by coincidence, and tightening the
+    tolerance narrows the window without shrinking the bag. This is the weakest link in
+    both criteria that use it, it predates them both, and it is measured in
+    :func:`_score_deliverable_coverage`'s docstring rather than asserted away.
     """
     decimals = len(raw.split(".")[1]) if "." in raw else 0
     tolerance = max(0.5 * (10 ** -decimals), abs(value) * 1e-9)
-    for candidate in (value, value / 100.0) if percent else (value,):
-        scale = max(0.5 * (10 ** -decimals) / 100.0, tolerance) if candidate != value else tolerance
-        if any(abs(candidate - known_value) <= scale for known_value in known):
-            return True
-    return False
+    candidates: list[tuple[float, float]] = [(value, tolerance)]
+    if percent:
+        fraction = value / 100.0
+        candidates.append((fraction, max(tolerance / 100.0, abs(fraction) * 1e-9)))
+    return any(
+        abs(candidate - known_value) <= scale
+        for candidate, scale in candidates
+        for known_value in known
+    )
 
 
 def _score_numeric_fidelity(markdown: str, paths: RunPaths) -> CriterionScore:
@@ -1034,15 +1055,34 @@ def _score_deliverable_coverage(
       the same archive. :func:`_result_file_cited` asks who wrote the file, and the same
       injection now scores exactly what the same sentences score with no citation at all.
 
-    **What remains, stated rather than closed.** Adding one sentence per demand that
-    merely *mentions* it still gains up to **+0.094** of the stage total, on 88 of 263
-    drafts. That is the free half doing what it is for, and it is the largest gradient
-    left; a criterion where mentioning earned nothing would also refuse the honest report
-    that says a requirement could not be met and why, which the rest of this design
-    requires to stay valid. A fitness function whose own feedback is a recipe for beating
-    it is the failure this module exists to prevent, reached twice from directions the
-    design did not consider -- after :func:`_cap_quantification_by_fidelity` and again
-    here -- so the number is published rather than the claim that there is none.
+    **What remains, and what the last version of this docstring got wrong about it.**
+    It said the free half -- +0.094 on 88 of 263 drafts -- was the largest gradient left.
+    A third adversarial replay found two larger ones, both of them in the on-disk half
+    this docstring had just called "the whole defence":
+
+    * **cite a file the run did not earn.** The benchmark's reference papers are copied
+      into ``workspace/literature/`` before the agent starts, and
+      ``results/experiment_manifest.json`` is AutoR's own record. Both sat inside the
+      directory whitelist. Median +0.0625 on the stage total, coverage 1.000 on 263 of
+      263 drafts. Closed above, by asking when the file was written and who wrote it
+      rather than which directory it is in.
+    * **invent a number.** Median +0.0625, maximum +0.3810, past the archive's gate on
+      173 of 263 drafts, and it moves three criteria at once -- this one, then
+      ``quantification``, then ``numeric_fidelity`` through the cap. Two causes. The
+      tolerance bug in :func:`_matches_artifact_number` is fixed. The other is not
+      fixable here: ``_artifact_numbers`` is a bag of every number in every result and
+      data file, a median of **5,400** per archived run and **126,413** on one of them,
+      most of them in [0, 1]. Against a bag that size an invented three-significant-figure
+      metric matches something by coincidence. That weakness predates this criterion --
+      it is ``numeric_fidelity``'s oracle too -- and adding a second consumer made it
+      worth more, which is this criterion's fault and is recorded here rather than
+      anywhere it would be easier to miss.
+
+    So the honest statement is not that the class is closed. It is that four routes are
+    closed, one is bounded at half by design, and one -- a number nobody measured, in a
+    draft whose other numbers are real -- is still worth more than doing the work.
+    ``tools/rubric_replay.py`` prices every one of them on the archive, and the next
+    change to this criterion should start by running it.
 
     Verdict-blind, and structurally so: nothing here opens
     ``paths.hypothesis_outcomes`` or reads an :data:`OUTCOME_BLIND_FIELDS` key. A
@@ -1170,8 +1210,9 @@ _QUOTE_RUN_WORDS = 8
 
 #: Fixed spans of this criterion's own shortfall templates. The ratchet prints the
 #: shortfall into the polish prompt, so anything the shortfall says is text the next
-#: draft has in front of it -- and pasting it back used to raise the *total* on every
-#: draft it was tried on, median +0.069, all of them past ``DEFAULT_MIN_GAIN``. A fitness
+#: draft has in front of it -- and pasting it back used to raise the *total* on 88 of the
+#: 118 drafts that carried one, median +0.036, all of them past ``DEFAULT_MIN_GAIN``. A
+#: fitness
 #: function whose own feedback is a recipe for beating it is the failure this module's
 #: docstring exists to prevent, arrived at from a direction the design did not consider.
 _SHORTFALL_MARKERS = (
@@ -1240,14 +1281,25 @@ def _result_file_cited(
 ) -> bool:
     """Whether a sentence names a file this run wrote *as a result*.
 
-    Three narrowings against "the path resolves", each closing a measured route to a free
-    score. An absolute path is refused outright -- ``/etc/hostname`` is on every machine.
-    The path must land under one of the run's own output directories, so a benchmark's
-    read-only input under ``data/`` is not an answer the run produced. And AutoR's own
-    record files are excluded: ``stages/``, ``artifacts/``, ``notes/`` and ``reviews/``
-    exist on every run by construction, so citing them would price bookkeeping as
-    evidence -- the substitution this whole criterion exists to catch, arrived at through
-    the criterion itself.
+    Four narrowings against "the path resolves", each closing a measured route to a free
+    score, and the fourth is the one the first three missed.
+
+    An absolute path is refused outright -- ``/etc/hostname`` is on every machine. The
+    path must land under one of the run's own output directories, so a benchmark's
+    read-only input under ``data/`` is not an answer. AutoR's own record files are
+    excluded through :func:`is_autor_own_record` and :func:`_harness_written_records`,
+    the same pair :func:`_fresh_artifact_kinds` uses -- ``stages/``, ``artifacts/``,
+    ``notes/``, ``reviews/`` and ``results/experiment_manifest.json`` exist on every run
+    by construction, and pricing bookkeeping as evidence is the substitution this
+    criterion exists to catch, arrived at through the criterion itself.
+
+    And the file has to have been written **during this run**. A directory whitelist
+    alone was not enough: the benchmark's reference papers are copied into
+    ``workspace/literature/`` before the agent starts -- md5-identical to
+    ``<task>/related_work/``, mtime before the run's own first write -- so a sentence
+    citing ``literature/paper_000.pdf`` bought the on-disk half at every stage, on 263
+    of 263 archived drafts, for a median total gain of +0.0625. Being handed a paper is
+    not having produced a result.
     """
     roots = [paths.results_dir, paths.figures_dir, paths.report_dir, paths.literature_dir]
     for extra in artifact_roots or ():
@@ -1255,6 +1307,8 @@ def _result_file_cited(
             extra / name for name in ("results", "figures", "report", "outputs", "literature")
         )
     resolved_roots = [root.resolve() for root in roots]
+    harness_written = _harness_written_records(paths)
+    started = _run_started_at(paths)
 
     for reference in _extract_path_references(sentence):
         candidate = PurePosixPath(reference.strip())
@@ -1264,12 +1318,29 @@ def _result_file_cited(
             target = (base / reference).resolve()
             if not target.is_file():
                 continue
-            if any(
-                target == root or root in target.parents
-                for root in resolved_roots
-            ):
-                return True
+            if not any(target == root or root in target.parents for root in resolved_roots):
+                continue
+            if is_autor_own_record(paths, target) or harness_written.covers(target):
+                continue
+            try:
+                if started is not None and target.stat().st_mtime < started:
+                    continue
+            except OSError:
+                continue
+            return True
     return False
+
+
+def _run_started_at(paths: RunPaths) -> float | None:
+    """When this run first wrote anything, as an mtime floor for "the run produced it".
+
+    ``user_input.txt`` is written once, at the top of the run, before any stage executes,
+    so it dates the run without needing a clock the agent could move.
+    """
+    try:
+        return paths.user_input.stat().st_mtime
+    except OSError:
+        return None
 
 
 def _score_traceability(markdown: str) -> CriterionScore:

--- a/tests/test_rubric_deliverable_coverage.py
+++ b/tests/test_rubric_deliverable_coverage.py
@@ -139,8 +139,9 @@ class DeliverableCoverageTest(unittest.TestCase):
         """Actionable, and not pasteable.
 
         The shortfall used to carry the demand verbatim. The ratchet prints it into the
-        next polish prompt, so pasting it back raised the *total* on 89 of 89 archived
-        drafts — median +0.069, every one past `DEFAULT_MIN_GAIN`. It now names the
+        next polish prompt, so pasting it back raised the *total* on 88 of the 118
+        archived drafts that carried one — median +0.036, every one past
+        `DEFAULT_MIN_GAIN`. It now names the
         subject instead, and `_SHORTFALL_MARKERS` filters the text itself.
         """
         markdown = draft(
@@ -259,7 +260,7 @@ class DeliverableCoverageTest(unittest.TestCase):
     def test_pasting_the_shortfall_back_earns_nothing(self) -> None:
         """The ratchet prints the shortfall into the next polish prompt.
 
-        Before the filter this was the cheapest new champion in the system: +0.069 median
+        Before the filter this was the cheapest new champion in the system: +0.036 median
         on the total across 89 archived drafts, all past `DEFAULT_MIN_GAIN`, for a paste.
         """
         markdown = draft(objective="x", what_i_did="y", key_results="Nothing yet.")
@@ -283,12 +284,24 @@ class DeliverableCoverageTest(unittest.TestCase):
         """
         from src.rubric import _result_file_cited
 
+        write_text(self.paths.results_dir / "experiment_manifest.json", '{"experiments": []}')
+        # The benchmark copies its reference papers into `literature/` before the agent
+        # starts. A directory whitelist called that a result; an mtime does not.
+        handed_over = self.paths.literature_dir / "paper_000.pdf"
+        write_text(handed_over, "%PDF-1.4\n" + "x" * 400)
+        import os
+
+        stamp = os.path.getmtime(self.paths.user_input) - 3600
+        os.utime(handed_over, (stamp, stamp))
+
         for path in (
             "/etc/hostname",
             "stages/06_analysis.md",
             "workspace/artifacts/deliverables_coverage.json",
             "workspace/notes/open_questions.md",
             "workspace/data/input.csv",
+            "workspace/results/experiment_manifest.json",
+            "workspace/literature/paper_000.pdf",
         ):
             with self.subTest(path=path):
                 self.assertFalse(
@@ -381,6 +394,22 @@ class IdentifiersAreNotMeasurementsTest(unittest.TestCase):
         for prefix in ("as shown in Fig. ", "in equation ", "see Section ", "Table "):
             with self.subTest(prefix=prefix):
                 self.assertFalse(_is_measurement_like("3.5", 3.5, prefix=prefix))
+
+    def test_a_percentage_is_matched_against_its_own_fraction_not_a_neighbourhood(self) -> None:
+        """`74.1%` was satisfied by a results file holding `0.700`.
+
+        The fraction branch read `max(0.5 * 10**-decimals / 100, tolerance)`, and the
+        first term is a hundredth of the second, so the max is always `tolerance` — the
+        window was ±0.05 on the fraction where the docstring three lines above promised
+        ±0.0005. Five percentage points. The same function decides `numeric_fidelity`.
+        """
+        from src.rubric import _matches_artifact_number
+
+        self.assertTrue(_matches_artifact_number(74.1, "74.1", True, {0.741}))
+        self.assertTrue(_matches_artifact_number(74.1, "74.1", True, {74.1}))
+        self.assertFalse(_matches_artifact_number(74.1, "74.1", True, {0.700}))
+        self.assertFalse(_matches_artifact_number(74.1, "74.1", True, {0.79}))
+        self.assertFalse(_matches_artifact_number(0.741, "0.741", False, {0.700}))
 
     def test_a_measurement_is_still_a_measurement(self) -> None:
         from src.rubric import _is_measurement_like

--- a/tools/rubric_replay.py
+++ b/tools/rubric_replay.py
@@ -64,6 +64,33 @@ def _drafts(run_dir: Path):
         yield paths, stage, markdown, [workspace]
 
 
+def _mentioned(paths) -> str | None:
+    """One sentence per demand that *mentions* it and grounds nothing: the free half."""
+    demands = task_demands(task_statement(read_text(paths.user_input)))
+    if not demands:
+        return None
+    return "\n".join(
+        f"Our finding on this point is recorded fully; see detail on {' '.join(sorted(terms)[:4])}."
+        for terms in _demand_terms(demands)
+    )
+
+
+def _cited(paths, path: str) -> str | None:
+    """The same sentences, citing a path -- the round-2 and round-3 exploits."""
+    body = _mentioned(paths)
+    if body is None:
+        return None
+    return "\n".join(f"{line[:-1]} in `{path}`." for line in body.splitlines())
+
+
+def _invented(paths) -> str | None:
+    """The same sentences carrying a number nobody measured -- the round-3 exploit."""
+    body = _mentioned(paths)
+    if body is None:
+        return None
+    return "\n".join(f"{line[:-1]}, which gives 74.1% overall." for line in body.splitlines())
+
+
 def _restated(paths) -> str:
     """A draft that says every demand back and does nothing: the free-half probe."""
     demands = task_demands(task_statement(read_text(paths.user_input)))
@@ -101,6 +128,8 @@ def main() -> int:
     old_totals: list[float] = []
     new_totals: list[float] = []
     restated_scores: list[float] = []
+    probe_deltas: dict[str, list[float]] = {}
+    probe_full: dict[str, int] = {}
     paste_task_delta: list[float] = []
     paste_shortfall_delta: list[float] = []
     shortfall_population = 0
@@ -139,6 +168,34 @@ def main() -> int:
                     paths=paths, stage=stage, markdown=_restated(paths), artifact_roots=roots
                 ).by_key["deliverable_coverage"].score
             )
+
+            # Every route anyone has found to buy score with prose, priced on the same
+            # draft. A route missing from this list is a claim in the docs with no owner.
+            probes = {
+                "mention only (the documented free half)": _mentioned(paths),
+                "  + cite the benchmark's own reference paper": _cited(
+                    paths, "workspace/literature/paper_000.pdf"
+                ),
+                "  + cite AutoR's own experiment manifest": _cited(
+                    paths, "workspace/results/experiment_manifest.json"
+                ),
+                "  + cite a path that merely resolves": _cited(paths, "/etc/hostname"),
+                "  + an invented percentage": _invented(paths),
+            }
+            for label, injection in probes.items():
+                if injection is None:
+                    continue
+                probed = score_stage(
+                    paths=paths,
+                    stage=stage,
+                    markdown=markdown.replace(
+                        "## Files Produced", injection + "\n\n## Files Produced", 1
+                    ),
+                    artifact_roots=roots,
+                )
+                probe_deltas.setdefault(label, []).append(probed.total - score.total)
+                if probed.by_key["deliverable_coverage"].score >= 1.0 - 1e-9:
+                    probe_full[label] = probe_full.get(label, 0) + 1
 
             statement = task_statement(read_text(paths.user_input))
             pasted = markdown.replace("## Files Produced", statement + "\n\n## Files Produced", 1)
@@ -179,9 +236,14 @@ def main() -> int:
     line("drafts at 1.000 before / gaining headroom",
          f"{headroom_before} / {headroom_after}")
     print()
-    print("free-half probes (a gain here is a score bought without doing the work):")
+    print("prose probes (a gain here is score bought without doing the work):")
     line("  restated demands, no evidence: mean / max",
          f"{statistics.mean(restated_scores):.4f} / {max(restated_scores):.4f}")
+    for label, deltas in probe_deltas.items():
+        line(f"  {label}",
+             f"median {statistics.median(deltas):+.4f}  max {max(deltas):+.4f}  "
+             f"past 0.005: {sum(d > 0.005 for d in deltas)}/{len(deltas)}  "
+             f"coverage at 1.000: {probe_full.get(label, 0)}")
     line("  paste the task statement: median total delta",
          f"{statistics.median(paste_task_delta):+.4f}")
     line("  paste the shortfall: median / n moved / n",


### PR DESCRIPTION
Third adversarial round. It found **two** ways to buy score larger than the one #223's docs called largest — and both are inside the half those docs called "the whole defence".

| route | measured on 263 archived drafts | status |
|:---|---:|:---|
| cite a file the run did not earn | coverage **1.000 on 263/263**, median **+0.0625** | closed here |
| **invent a number** | median **+0.0625**, max **+0.3810**, past the archive gate on **173/263** | *partly* closed |
| mention a demand, ground nothing | +0.094 max, 88/263 | open by design |

## A file the run did not earn

#223 replaced *does the path resolve* with a directory whitelist. Still the wrong question. The benchmark copies its reference papers into `workspace/literature/` **before the agent starts** — md5-identical to `<task>/related_work/`, mtime an hour before the run's own first write — and `results/experiment_manifest.json` is one of AutoR's own `RECORD_ARTIFACTS`. Both were inside the whitelist.

`_result_file_cited` now asks the two questions this module already knew how to ask — `is_autor_own_record` and `_harness_written_records`, the pair `_fresh_artifact_kinds` has used all along — plus an mtime floor at the run's own start.

Three rounds, three versions of this one predicate, and the progression is the lesson:

> *does it resolve* → *is it in an output directory* → *did this run write it, and is it the run's work rather than its bookkeeping*

## An invented number

It moves three criteria at once: this one, then `quantification`, then `numeric_fidelity` through the cap. Two causes; only one is fixable here.

**Fixable, and older than this criterion.** The percentage branch of `_matches_artifact_number` computed `max(0.5 * 10**-decimals / 100, tolerance)` — and the first term is a hundredth of the second, so the max is *always* `tolerance`. `74.1%` was matched within ±0.05 of 0.741 instead of ±0.0005 — five percentage points — and was satisfied by a results file holding **`0.700`**. Fixed and pinned.

**Not fixable here.** `_artifact_numbers` pools every number in every JSON, CSV and text file under `results/` and `data/`: a median of **5,400** per archived run, **126,413** on one of them, most in [0, 1]. Against a bag that size an invented three-significant-figure metric matches by coincidence, and tightening the tolerance narrows the window without shrinking the bag. That oracle predates this work — `numeric_fidelity` has always used it — but adding a second consumer made the weakness worth more, which is this criterion's doing. It is now recorded where the criterion is.

So the docstring and §2.4.1 **no longer claim the class is closed.**

## Things this repo had already retracted and left standing

- **"89 of 89 drafts / median +0.069"** survived in four places — two comments and two test docstrings — after being corrected to "88 of 118 / +0.036" in two others. `tools/rubric_replay.py` names it as a known error in its own module docstring while the tree still carried it.
- **`tools/rubric_replay.py` claimed to re-derive every published number** and had no probe for the ones that matter. It now prices all five prose routes on every archived draft.
- **`src/archive.py`'s derivation of `DEFAULT_MIN_GAIN`** still read "1.5 of 18" on an eight-criterion rubric. Live figures are 1.5/21 and 1.5/16; the constant sits between them and stays, with the arithmetic written out.

## The pattern, which is worth more than the criterion

Each round found a way to buy score that the previous round's fix had left open or introduced, and each round found published numbers that did not re-derive. A mechanically-scored self-improvement loop is a target; the author of the target is the worst person to estimate its attack surface. `docs/framework.md` §2.4.1 now says so, and the tool exists so the next round starts from prices rather than prose.

2561 tests pass, 1 skipped.

**Note on the benchmark arm currently running:** it is pinned to `2ffaeb4`, which predates this PR. It measures the tree before these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)