### PR TITLE
The grader's window is 15, and I read it off a three-week-old checkout

### DIFF
--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -256,8 +256,10 @@ The markdown gates are not "a file exists". `validate_markdown_report` fails Sta
 retries it, if `report.md` is missing, is shorter than `MIN_REPORT_CHARS` (1,200) characters,
 references no figures, still holds placeholder text, or carries a figure reference that is
 absolute, remote, unrenderable, or points at a file that is not there — or if
-`report/images/` holds more than `MAX_REPORT_FIGURES` (15, a ceiling — only
-`JUDGE_VISIBLE_FIGURES` = 5 of them reach the grader) rendered figures, or fewer than the
+`report/images/` holds more than `MAX_REPORT_FIGURES` (15, a ceiling and not a target;
+`JUDGE_VISIBLE_FIGURES` is what the grader actually reads and tracks
+`evaluation/score.py`, which upstream raised from 5 to 15 on 2026-08-14) rendered figures,
+or fewer than the
 run's floor. `validate_report_plan_coverage` adds the plan gates listed above. A broken figure
 link is the expensive defect here: the judge reads the prose promising a figure and is shown
 nothing.

--- a/src/prompts/07_writing_markdown.md
+++ b/src/prompts/07_writing_markdown.md
@@ -145,12 +145,13 @@ report/
   the ceiling adds nothing and costs the reader. What decides the score is whether the key
   quantities were produced and shown, not how many panels surround them.
 - **Only the first {{JUDGE_VISIBLE_FIGURES}} images reach the reviewer**, found in filesystem
-  order — not in the order you wrote them, and not by importance. So the {{JUDGE_VISIBLE_FIGURES}}
-  that matter most should be the only ones there, or the ones there should all matter. Past
-  {{JUDGE_VISIBLE_FIGURES}} it is directory order, not your report, that chooses what is seen: a
-  further figure does not add a further chance to be credited, it makes it arbitrary which of
-  yours are. Fewer, denser figures are strictly better, and a composite panel that carries three
-  claims beats three figures that carry one each.
+  order — not in the order you wrote them, and not by importance. Past
+  {{JUDGE_VISIBLE_FIGURES}} it is directory order, not your report, that chooses what is seen, so
+  a figure beyond that does not add a further chance to be credited: it makes it arbitrary which
+  of yours are. Well inside the limit this costs you nothing, which is the normal case and the
+  one to aim for. Fewer, denser figures are still better on their own merits — a composite panel
+  carrying three claims beats three panels carrying one each, because the reader forms a verdict
+  from what is in front of them, not from how many files you wrote.
 - Save **every** figure under `{{WORKSPACE_REPORT_IMAGES_DIR}}` as a **PNG**. PDF, EPS, SVG, TIFF,
   and BMP cannot be rendered by the report viewer and count as no figure at all.
 - Put nothing but figures in `report/images/`, and leave no plot behind in

--- a/src/utils.py
+++ b/src/utils.py
@@ -363,20 +363,27 @@ MIN_REPORT_CHARS = 1200
 #: its sign turns out to be.
 MAX_REPORT_FIGURES = 15
 
-#: How many figures actually reach the grader, which is not the same number.
+#: How many figures actually reach the grader. **This tracks someone else's repository.**
 #:
-#: `evaluation/score.py:88` walks ``outputs/`` and then ``report/`` with an unsorted
-#: ``rglob`` and attaches ``generated_images[:5]`` to *every* image checklist item.
-#: Filesystem order is not alphabetical, so past the fifth figure it is directory order,
-#: not the report, that decides which of them a grader sees.
+#: `evaluation/score.py` walks ``outputs/`` and then ``report/`` with an unsorted ``rglob``
+#: and attaches ``generated_images[:N]`` to *every* image checklist item, and N is not
+#: ours. It was 5 for as long as anyone here had looked, and ResearchClawBench raised it to
+#: 15 in ``bfffc48`` on 2026-08-14, "Increase judge generated image cap". A checkout taken
+#: before that date says 5 and is simply stale -- which is how this constant came to be
+#: written as 5 a day *after* upstream changed it, off a clone last pulled on 2026-07-28,
+#: and how a prompt "correction" shipped asserting the opposite of the truth.
 #:
