### PR TITLE
Bound the reviewer's send-backs, and give the router grounds to depart

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -679,12 +679,18 @@ removes the *incentive* to improve the answer; drift rejection removes the *rewa
 refused and a `verdict_drift` row is written. It does not undo the edit: `_revert` copies the
 champion markdown back over the draft and touches nothing else, so a polish round that rewrote
 `hypothesis_outcomes.json` leaves it rewritten, and the promoted summary and the outcomes file end
-up disagreeing. Detection is real; restoration is not implemented. Nor is the exemption human-only —
-`consider` returns "directed" for any attempt with `is_polish_round=False`, and the manager sets
-that for a *reviewer's* decision as well as a human's, its own comment reading "a human or reviewer
-decision". Unattended, the reviewer is a model, so a model-directed revision can move a verdict
-without meeting the drift check at all. A revision a **human** asked for is exempt by design: the
-ratchet governs AutoR's own rounds, not the direction it is given.
+up disagreeing. Detection is real; restoration is not implemented.
+
+The exemption is now human-only. It used to cover an automated reviewer too — `consider` returned
+"directed" for any attempt with `is_polish_round=False`, and the manager set that for a reviewer's
+decision as well as a person's — so unattended, which is the only mode the benchmark uses, a model
+could move a verdict without meeting the drift check and promote a draft the rubric scored worse.
+Measured over 41 ResearchClawBench runs it did the second 142 times and the first 4. `consider`
+now takes `directed_by`, and a round directed by anything other than a human is measured: a drift
+is refused, a regression is reverted, and a flat round still stands because a request the rubric
+cannot see is not a request that failed. A revision a **human** asked for is exempt by design and
+unchanged: the ratchet governs AutoR's own rounds, not the direction it is given by the person
+whose project this is.
 
 ### 5.3 Machinery that reports on itself, in the unflattering direction
 
@@ -1052,6 +1058,23 @@ a node with a decision at it. **The graph was quiet because the runs were dying,
 controller was mis-wired** — which is the opposite of the first diagnosis this section reached, and
 the reason it is written down.
 
