### PR TITLE
Decide staleness from the declared topology, not from the stage number

### DIFF
--- a/src/coeffects.py
+++ b/src/coeffects.py
@@ -1,0 +1,201 @@
+"""What each stage read when it was approved, and whether it still reads the same thing.
+
+A stage's approval is a claim about a state of the run: *given these inputs, this output
+was accepted*. Nothing recorded the first half. Staleness was decided by arithmetic on the
+stage number — :func:`src.manifest.rollback_to_stage` marked everything after the target —
+and that is the approximation :mod:`src.information_flow` was written to remove one layer
+up:
+
+    every context block was gated by a threshold on the stage number, so "who needs this"
+    was approximated by "everyone from here on"
+
+The information layer replaced the threshold with a declared topology: each ``Channel``
+names the stage that produces it and the stages that read it. The lifecycle layer never
+got the same treatment, so the same approximation is still deciding whose approval
+survives a change.
+
+Two things it gets wrong, in opposite directions.
+
+**It misses a consumer that sits earlier than its producer.** ``research_rounds`` is
+produced at Stage 06 and read at Stages 02 through 07 — Stages 03 to 06 repeat as a round,
+so information genuinely flows backwards. A change at Stage 06 leaves every earlier
+consumer's approval standing, because 2 is not greater than 6.
+
+**It fires on stages that read nothing that moved.** Rolling back to Stage 03 marks Stage
+07 stale whether or not anything Stage 07 declares has changed. That is usually right, and
+it is right for a reason nobody checked rather than by a rule anyone can state.
+
+This module states the rule. A stage's *committed view* is a digest per declared channel,
+taken when the stage is approved. Its *current view* is the same digest taken now. The
+stage is stale when they differ, and the channels that differ are the reason — which the
+declared topology turns into the name of the stage that caused it.
+
+**The view is over what the stage reads, not over the files behind it.** A channel is a
+rendered block, and rendering is what the stage actually saw; going through the files
+instead would need a second declaration of which file backs which channel, and two
+spellings of one mapping is how they drift apart. It also gives the comparison the right
+grain: two states are the same exactly when no channel this stage reads can tell them
+apart.
+
+**Only channels with a producer are in the view.** ``run_configuration``,
+``project_context``, ``artifact_index`` and the rest come from outside the stage graph;
+they are the environment the run sits in rather than a dependency on another stage's work,
+and a rollback does not withdraw them.
+
+**And one producer channel is excluded, by name and with a reason.**
+``experiment_manifest`` is AutoR's own inventory, rewritten at every stage boundary with a
+fresh ``generated_at``, so its digest moves on byte-identical research. Measured: two
+renders either side of one ``write_experiment_manifest`` differ while the other eight
+producer channels are unchanged. Left in, it would mark Stages 05 to 08 stale at every
+boundary — the same flicker ``src.artifact_index`` documents for the rubric. What it
+inventories is the artifacts, and those are versioned by :mod:`src.provenance`, so a change
+that matters is visible through the channels that read them.
+:class:`ChannelViewStabilityTests` is what keeps that exclusion honest: every producer
+channel must either render stably across a boundary rewrite or be named here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from .information_flow import CHANNELS, Channel, ChannelContext, dependency_edges
+from .utils import RunPaths, StageSpec
+
+#: Producer channels whose rendering moves without the research moving. Named rather
+#: than detected, because the alternative — normalising a volatile field out of the
+#: rendered text — is a second parser for a format the channel already owns.
+VOLATILE_CHANNELS = frozenset({"experiment_manifest"})
+
+
+def declared_inputs(stage: StageSpec, channels: Sequence[Channel] = CHANNELS) -> list[Channel]:
+    """The channels this stage reads that another stage produces.
+
+    The stage's coeffect specification, read off the same declaration the prompt is
+    assembled from, so a stage cannot depend on something it did not declare and cannot
+    declare something it does not read.
+    """
+
+    return [
+        channel
+        for channel in channels
+        if channel.produced_by is not None
+        and channel.key not in VOLATILE_CHANNELS
+        and stage.slug in channel.consumed_by
+    ]
+
+
+def _digest(block: str) -> str:
+    return hashlib.sha256(block.encode("utf-8")).hexdigest()[:16]
+
+
+def current_view(
+    paths: RunPaths, stage: StageSpec, channels: Sequence[Channel] = CHANNELS
+) -> dict[str, str]:
+    """A digest per declared channel, as this stage would read it right now.
+
+    A channel that raises is recorded under the exception's name rather than as absent.
+    An unreadable input and a missing one are different states, and a stage approved
+    against one should be stale when the run is in the other.
+    """
+
+    context = ChannelContext(paths=paths, stage=stage, attempt_no=0)
+    view: dict[str, str] = {}
+    for channel in declared_inputs(stage, channels):
+        try:
+            rendered = channel.build(context) or ""
+        except Exception as error:  # noqa: BLE001 - the class is the observation
+            rendered = f"<unreadable: {type(error).__name__}>"
+        view[channel.key] = _digest(rendered)
+    return view
+
+
+def drifted_channels(
+    paths: RunPaths,
+    stage: StageSpec,
+    committed: Mapping[str, str],
+    channels: Sequence[Channel] = CHANNELS,
+) -> list[str]:
+    """Which of the stage's declared channels no longer read as they did at approval.
+
+    An empty ``committed`` returns nothing. A stage approved before this module existed
+    recorded no view, and reading "no record" as "everything changed" would mark every
+    approved stage of every resumed run stale at once — the fail-open rule
+    :mod:`src.provenance` uses, for the same reason.
+    """
+
+    if not committed:
+        return []
+    current = current_view(paths, stage, channels)
+    drifted = [key for key, digest in current.items() if committed.get(key) != digest]
+    # A channel the stage committed to and no longer declares is also a change: the
+    # topology moved under an approval that was given against the old one.
+    drifted.extend(key for key in committed if key not in current)
+    return sorted(set(drifted))
+
+
+def producer_of(key: str, channels: Sequence[Channel] = CHANNELS) -> str:
+    """Which stage produces a channel, for saying *why* a consumer went stale.
+
+    Read off :func:`src.information_flow.dependency_edges` rather than the channel list,
+    so the explanation and the topology come from one place. The edge list is the
+    inspectable form of the graph the module docstring promises, and this is the
+    inspection: a drifted consumer is reported with the producer that moved.
+    """
+
+    for producer, _consumer, channel_key in dependency_edges(tuple(channels)):
+        if channel_key == key:
+            return producer
+    return "run_config"
+
+
+@dataclass(frozen=True)
+class Drift:
+    """One approved stage whose declared inputs have moved since it was approved."""
+
+    stage_slug: str
+    channels: tuple[str, ...]
+
+    def render(self, all_channels: Sequence[Channel] = CHANNELS) -> str:
+        causes = ", ".join(
+            f"{key} (from {producer_of(key, all_channels)})" for key in self.channels
+        )
+        return f"{self.stage_slug}: {causes}"
+
+
+def drift_across_run(
+    paths: RunPaths,
+    entries: Sequence[object],
+    channels: Sequence[Channel] = CHANNELS,
+) -> list[Drift]:
+    """Every approved stage whose committed view no longer matches, and what moved.
+
+    ``entries`` is the manifest's stage list. Typed loosely on purpose: importing
+    ``StageManifestEntry`` here would close a cycle, since :mod:`src.manifest` is what
+    calls this.
+    """
+
+    from .utils import STAGES
+
+    by_slug = {stage.slug: stage for stage in STAGES}
+    drifts: list[Drift] = []
+    for entry in entries:
+        if not getattr(entry, "approved", False):
+            continue
+        stage = by_slug.get(getattr(entry, "slug", ""))
+        if stage is None:
+            continue
+        committed = getattr(entry, "committed_view", None) or {}
+        moved = drifted_channels(paths, stage, committed, channels)
+        if moved:
+            drifts.append(Drift(stage_slug=stage.slug, channels=tuple(moved)))
+    return drifts
+
+
+def format_drift(drifts: Sequence[Drift], channels: Sequence[Channel] = CHANNELS) -> str:
+    if not drifts:
+        return "No approved stage reads anything that has moved."
+    lines = [f"{len(drifts)} approved stage(s) read something that has moved:"]
+    lines.extend(f"- {drift.render(channels)}" for drift in drifts)
+    return "\n".join(lines)

--- a/src/manifest.py
+++ b/src/manifest.py
@@ -29,6 +29,12 @@ class StageManifestEntry:
     invalidated_by_stage: str | None = None
     updated_at: str = ""
     approved_at: str | None = None
+    #: A digest per declared input channel, taken when the stage was approved. What the
+    #: stage read, so that "is this approval still good" can be answered by comparing
+    #: rather than by arithmetic on the stage number. Empty for a stage approved before
+    #: this field existed, which :func:`src.coeffects.drifted_channels` reads as "no
+    #: claim" rather than as "everything changed".
+    committed_view: dict[str, str] = field(default_factory=dict)
 
     @property
     def settled(self) -> bool:
@@ -63,6 +69,7 @@ class StageManifestEntry:
             "invalidated_by_stage": self.invalidated_by_stage,
             "updated_at": self.updated_at,
             "approved_at": self.approved_at,
+            "committed_view": dict(self.committed_view),
         }
 
     @classmethod
@@ -88,6 +95,10 @@ class StageManifestEntry:
             invalidated_by_stage=str(payload["invalidated_by_stage"]) if payload.get("invalidated_by_stage") is not None else None,
             updated_at=str(payload.get("updated_at") or ""),
             approved_at=str(payload["approved_at"]) if payload.get("approved_at") is not None else None,
+            committed_view={
+                str(key): str(value)
+                for key, value in dict(payload.get("committed_view") or {}).items()
+            },
         )
 
 
@@ -359,6 +370,17 @@ def mark_stage_approved_manifest(
     attempt_no: int,
     artifact_paths: list[str],
 ) -> RunManifest:
+    """Record the approval, and what the stage was reading when it was given.
+
+    An approval is a claim about a state: *given these inputs, this output was accepted*.
+    Only the second half was written down, so "is this approval still good" had to be
+    answered by arithmetic on the stage number. The committed view is the first half, and
+    it is taken here rather than at the three call sites so that no path can record an
+    approval without it — the same reason recovery is wired inside ``rollback_to_stage``.
+    """
+
+    from .coeffects import current_view
+
     update_manifest_run_status(
         paths,
         run_status="pending",
@@ -378,6 +400,7 @@ def mark_stage_approved_manifest(
         attempt_count=attempt_no,
         artifact_paths=artifact_paths,
         approved_at=_now(),
+        committed_view=current_view(paths, stage),
     )
 
 
@@ -464,6 +487,7 @@ def rollback_to_stage(paths: RunPaths, rollback_stage: StageSpec, reason: str | 
     run record.
     """
 
