### PR TITLE
A ceiling is not a target, and it is not the grader's window either

### DIFF
--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -256,7 +256,8 @@ The markdown gates are not "a file exists". `validate_markdown_report` fails Sta
 retries it, if `report.md` is missing, is shorter than `MIN_REPORT_CHARS` (1,200) characters,
 references no figures, still holds placeholder text, or carries a figure reference that is
 absolute, remote, unrenderable, or points at a file that is not there — or if
-`report/images/` holds more than `MAX_REPORT_FIGURES` (5) rendered figures, or fewer than the
+`report/images/` holds more than `MAX_REPORT_FIGURES` (15, a ceiling — only
+`JUDGE_VISIBLE_FIGURES` = 5 of them reach the grader) rendered figures, or fewer than the
 run's floor. `validate_report_plan_coverage` adds the plan gates listed above. A broken figure
 link is the expensive defect here: the judge reads the prose promising a figure and is shown
 nothing.

--- a/src/prompts/07_writing_markdown.md
+++ b/src/prompts/07_writing_markdown.md
@@ -1,5 +1,5 @@
 Your reader is a model. It receives `{{WORKSPACE_REPORT_FILE}}` verbatim plus the first
-{{MAX_REPORT_FIGURES}} images in `report/images/`, and reads it for an answer to each thing the task
+{{JUDGE_VISIBLE_FIGURES}} images in `report/images/`, and reads it for an answer to each thing the task
 asked for — one judgement per asked-for thing. A thing the task named and the report never mentions
 is the cheapest thing there is to lose: a complete answer to a nearby question is worth less than a
 partial answer to the one that was asked. Length is not rewarded; a figure that is described but not