+**"The agent decided" is not "the agent departed", and the second number is much smaller.** Over a
+later 41-run batch the router faced 252 decision points, answered at essentially all of them, and
+chose something other than the default at **16 — 6.3%**. 31 of the 41 runs walked a straight line;
+`graph_effect.json` says so in its own words on each of them. It was not being blocked: guards
+refused 48 moves across the batch and 46 of those were `finish`, the terminal edge closing rather
+than a departure being denied. It had no grounds. The prompt asks for a reason drawn from "what in
+*this stage's results* makes that the right move" and then showed it results with nothing wrong in
+them — the ratchet polishes every stage towards 1.000 and 71% of routing decisions were taken
+against a stage reporting exactly that, with the rubric's "where the points are" list empty. The
+grounds were on disk and unread: 30% of hypotheses came back `inconclusive` or `not_tested` and 84%
+of runs held at least one, and the prompt's own worked example of a good reason is "H2 is
+inconclusive because only one seed was run". `unfinished_business` now puts the unsettled verdicts
+and the open obligations in front of the router, and a saturated total is labelled as the ceiling it
+is rather than left to read as a verdict on the research. Whether that moves the departure rate is
+unmeasured — it changes what the router is shown, not what it is told to choose, and a prompt that
+instructed it to depart more often would be obeyed on the runs that had nothing to go back for.
+
 Four narrower suppressors were real and are fixed (#191). The largest by far:
 `--final-stage 07_writing` is the benchmark's default, the advance past the requested final stage was
 recorded as a *pruned* move, and a node with no live forward move makes `default_move` return None —
@@ -1246,10 +1269,22 @@ any.
 - **A rejected polish round is not undone, only refused.** `_revert` restores the champion stage
   summary and nothing else, so a round that rewrote `hypothesis_outcomes.json` and was rejected for
   `verdict_drift` leaves the new verdicts on disk, disagreeing with the summary that was promoted.
-- **The drift check exempts a reviewer, not just a human.** `consider` returns "directed" whenever
-  `is_polish_round` is false, and the manager sets that for a reviewer's decision as well as a
-  person's. Unattended — the only mode the benchmark uses — the reviewer is a model, so a
-  model-directed revision can move a verdict without meeting the check.
+- **The reviewer's send-backs are bounded, and its judgement is not deferred to.** An automated
+  reviewer is another instance of the same model reading the same draft, so there is no authority
+  here to defer to. Measured over 41 ResearchClawBench runs it refused 890 times and approved 496;
+  first approval arrived at a median of attempt 4 and the per-stage tail reached 18. 59% of the
+  1115 revisions it directed were aimed at stages already scoring 1.000 on the rubric, where no
+  improvement can register, and 71% moved the total by exactly 0.000. Three bounds now apply to it
+  and to none of them a human: `MAX_AUTOMATED_SENDBACKS` converts its fourth refusal of a stage
+  into an approval, a second refusal of a stage already at 1.000 is refused the same way
+  `should_continue` refuses AutoR's own round there, and `consider` measures what it directs. All
+  three promote rather than skip — unlike `MAX_STAGE_ATTEMPTS`, whose own comment records a run
+  that skipped its literature survey and wrote a report standing on nothing.
+- **The reviewer's *first* look at a saturated stage is never refused.** The rubric is nine
+  mechanical criteria and the reviewer is the only reader of the prose, so a stage whose counts and
+  ratios are green is where the reviewer might hold the only thing worth saying. Refusing that read
+  would cut 59% of directed rounds against the present rule's 48%, and would trade the one part of
+  the loop that could be load bearing for the part measured not to be.
 - **The router does not close the edge into Writing.** `_guard_validity_chain` removes it from the
   agent's menu, but `default_move` takes a guard-blocked advance as a last resort. The refusal that
   actually stops an unadjudicated Stage 07 is `validate_stage_artifacts`. This is deliberate — see

--- a/src/evolution.py
+++ b/src/evolution.py
@@ -147,7 +147,9 @@ class StageEvolutionState:
 @dataclass(frozen=True)
 class RoundOutcome:
     #: ``first`` | ``promoted`` | ``frontier`` | ``regressed`` | ``verdict_drift``
-    #: | ``directed`` (a human or the reviewer asked for this one; it stands).
+    #: | ``directed`` (someone asked for this one; it stands)
+    #: | ``directed_regressed`` (an automated reviewer asked for it and it measured
+    #: worse, so the champion was restored — a human's direction never lands here).
     verdict: str
     score: StageScore
     champion: StageScore | None
@@ -253,6 +255,7 @@ class EvolutionController:
         attempt_no: int,
         draft_path: Path,
         is_polish_round: bool = False,
+        directed_by: str = "human",
     ) -> RoundOutcome:
         """Measure the draft at ``draft_path`` and decide whether it may stand.
 
@@ -278,19 +281,67 @@ class EvolutionController:
         # 0. Was this round asked for by a person?
         #
         # The ratchet governs AutoR's own polish rounds. It does not govern a
-        # reviewer or a human who asked for a change: that is direction, and a
-        # measurement is not entitled to overrule it. AutoR would otherwise
-        # silently revert a requested edit because a rubric preferred the previous
-        # wording, which is the opposite of the arrangement this project is built
-        # on. The delta is still measured and recorded, so the ledger shows whether
-        # the requested change helped — the human keeps the decision and gets the
-        # number.
-        if not is_polish_round and champion is not None:
+        # human who asked for a change: that is direction, and a measurement is
+        # not entitled to overrule it. AutoR would otherwise silently revert a
+        # requested edit because a rubric preferred the previous wording, which is
+        # the opposite of the arrangement this project is built on. The delta is
+        # still measured and recorded, so the ledger shows whether the requested
+        # change helped — the human keeps the decision and gets the number.
+        #
+        # An *automated* reviewer is not that person, and this branch used to treat
+        # it as one. It is another instance of the same model reading the same
+        # draft, so there is no judgement here to defer to and no one who keeps the
+        # decision — the exemption written to protect a human's authority was being
+        # spent by a bot. Measured over 41 ResearchClawBench runs it was spent 1115
+        # times, of which 930 (83%) measured at or below zero and 142 (13%) measured
+        # *negative*: a draft the rubric scored worse than the one it replaced,
+        # promoted anyway because the sentence said it stood regardless.
+        #
+        # Zero still stands. 71% of these rounds moved the total by exactly 0.000,
+        # and a reviewer's request that the rubric cannot see is the case the
+        # exemption is for; reverting those would make the rubric the reviewer. Only
+        # a measured regression is refused, and it is refused the same way a polish
+        # round's regression is: the champion is restored and the ledger says so.
+        # Computed before the exemption below rather than after it, because a round
+        # that moved a verdict is the one thing no exemption may cover for anything
+        # that is not a person: `verdict_blind` removes the incentive to improve the
+        # answer and this removes the reward, and a bot that can step around it makes
+        # both decorative. Measured over 41 ResearchClawBench runs a directed round
+        # moved a verdict 4 times in 388 -- rare, and the whole point of the design.
+        drifted = (
+            (is_polish_round or directed_by != "human")
+            and bool(state.verdict_digest)
+            and bool(score.verdict_digest)
+            and score.verdict_digest != state.verdict_digest
+        )
+
+        if not is_polish_round and champion is not None and not drifted:
+            if directed_by != "human" and delta < 0:
+                state.flat_rounds += 1
+                outcome = RoundOutcome(
+                    "directed_regressed",
+                    score,
+                    champion,
+                    delta,
+                    self._revert(paths, stage, draft_path),
+                    f"An automated reviewer directed this revision and it measured worse "
+                    f"({delta:+.3f}); the champion was restored. A person's direction would "
+                    f"have stood.",
+                )
+                self._record(paths, stage, attempt_no, outcome, state, is_polish_round)
+                return outcome
             update = insert(state.frontier, score)
             state.frontier = list(update.members) if update.verdict != "incomparable" else [score]
             state.champion = score
             state.verdict_digest = score.verdict_digest
-            state.flat_rounds = 0
+            if delta > 0 or directed_by == "human":
+                # Resetting unconditionally let an automated reviewer switch off AutoR's
+                # own patience stop as a side effect: `should_continue` halts a stage on
+                # `flat_rounds >= patience`, and a send-back every other round meant the
+                # count could never accumulate. 71% of the reviewer's rounds measured
+                # exactly 0.000, so this was the usual case rather than the edge one. A
+                # round that moved the number earned the reset; a flat one did not.
+                state.flat_rounds = 0
             self._persist(paths, stage, state, markdown)
             outcome = RoundOutcome(
                 "directed",
@@ -304,12 +355,6 @@ class EvolutionController:
             return outcome
 
         # 1. Did this round move what the run concludes?
-        drifted = (
-            is_polish_round
-            and bool(state.verdict_digest)
-            and bool(score.verdict_digest)
-            and score.verdict_digest != state.verdict_digest
-        )
         if drifted:
             outcome = RoundOutcome(
                 verdict="verdict_drift",
@@ -318,9 +363,10 @@ class EvolutionController:
                 delta=delta,
                 reverted=self._revert(paths, stage, draft_path),
                 note=(
-                    "This round changed a hypothesis verdict. An improvement round may "
-                    "strengthen the evidence for a finding; it may not change the finding. "
-                    "The previous draft was restored."
+                    "This round changed a hypothesis verdict. A round AutoR or an "
+                    "automated reviewer asked for may strengthen the evidence for a "
+                    "finding; it may not change the finding. The previous draft was "
+                    "restored."
                 ),
             )
             state.flat_rounds += 1

--- a/src/manager.py
+++ b/src/manager.py
@@ -175,7 +175,9 @@ from .utils import (
     DEFAULT_STAGE_GRAPH,
     FIXED_STAGE_OPTIONS,
     INTAKE_STAGE,
+    MAX_AUTOMATED_SENDBACKS,
     MAX_STAGE_ATTEMPTS,
+    REVISION_CHOICES,
     STUCK_AFTER_IDENTICAL_FAILURES,
     attempts_exhausted,
     is_stuck,
@@ -209,6 +211,7 @@ from .utils import (
     parse_refinement_suggestions,
     read_attempt_count,
     read_polish_count,
+    read_sendback_count,
     read_text,
     required_stage_output_template,
     selected_output_format,
@@ -217,6 +220,7 @@ from .utils import (
     validate_stage_markdown,
     write_attempt_count,
     write_polish_count,
+    write_sendback_count,
     write_stage_handoff,
     write_text,
 )
@@ -2120,6 +2124,10 @@ class ResearchManager:
         polish_rounds = read_polish_count(paths, stage)
         entry_polish_rounds = polish_rounds
         is_polish_round = False
+        # Only read on a directed round, and a directed round is only reached after the
+        # assignment below. Bound here anyway: the first attempt of a stage is neither a
+        # polish round nor directed, and it reaches `consider` before either is set.
+        directed_by = "reviewer" if self.reviewer is not None else "human"
         if self.evolution is not None:
             self.evolution.begin_stage(paths, stage)
         revision_feedback: str | None = None
@@ -2448,6 +2456,7 @@ class ResearchManager:
                     attempt_no=attempt_no,
                     draft_path=result.stage_file_path,
                     is_polish_round=is_polish_round,
+                    directed_by=directed_by,
                 )
                 if outcome.reverted:
                     # `consider` wrote the champion back over the draft; everything
@@ -2474,8 +2483,11 @@ class ResearchManager:
                         continue
 
             # Anything from here is a human or reviewer decision, so the next
-            # attempt it produces is directed rather than self-initiated.
+            # attempt it produces is directed rather than self-initiated. Which of
+            # the two it was decides whether the ratchet may overrule the result:
+            # see `EvolutionController.consider`.
             is_polish_round = False
+            directed_by = "reviewer" if self.reviewer is not None else "human"
             mark_stage_human_review_manifest(
                 paths,
                 stage,
@@ -2896,6 +2908,27 @@ class ResearchManager:
             stage_markdown=stage_markdown,
             suggestions=suggestions,
         )
+        # Before anything downstream reads the verdict. `_settle_obligations` branches on
+        # `decision.choice == "5"` to record what this stage deferred, and the effort plan
+        # counts a refusal as a contest -- a promotion patched in after the return would be
+        # invisible to both, and the run would carry an approval nobody accounted for.
+        overruled = self._sendback_is_out_of_budget(paths=paths, stage=stage, choice=decision.choice)
+        if overruled is not None:
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} attempt {attempt_no} sendback_refused",
+                f"{overruled}.\nThe automated reviewer asked for choice "
+                f"{decision.choice}; the stage was promoted instead.\n"
+                f"reviewer reason: {decision.reason or '(none recorded)'}\n"
+                f"reviewer feedback:\n{decision.feedback or '(none recorded)'}",
+            )
+            self.ui.show_status(
+                f"{stage.stage_title}: {overruled}; promoting.", level="info"
+            )
+            decision = replace(decision, choice="5", comments=[], feedback="")
+        elif decision.choice in REVISION_CHOICES:
+            write_sendback_count(paths, stage, read_sendback_count(paths, stage) + 1)
+
         self._render_review_decision(decision)
         log_body = [
             f"mode: automated",
@@ -2937,6 +2970,55 @@ class ResearchManager:
         # the refine path can send back a passage instead of the whole stage.
         self._pending_comments = list(decision.comments or [])
         return decision.choice, decision.feedback or None
+
+    def _sendback_is_out_of_budget(
+        self, *, paths: RunPaths, stage: StageSpec, choice: str
+    ) -> str | None:
+        """Why this automated send-back may not be spent, or None to let it through.
+
+        Two stops, and neither applies to a human. A person who asks for a change is
+        exercising judgement AutoR has no standing to overrule. An automated reviewer is
+        another instance of the same model reading the same draft, and an unbounded
+        deference to it is a deference to nothing -- measured over 41 ResearchClawBench
+        runs it refused 890 times and approved 496, and its refusals produced 1115
+        revisions of which 71% moved the rubric by exactly 0.000.
+
+        The first stop is the saturated one. The ratchet already refuses to spend its
+        *own* round on a stage scoring 1.000, because a rubric at its ceiling cannot
+        register an improvement and a round aimed at one buys churn -- that is
+        `should_continue`, and it has been there since the ratchet landed. The reviewer
+        was never subject to it, and 59% of its send-backs were aimed at stages already
+        at 1.000.
+
+        The reviewer's *first* look is exempt from that stop even at 1.000, and it has to
+        be: the rubric is nine mechanical criteria and the reviewer is the only reader of
+        the prose, so a stage whose counts and ratios are all green is exactly where the
+        reviewer might have the only thing to say. Refusing that read to save the last
+        11 percentage points would trade the one part of the loop that could be load
+        bearing for the part measured not to be.
+
+        The second stop is the budget, and it exists because the first cannot bound a
+        stage the rubric never saturates. It promotes rather than skips: nothing is
+        discarded, the draft that stands is the one the reviewer had already scored
+        acceptable on every mechanical criterion, and the run keeps its stage.
+        """
+        if self.reviewer is None or choice not in REVISION_CHOICES:
+            return None
+        spent = read_sendback_count(paths, stage)
+        if spent >= MAX_AUTOMATED_SENDBACKS:
+            return (
+                f"the automated reviewer has already sent this stage back "
+                f"{spent} time(s), which is its budget of {MAX_AUTOMATED_SENDBACKS}"
+            )
+        if spent >= 1 and self.evolution is not None and self._evolution_measures(stage):
+            champion = self.evolution.state(paths, stage).champion
+            if champion is not None and champion.total >= 1.0 - 1e-9:
+                return (
+                    "the draft already scores 1.000 on every rubric criterion and the "
+                    "reviewer has had its look, so another round has nothing measurable "
+                    "left to move"
+                )
+        return None
 
     def _settle_obligations(
         self,

--- a/src/router.py
+++ b/src/router.py
@@ -37,6 +37,8 @@ from pathlib import Path
 from typing import Any
 
 from .approval_agent import extract_json_payload
+from .obligations import load_ledger
+from .preregistration import load_hypothesis_outcomes
 from .rubric import StageScore, format_score_for_prompt
 from .stage_graph import FINISH, GraphState, Move, StageGraph, block_census
 from .utils import (
@@ -471,6 +473,22 @@ class StageRouter:
         if score is not None:
             sections += ["", "## Measured standing of the stage you just finished", "",
                          format_score_for_prompt(score)]
+            if score.total >= 1.0 - 1e-9:
+                # A ceiling is not a verdict on the research. The ratchet stops at 1.000
+                # and most stages reach it, so a router told only the total is told the
+                # same thing at almost every node -- see `unfinished_business`.
+                sections += [
+                    "",
+                    "This is the rubric's ceiling, and the ratchet polishes every stage "
+                    "towards it, so most stages arrive here reporting 1.000. It means the "
+                    "mechanical checks pass — references resolve, numbers trace to files, "
+                    "the contract is met. It does not mean the research question was "
+                    "answered, and it is not evidence for advancing.",
+                ]
+
+        unsettled = unfinished_business(paths, stage)
+        if unsettled:
+            sections += ["", unsettled]
 
         evidence = self._archive_evidence(stage.slug, [move.target for move in moves if move.admissible])
         if evidence:
@@ -510,6 +528,83 @@ class StageRouter:
                 "- Choose `finish` only if the run has produced what it set out to produce."
             )
         return "\n".join(sections)
+
+
+#: Verdicts that mean the hypothesis was settled. Everything else -- ``inconclusive``,
+#: ``not_tested``, a blank, a verdict the schema does not know -- is a question the run
+#: asked and did not answer, which is the strongest reason there is to go back.
+_SETTLED_VERDICTS = frozenset({"supported", "refuted"})
+
+
+def unfinished_business(paths: RunPaths, stage: StageSpec) -> str:
+    """What is still owed, rendered for the routing prompt. Empty when nothing is.
+
+    The router used to be handed the stage's rubric total and nothing else, and the
+    ratchet grinds that total to 1.000 before the router ever sees it -- measured over
+    41 ResearchClawBench runs, 71% of routing decisions were made against a stage
+    reporting a perfect score with every criterion at 1.00 and the "where the points
+    are" list empty. The prompt asks for a `reason` grounded in "what in *this stage's
+    results* makes that the right move" and then shows results with nothing wrong in
+    them, so the only defensible answer is the forward one. The router departed at 16 of
+    252 decision points (6.3%) and 31 of 41 runs walked a straight line.
+
+    It was not being blocked. Guards refused 48 moves across those runs and 46 of them
+    were `finish`, which is the terminal edge being closed rather than a departure being
+    denied. The router had the moves; it had no grounds.
+
+    These are the grounds, and they were on disk the whole time. 30% of hypotheses came
+    back `inconclusive` or `not_tested` and 84% of runs held at least one -- the prompt's
+    own worked example of a good reason is "H2 is inconclusive because only one seed was
+    run", and the run knew which hypotheses those were and never said. Obligations are
+    the same shape from the reviewer's side: a debt it recorded, still open, and a stage
+    it named to pay it.
+
+    Facts, not advice. Nothing here tells the router to go back -- it lists what is
+    unsettled and lets the move follow, because an instruction to depart more often is a
+    thumb on the scale and would be obeyed on the runs that had nothing to go back for.
+    """
+    lines: list[str] = []
+
+    unsettled = [
+        outcome
+        for outcome in load_hypothesis_outcomes(paths)
+        if outcome.verdict not in _SETTLED_VERDICTS
+    ]
+    if unsettled:
+        lines += [
+            f"**{len(unsettled)} hypothesis verdict(s) are not settled.** A hypothesis the "
+            "run could not decide is a question it asked and did not answer. Writing up "
+            "around one is the failure this graph exists to avoid; going back to the stage "
+            "that could settle it is a first-class move.",
+            "",
+        ]
+        for outcome in unsettled:
+            verdict = outcome.verdict or "(no verdict recorded)"
+            rationale = truncate_text(outcome.rationale, max_chars=400)
+            lines.append(f"- `{outcome.identifier or '(unnamed)'}` — **{verdict}**: {rationale}")
+        lines.append("")
+
+    ledger = load_ledger(paths)
+    # The reviewer's own record of what it let through on the promise that a later stage
+    # would settle it. `open_for` asks the ledger which of those this stage is on the hook
+    # for, which is the same question the routing decision is about to answer.
+    owed = ledger.open_for(stage)
+    if owed:
+        lines += [
+            f"**{len(owed)} obligation(s) the reviewer recorded are still open against "
+            "this stage.**",
+            "",
+        ]
+        for obligation in owed:
+            lines.append(
+                f"- `{obligation.obligation_id}` (raised at {obligation.origin_stage}, "
+                f"deferred {obligation.deferrals}x): {truncate_text(obligation.text, max_chars=400)}"
+            )
+        lines.append("")
+
+    if not lines:
+        return ""
+    return "\n".join(["## What is still unsettled", "", *lines]).rstrip()
 
 
 def _default_reason(default: Move, moves: list[Move]) -> str:

--- a/src/utils.py
+++ b/src/utils.py
@@ -101,6 +101,27 @@ MAX_STAGE_ATTEMPTS: int | None = None
 STUCK_AFTER_IDENTICAL_FAILURES = 3
 
 
+#: Send-backs an *automated* reviewer may spend on one stage before its next refusal is
+#: converted into an approval.
+#:
+#: Not :data:`MAX_STAGE_ATTEMPTS`, and deliberately not: that ceiling ends a stage by
+#: auto-skipping it, which is the expensive failure its own comment records. This one
+#: never discards anything. It ends the *argument* by promoting the draft the stage
+#: already has, which is the draft the reviewer had already scored acceptable on every
+#: mechanical criterion.
+#:
+#: Measured over 41 ResearchClawBench runs before the bound existed: the automated
+#: reviewer refused 890 times and approved 496, first approval arrived at a median of
+#: attempt 4, and the per-stage distribution ran out to 18. 72% of stages were sent back
+#: more than twice. Three is above the median and below the tail.
+#:
+#: A human reviewer is not bounded here. A person who asks for a change is exercising
+#: judgement AutoR has no standing to overrule; an automated reviewer is another
+#: instance of the same model, and deferring to it without limit is deferring to
+#: nothing.
+MAX_AUTOMATED_SENDBACKS = 3
+
+
 def is_stuck(recent_failures: Sequence[Sequence[str]]) -> bool:
     """Whether the last :data:`STUCK_AFTER_IDENTICAL_FAILURES` attempts failed identically.
 
