### PR TITLE
The two arms in §6.8 were not given the same budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,8 +865,14 @@ statements with no AutoR at all.
 | bare Claude Code (Opus) | **29.24** | 25 (16%) | 25 |
 | AutoR (Opus), post-repair | 23.57 | 35 (23%) | 15 |
 
-Paired over the forty tasks that is **−5.67 ± 1.84**. The scaffold currently makes the model worse
-at the benchmark than not having it, and it does so while writing 36% more prose — it covers less,
+Paired over the forty tasks that is **−5.67 ± 1.84** — but the two arms were not given the same
+budget, and the confound is about as large as the effect: the AutoR arm ran with
+`--stage-timeout 1800` and 28 of its 40 runs logged `Stage timed out`, while the bare arm had no
+per-stage cap. On the twelve AutoR runs that never hit the cap the paired deficit is **−3.93**
+rather than −6.42. That is a post-hoc subgroup and not a corrected value, so the honest reading is
+that the scaffold is behind and the published margin is unreliable
+([§6.8](docs/framework.md#68-the-scaffold-is-currently-worth-less-than-no-scaffold)).
+It is behind while writing 36% more prose — it covers less,
 not less well. [§6.8](docs/framework.md#68-the-scaffold-is-currently-worth-less-than-no-scaffold) is
 the account of why, and `RUBRIC_VERSION` 7 is the first change aimed at it.
 

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1075,6 +1075,28 @@ delta), and AutoR wins fifteen of forty. Eight stages of preregistration, adjudi
 reviewer gates, a rigour rubric and a champion ratchet make the same model, on the same hardware,
 measurably **worse** at the task than being handed the task.
 
+**That number has a confound in it of roughly its own size, found while building the harness for
+the next arm and not before publishing this one.** The two arms were not given the same budget.
+Read off each run's own `_meta.json`: the AutoR arm ran with `--stage-timeout 1800`, the bare arm
+under a single `timeout 43200` wall clock with no per-stage cap at all. **28 of the 40 AutoR runs
+logged `Stage timed out`.** Inside that arm, the 28 that hit the cap average **22.08** and the 12
+that did not average **27.06** — a 4.99-point gap, which is the same size as the between-arm
+difference the table is about. Paired against bare Claude Code the deficit is **−6.42** on the
+timed-out tasks and **−3.93** on the twelve that were not.
+
+Three things follow, and the third is the one that matters most.
+
+1. The deficit does not disappear when the cap does. On the twelve unconstrained tasks AutoR is
+   still 3.93 points behind, so "the scaffold is behind" survives; "by 5.67" does not.
+2. The 12-task figure is a **post-hoc subgroup**, and the tasks that exhaust a stage budget are
+   plausibly the harder ones, so it is not a corrected value. It bounds the confound; it does not
+   remove it.
+3. §2.5 exists because a mechanism has to carry its own control arm, and this is that principle
+   failing on the measurement the whole section is built from. The two arms were compared on
+   mean, zero-criteria, prose length and figure count, and nobody diffed the *command lines*
+   until a review of the next arm's tooling did it. A benchmark comparison is a claim about two
+   configurations, and the configuration is part of the claim.
+
 The composition of that deficit is not where the design's story predicted. AutoR is not shipping
 less: its median report is 36,330 bytes against bare Claude Code's 26,669, 36% *more* prose. It is
 not shipping fewer figures: both arms have ~5 images in front of the judge. It covers **less** —
@@ -1175,7 +1197,9 @@ any.
 - **The benchmark number is 23.57, and the same-model baseline beats it.** §6.8 is the full
   account: bare Claude Code scores 29.24 on the same forty tasks with the same model, the same
   machine and the same judge, so the paired deficit is −5.67 ± 1.84 and the scaffold is currently
-  net-negative. The cross-agent table in §6.1 is the **pre-repair** 14.16 batch and is also
+  net-negative — with the caveat §6.8 now carries, that the AutoR arm ran under an eight-fold
+  tighter stage timeout than the control and that 28 of its 40 runs hit it, which puts a confound
+  of about the effect's own size inside that margin. The cross-agent table in §6.1 is the **pre-repair** 14.16 batch and is also
   **cross-model** — all three comparison agents run GPT-5.4 — so it is not a clean harness
   comparison in either direction; it is **single-attempt** where the public leaderboard aggregates
   the *best* score per (task, agent) pair; and both numbers are `gpt-5.1` numbers, where judge

--- a/tools/rcb_arm_watch.py
+++ b/tools/rcb_arm_watch.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Wait for a benchmark arm to finish, score it with the reference judge, print the table.
+
+Vendored from the harness that measured the `2ffaeb4` arm, paths and all, because the
+defects it works around were each found the expensive way and a copy that lives only in a
+scratch directory is a lesson that expires. The three constants at the top are what a
+second arm has to change.
+
+Runs detached. Scores each task as soon as its report exists rather than waiting for
+the whole batch, so the scoring is mostly done by the time the last run lands.
+
+Three things this is careful about, each because getting it wrong has cost a
+measurement here before:
+
+* **The judge is part of the result.** `score_rcb_run.py` defaults to the reference
+  judge `gpt-5.1`; judge choice has been measured to move a score by ~16 points, so a
+  number scored with anything else is not comparable to the arms in the table. The
+  scorer prints the judge on every result and refuses to write one without it.
+* **The instrument is held fixed.** The other two arms were scored with the copy of
+  `score_rcb_run.py` under `autor-rcb-rerun/AutoR`, so this uses that same file rather
+  than the one in the arm's own pinned clone. The newer copy only adds multi-draw
+  support, but "only adds" is a claim about a diff, and holding the file identical is
+  free.
+* **A judge failure is not a zero.** The scorer refuses to write a result when any
+  criterion's judge call failed, because the stock scorer records those as `score: 0`,
+  indistinguishable from a criterion the report genuinely missed. A refusal here is
+  retried, and if it keeps refusing the task is reported as *unscored* and left out of
+  the mean rather than folded in as a zero.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ARM = Path(__file__).resolve().parent
+WORKSPACES = Path("/rmeng_data/robtang/rcb_runs/arm_2ffaeb4")
+SCORES = ARM / "scores"
+BENCH = Path("/home/robtang_google_com/RCB")
+
+#: The same file the other two arms in the table were scored with. See the docstring.
+SCORER = Path("/rmeng_data/robtang/autor-rcb-rerun/AutoR/tools/score_rcb_run.py")
+
+#: Where the arms this one is compared against already live.
+OTHER_ARMS = {
+    "AutoR (Opus), pre-fix": Path("/rmeng_data/robtang/autor-rcb-rerun/arm_scores/full40"),
+    "bare Claude Code (Opus)": Path(
+        "/rmeng_data/robtang/autor-rcb-rerun/arm_scores/control_bare_cc"
+    ),
+}
+
+#: A report below this is the adapter's stub, not a deliverable. `MIN_REPORT_CHARS`.
+MIN_REPORT_BYTES = 1200
+
+POLL_SECONDS = 300
+SCORE_TIMEOUT = 1800
+MAX_ATTEMPTS = 3
+EXPECTED_TASKS = 40
+
+
+def log(message: str) -> None:
+    stamp = datetime.now(timezone.utc).astimezone().strftime("%m-%d %H:%M:%S")
+    line = f"[{stamp}] {message}"
+    print(line, flush=True)
+    with (ARM / "watch.log").open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+
+
+#: What the batch runner's command line looks like, and nothing else's.
+_RUNNER_MARKERS = ("run_batch.py", str(WORKSPACES))
+
+
+def find_runner() -> int | None:
+    """The batch runner's pid, found by scanning /proc rather than by being told.
+
+    Taking the pid as an argument is how this went wrong the first time: the shell
+    that computed it used `pgrep -f "run_batch.py --autor ..."`, which matched *its own
+    command line* — the pattern was in it — and handed over the pid of a wrapper that
+    exited seconds later. The watcher then saw "runner gone, no reports" and would have
+    written a results table off an empty directory.
+
+    So the pid is derived here, from a marker no shell running this scan can carry: the
+    interpreter's own argv, plus the workspaces path. Re-derived every poll, so a runner
+    that is restarted is picked back up instead of being declared finished.
+    """
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            raw = (entry / "cmdline").read_bytes().decode("utf-8", "replace")
+        except OSError:
+            continue
+        argv = [part for part in raw.split("\0") if part]
+        if not argv or "python" not in Path(argv[0]).name:
+            continue
+        if all(any(marker in part for part in argv) for marker in _RUNNER_MARKERS):
+            return int(entry.name)
+    return None
+
+
+def task_of(workspace: Path) -> str:
+    """`Astronomy_000_20260815_172437` -> `Astronomy_000`."""
+    name = workspace.name
+    parts = name.rsplit("_", 2)
+    return parts[0] if len(parts) == 3 and parts[1].isdigit() else name
+
+
+def batch_state() -> dict[str, dict]:
+    """What the runner says about each task. The authoritative completion signal.
+
+    `run_batch.py` rewrites this atomically after every task, with `status`,
+    `exit_code`, `report_bytes` and `images`. The first version of this watcher never
+    read it, and that was the whole bug: it treated "a report file exists and is big
+    enough" as "the task is finished", but the workspace contract requires the agent to
+    keep `report/report.md` current *at every stage*, so a report exists for hours
+    before the run ends.
+    """
+    try:
+        return json.loads((ARM / "batch_state.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def finished_workspaces() -> dict[str, Path]:
+    """Workspaces the runner has recorded as over, with a report worth scoring.
+
+    Two gates, and the first one is the one that matters.
+
+    **The runner has to have finished the task.** Scoring a live workspace does not
+    just risk a stale draft -- it changes what the judge is shown. `collect_figures`
+    trims `report/images/` at export time down to the figures the report actually
+    references; the benchmark's scorer then takes the first five images it finds in an
+    unordered walk, and image criteria carry 60.6% of the total weight. Measured on this
+    box: every finished run in the reference arm ends with 4 or 5 images, while two
+    workspaces in this arm are sitting at 11 and 12 mid-flight. Score one of those early
+    and three fifths of the weight is judged on a random five of twelve. Measured on the
+    reference arm, the agent kept running for a median of 992 s after the last write to
+    `report.md` -- 39 of 40 longer than one poll -- so this window is not a rare race,
+    it is the normal case, and it moves the score one way only, on one arm only.
+    """
+    state = batch_state()
+    out: dict[str, Path] = {}
+    for workspace in sorted(WORKSPACES.glob("*/")):
+        if workspace.name.startswith("."):
+            continue  # the runner's own TMPDIR
+        task = task_of(workspace)
+        if state.get(task, {}).get("status") not in {"completed", "failed"}:
+            continue
+        report = workspace / "report" / "report.md"
+        try:
+            if not report.is_file() or report.stat().st_size < MIN_REPORT_BYTES:
+                continue
+        except OSError:
+            continue
+        out[task] = workspace
+    return out
+
+
+def score_one(task: str, workspace: Path) -> bool:
+    out = SCORES / f"{task}.json"
+    if out.exists():
+        return True
+    SCORES.mkdir(parents=True, exist_ok=True)
+    log(f"scoring {task}")
+    started = time.time()
+    with (SCORES / f"{task}.log").open("w", encoding="utf-8") as handle:
+        try:
+            completed = subprocess.run(  # noqa: S603
+                [
+                    sys.executable, str(SCORER),
+                    "--workspace", str(workspace),
+                    "--bench", str(BENCH),
+                    "--out", str(out),
+                ],
+                stdout=handle, stderr=subprocess.STDOUT,
+                timeout=SCORE_TIMEOUT, check=False,
+            )
+            code = completed.returncode
+        except subprocess.TimeoutExpired:
+            code = -1
+            handle.write("\nTIMED OUT\n")
+    elapsed = int(time.time() - started)
+    if code == 0 and out.exists():
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        # `total_score` is already a weight-weighted sum of 0-100 criterion scores,
+        # so dividing by the weight gives the 0-100 arm score directly. Scaling by
+        # 100 again reads 2357 for a 23.57 and is how a dry run earns its keep.
+        total = payload["total_score"] / payload["total_weight"]
+        log(f"  {task}: {total:.2f}  judge={payload.get('judge_model')}  {elapsed}s")
+        return True
+    log(f"  {task}: scorer exit={code} after {elapsed}s (no result written)")
+    return False
+
+
+def arm_scores(directory: Path) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for path in sorted(directory.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            out[path.stem] = payload["total_score"] / payload["total_weight"]
+        except (OSError, ValueError, KeyError, ZeroDivisionError):
+            continue
+    return out
+
+
+def zero_criteria(directory: Path) -> tuple[int, int]:
+    zeros = total = 0
+    for path in sorted(directory.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        for item in payload.get("items", []):
+            total += 1
+            if not (item.get("score") or 0):
+                zeros += 1
+    return zeros, total
+
+
+def write_table(unscored: list[str], no_report: list[str]) -> str:
+    arms = {"AutoR (Opus), 2ffaeb4": SCORES}
+    arms.update(OTHER_ARMS)
+    scores = {name: arm_scores(path) for name, path in arms.items()}
+    control = scores["bare Claude Code (Opus)"]
+    mine = scores["AutoR (Opus), 2ffaeb4"]
+
+    lines = [
+        "# ResearchClawBench, one attempt per task, judge `gpt-5.1`",
+        "",
+        f"Written {datetime.now(timezone.utc).astimezone().isoformat(timespec='seconds')}.",
+        "",
+        "| arm | n | mean | median | tasks scoring 0 | zero criteria |",
+        "| --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for name, table in scores.items():
+        if not table:
+            lines.append(f"| {name} | 0 | — | — | — | — |")
+            continue
+        values = list(table.values())
+        zeros, criteria = zero_criteria(arms[name])
+        # A mean over fewer than all 40 is not the same quantity as the reference arms'
+        # mean over 40, so it is not bolded and it carries its own denominator. The
+        # tasks that are missing are the ones that failed, so dropping them is not
+        # neutral -- it moves this arm up against arms that dropped nothing.
+        mean = f"**{statistics.mean(values):.2f}**" if len(values) == EXPECTED_TASKS \
+            else f"{statistics.mean(values):.2f} ({len(values)}/{EXPECTED_TASKS})"
+        lines.append(
+            f"| {name} | {len(values)} | {mean} | "
+            f"{statistics.median(values):.2f} | {sum(v == 0 for v in values)} | "
+            f"{zeros}/{criteria}" + (f" ({zeros / criteria:.0%})" if criteria else "") + " |"
+        )
+
+    lines += ["", "## Paired, over the tasks both arms scored", ""]
+    for other_name, other in ((n, scores[n]) for n in OTHER_ARMS):
+        common = sorted(set(mine) & set(other))
+        if len(common) < 2:
+            lines.append(f"- vs {other_name}: only {len(common)} shared task(s), no comparison.")
+            continue
+        deltas = [mine[t] - other[t] for t in common]
+        mean = statistics.mean(deltas)
+        sem = statistics.stdev(deltas) / (len(deltas) ** 0.5)
+        wins = sum(d > 0 for d in deltas)
+        ties = sum(d == 0 for d in deltas)
+        lines.append(
+            f"- **vs {other_name}** (n={len(common)}): "
+            f"{mean:+.2f} ± {sem:.2f} (1 paired SE, sample sd), "
+            f"this arm wins {wins}, loses {len(common) - wins - ties}, ties {ties}. "
+            f"Paired sd {statistics.stdev(deltas):.2f}, so this design resolves about "
+            f"{2.8 * statistics.stdev(deltas) / (len(common) ** 0.5):.1f} points."
+        )
+
+    lines += [
+        "",
+        "## Reading this",
+        "",
+        "**The arms were not run under the same budget, and the difference is bigger than",
+        "the effect anyone is looking for.** Measured from each run's own `_meta.json`:",
+        "",
+        "| arm | stage timeout | batch concurrency | wall limit |",
+        "| --- | ---: | ---: | ---: |",
+        "| AutoR 2ffaeb4 (this arm) | 14,400 s (adapter default) | 40 | none |",
+        "| AutoR pre-fix | **1,800 s** | 8 | none |",
+        "| bare Claude Code | n/a — no stage concept | — | 43,200 s |",
+        "",
+        "28 of the 40 pre-fix runs logged `Stage timed out`, and those 28 average **22.08**",
+        "against **27.06** for the 12 that did not — a 4.99-point gap inside that one arm,",
+        "which is the same size as the between-arm differences this table is about. So:",
+        "",
+        "- **This arm against the pre-fix arm is not a controlled comparison.** It confounds",
+        "  every code change since with an eight-fold larger per-stage budget. Read it as an",
+        "  upper bound on what the code did, not as what the code did.",
+        "- The pre-fix arm's deficit against bare Claude Code is also confounded: paired, it",
+        "  is −6.42 on the 28 timed-out tasks and −3.93 on the 12 that were not. The −5.67",
+        "  published in the README averages the two. The subset figure is a post-hoc",
+        "  subgroup and the tasks that time out may simply be the harder ones, so it does",
+        "  not establish a corrected value — it establishes that the number has a confound",
+        "  in it, of roughly its own size.",
+        "",
+        "Other things a reader needs:",
+        "",
+        "- One draw per task. Eight draws over one unchanged artifact set spanned 8.5 points",
+        "  (sd 3.4), so no individual row means anything; only the means and the paired",
+        "  standard errors above do, and the resolvable difference is printed with them.",
+        "- All three arms are scored by the same `score_rcb_run.py` with the same judge,",
+        "  `gpt-5.1`, and no arm's total is quoted if any of its judge calls failed.",
+        "- Scoring starts only after the runner records a task as finished, because the",
+        "  report and its figure set are still changing until export.",
+        "- This arm is pinned to `2ffaeb4`, which is **before** PR #224. It measures the",
+        "  tree as of the third audit round's findings, not after them.",
+    ]
+    if unscored:
+        lines.append(
+            f"- **{len(unscored)} task(s) produced a report the judge could not score** and are "
+            f"left out of the mean rather than folded in as zeros: {', '.join(unscored)}."
+        )
+    if no_report:
+        lines.append(
+            f"- **{len(no_report)} task(s) produced no report at all**: {', '.join(no_report)}."
+        )
+    return "\n".join(lines) + "\n"
+
+
+def acquire_lock() -> "object | None":
+    """One watcher at a time. Two would double every judge call and race the table."""
+    import fcntl
+
+    handle = (ARM / "watch.lock").open("w")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        return None
+    handle.write(f"{os.getpid()}\n")
+    handle.flush()
+    return handle
+
+
+def main() -> int:
+    lock = acquire_lock()
+    if lock is None:
+        log("another watcher holds watch.lock; exiting")
+        return 1
+    pid = find_runner()
+    if pid is None:
+        log("no batch runner found — refusing to start; nothing would be watched")
+        return 1
+    log(f"watching runner pid {pid}; scores -> {SCORES}")
+    attempts: dict[str, int] = {}
+    #: Two consecutive polls with no runner before believing it. A runner that is
+    #: momentarily unreadable in /proc must not end the watch on the strength of one
+    #: look, because ending the watch is what writes the results table.
+    gone_polls = 0
+
+    while True:
+        pid = find_runner()
+        gone_polls = 0 if pid is not None else gone_polls + 1
+        alive = pid is not None or gone_polls < 2
+        done = finished_workspaces()
+        for task, workspace in done.items():
+            if (SCORES / f"{task}.json").exists():
+                continue
+            if attempts.get(task, 0) >= MAX_ATTEMPTS:
+                continue
+            attempts[task] = attempts.get(task, 0) + 1
+            score_one(task, workspace)
+
+        scored = len(list(SCORES.glob("*.json")))
+        settled = sum(
+            1
+            for task in done
+            if (SCORES / f"{task}.json").exists() or attempts.get(task, 0) >= MAX_ATTEMPTS
+        )
+        log(f"runner={'alive' if alive else 'gone'}  reports={len(done)}  scored={scored}")
+
+        if not alive and settled >= len(done) and len(done) > 0:
+            break
+        if not alive and not done:
+            log("runner gone and no reports at all; stopping")
+            break
+        time.sleep(POLL_SECONDS)
+
+    done = finished_workspaces()
+    unscored = sorted(t for t in done if not (SCORES / f"{t}.json").exists())
+    # Dot-directories are the runner's own TMPDIR, not tasks. Counting `.tmp` as a task
+    # both printed a phantom failed row and pushed the directory count to 41, which
+    # silently disabled the "never staged" guard below.
+    all_dirs = {
+        task_of(p)
+        for p in WORKSPACES.glob("*/")
+        if p.is_dir() and not p.name.startswith(".")
+    }
+    state = batch_state()
+    no_report = sorted(all_dirs - set(done))
+    never_staged = sorted(
+        set(state) - all_dirs
+    ) if state else []
+    if never_staged:
+        no_report.extend(f"{task} (never staged)" for task in never_staged)
+    if len(all_dirs) < EXPECTED_TASKS:
+        no_report.append(f"({EXPECTED_TASKS - len(all_dirs)} task(s) never reached a workspace)")
+    unfinished = sorted(
+        task for task, row in state.items()
+        if row.get("status") not in {"completed", "failed"}
+    )
+    if unfinished:
+        log(f"batch not complete: {len(unfinished)} task(s) unfinished: {unfinished}")
+
+    try:
+        table = write_table(unscored, no_report)
+    except Exception as exc:  # noqa: BLE001 - a table that fails to render must still say so
+        table = (
+            f"# Results could not be rendered\n\n`{type(exc).__name__}: {exc}`\n\n"
+            f"Scored: {len(list(SCORES.glob('*.json')))}. Unscored: {unscored}. "
+            f"No report: {no_report}.\n"
+        )
+        log(f"write_table failed: {type(exc).__name__}: {exc}")
+    scratch = ARM / "RESULTS.md.tmp"
+    scratch.write_text(table, encoding="utf-8")
+    os.replace(scratch, ARM / "RESULTS.md")
+    (ARM / "WATCH_DONE").write_text(
+        datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds") + "\n",
+        encoding="utf-8",
+    )
+    log("wrote RESULTS.md")
+    print()
+    print(table)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Found while an adversarial review of the **next** arm's watcher diffed the two existing arms' command lines — something nobody had done before publishing the comparison they support.

Read off each run's own `_meta.json`:

| arm | stage timeout | batch concurrency | wall limit |
|:---|---:|---:|---:|
| AutoR (Opus), 23.57 | **1,800 s** | 8 | none |
| bare Claude Code (Opus), 29.24 | n/a — no stage concept | — | 43,200 s |

**28 of the 40 AutoR runs logged `Stage timed out`.** Inside that arm:

| subset | n | mean | paired vs bare CC |
|:---|---:|---:|---:|
| hit the stage cap | 28 | 22.08 | **−6.42** |
| never hit it | 12 | 27.06 | **−3.93** |

A 4.99-point gap *inside one arm*, which is the same size as the between-arm difference the table is about.

## What survives and what does not

- **Survives:** the scaffold is behind on the unconstrained subset too, by 3.93 points. "AutoR is behind bare Claude Code" is not rescued by the confound.
- **Does not:** the margin. `−5.67 ± 1.84` averages a crippled subset with an uncrippled one.
- **Not a correction:** the 12-task figure is a post-hoc subgroup, and tasks that exhaust a stage budget are plausibly the harder ones. It bounds the confound; it does not remove it. Both places it appears say so.

## Why this one stings

§2.5's whole argument is that a mechanism must ship with its own control arm. This is that principle failing on the measurement §6 is built from. The two arms were compared on mean, zero-criteria, prose length and figure count — and nobody diffed the *configurations*. A benchmark comparison is a claim about two configurations, and the configuration is part of the claim.

## `tools/rcb_arm_watch.py`

The harness that found it, vendored rather than left in a scratch directory. Every guard in it is a defect someone hit, most of them in the hour before this PR:

- **Scores a task only once the runner records it finished.** `report/report.md` exists and changes *throughout* a run, and `collect_figures` trims `report/images/` to the referenced set only at export. Every finished run in the reference arm ends at 4–5 images; two workspaces in the live arm are sitting at 11 and 12 mid-flight. The bench's scorer takes the first five images it walks over, and image criteria carry **60.6%** of the weight — so scoring early judges three fifths of the weight on a random five of twelve. One direction, one arm. The first version of this watcher had no such gate and polled every 300 s, while the reference arm kept running a median of 992 s after the last write to `report.md`.
- **Finds the runner by scanning `/proc`,** not by being handed a pid. The first launch used `pgrep -f "run_batch.py --autor ..."` — which matched the launching shell's own command line — and attached to a wrapper that exited seconds later. Two polls more and it would have written a results table off an empty directory.
- **A mean over fewer than 40 tasks prints its denominator and is not bolded.** Dropping the runs that failed is not neutral against arms that dropped none; on a fixture it silently read +3.02.
- **A judge failure is never a zero.** The scorer refuses to write a total, and the task is named as unscored rather than folded in.
- One instance at a time, atomic table write, and the table still renders when something in it raises.

2560 tests pass, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)