@@ -140,10 +140,17 @@ report/
     └── validation.png
 ```
 
-- **Publish at most {{MAX_REPORT_FIGURES}} figures.** The reviewer is shown only the first
-  {{MAX_REPORT_FIGURES}} images found in the report directory, in filesystem order — not in the
-  order you wrote them, and not by importance. A sixth figure does not add a sixth chance to be
-  credited; it makes it random which of yours are seen. Fewer, denser figures are strictly better.
+- **{{MAX_REPORT_FIGURES}} figures is a ceiling, and it is not a target.** Publish the figures the
+  report argues from and stop. A study that settles three questions publishes three; padding to
+  the ceiling adds nothing and costs the reader. What decides the score is whether the key
+  quantities were produced and shown, not how many panels surround them.
+- **Only the first {{JUDGE_VISIBLE_FIGURES}} images reach the reviewer**, found in filesystem
+  order — not in the order you wrote them, and not by importance. So the {{JUDGE_VISIBLE_FIGURES}}
+  that matter most should be the only ones there, or the ones there should all matter. Past
+  {{JUDGE_VISIBLE_FIGURES}} it is directory order, not your report, that chooses what is seen: a
+  further figure does not add a further chance to be credited, it makes it arbitrary which of
+  yours are. Fewer, denser figures are strictly better, and a composite panel that carries three
+  claims beats three figures that carry one each.
 - Save **every** figure under `{{WORKSPACE_REPORT_IMAGES_DIR}}` as a **PNG**. PDF, EPS, SVG, TIFF,
   and BMP cannot be rendered by the report viewer and count as no figure at all.
 - Put nothing but figures in `report/images/`, and leave no plot behind in
@@ -180,7 +187,8 @@ Figures are the highest-value part of this deliverable. The reviewer grades them
 image side by side with the corresponding figure from the published study and asking whether yours
 shows the same thing. They were chosen at Stage 03; this phase produces them.
 
-5. **Publish the planned figures in slot order, at most {{MAX_REPORT_FIGURES}}.** Every slot you
+5. **Publish the planned figures in slot order, at most {{MAX_REPORT_FIGURES}} and preferably far
+   fewer — the first {{JUDGE_VISIBLE_FIGURES}} are what a reviewer sees.** Every slot you
    do not publish needs `dropped_because` in `report_plan.json` and a sentence in `Key Results`;
    a slot you publish that the plan does not name will be flagged in `report_review.json`.
    Dropping is for a figure the results made impossible, not for one you ran out of time for:
@@ -206,8 +214,9 @@ shows the same thing. They were chosen at Stage 03; this phase produces them.
    needs a label **and a unit**; every series needs a legend entry; every panel needs a title.
    Assume the reviewer sees the image on its own, without the caption.
 9. Do not generate decorative figures, and do not publish a figure the report does not discuss.
-   An unreferenced image spends one of your {{MAX_REPORT_FIGURES}} slots on something no caption
-   defends.
+   An unreferenced image can take one of the {{JUDGE_VISIBLE_FIGURES}} places a reviewer looks at,
+   and spend it on something no caption defends. Time spent on a figure nobody asked for is time
+   not spent producing the quantity the task did ask for.
 
 ### Phase 3: Drafting
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -339,6 +339,21 @@ MIN_REPORT_CHARS = 1200
 #: distinct claim, and a run with four questions publishes four figures.
 MAX_REPORT_FIGURES = 15
 
+#: How many figures actually reach the grader, which is not the same number.
+#:
+#: `evaluation/score.py:88` walks ``outputs/`` and then ``report/`` with an unsorted
+#: ``rglob`` and attaches ``generated_images[:5]`` to *every* image checklist item.
+#: Filesystem order is not alphabetical, so past the fifth figure it is directory order,
+#: not the report, that decides which of them a grader sees.
+#:
+#: These two were one number until the ceiling moved to 15, and for a while every Stage 07
+#: prompt carried the sentence "the reviewer is shown only the first 15 images", which is
+#: false, followed by "a sixth figure does not add a sixth chance to be credited", which
+#: still counted from the old value. A prompt that misdescribes the grading is worse than
+#: one that says nothing about it, so the ceiling and the window are separate constants
+#: now and the prompt states both.
+JUDGE_VISIBLE_FIGURES = 5
+
 #: Distinct figures a markdown report must carry. One is the floor for an ordinary research
 #: run, where how much the question needs illustrating is the researcher's call.
 #:
@@ -910,6 +925,7 @@ def format_stage_template(template: str, stage: StageSpec, paths: RunPaths) -> s
         "{{WORKSPACE_REPORT_IMAGES_DIR}}": str(paths.report_images_dir.resolve()),
         "{{OUTPUT_FORMAT}}": selected_output_format(paths),
         "{{MAX_REPORT_FIGURES}}": str(MAX_REPORT_FIGURES),
+        "{{JUDGE_VISIBLE_FIGURES}}": str(JUDGE_VISIBLE_FIGURES),
         "{{WORKSPACE_FIGURES_DIR}}": str(paths.figures_dir.resolve()),
         "{{WORKSPACE_ARTIFACTS_DIR}}": str(paths.artifacts_dir.resolve()),
         "{{WORKSPACE_NOTES_DIR}}": str(paths.notes_dir.resolve()),
@@ -1496,10 +1512,10 @@ def validate_markdown_report(paths: RunPaths) -> list[str]:
         )
     elif published > MAX_REPORT_FIGURES:
         problems.append(
-            f"report/images/ holds {published} figures but only {MAX_REPORT_FIGURES} reach the "
-            "reviewer, chosen in filesystem order rather than by importance. Merge related panels "
-            f"into one composite figure or delete the weakest, until at most {MAX_REPORT_FIGURES} "
-            "remain."
+            f"report/images/ holds {published} figures, above the ceiling of "
+            f"{MAX_REPORT_FIGURES}. Only {JUDGE_VISIBLE_FIGURES} of them reach the reviewer, "
+            "chosen in filesystem order rather than by importance. Merge related panels into one "
+            f"composite figure or delete the weakest, until at most {MAX_REPORT_FIGURES} remain."
         )
 
     return problems

--- a/tests/test_rcb_scoring.py
+++ b/tests/test_rcb_scoring.py
@@ -27,6 +27,7 @@ from src.rcb import (
 from src.utils import (
     read_text,
     FIXED_STAGE_OPTIONS,
+    JUDGE_VISIBLE_FIGURES,
     MAX_REPORT_FIGURES,
     STAGES,
     build_run_paths,
@@ -346,13 +347,14 @@ class FigureBudgetGateTests(unittest.TestCase):
         paths = self._paths()
         self._populate(paths, MAX_REPORT_FIGURES + 1)
         problems = validate_stage_artifacts(STAGE_07, paths)
-        # The message quotes the ceiling; pinning the literal made this a test of the
-        # constant's value rather than of the gate, and it broke when the benchmark raised
-        # its own cap from 5 to 15.
-        self.assertTrue(
-            any(f"only {MAX_REPORT_FIGURES} reach the reviewer" in problem for problem in problems),
-            problems,
-        )
+        # The message quotes both numbers, and they are different numbers: the ceiling is
+        # what a report may publish, and the window is what the grader reads. This used to
+        # assert "only {ceiling} reach the reviewer", which was true while the two were one
+        # constant and became a false claim the gate was printing when the ceiling moved to
+        # 15. Pin the distinction, not either literal.
+        joined = " ".join(problems)
+        self.assertIn(f"above the ceiling of {MAX_REPORT_FIGURES}", joined, problems)
+        self.assertIn(f"Only {JUDGE_VISIBLE_FIGURES} of them reach the reviewer", joined, problems)
 
     def test_the_review_artifact_names_the_overshoot(self) -> None:
         paths = self._paths()

--- a/tests/test_report_figure_floor.py
+++ b/tests/test_report_figure_floor.py
@@ -111,8 +111,11 @@ class GateTest(unittest.TestCase):
     def test_the_ceiling_still_bites_above_the_floor(self) -> None:
         self._configure(BENCHMARK_MIN_REPORT_FIGURES)
         self._report(MAX_REPORT_FIGURES + 2)
-        self.assertTrue(any("only" in p and "reach the reviewer" in p
-                            for p in validate_markdown_report(self.paths)))
+        problems = " ".join(validate_markdown_report(self.paths))
+        self.assertIn(f"above the ceiling of {MAX_REPORT_FIGURES}", problems)
+        # The grader's window is a different number from the ceiling, and the refusal has
+        # to name the one the agent can act on without misstating the other.
+        self.assertIn("reach the reviewer", problems)
 
 
 class ConfigPersistenceTest(unittest.TestCase):

--- a/tests/test_the_ceiling_is_not_the_window.py
+++ b/tests/test_the_ceiling_is_not_the_window.py
@@ -1,0 +1,105 @@
+"""What a report may publish and what a grader reads are two numbers, not one.
+
+They were one constant until the ceiling moved from 5 to 15, and the prompt kept the
+sentence built for the old value. For a while every Stage 07 agent was told, in the same
+paragraph, that "the reviewer is shown only the first 15 images" — false, the grader
+attaches `generated_images[:5]` to each image item — and that "a sixth figure does not
+add a sixth chance to be credited", which counts from a ceiling that no longer existed.
+
+A prompt that misdescribes the grading is worse than one that says nothing about it: the
+agent optimises against the description. So the two numbers are separate constants, and
+these tests fail if anything merges them again.
+"""
+
+from __future__ import annotations
+
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.utils import (
+    JUDGE_VISIBLE_FIGURES,
+    MAX_REPORT_FIGURES,
+    STAGES,
+    build_run_paths,
+    ensure_run_layout,
+    format_stage_template,
+    read_text,
+)
+
+PROMPTS = Path(__file__).resolve().parent.parent / "src" / "prompts"
+STAGE_07 = next(stage for stage in STAGES if stage.number == 7)
+
+
+class TheTwoNumbersAreDistinctTest(unittest.TestCase):
+    def test_the_grader_window_is_not_the_publishing_ceiling(self) -> None:
+        self.assertLessEqual(JUDGE_VISIBLE_FIGURES, MAX_REPORT_FIGURES)
+        self.assertNotEqual(
+            JUDGE_VISIBLE_FIGURES,
+            MAX_REPORT_FIGURES,
+            "if these are ever equal again, every sentence that distinguishes them "
+            "becomes untestable — change the test deliberately, not by accident",
+        )
+
+    def test_the_window_matches_the_benchmark_scorer(self) -> None:
+        """`evaluation/score.py` slices `generated_images[:5]` per image item."""
+        self.assertEqual(JUDGE_VISIBLE_FIGURES, 5)
+
+
+class TheStage07PromptTellsTheTruthTest(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        self.rendered = format_stage_template(
+            read_text(PROMPTS / "07_writing_markdown.md"), STAGE_07, self.paths
+        )
+
+    def test_no_placeholder_survives_rendering(self) -> None:
+        self.assertEqual(re.findall(r"\{\{[A-Z_]+\}\}", self.rendered), [])
+
+    def test_it_does_not_claim_the_ceiling_is_what_the_reviewer_sees(self) -> None:
+        """The exact false sentence this file exists for."""
+        self.assertNotIn(f"first {MAX_REPORT_FIGURES} images", self.rendered)
+        self.assertNotIn(f"only the first {MAX_REPORT_FIGURES}", self.rendered)
+
+    def test_it_states_the_real_window(self) -> None:
+        self.assertIn(f"first {JUDGE_VISIBLE_FIGURES} images reach the reviewer", self.rendered)
+
+    def test_it_says_the_ceiling_is_not_a_target(self) -> None:
+        """A ceiling an agent reads as a quota is a quota."""
+        self.assertIn(f"{MAX_REPORT_FIGURES} figures is a ceiling", self.rendered)
+        self.assertIn("not a target", self.rendered)
+
+    def test_it_puts_the_work_above_the_figure_count(self) -> None:
+        # Matched on unwrapped text: the sentence wraps in the template.
+        flowed = " ".join(self.rendered.split())
+        self.assertIn("whether the key quantities were produced and shown", flowed)
+
+
+class TheGateSaysTheSameThingTest(unittest.TestCase):
+    def test_the_over_ceiling_refusal_distinguishes_them(self) -> None:
+        from src.utils import validate_markdown_report
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(paths)
+        paths.report_file.write_text(
+            "# R\n\n## Results\n\n" + "".join(
+                f"![f{i}](images/f{i}.png)\n" for i in range(MAX_REPORT_FIGURES + 1)
+            ) + "body " * 400,
+            encoding="utf-8",
+        )
+        for i in range(MAX_REPORT_FIGURES + 1):
+            (paths.report_images_dir / f"f{i}.png").write_bytes(b"x" * 200)
+        problems = " ".join(validate_markdown_report(paths))
+        if "ceiling" not in problems:
+            self.skipTest("the over-ceiling branch did not fire in this fixture")
+        self.assertIn(f"Only {JUDGE_VISIBLE_FIGURES} of them reach the reviewer", problems)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Fifteen stays.** What changes is that the number stops being asked to mean two things at once, and the prompt stops asserting something false about how the run will be graded.

## The false sentence

`MAX_REPORT_FIGURES` was 5 when it was *also* the number of images the grader reads, so one constant said both. #217 moved the ceiling to 15 and every place that had been true became false. Rendered into a real Stage 07 prompt, an agent was being told:

> Publish at most **15** figures. The reviewer is shown only the first **15** images found in the report directory, in filesystem order… **A sixth figure** does not add a sixth chance to be credited

- Sentence 1 is the ceiling. Fine.
- Sentence 2 is **false** — `evaluation/score.py:88` attaches `generated_images[:5]` to *every* image checklist item.
- Sentence 3 counts from a ceiling that had not existed for a week.

The stage gate carried the same false clause: *"only 15 reach the reviewer"*. A prompt that misdescribes the grading is worse than one that says nothing about it, because the agent optimises against the description.

## What an agent reads now

`JUDGE_VISIBLE_FIGURES = 5` is its own constant, templated as `{{JUDGE_VISIBLE_FIGURES}}`. Rendered:

> - **15 figures is a ceiling, and it is not a target.** Publish the figures the report argues from and stop. A study that settles three questions publishes three; padding to the ceiling adds nothing and costs the reader. **What decides the score is whether the key quantities were produced and shown, not how many panels surround them.**
> - **Only the first 5 images reach the reviewer**, found in filesystem order — not in the order you wrote them, and not by importance… a further figure does not add a further chance to be credited, it makes it arbitrary which of yours are. Fewer, denser figures are strictly better, and a composite panel that carries three claims beats three figures that carry one each.

That last clause of the first bullet is the point of the change: the ceiling is a bound on waste, not an allowance to spend, and the effort belongs on the data and the few figures that carry it.

The gate now says `holds 16 figures, above the ceiling of 15. Only 5 of them reach the reviewer…` — both numbers, neither misstated.

## Tests

Two were pinning the false wording — one asserted the message says `only {ceiling} reach the reviewer`, which is precisely the claim that went wrong. Both now pin the *distinction* rather than either literal.

`tests/test_the_ceiling_is_not_the_window.py` renders the real Stage 07 prompt and fails if anything merges the two numbers again, asserts the window matches `evaluation/score.py`, asserts no placeholder survives rendering, and asserts the prompt still says the ceiling is not a target.

2569 tests pass, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)