@@ -287,6 +308,14 @@ FIXED_STAGE_OPTIONS = [
     "5. Approve and continue",
     "6. Abort",
 ]
+
+#: The options above that send the stage back rather than settling it. Derived from the
+#: menu rather than written out again: 1-3 take a suggestion, 4 supplies feedback, and
+#: all four produce another attempt. Five approves and six aborts, and neither is a
+#: send-back. Existing call sites spell out `{"1", "2", "3"}` and `== "4"` separately
+#: because they branch differently on each; a caller that only needs "was this a
+#: send-back" should not have to know that.
+REVISION_CHOICES = frozenset(option[0] for option in FIXED_STAGE_OPTIONS[:4])
 
 APPROVED_STAGE_ENTRY_PATTERN = re.compile(r"^#{1,6}\s*Stage\s+(\d{2}):.*$", flags=re.MULTILINE)
 
@@ -2373,6 +2402,30 @@ def read_polish_count(paths: RunPaths, stage: StageSpec) -> int:
 
 def write_polish_count(paths: RunPaths, stage: StageSpec, count: int) -> None:
     write_text(_polish_count_path(paths, stage), str(count))
+
+
+def _sendback_count_path(paths: RunPaths, stage: StageSpec) -> Path:
+    return paths.operator_state_dir / f"{stage.slug}.sendback_count.txt"
+
+
+def read_sendback_count(paths: RunPaths, stage: StageSpec) -> int:
+    """Send-backs the automated reviewer has spent on this stage.
+
+    Persisted beside the polish count and for the same reason: a stage can be entered
+    more than once, and a budget that resets on a graph revisit is not a budget. It is
+    counted separately from both of them because it is spent by a different party --
+    the polish count is AutoR's own rounds and the attempt count is every operator
+    call including the ones a validation error caused.
+    """
+    path = _sendback_count_path(paths, stage)
+    if not path.exists():
+        return 0
+    text = read_text(path).strip()
+    return int(text) if text.isdigit() else 0
+
+
+def write_sendback_count(paths: RunPaths, stage: StageSpec, count: int) -> None:
+    write_text(_sendback_count_path(paths, stage), str(count))
 
 
 def read_attempt_count(paths: RunPaths, stage: StageSpec) -> int:

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -73,7 +73,9 @@ class RatchetTests(unittest.TestCase):
             ),
         )
 