+    from .coeffects import drift_across_run, format_drift
     from .effects import recover_to_stage
     from .utils import append_log_entry
 
@@ -473,12 +497,50 @@ def rollback_to_stage(paths: RunPaths, rollback_stage: StageSpec, reason: str | 
     recovery = recover_to_stage(paths, rollback_stage, invalidated_reason)
     if recovery.touched:
         append_log_entry(paths.logs, "rollback recovery", recovery.render())
+
+    # Which approvals below the target no longer hold, asked of the declared topology
+    # rather than of the numbering. Information does flow backwards here: ``research_rounds``
+    # is produced at Stage 06 and read from Stage 02 on, because Stages 03 to 06 repeat as a
+    # round. A stage-number rule leaves those approvals standing after the thing they were
+    # given against has been withdrawn, and no arithmetic on 2 and 6 can see it.
+    #
+    # Computed after the recovery, so the comparison is against the workspace the rollback
+    # leaves rather than the one it found.
+    drifts = drift_across_run(paths, manifest.stages)
+    drifted_below = {
+        drift.stage_slug
+        for drift in drifts
+        if any(
+            entry.slug == drift.stage_slug and entry.number < rollback_stage.number
+            for entry in manifest.stages
+        )
+    }
+    if drifts:
+        append_log_entry(paths.logs, "rollback drift", format_drift(drifts))
+
     updated_stages: list[StageManifestEntry] = []
 
     for entry in manifest.stages:
         payload = entry.to_dict()
         if entry.number < rollback_stage.number:
-            updated_stages.append(entry)
+            if entry.slug not in drifted_below:
+                updated_stages.append(entry)
+                continue
+            payload.update(
+                {
+                    "status": "stale",
+                    "approved": False,
+                    "dirty": True,
+                    "stale": True,
+                    "approved_at": None,
+                    "invalidated_reason": (
+                        f"{invalidated_reason} (this stage reads a channel the rollback moved)"
+                    ),
+                    "invalidated_by_stage": rollback_stage.slug,
+                }
+            )
+            payload["updated_at"] = _now()
+            updated_stages.append(StageManifestEntry.from_dict(payload))
             continue
         if entry.number == rollback_stage.number:
             payload.update(

--- a/tests/test_coeffects.py
+++ b/tests/test_coeffects.py
@@ -1,0 +1,305 @@
+"""Staleness asked of the declared topology instead of the stage number.
+
+:class:`ChannelViewStabilityTests` is the one that keeps :data:`VOLATILE_CHANNELS`
+honest: every producer channel either renders the same twice across a boundary rewrite,
+or is named there with a reason. Without it, the exclusion list is an assertion about the
+channels rather than a measurement of them.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest import mock
+
+from src.coeffects import (
+    VOLATILE_CHANNELS,
+    Drift,
+    current_view,
+    declared_inputs,
+    drift_across_run,
+    drifted_channels,
+    format_drift,
+    producer_of,
+)
+from src.experiment_manifest import write_experiment_manifest
+from src.information_flow import CHANNELS, ChannelContext
+from src.manifest import (
+    ensure_run_manifest,
+    mark_stage_approved_manifest,
+    rollback_to_stage,
+)
+from src.provenance import observe
+from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+
+STAGE_02, STAGE_03, STAGE_04, STAGE_05, STAGE_06, STAGE_07 = (
+    STAGES[1],
+    STAGES[2],
+    STAGES[3],
+    STAGES[4],
+    STAGES[5],
+    STAGES[6],
+)
+
+
+class CoeffectTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+        ensure_run_manifest(self.paths)
+
+    def write_rounds(self, decision: str) -> None:
+        write_text(
+            self.paths.research_rounds,
+            json.dumps(
+                {
+                    "rounds": [
+                        {"round": 1, "decision": decision, "rationale": "because", "acted_on": True}
+                    ]
+                }
+            )
+            + "\n",
+        )
+
+
+class DeclaredInputsTests(CoeffectTestCase):
+    def test_only_channels_another_stage_produces_are_declared_inputs(self) -> None:
+        keys = {channel.key for channel in declared_inputs(STAGE_07)}
+
+        self.assertIn("preregistration", keys)
+        self.assertNotIn(
+            "run_configuration",
+            keys,
+            "ambient context is the environment the run sits in, not a dependency on a stage",
+        )
+
+    def test_a_volatile_channel_is_not_a_declared_input(self) -> None:
+        keys = {channel.key for channel in declared_inputs(STAGE_07)}
+        self.assertNotIn("experiment_manifest", keys)
+
+    def test_the_topology_is_respected_rather_than_the_numbering(self) -> None:
+        """``research_rounds`` is produced at 06 and read at 02. Information flows back."""
+
+        keys = {channel.key for channel in declared_inputs(STAGE_02)}
+        self.assertIn("research_rounds", keys)
+        self.assertEqual(producer_of("research_rounds"), STAGE_06.slug)
+
+
+class ChannelViewStabilityTests(CoeffectTestCase):
+    def test_every_producer_channel_is_stable_across_a_boundary_or_named_volatile(self) -> None:
+        """The measurement behind :data:`VOLATILE_CHANNELS`.
+
+        A channel whose digest moves without the research moving would mark its consumers
+        stale at every stage boundary. If this fails, either the channel got a volatile
+        field and should lose it, or it belongs in ``VOLATILE_CHANNELS`` with a reason.
+        """
+
+        write_text(self.paths.results_dir / "metrics.json", '{"accuracy": 0.9}\n')
+        write_text(self.paths.experimental_protocol, '{"baselines": [{"name": "control"}]}\n')
+        write_text(self.paths.report_plan, '{"figures": []}\n')
+        write_text(self.paths.preregistration, '{"hypotheses": [{"id": "H1", "type": "empirical"}]}\n')
+        write_text(self.paths.hypothesis_outcomes, '{"outcomes": []}\n')
+        self.write_rounds("converged")
+        write_experiment_manifest(self.paths)
+
+        def render(stage, channel):
+            context = ChannelContext(paths=self.paths, stage=stage, attempt_no=0)
+            return channel.build(context) or ""
+
+        unstable: list[str] = []
+        for channel in CHANNELS:
+            if channel.produced_by is None:
+                continue
+            consumer = next(
+                (stage for stage in STAGES if stage.slug in channel.consumed_by), None
+            )
+            if consumer is None:
+                continue
+            before = render(consumer, channel)
+            write_experiment_manifest(self.paths)  # the boundary rewrite
+            after = render(consumer, channel)
+            if before != after and channel.key not in VOLATILE_CHANNELS:
+                unstable.append(channel.key)
+
+        self.assertEqual(
+            unstable,
+            [],
+            "these producer channels render differently on unchanged research; fix the "
+            f"channel or name it in VOLATILE_CHANNELS with a reason: {unstable}",
+        )
+
+    def test_the_named_volatile_channel_really_is_volatile(self) -> None:
+        """An exclusion nobody can contradict is an assertion, not a measurement.
+
+        Two claims, and together they are the volatility. The rendered block carries
+        ``generated_at``; and rendering the channel *rewrites the file it renders*, so that
+        field is refreshed from the clock on every render. Whenever two stage boundaries
+        fall in different seconds — which ``src.artifact_index`` records as often — the
+        digest moves on research that did not.
+
+        Asserted this way rather than by rendering twice and comparing, because two renders
+        inside one test land in the same second and the comparison passes for the wrong
+        reason. That is the same clock-tick hazard, met while trying to measure it.
+        """
+
+        channel = next(item for item in CHANNELS if item.key == "experiment_manifest")
+        context = ChannelContext(paths=self.paths, stage=STAGE_07, attempt_no=0)
+
+        first = channel.build(context) or ""
+        stamp = json.loads(self.paths.experiment_manifest.read_text(encoding="utf-8"))["generated_at"]
+        self.assertIn(stamp, first, "the block carries the manifest's wall-clock stamp")
+
+        # The clock is moved rather than waited for. Two renders inside one test land in
+        # the same second, and the file's mtime granularity is coarser than the gap
+        # between them, so neither a re-render nor a stat can tell the two apart here --
+        # the clock-tick hazard `src.artifact_index` documents, met while measuring it.
+        with mock.patch("src.experiment_manifest.datetime", wraps=datetime) as clock:
+            clock.now.return_value = datetime(2031, 1, 1, 0, 0, 0)
+            later = channel.build(context) or ""
+
+        self.assertNotEqual(
+            first,
+            later,
+            "experiment_manifest is excluded from the view because rendering it rewrites "
+            "the file it renders, refreshing a wall-clock stamp the block carries; if that "
+            "stops being true, drop it from VOLATILE_CHANNELS rather than leaving an "
+            "exclusion nothing measures",
+        )
+
+
+class DriftTests(CoeffectTestCase):
+    def test_no_committed_view_means_no_drift(self) -> None:
+        """Fail-open. A run approved before this field existed must not go stale at once."""
+
+        self.assertEqual(drifted_channels(self.paths, STAGE_07, {}), [])
+
+    def test_an_unchanged_input_does_not_drift(self) -> None:
+        write_text(self.paths.preregistration, '{"hypotheses": [{"id": "H1"}]}\n')
+        committed = current_view(self.paths, STAGE_07)
+
+        self.assertEqual(drifted_channels(self.paths, STAGE_07, committed), [])
+
+    def test_a_changed_input_drifts_and_names_itself(self) -> None:
+        self.write_rounds("refine_design")
+        committed = current_view(self.paths, STAGE_02)
+
+        self.write_rounds("abandon")
+
+        self.assertEqual(drifted_channels(self.paths, STAGE_02, committed), ["research_rounds"])
+
+    def test_a_change_the_stage_does_not_declare_is_not_drift(self) -> None:
+        write_text(self.paths.preregistration, '{"hypotheses": [{"id": "H1"}]}\n')
+        committed = current_view(self.paths, STAGE_02)
+
+        write_text(self.paths.preregistration, '{"hypotheses": [{"id": "H2"}]}\n')
+
+        self.assertNotIn("preregistration", {c.key for c in declared_inputs(STAGE_02)})
+        self.assertEqual(drifted_channels(self.paths, STAGE_02, committed), [])
+
+    def test_drift_is_reported_with_the_stage_that_caused_it(self) -> None:
+        rendered = Drift(stage_slug=STAGE_02.slug, channels=("research_rounds",)).render()
+        self.assertIn("research_rounds", rendered)
+        self.assertIn(STAGE_06.slug, rendered)
+
+    def test_only_approved_stages_are_examined(self) -> None:
+        self.write_rounds("refine_design")
+        mark_stage_approved_manifest(self.paths, STAGE_02, 1, [])
+        self.write_rounds("abandon")
+
+        manifest = ensure_run_manifest(self.paths)
+        drifts = drift_across_run(self.paths, manifest.stages)
+
+        self.assertEqual([drift.stage_slug for drift in drifts], [STAGE_02.slug])
+        self.assertIn(STAGE_02.slug, format_drift(drifts))
+
+
+class ApprovalRecordsWhatItReadTests(CoeffectTestCase):
+    def test_an_approval_records_the_view_it_was_given_against(self) -> None:
+        self.write_rounds("converged")
+        mark_stage_approved_manifest(self.paths, STAGE_02, 1, [])
+
+        entry = next(
+            item for item in ensure_run_manifest(self.paths).stages if item.slug == STAGE_02.slug
+        )
+        self.assertIn("research_rounds", entry.committed_view)
+
+    def test_the_view_survives_a_manifest_round_trip(self) -> None:
+        self.write_rounds("converged")
+        mark_stage_approved_manifest(self.paths, STAGE_02, 1, [])
+        first = next(
+            item for item in ensure_run_manifest(self.paths).stages if item.slug == STAGE_02.slug
+        ).committed_view
+
+        reloaded = next(
+            item for item in ensure_run_manifest(self.paths).stages if item.slug == STAGE_02.slug
+        ).committed_view
+
+        self.assertEqual(first, reloaded)
+        self.assertTrue(first)
+
+
+class RollbackReadsTheTopologyTests(CoeffectTestCase):
+    def test_a_rollback_invalidates_an_earlier_stage_that_reads_what_moved(self) -> None:
+        """The hole a stage-number rule cannot see.
+
+        Stage 02 declares ``research_rounds``, which Stage 06 produces — Stages 03 to 06
+        repeat as a round, so information flows backwards. Rolling back to Stage 03 used to
+        leave Stage 02 approved against a round record that had moved under it, because 2
+        is not greater than 3.
+        """
+
+        self.write_rounds("refine_design")
+        mark_stage_approved_manifest(self.paths, STAGE_02, 1, [])
+        self.write_rounds("abandon")
+
+        rollback_to_stage(self.paths, STAGE_03, "the design was wrong")
+
+        entry = next(
+            item for item in ensure_run_manifest(self.paths).stages if item.slug == STAGE_02.slug
+        )
+        self.assertTrue(entry.stale)
+        self.assertFalse(entry.approved)
+        self.assertIn("reads a channel the rollback moved", entry.invalidated_reason or "")
+
+    def test_an_earlier_stage_that_reads_nothing_that_moved_keeps_its_approval(self) -> None:
+        """The narrowing has to be real, or the rule is the old one with more machinery."""
+
+        self.write_rounds("converged")
+        mark_stage_approved_manifest(self.paths, STAGE_02, 1, [])
+
+        rollback_to_stage(self.paths, STAGE_03, "the design was wrong")
+
+        entry = next(
+            item for item in ensure_run_manifest(self.paths).stages if item.slug == STAGE_02.slug
+        )
+        self.assertTrue(entry.approved)
+        self.assertFalse(entry.stale)
+
+    def test_the_stage_number_rule_still_holds_above_the_target(self) -> None:
+        """The topology is added to the numbering, not substituted for it.
+
+        Above the target the recovery has withdrawn the stage's own output, so its approval
+        is void whatever it reads. Replacing the numbering here would leave a stage approved
+        with its artifacts deleted.
+        """
+
+        write_text(self.paths.data_dir / "late.csv", "id\n1\n")
+        observe(self.paths, STAGE_05)
+        mark_stage_approved_manifest(self.paths, STAGE_05, 1, [])
+
+        rollback_to_stage(self.paths, STAGE_03, "the design was wrong")
+
+        entry = next(
+            item for item in ensure_run_manifest(self.paths).stages if item.slug == STAGE_05.slug
+        )
+        self.assertTrue(entry.stale)
+        self.assertFalse((self.paths.data_dir / "late.csv").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_declared_symbols_are_wired.py
+++ b/tests/test_declared_symbols_are_wired.py
@@ -25,13 +25,13 @@ place the product actually starts from, including ``studio.py``, without which t
 ``src/backend/`` package would read as dead.
 
 ``tests/`` and ``tools/`` are deliberately *not* roots. A test is the thing that keeps a
-dead symbol green -- twenty of the thirty-one symbols listed below have one -- so counting
+dead symbol green -- nineteen of the thirty symbols listed below have one -- so counting
 a test as wiring would make the gate assert nothing. An instrument is not evidence:
 ``archive_sample_complexity`` was importing ``RunRecord`` and crashing on it at the same
 time. A symbol that only ``tools/`` reaches is still exempt, but by a line somebody wrote,
 and :attr:`Exempt.reached_from` makes that line checkable.
 
-That twenty is :func:`allowlisted_symbols_with_a_test`, printed by the census and pinned
+That nineteen is :func:`allowlisted_symbols_with_a_test`, printed by the census and pinned
 against this sentence by
 :meth:`AllowlistIsHonestTests.test_the_stated_count_of_tested_symbols_is_the_measured_one`,
 because the first version of the sentence said twenty-one and no instrument could
@@ -198,15 +198,6 @@ ALLOWLIST: dict[str, Exempt] = {
         "So wiring the renderer means first deciding that a stage should be told which "
         "skills exist -- the pack is pull-based by design, and telling every stage about it "
         "up front is the cost the skill mechanism was built to avoid."
-    ),
-    # -- a documented claim about a function nothing calls --------------------------------
-    "src/information_flow.py::dependency_edges": Exempt(
-        "This module's own docstring says 'The graph is inspectable. `dependency_edges()` "
-        "returns the producer -> consumer pairs, so the information topology can be "
-        "printed, tested, and diffed', and README.md repeats the claim. Both are true of "
-        "the function and false of the product: only `test_information_flow.py` calls it, "
-        "so the topology is tested and never printed. Wiring means giving the inspection an "
-        "output -- a CLI subcommand or a run artifact -- which is a new surface."
     ),
     "src/stage_graph.py::admissible_moves": Exempt(
         "This module's docstring says '`admissible_moves` withdraws a revisit whose "


### PR DESCRIPTION
## The defect

`rollback_to_stage` marked every stage numbered above the target stale. That is arithmetic standing in for a dependency — and it is the same approximation `information_flow.py` was written to remove one layer up:

> every context block was gated by a threshold on the stage number, so "who needs this" was approximated by "everyone from here on"

That module replaced the threshold with a declared topology: each `Channel` names its producer and its consumers. **The lifecycle layer never got the same treatment**, so the approximation was still deciding whose approval survives a change.

It fails in a direction arithmetic cannot see:

```
research_rounds   produced_by 06_analysis   consumed_by 02,03,04,05,06,07
```

Stages 03–06 repeat as a round, so **information genuinely flows backwards**. A change at Stage 06 left Stage 02's approval standing, because 2 is not greater than 6.

## The mechanism

An approval is a claim about a state — *given these inputs, this output was accepted* — and only the second half was recorded. `committed_view` is the first half: a digest per declared input channel, taken inside `mark_stage_approved_manifest` so no path can approve without it. `src/coeffects.py` compares it to the current render and names the channels that moved, resolving each to its producing stage through `dependency_edges`.

The rule is **additive**:

> a stage is stale when its own output was withdrawn, **or** when its committed view no longer matches

The first clause is the old rule and it stays — above the target the recovery has deleted the stage's artifacts, so its approval is void whatever it reads. Replacing it would leave stages approved with their outputs gone. `test_the_stage_number_rule_still_holds_above_the_target` pins that.

## Three decisions, each with a measurement

**The view is over the rendered channel, not the files behind it.** Going through files needs a second declaration of which file backs which channel, and two spellings of one mapping is how they drift apart. It also gives the right grain: two states are the same, for this stage, exactly when no channel it reads can tell them apart.

**Only channels with a producer are in it.** Run configuration, project context, artifact index come from outside the stage graph — environment, not a dependency on another stage's work.

**`experiment_manifest` is excluded by name.** Its renderer *rewrites the file it renders* with a fresh `generated_at`, so its digest moves on unchanged research. Left in, it would mark Stages 05–08 stale at every boundary — the flicker `artifact_index.py` already documents for the rubric. Two tests keep the exclusion honest:

- `test_every_producer_channel_is_stable_across_a_boundary_or_named_volatile` — the list cannot grow by assertion
- `test_the_named_volatile_channel_really_is_volatile` — the one exclusion is measured, with the clock *moved* (`mock.patch`) rather than waited for, because two renders inside one test land in the same second and comparing them passes for the wrong reason

## Retiring an allowlist entry

`dependency_edges` was in `test_declared_symbols_are_wired`'s ALLOWLIST as a documented claim nothing called — *"the topology is tested and never printed"*. It is read now, so the exemption is retired and the module's own census sentence moves with it. The gate asked for exactly this and then verified it: the first run after wiring failed with *"these are referenced by production now; drop them from ALLOWLIST"*.

## Fail-open

No committed view means no drift. A run approved before this field existed records nothing, and reading "no record" as "everything changed" would mark every approved stage of every resumed run stale at once — the same rule, for the same reason, as the provenance ledger in #218.

## Docs

`docs/iclr/composable-stage-graphs.md` — the design write-up this and #218 implement, with a status table separating what runs from what does not.

## Testing

16 new tests. Suite **2569 → 2585, green**. Baseline clean on `origin/main` before branching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)