-#: These two were one number until the ceiling moved to 15, and for a while every Stage 07
-#: prompt carried the sentence "the reviewer is shown only the first 15 images", which is
-#: false, followed by "a sixth figure does not add a sixth chance to be credited", which
-#: still counted from the old value. A prompt that misdescribes the grading is worse than
-#: one that says nothing about it, so the ceiling and the window are separate constants
-#: now and the prompt states both.
-JUDGE_VISIBLE_FIGURES = 5
+#: Filesystem order is not alphabetical, so past the Nth figure it is directory order, not
+#: the report, that decides which of them a grader sees. That is why the number matters,
+#: and why it is worth a test rather than a memory:
+#: `tests/test_the_ceiling_is_not_the_window.py` reads the bench's own source when a
+#: checkout is available and fails when this drifts from it again.
+#:
+#: It equals :data:`MAX_REPORT_FIGURES` today. They remain two different ideas -- one is
+#: what a report may publish, the other is what a grader reads -- and they have now
+#: coincided twice. Keeping them separate makes the next upstream move a one-line change
+#: instead of an archaeology exercise.
+JUDGE_VISIBLE_FIGURES = 15
 
 #: Distinct figures a markdown report must carry. One is the floor for an ordinary research
 #: run, where how much the question needs illustrating is the researcher's call.

--- a/tests/test_the_ceiling_is_not_the_window.py
+++ b/tests/test_the_ceiling_is_not_the_window.py
@@ -1,14 +1,20 @@
-"""What a report may publish and what a grader reads are two numbers, not one.
+"""What a report may publish and what a grader reads are two numbers that keep moving.
 
-They were one constant until the ceiling moved from 5 to 15, and the prompt kept the
-sentence built for the old value. For a while every Stage 07 agent was told, in the same
-paragraph, that "the reviewer is shown only the first 15 images" — false, the grader
-attaches `generated_images[:5]` to each image item — and that "a sixth figure does not
-add a sixth chance to be credited", which counts from a ceiling that no longer existed.
+`MAX_REPORT_FIGURES` is ours: how many figures a report may publish. `JUDGE_VISIBLE_FIGURES`
+is not ours: `evaluation/score.py` slices `generated_images[:N]` for every image item, and
+ResearchClawBench chooses N. It was 5, and upstream raised it to 15 in `bfffc48` on
+2026-08-14.
 