-    def offer(self, markdown: str, attempt_no: int, *, polish: bool = True):
+    def offer(
+        self, markdown: str, attempt_no: int, *, polish: bool = True, directed_by: str = "human"
+    ):
         draft = self.paths.stage_tmp_file(STAGE_06)
         write_text(draft, markdown)
         return self.controller.consider(
@@ -82,6 +84,7 @@ class RatchetTests(unittest.TestCase):
             attempt_no=attempt_no,
             draft_path=draft,
             is_polish_round=polish,
+            directed_by=directed_by,
         )
 
     # -- the ratchet ---------------------------------------------------------
@@ -146,6 +149,126 @@ class RatchetTests(unittest.TestCase):
         self.assertFalse(outcome.reverted)
         self.assertLess(outcome.delta, 0)
         self.assertEqual(read_text(self.paths.stage_tmp_file(STAGE_06)).strip(), weak.strip())
+
+    def test_an_automated_reviewers_worse_revision_is_reverted(self) -> None:
+        """The exemption above is a human's, and a bot was spending it.
+
+        Measured over 41 ResearchClawBench runs, the automated reviewer directed 1115
+        revisions; 142 of them scored *below* the draft they replaced and every one was
+        promoted, because the branch could not tell a person's judgement from another
+        instance of the same model reading the same draft.
+        """
+        strong = stage_markdown(STAGE_06)
+        self.offer(strong, 1, polish=False)
+        weak = stage_markdown(STAGE_06, key_results="Things improved.")
+        outcome = self.offer(weak, 2, polish=False, directed_by="reviewer")
+
+        self.assertEqual(outcome.verdict, "directed_regressed")
+        self.assertTrue(outcome.reverted)
+        self.assertLess(outcome.delta, 0)
+        self.assertEqual(read_text(self.paths.stage_tmp_file(STAGE_06)).strip(), strong.strip())
+
+    def test_an_automated_reviewers_flat_revision_still_stands(self) -> None:
+        """71% of those 1115 rounds measured exactly 0.000, and those are the case the
+        exemption is for: a request the rubric cannot see is not a request that failed.
+        Reverting them would make the rubric the reviewer."""
+        markdown = stage_markdown(STAGE_06)
+        self.offer(markdown, 1, polish=False)
+        outcome = self.offer(markdown, 2, polish=False, directed_by="reviewer")
+
+        self.assertEqual(outcome.delta, 0.0)
+        self.assertEqual(outcome.verdict, "directed")
+        self.assertFalse(outcome.reverted)
+
+    def test_an_automated_reviewers_better_revision_stands(self) -> None:
+        weak = stage_markdown(STAGE_06, key_results="Things improved.")
+        self.offer(weak, 1, polish=False)
+        strong = stage_markdown(STAGE_06)
+        outcome = self.offer(strong, 2, polish=False, directed_by="reviewer")
+
+        self.assertEqual(outcome.verdict, "directed")
+        self.assertFalse(outcome.reverted)
+        self.assertGreater(outcome.delta, 0)
+
+    def test_the_reverted_reviewer_round_spends_patience(self) -> None:
+        """Otherwise a reviewer could hold a stage open forever: `should_continue` stops
+        on `flat_rounds >= patience`, and a round that resets the counter is a round that
+        buys the next one."""
+        self.offer(stage_markdown(STAGE_06), 1, polish=False)
+        before = self.controller.state(self.paths, STAGE_06).flat_rounds
+        self.offer(
+            stage_markdown(STAGE_06, key_results="Things improved."),
+            2, polish=False, directed_by="reviewer",
+        )
+        self.assertEqual(self.controller.state(self.paths, STAGE_06).flat_rounds, before + 1)
+
+    def test_a_reverted_reviewer_round_does_not_move_the_recorded_verdict(self) -> None:
+        """The champion is what stands, so the digest that describes it must not advance
+        past it -- a drift check comparing against a digest no draft on disk holds would
+        fire on the next round for a change this one already undid."""
+        strong = stage_markdown(STAGE_06)
+        self.offer(strong, 1, polish=False)
+        digest = self.controller.state(self.paths, STAGE_06).verdict_digest
+        self.offer(
+            stage_markdown(STAGE_06, key_results="Things improved."),
+            2, polish=False, directed_by="reviewer",
+        )
+        self.assertEqual(self.controller.state(self.paths, STAGE_06).verdict_digest, digest)
+
+    def test_an_automated_reviewer_may_not_move_a_verdict_either(self) -> None:
+        """The exemption covered the drift check too, and `docs/framework.md` §5.4 lists
+        that as a known hole: "a model-directed revision can move a verdict without
+        meeting the check". Verdict-blindness removes the incentive to improve the answer
+        and drift rejection removes the reward; a party that steps around one makes both
+        decorative. Measured, this fires on 4 of 388 adjacent candidate pairs."""
+        self.offer(stage_markdown(STAGE_06), 1, polish=False)
+        self.write_outcomes("refuted")
+        outcome = self.offer(stage_markdown(STAGE_06), 2, polish=False, directed_by="reviewer")
+
+        self.assertEqual(outcome.verdict, "verdict_drift")
+        self.assertTrue(outcome.reverted)
+
+    def test_a_human_may_still_move_a_verdict(self) -> None:
+        """Unchanged, and deliberately: the ratchet governs AutoR's own rounds, not the
+        direction it is given by the person whose project this is."""
+        self.offer(stage_markdown(STAGE_06), 1, polish=False)
+        self.write_outcomes("refuted")
+        outcome = self.offer(stage_markdown(STAGE_06), 2, polish=False)
+
+        self.assertEqual(outcome.verdict, "directed")
+        self.assertFalse(outcome.reverted)
+
+    def test_a_flat_reviewer_round_does_not_reset_autors_patience(self) -> None:
+        """`should_continue` stops a stage on `flat_rounds >= patience`. A directed round
+        used to reset that counter unconditionally, so an automated reviewer sending a
+        stage back every other round switched the stop off as a side effect -- and 71% of
+        its rounds measured exactly 0.000, which makes that the usual case."""
+        markdown = stage_markdown(STAGE_06)
+        self.offer(markdown, 1, polish=False)
+        self.offer(stage_markdown(STAGE_06, key_results="Things improved."), 2)
+        flat = self.controller.state(self.paths, STAGE_06).flat_rounds
+        self.assertGreater(flat, 0)
+
+        self.offer(markdown, 3, polish=False, directed_by="reviewer")
+        self.assertEqual(self.controller.state(self.paths, STAGE_06).flat_rounds, flat)
+
+    def test_a_human_round_still_resets_patience(self) -> None:
+        markdown = stage_markdown(STAGE_06)
+        self.offer(markdown, 1, polish=False)
+        self.offer(stage_markdown(STAGE_06, key_results="Things improved."), 2)
+        self.assertGreater(self.controller.state(self.paths, STAGE_06).flat_rounds, 0)
+
+        self.offer(markdown, 3, polish=False)
+        self.assertEqual(self.controller.state(self.paths, STAGE_06).flat_rounds, 0)
+
+    def test_a_reviewer_round_that_gains_resets_patience(self) -> None:
+        weak = stage_markdown(STAGE_06, key_results="Things improved.")
+        self.offer(weak, 1, polish=False)
+        self.offer(weak, 2)
+        self.assertGreater(self.controller.state(self.paths, STAGE_06).flat_rounds, 0)
+
+        self.offer(stage_markdown(STAGE_06), 3, polish=False, directed_by="reviewer")
+        self.assertEqual(self.controller.state(self.paths, STAGE_06).flat_rounds, 0)
 
     def test_every_candidate_is_kept_including_the_ones_that_lost(self) -> None:
         """A discarded candidate is the only evidence that anything was discarded."""

--- a/tests/test_graph_walk.py
+++ b/tests/test_graph_walk.py
@@ -785,7 +785,10 @@ class GraphWalkTests(unittest.TestCase):
             self.assertIn(row["stage"], {stage.slug for stage in STAGES})
             self.assertIn(
                 row["verdict"],
-                {"first", "promoted", "frontier", "regressed", "directed", "verdict_drift"},
+                {
+                    "first", "promoted", "frontier", "regressed", "directed",
+                    "directed_regressed", "verdict_drift",
+                },
             )
 
         summary = json.loads(read_text(paths.evolution_dir / "summary.json"))

--- a/tests/test_manager_smoke.py
+++ b/tests/test_manager_smoke.py
@@ -13,15 +13,19 @@ from src.intake import load_intake_context
 from src.evolution import EvolutionConfig
 from src.manager import ResearchManager
 from src.manifest import load_run_manifest
+from src.rubric import RUBRIC_VERSION, CriterionScore, StageScore
 from src.project_bootstrap import StageAssessment
 from src.utils import (
     DEFAULT_REFINEMENT_SUGGESTIONS,
     INTAKE_STAGE,
+    MAX_AUTOMATED_SENDBACKS,
     STAGES,
     OperatorResult,
     approved_stage_summaries,
     build_run_paths,
     load_run_config,
+    read_sendback_count,
+    write_sendback_count,
     read_text,
     relative_to_run,
     selected_output_format,
@@ -904,6 +908,183 @@ class ManagerSmokeTests(unittest.TestCase):
             self.assertEqual(reviewer.calls, 2)
             self.assertEqual(operator.continue_modes[STAGE_01.slug], [False, True])
             self.assertIn("Invocation marker: 2", read_text(paths.stage_file(STAGE_01)))
+
+    def _reviewer_manager(self, tmp_dir: str, reviewer, **kwargs):
+        manager = ResearchManager(
+            project_root=REPO_ROOT,
+            runs_dir=Path(tmp_dir) / "runs",
+            operator=ScriptedSmokeOperator(),
+            output_stream=io.StringIO(),
+            reviewer=reviewer,
+            approval_mode="agent",
+            review_operator="claude",
+            review_model="sonnet",
+            evolution=kwargs.pop("evolution_override", EvolutionConfig(rounds=0)),
+            **kwargs,
+        )
+        return manager, manager._create_run("Smoke-test send-back budget.", venue="neurips_2025")
+
+    @staticmethod
+    def _refusals(count: int) -> list[ReviewDecision]:
+        return [
+            ReviewDecision(
+                choice="4",
+                decision_token="custom_feedback",
+                reason=f"Refusal {index + 1}.",
+                feedback=f"Sharpen paragraph {index + 1}.",
+            )
+            for index in range(count)
+        ]
+
+    def test_the_automated_reviewer_runs_out_of_send_backs(self) -> None:
+        """Measured over 41 ResearchClawBench runs the automated reviewer refused 890
+        times and approved 496, first approval landing at a median of attempt 4 and the
+        per-stage distribution running out to 18. Unbounded deference to another instance
+        of the same model is deference to nothing."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            reviewer = ScriptedReviewer(self._refusals(20))
+            manager, paths = self._reviewer_manager(tmp_dir, reviewer)
+
+            self.assertTrue(manager._run_stage(paths, STAGE_01))
+
+            self.assertEqual(reviewer.calls, MAX_AUTOMATED_SENDBACKS + 1)
+            self.assertEqual(read_sendback_count(paths, STAGE_01), MAX_AUTOMATED_SENDBACKS)
+            self.assertIn("sendback_refused", read_text(paths.logs))
+
+    def test_running_out_of_send_backs_promotes_rather_than_skips(self) -> None:
+        """`MAX_STAGE_ATTEMPTS` ends a stage by auto-skipping it, and its own comment
+        records a ResearchClawBench run that skipped its literature survey that way and
+        wrote a report standing on nothing. This bound must not be that bound: the draft
+        the reviewer had already scored acceptable on every mechanical criterion is the
+        one that stands."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manager, paths = self._reviewer_manager(tmp_dir, ScriptedReviewer(self._refusals(20)))
+
+            self.assertTrue(manager._run_stage(paths, STAGE_01))
+
+            manifest = load_run_manifest(paths.run_manifest)
+            assert manifest is not None
+            entry = next(item for item in manifest.stages if item.slug == STAGE_01.slug)
+            self.assertTrue(entry.approved)
+            self.assertFalse(entry.skipped)
+            self.assertTrue(paths.stage_file(STAGE_01).exists())
+            self.assertEqual(manager.auto_skipped_stages, [])
+
+    def test_the_budget_survives_a_second_entry_into_the_stage(self) -> None:
+        """A graph revisit, a rollback and a resume all re-enter a stage. A budget that
+        resets there is not a budget -- that per-entry reset is why the measured tail
+        reached 18 send-backs on one stage under a ceiling of 8."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            reviewer = ScriptedReviewer(self._refusals(20))
+            manager, paths = self._reviewer_manager(tmp_dir, reviewer)
+
+            manager._run_stage(paths, STAGE_01)
+            spent = read_sendback_count(paths, STAGE_01)
+            manager._run_stage(paths, STAGE_01)
+
+            self.assertEqual(read_sendback_count(paths, STAGE_01), spent)
+            self.assertEqual(reviewer.calls, MAX_AUTOMATED_SENDBACKS + 2)
+
+    def test_an_approval_never_spends_the_budget(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            reviewer = ScriptedReviewer(
+                [ReviewDecision(choice="5", decision_token="approve", reason="Fine.")]
+            )
+            manager, paths = self._reviewer_manager(tmp_dir, reviewer)
+
+            self.assertTrue(manager._run_stage(paths, STAGE_01))
+            self.assertEqual(read_sendback_count(paths, STAGE_01), 0)
+
+    def test_a_human_reviewer_is_not_bounded(self) -> None:
+        """The budget is on the automated reviewer. A person asking for a change is
+        exercising judgement AutoR has no standing to overrule, and `_ask_choice` is the
+        path a person takes."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            runs_dir = Path(tmp_dir) / "runs"
+            manager = ResearchManager(
+                project_root=REPO_ROOT,
+                runs_dir=runs_dir,
+                operator=ScriptedSmokeOperator(),
+                output_stream=io.StringIO(),
+                evolution=EvolutionConfig(rounds=0),
+            )
+            paths = manager._create_run("Smoke-test human refusals.", venue="neurips_2025")
+            asks = ["1"] * (MAX_AUTOMATED_SENDBACKS + 2) + ["5"]
+
+            with patch.object(manager, "_ask_choice", side_effect=asks):
+                self.assertTrue(manager._run_stage(paths, STAGE_01))
+
+            self.assertEqual(read_sendback_count(paths, STAGE_01), 0)
+            manifest = load_run_manifest(paths.run_manifest)
+            assert manifest is not None
+            entry = next(item for item in manifest.stages if item.slug == STAGE_01.slug)
+            self.assertEqual(entry.attempt_count, len(asks))
+
+    def _score(self, total: float) -> StageScore:
+        return StageScore(
+            stage_slug=STAGE_01.slug, attempt_no=1, rubric_version=RUBRIC_VERSION,
+            criteria=(CriterionScore("contract", "Contract compliance", 2.0, total, "", ""),),
+            total=total, verdict_digest="d",
+        )
+
+    def _saturated_manager(self, tmp_dir: str, reviewer, total: float, spent: int):
+        manager, paths = self._reviewer_manager(
+            tmp_dir, reviewer, evolution_override=EvolutionConfig(rounds=2)
+        )
+        write_sendback_count(paths, STAGE_01, spent)
+        manager.evolution.state(paths, STAGE_01).champion = self._score(total)
+        return manager, paths
+
+    def test_a_second_send_back_at_the_rubric_ceiling_is_refused(self) -> None:
+        """`should_continue` has refused AutoR's *own* round at 1.000 since the ratchet
+        landed, because a rubric at its ceiling cannot register an improvement. The
+        reviewer was never subject to it: 59% of its 1115 directed rounds were aimed at
+        stages already scoring 1.000, and 71% moved the total by exactly 0.000."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            reviewer = ScriptedReviewer(self._refusals(4))
+            manager, paths = self._saturated_manager(tmp_dir, reviewer, 1.0, spent=1)
+
+            refusal = manager._sendback_is_out_of_budget(paths=paths, stage=STAGE_01, choice="4")
+
+            self.assertIsNotNone(refusal)
+            assert refusal is not None
+            self.assertIn("1.000", refusal)
+
+    def test_the_reviewers_first_look_is_never_refused_for_being_at_the_ceiling(self) -> None:
+        """The rubric is nine mechanical criteria and the reviewer is the only reader of
+        the prose, so a stage whose counts and ratios are all green is exactly where the
+        reviewer might hold the only thing worth saying. Refusing that read would trade
+        the one part of the loop that could be load bearing for the part measured not to
+        be -- and it buys only 11 percentage points: strict refusal cuts 59% of directed
+        rounds against this rule's 48%."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            reviewer = ScriptedReviewer(self._refusals(4))
+            manager, paths = self._saturated_manager(tmp_dir, reviewer, 1.0, spent=0)
+
+            self.assertIsNone(
+                manager._sendback_is_out_of_budget(paths=paths, stage=STAGE_01, choice="4")
+            )
+
+    def test_a_stage_below_the_ceiling_keeps_its_send_backs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            reviewer = ScriptedReviewer(self._refusals(4))
+            manager, paths = self._saturated_manager(tmp_dir, reviewer, 0.94, spent=2)
+
+            self.assertIsNone(
+                manager._sendback_is_out_of_budget(paths=paths, stage=STAGE_01, choice="4")
+            )
+
+    def test_an_approval_is_never_out_of_budget(self) -> None:
+        """The predicate is asked on every verdict, and one that refused an approval
+        would hold a stage open with no way out at all."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            reviewer = ScriptedReviewer(self._refusals(4))
+            manager, paths = self._saturated_manager(tmp_dir, reviewer, 1.0, spent=9)
+
+            for choice in ("5", "6"):
+                self.assertIsNone(
+                    manager._sendback_is_out_of_budget(paths=paths, stage=STAGE_01, choice=choice)
+                )
 
     def test_stage_can_be_skipped_after_exhausted_retries(self) -> None:
         class DummyTTY:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -15,7 +15,16 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from src.router import ROUTING_MODES, RoutingDecision, StageRouter, format_decision, routing_summary
+from src.obligations import ledger_path
+from src.router import (
+    ROUTING_MODES,
+    RoutingDecision,
+    StageRouter,
+    format_decision,
+    routing_summary,
+    unfinished_business,
+)
+from src.rubric import RUBRIC_VERSION, CriterionScore, StageScore
 from src.stage_graph import FINISH, GraphState, StageGraph, Visit, enter, leave
 from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
 from tests import prereg_support
@@ -611,3 +620,151 @@ class RouterTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class UnfinishedBusinessTests(unittest.TestCase):
+    """What the router is shown, and why the old prompt could not produce a departure.
+
+    Over 41 ResearchClawBench runs the router faced 252 decision points and departed
+    from the default at 16 (6.3%); 31 of 41 runs walked a straight line. It was not
+    being blocked -- guards refused 48 moves and 46 of those were `finish`, the
+    terminal edge closing rather than a departure being denied. It had no grounds:
+    71% of those decisions were taken against a stage reporting a perfect 1.000 with
+    the rubric's own "where the points are" list empty, while 30% of hypotheses came
+    back unsettled and 84% of runs held at least one. The prompt's worked example of
+    a good reason is "H2 is inconclusive because only one seed was run", and the run
+    knew which hypotheses those were and never said.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+
+    def outcomes(self, *verdicts: str) -> None:
+        write_text(
+            self.paths.hypothesis_outcomes,
+            json.dumps({
+                "outcomes": [
+                    {"id": f"H{index}", "verdict": verdict,
+                     "rationale": f"Reason {index}.", "evidence": []}
+                    for index, verdict in enumerate(verdicts, start=1)
+                ]
+            }),
+        )
+
+    def ledger(self, *obligations: dict) -> None:
+        write_text(
+            ledger_path(self.paths),
+            json.dumps({"version": 1, "obligations": list(obligations)}),
+        )
+
+    def test_an_inconclusive_hypothesis_is_named(self) -> None:
+        self.outcomes("supported", "inconclusive", "refuted")
+        text = unfinished_business(self.paths, STAGE_06)
+        self.assertIn("1 hypothesis verdict(s) are not settled", text)
+        self.assertIn("`H2`", text)
+        self.assertIn("Reason 2.", text)
+
+    def test_a_settled_run_says_nothing_at_all(self) -> None:
+        """Silence is the point. A section that always appears is a section the model
+        learns to skip, and an instruction to depart more often would be obeyed on the
+        runs that had nothing to go back for."""
+        self.outcomes("supported", "refuted")
+        self.assertEqual(unfinished_business(self.paths, STAGE_06), "")
+
+    def test_a_run_with_no_outcomes_file_says_nothing(self) -> None:
+        self.assertEqual(unfinished_business(self.paths, STAGE_06), "")
+
+    def test_not_tested_counts_as_unsettled(self) -> None:
+        """`not_tested` is a hypothesis the run froze and never reached. Reading only
+        `inconclusive` would let the emptier failure through."""
+        self.outcomes("not_tested")
+        self.assertIn("not settled", unfinished_business(self.paths, STAGE_06))
+
+    def test_a_blank_verdict_counts_as_unsettled(self) -> None:
+        """The allowlist is on settled verdicts, not a denylist of unsettled ones: a
+        verdict the schema does not know must not read as an answer."""
+        self.outcomes("")
+        self.assertIn("not settled", unfinished_business(self.paths, STAGE_06))
+
+    def test_an_open_obligation_naming_this_stage_is_listed(self) -> None:
+        self.outcomes("supported")
+        self.ledger({"obligation_id": "O001", "text": "Report the null.",
+                     "origin_stage": "05_experimentation", "target_stage": STAGE_06.slug,
+                     "status": "open", "deferrals": 2})
+        text = unfinished_business(self.paths, STAGE_06)
+        self.assertIn("`O001`", text)
+        self.assertIn("Report the null.", text)
+        self.assertIn("deferred 2x", text)
+
+    def test_a_discharged_obligation_is_not_listed(self) -> None:
+        self.outcomes("supported")
+        self.ledger({"obligation_id": "O001", "text": "Report the null.",
+                     "origin_stage": "05_experimentation", "target_stage": STAGE_06.slug,
+                     "status": "discharged"})
+        self.assertEqual(unfinished_business(self.paths, STAGE_06), "")
+
+    def test_an_obligation_aimed_at_another_stage_is_not_listed(self) -> None:
+        self.outcomes("supported")
+        self.ledger({"obligation_id": "O001", "text": "Report the null.",
+                     "origin_stage": "05_experimentation", "target_stage": "07_writing",
+                     "status": "open"})
+        self.assertEqual(unfinished_business(self.paths, STAGE_06), "")
+
+
+class RoutingPromptCarriesTheGroundsTests(RouterTests):
+    def prompt(self) -> str:
+        _decision, operator = self.choose(
+            json.dumps({"target": "07_writing", "reason": "Done."})
+        )
+        return operator.prompts[0]
+
+    def test_the_prompt_names_the_unsettled_hypothesis(self) -> None:
+        prereg_support.write_hypothesis_manifest(self.paths)
+        prereg_support.freeze_preregistration(self.paths)
+        write_text(
+            self.paths.hypothesis_outcomes,
+            json.dumps({"outcomes": [
+                {"id": "H1", "verdict": "inconclusive",
+                 "rationale": "Only one seed was run.", "evidence": []}
+            ]}),
+        )
+        text = self.prompt()
+        self.assertIn("What is still unsettled", text)
+        self.assertIn("Only one seed was run.", text)
+
+    def test_a_settled_run_gets_no_unsettled_section(self) -> None:
+        self.adjudicate()
+        self.assertNotIn("What is still unsettled", self.prompt())
+
+    def test_a_perfect_score_is_labelled_as_a_ceiling(self) -> None:
+        """A router told only the total is told the same thing at almost every node."""
+        operator = FakeRoutingOperator(json.dumps({"target": "07_writing", "reason": "Done."}))
+        router = StageRouter(operator, mode="agent")
+        router.choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState(),
+            score=StageScore(
+                stage_slug=STAGE_06.slug, attempt_no=1, rubric_version=RUBRIC_VERSION,
+                criteria=(CriterionScore("contract", "Contract", 2.0, 1.0, "ok", ""),),
+                total=1.0,
+            ),
+        )
+        text = operator.prompts[0]
+        self.assertIn("rubric's ceiling", text)
+        self.assertIn("is not evidence for advancing", text)
+
+    def test_a_score_below_the_ceiling_is_not_labelled(self) -> None:
+        operator = FakeRoutingOperator(json.dumps({"target": "07_writing", "reason": "Done."}))
+        router = StageRouter(operator, mode="agent")
+        router.choose(
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=GraphState(),
+            score=StageScore(
+                stage_slug=STAGE_06.slug, attempt_no=1, rubric_version=RUBRIC_VERSION,
+                criteria=(CriterionScore("contract", "Contract", 2.0, 0.8, "thin", "add one"),),
+                total=0.8,
+            ),
+        )
+        self.assertNotIn("rubric's ceiling", operator.prompts[0])