-A prompt that misdescribes the grading is worse than one that says nothing about it: the
-agent optimises against the description. So the two numbers are separate constants, and
-these tests fail if anything merges them again.
+Both mistakes this file exists to prevent have already been made here, a day apart and in
+opposite directions. First the ceiling moved to 15 while the prompt kept the sentence built
+for 5, so every Stage 07 agent read "the reviewer is shown only the first 15 images" next to
+"a sixth figure does not add a sixth chance to be credited". Then that was "corrected" to 5
+— off a bench checkout last pulled three weeks earlier, a day after upstream had moved to
+15 — which shipped a prompt asserting the opposite of the truth.
+
+A prompt that misdescribes the grading is worse than one that says nothing about it, because
+the agent optimises against the description. So the constant is checked against the bench's
+own source, not against anyone's memory of it.
 """
 
 from __future__ import annotations
@@ -32,19 +38,46 @@ PROMPTS = Path(__file__).resolve().parent.parent / "src" / "prompts"
 STAGE_07 = next(stage for stage in STAGES if stage.number == 7)
 
 
-class TheTwoNumbersAreDistinctTest(unittest.TestCase):
-    def test_the_grader_window_is_not_the_publishing_ceiling(self) -> None:
-        self.assertLessEqual(JUDGE_VISIBLE_FIGURES, MAX_REPORT_FIGURES)
-        self.assertNotEqual(
-            JUDGE_VISIBLE_FIGURES,
-            MAX_REPORT_FIGURES,
-            "if these are ever equal again, every sentence that distinguishes them "
-            "becomes untestable — change the test deliberately, not by accident",
-        )
+#: Where a ResearchClawBench checkout may be, if this machine has one. The check that
+#: matters skips rather than guesses when it is absent, because a test that invents the
+#: number it is verifying is the failure it is meant to catch.
+_BENCH_CANDIDATES = (
+    Path.home() / "RCB",
+    Path.home() / "ResearchClawBench",
+    Path("/rmeng_data/robtang/RCB"),
+)
+_SLICE = re.compile(r"generated_images\[:(\d+)\]")
 
-    def test_the_window_matches_the_benchmark_scorer(self) -> None:
-        """`evaluation/score.py` slices `generated_images[:5]` per image item."""
-        self.assertEqual(JUDGE_VISIBLE_FIGURES, 5)
+
+class TheWindowTracksTheBenchTest(unittest.TestCase):
+    def test_the_window_matches_the_benchmark_source(self) -> None:
+        """Read the number out of the grader rather than restating it from memory.
+
+        This is the assertion that would have caught both directions of the mistake: the
+        prompt describing a 15-figure window when the bench sliced 5, and the constant
+        being set to 5 the day after the bench moved to 15.
+        """
+        for root in _BENCH_CANDIDATES:
+            source = root / "evaluation" / "score.py"
+            if not source.is_file():
+                continue
+            found = _SLICE.search(source.read_text(encoding="utf-8", errors="replace"))
+            self.assertIsNotNone(found, f"{source} no longer slices generated_images")
+            assert found is not None  # for type checkers
+            self.assertEqual(
+                int(found.group(1)),
+                JUDGE_VISIBLE_FIGURES,
+                f"{source} slices generated_images[:{found.group(1)}] and "
+                f"JUDGE_VISIBLE_FIGURES is {JUDGE_VISIBLE_FIGURES}. Upstream moved; follow "
+                "it, and re-read every sentence in the Stage 07 prompt that quotes either "
+                "number before deciding which one is wrong.",
+            )
+            return
+        self.skipTest("no ResearchClawBench checkout on this machine")
+
+    def test_a_report_may_not_publish_more_than_the_grader_reads(self) -> None:
+        """They are different ideas and happen to be equal; this is the relation that holds."""
+        self.assertLessEqual(JUDGE_VISIBLE_FIGURES, MAX_REPORT_FIGURES)
 
 
 class TheStage07PromptTellsTheTruthTest(unittest.TestCase):
@@ -60,12 +93,7 @@ class TheStage07PromptTellsTheTruthTest(unittest.TestCase):
     def test_no_placeholder_survives_rendering(self) -> None:
         self.assertEqual(re.findall(r"\{\{[A-Z_]+\}\}", self.rendered), [])
 
-    def test_it_does_not_claim_the_ceiling_is_what_the_reviewer_sees(self) -> None:
-        """The exact false sentence this file exists for."""
-        self.assertNotIn(f"first {MAX_REPORT_FIGURES} images", self.rendered)
-        self.assertNotIn(f"only the first {MAX_REPORT_FIGURES}", self.rendered)
-
-    def test_it_states_the_real_window(self) -> None:
+    def test_it_states_the_window_the_bench_actually_uses(self) -> None:
         self.assertIn(f"first {JUDGE_VISIBLE_FIGURES} images reach the reviewer", self.rendered)
 
     def test_it_says_the_ceiling_is_not_a_target(self) -> None:

--- a/tools/rcb_arm_watch.py
+++ b/tools/rcb_arm_watch.py
@@ -48,10 +48,19 @@ BENCH = Path("/home/robtang_google_com/RCB")
 SCORER = Path("/rmeng_data/robtang/autor-rcb-rerun/AutoR/tools/score_rcb_run.py")
 
 #: Where the arms this one is compared against already live.
+#: Both re-expressed under the grader's *current* 15-image window.
+#:
+#: `full40` is not re-scored and does not need to be: no run in it publishes more than
+#: five images by the bench's own `IMAGE_EXTENSIONS`, so `generated_images[:5]` and
+#: `[:15]` hand the judge an identical list. Its numbers are window-invariant, and
+#: re-scoring would only add a second draw of judge noise to one arm.
+#:
+#: `control_bare_cc` is re-scored, because 29 of its 44 runs publish more than five and
+#: the original pass could only ever show the judge five of them.
 OTHER_ARMS = {
     "AutoR (Opus), pre-fix": Path("/rmeng_data/robtang/autor-rcb-rerun/arm_scores/full40"),
     "bare Claude Code (Opus)": Path(
-        "/rmeng_data/robtang/autor-rcb-rerun/arm_scores/control_bare_cc"
+        "/rmeng_data/robtang/autor-rcb-rerun/arm_scores/control_bare_cc_w15"
     ),
 }
 
@@ -289,13 +298,17 @@ def write_table(unscored: list[str], no_report: list[str]) -> str:
         "| bare Claude Code | n/a — no stage concept | — | 43,200 s |",
         "",
         "A second difference between the AutoR arms, unrelated to the code under test:",
-        "`MAX_REPORT_FIGURES` was 5 for the pre-fix arm and is 15 here (#217). Every pre-fix",
-        "run shipped 4-5 figures; this arm's finished runs ship 8-13. The benchmark's grader",
-        "attaches only the first five images of an unsorted walk to each image criterion, and",
-        "image criteria carry 60.6% of the weight, so the two arms differ in *which* figures",
-        "a grader sees, not only in how many. Whether that costs anything is unmeasured and",
-        "the only relevant data points the other way: on the uncapped bare-agent arm, the 26",
-        "runs publishing more than five averaged 30.74 against 26.47 for the 14 that did not.",
+        "`MAX_REPORT_FIGURES` was 5 for the pre-fix arm and is 15 here, following",
+        "ResearchClawBench raising its own judge cap from 5 to 15 (`bfffc48`, 2026-08-14).",
+        "Every pre-fix run shipped 4-5 figures; this arm's finished runs ship 8-13. Under the",
+        "current 15-image window that is no longer a difference in *which* figures a grader",
+        "sees -- it sees all of them in both arms -- but it is still a difference in how many,",
+        "and image criteria carry 60.6% of the weight.",
+        "",
+        "Everything in this table is scored under that current window. `full40` needed no",
+        "re-score (no run in it publishes more than five images, so the two windows hand the",
+        "judge an identical list); the bare-agent arm was re-scored, because 29 of its 44 runs",
+        "publish more than five and the original pass could only show the judge five.",
         "",
         "28 of the 40 pre-fix runs logged `Stage timed out`, and those 28 average **22.08**",
         "against **27.06** for the 12 that did not — a 4.99-point gap inside that one arm,",


### PR DESCRIPTION
#227 "corrected" the Stage 07 prompt to say **five** images reach the reviewer, and added `JUDGE_VISIBLE_FIGURES = 5` to make it stick. Both are wrong.

ResearchClawBench raised its own cap in **`bfffc48`, 2026-08-14** — *"Increase judge generated image cap"*, `generated_images[:5]` → `[:15]`. The local clone I read that from was last pulled **2026-07-28**. So I wrote the constant as 5 a day after upstream changed it, called the prompt's truthful "15" a false statement, and shipped the reverse of the fact. **#217 had been right all along:** the ceiling followed the benchmark's, 5 to 15.

## What changes

- `JUDGE_VISIBLE_FIGURES = 15`, with a docstring that says out loud the value is not ours to choose.
- The prompt says 15 in both places again.
- **What survives from #227 is the part that was never about the number:** fifteen is a ceiling and not a target, publish the figures the report argues from and stop, and what decides the score is whether the key quantities were produced and shown.

The durable fix is not the corrected literal — it is that nothing restates it from memory any more. `tests/test_the_ceiling_is_not_the_window.py` finds a bench checkout, greps `generated_images[:N]` out of `evaluation/score.py`, and fails when the constant drifts from it. Mutation-verified: with the bench temporarily set to `[:7]` the test fails and names both numbers. Where there is no checkout it **skips rather than guessing** — a test that invents the number it is verifying is the failure it exists to catch.

## The measurement consequence, which is larger than the code one

Every score in `docs/framework.md` §6.8 was taken on 2026-08-14 at 00:40 — **six hours before** upstream moved the window. All of them are five-image numbers. Measured with the bench's own `IMAGE_EXTENSIONS` over each arm's workspaces:

| arm | runs | max images the scorer finds | over five | window change |
|:---|---:|---:|---:|:---|
| `full40` | 43 | 5 | **0** | no-op — identical list |
| `control_bare_cc` | 45 | 13 | 29 | different list |
| `arm_2ffaeb4` (live) | 40 | 13 | 12 | different list |

So **`full40`'s 23.57 is window-invariant** and is not re-scored; doing so would only add a second draw of judge noise to one arm of a comparison. The bare-agent control **is** being re-scored under the current window into `arm_scores/control_bare_cc_w15`, and the live arm's watcher now reads that directory.

First evidence this is not a rounding error: the one task the new arm has finished published twelve figures and scored **8.05** under the old window and **13.00** under the current one. The run did not change; the number of its figures the grader was allowed to look at did.

2568 tests pass, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)