### PR DESCRIPTION
## What was measured

41 ResearchClawBench runs on `1069e77`, timed by segmenting `logs_raw.jsonl` on the harness's own `_meta` markers.

Median run is **15.4 h**. First-pass execution is **3.1 h** — the same order as bare Claude Code's 2.1 h on the same 40 tasks. The other 12 h is review (39%) and redo (32%).

It buys nothing measurable. Paired against the previous code, review time went **down** 0.91 h and redo rounds **down** 3.64 while the score went **up** 4.45. Δtime vs Δscore is r = +0.06…+0.14 at n=39 (needs 0.32).

## One cause, four defects

`consider`'s exemption for a directed round was written to protect a **human's** judgement — *"a measurement is not entitled to overrule it"* — and an automated reviewer was spending it. It is another instance of the same model reading the same draft; there is no authority there to defer to.

| | measured | change |
|---|---|---|
| directed rounds carrying "stands regardless of measurement" | 1115 / 1115 | `consider` takes `directed_by` |
| …that measured **worse** and were promoted anyway | 142 (13%) | reverted |
| …that measured exactly 0.000 | 788 (71%) | **still stand** |
| directed rounds that moved a hypothesis verdict past the drift check | 4 / 388 pairs | refused |
| directed rounds aimed at a stage already at 1.000 | 655 (59%) | second one refused |
| reviewer refusals / approvals | 890 / 496 | budget of 3 |

A flat round still stands: a request the rubric cannot see is not a request that failed, and reverting those would make the rubric the reviewer.

The reviewer's **first** look at a saturated stage is never refused. The rubric is nine mechanical criteria and the reviewer is the only reader of the prose. That exemption costs 11 points of blast radius — 48% of directed rounds cut against a strict rule's 59%.

`MAX_AUTOMATED_SENDBACKS` is deliberately **not** `MAX_STAGE_ATTEMPTS`. That ceiling ends a stage by *auto-skipping* it, and its own comment records a run that skipped its literature survey that way and wrote a report standing on nothing. This one promotes the draft the reviewer had already scored acceptable on every mechanical criterion. Nothing is discarded.

A directed round also reset `flat_rounds` unconditionally, so a send-back every other round switched off AutoR's own patience stop as a side effect. Now only a round that moved the number, or a human's, earns the reset.

## The graph

252 decision points, **16 departures (6.3%)**, 31 of 41 runs a straight line.

Not blocked — guards refused 48 moves and **46 were `finish`**, the terminal edge closing rather than a departure being denied. It had no grounds. The prompt asks for a reason drawn from *"what in this stage's results makes that the right move"* and then showed a stage the ratchet had polished to 1.000 with the rubric's "where the points are" list empty; **71% of routing decisions were taken against exactly that**.

The grounds were on disk and unread: **30% of hypotheses came back `inconclusive` or `not_tested`, and 84% of runs held at least one**. The prompt's own worked example of a good reason is *"H2 is inconclusive because only one seed was run"*.

`unfinished_business` now puts the unsettled verdicts and the open obligations in front of the router, and a saturated total is labelled as the ceiling it is.

Facts, not advice. Nothing added tells the router to go back — an instruction to depart more often would be obeyed on the runs that had nothing to go back for. **Whether it moves the departure rate is unmeasured.**

## Verification

- 2633 tests pass; `python -m py_compile` clean.
- 23 mutations tried against the new tests (stop removed, counter frozen, budget reset per entry, promote→abort, human case swallowed, threshold loosened, drift narrowed, patience reset restored, …). **All 23 caught.**
- `docs/framework.md` §5.2 and §5.4 described the old contract and listed two of these as known holes; both updated, and §6.7's "the agent decided" number is now distinguished from "the agent departed".

## What this does not claim

No RCB score for this code exists yet. The gains above are properties of the loop, not of the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)