### PR TITLE
Judge what a backward move bought, and take it back when it lost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ docs/*
 !docs/ui-design/
 !docs/ui-design/**
 docs/ui-design/.DS_Store
+# Paper material. Same shape as ui-design above, and for the same reason the
+# comment gives: `!docs/*.md` reaches files directly under docs/ and not a
+# subdirectory, so a page added here is silently untracked without these two lines.
+!docs/iclr/
+!docs/iclr/**
 examples/
 agentspace/
 assets/paper_gallery_source/

--- a/docs/iclr/composable-stage-graphs.md
+++ b/docs/iclr/composable-stage-graphs.md
@@ -1,0 +1,452 @@
+# Composable Stage Graphs
+
+*Design notes for the AutoR framework paper. This document states the model, the
+mechanisms that implement it, and what each one is measured against. It is written to be
+lifted into a paper, so every claim here is either implemented and tested in this
+repository or marked as not yet.*
+
+---
+
+## 1. The problem: a research run is not a pipeline, and a pipeline is not a graph
+
+AutoR runs a research project as eight stages. Real research does not walk them once.
+Analysis discovers that the experiment answered a different question than the one that was
+asked; writing discovers that a claim has no result behind it; a result nobody planned for
+turns out to be worth more than the one that was. Each of those is a *backward* move, and
+AutoR's topology admits thirteen of them.
+
+Admitting a backward move is the easy half. The hard half is what the move does to the run.
+A stage that has been visited has changed the shared workspace: it wrote data, code,
+figures, notes, manifests. A backward edge that leaves those changes in place does not undo
+a decision, it merely stops talking about it — and the run continues on top of the state the
+abandoned decision produced.
+
+This is the failure a graph topology invites and a pipeline never had to face. It has two
+halves, and they are orthogonal:
+
+- **What a stage changed.** When a stage is withdrawn, the modifications it made to the
+  shared workspace must be undone — completely, and without taking anything else with them.
+- **What a stage read.** A stage's approval is a claim about a state: *given these inputs,
+  this output was accepted.* When an input moves, that claim expires, and the run has to
+  know which claims those are.
+
+We call the first **temporal composability** and the second **spatial composability**. They
+are independent: a system can undo perfectly and still act on a stale approval, or track
+dependencies perfectly and still leave withdrawn artifacts on disk. AutoR did the second
+badly and the first not at all.
+
+### 1.1 What it cost, measured
+
+Six of the graph's forward edges are guarded by counting files under `workspace/`. Before
+the work described here, rolling back was a manifest edit — it set `status`, `approved`,
+`dirty`, `stale` on the entries at and after the target and left the workspace untouched.
+So the count those guards read still included everything the abandoned stages had written:
+
+```
+gate before rollback: True | 1 machine-readable design artifact(s) and a declared protocol
+gate after  rollback: True | 1 machine-readable design artifact(s) and a declared protocol
+files still on disk: ['design_matrix.csv']
+```
+
+A run that reached Stage 06, found the design wrong and went back to Stage 03 met an edge
+out of Stage 03 that was **already open** — opened by the data Stages 04 and 05 had produced
+under the design being abandoned. The gate whose purpose is to prove that *this* visit did
+the work was answering for the visit the run had just repudiated.
+
+The system was aware of the invariant it did not have. One guard's own comment reads:
+
+> Every other guard here reads stage artifacts, which a rollback invalidates. This one
+> reads a ledger, so the scoping has to be explicit.
+
+The sentence was the stated reason for scoping one guard narrowly and leaving five broad.
+It was false for all five. And the same class of defect had already been patched once, by
+hand, at one path: a skipped stage's round declaration was "never consumed and never
+unlinked", so the next visit closed its round from the previous visit's file, "inheriting a
+conclusion drawn from results it did not produce." One instance, one patch, no mechanism.
+
+---
+
+## 2. The model
+
+We model a run as a set of **stages** over a shared **run context**. A stage is a triple:
+
+| Component | Meaning |
+| --- | --- |
+| **declared inputs** | the channels this stage reads, each naming the stage that produces it |
+| **provision** | the channels and artifact families this stage may write |
+| **effect** | what it does to the context when it runs, together with how to take that back |
+
+Two derived notions drive everything below.
+
+**A stage's contribution is attributable.** Every change to the shared workspace belongs to
+exactly one stage. Without this, "withdraw Stage 04's contribution" has no referent, and
+neither undo nor staleness can be defined. This is a precondition that most agent pipelines
+leave implicit and therefore do not have.
+
+**A stage's approval carries the state it was given against.** Not just *that* the stage was
+approved, but *what it was reading* when the approval was given. The pair is what makes
+"is this approval still good" a comparison rather than an inference from stage numbering.
+
+---
+
+## 3. Temporal composability: withdrawal that is exact
+
+### 3.1 Inverses, not snapshots
+
+A snapshot of the run is all-or-nothing. It can restore the state before Stage 04, and it
+cannot withdraw Stage 04 while Stage 06 stands, because it holds no representation of one
+stage's contribution separately from the run's. That distinction is the entire reason the
+topology is a graph: a late finding invalidates *a* decision, not every decision that
+happened to follow it in wall-clock order. A rollback that discards Stage 05's honest
+measurement along with Stage 04's wrong design has thrown away the evidence that justified
+the move.
+
+So each write carries the operation that undoes it, and the run accumulates those per
+stage. Withdrawing a range is applying its accumulators in reverse. Two properties follow
+without further assumptions:
+
+- **Reverse-order withdrawal is always sound.** Reverting in the reverse of the order
+  applied hands each inverse the state its own application produced, whatever the writes
+  were.
+- **Composite inverses are free.** A stage author supplies the inverse of each atomic
+  operation; the inverse of any sequence is the reverse composition. Teardown is *derived
+  from* loading rather than written alongside it, which is what removes it from the set of
+  things an author can forget.
+
+### 3.2 Inverses are data, not closures
+
+A run resumes in a new process — resumption is routine and a single stage may run for four
+hours — so an inverse held as a Python closure is an inverse that does not survive the event
+most likely to require it. Each inverse is a kind plus a JSON payload, appended to a
+per-stage log as the stage runs. A crash mid-stage therefore leaves a partial accumulator
+that still withdraws everything the stage had managed to do.
+
+### 3.3 Undo has no preconditions
+
+No inverse may fail: deleting a path that is already gone succeeds, restoring bytes creates
+the parent directories it needs. An undo that can refuse turns a rollback into a state the
+system has no rule for, and turns the recovery it was supposed to perform into a partial one
+that nobody records. Where a natural undo *does* carry a precondition, we take the weaker
+unconditional operation instead — for a registered child stage, the inverse *retires* it
+rather than *removing* it, because removal has premises and retirement does not.
+
+### 3.4 Attribution is observed, not declared
+
+A stage's work is performed by an agent process writing files directly, so the framework
+cannot intercept the writes. It compares instead: a ledger keeps a content identity per file
+per version, and a scan at each stage boundary attributes whatever is new or changed to the
+stage that just ran.
+
+This is weaker than instrumentation in exactly one way, and the ledger records where: a
+version whose bytes were never held can be withdrawn from the guards and deleted, but not
+rewound to.
+
+### 3.5 A row is a version chain, not a state
+
+A file created at Stage 02 and rewritten at Stage 05 has two versions. Rolling back to
+Stage 04 does **not** withdraw it — it rewinds it to what Stage 02 left. Withdrawal is for
+files whose *creator* is inside the withdrawn range.
+
+Collapsing the two cases into "delete" is the obvious implementation and it is wrong: it
+takes Stage 02's honest work along with Stage 05's, which is precisely the loss the graph
+exists to avoid. This is the single design decision that most distinguishes withdrawal in a
+graph from rollback in a pipeline.
+
+### 3.6 Version identity is a fresh name, never a value
+
+Each version gets an identifier drawn from a counter that only increases and is never
+reissued. Two stages can produce byte-identical output — a re-run after a rollback usually
+does — and a consumer comparing values could not tell the re-run from the original. A
+consumer that recorded `a000007` and now reads `a000019` knows its input changed without
+comparing anything about the content.
+
+---
+
+## 4. Spatial composability: staleness as a comparison, not as arithmetic
+
+### 4.1 The declared topology already existed; nothing read it for this
+
+AutoR declares eighteen typed information channels. Each names the stage that produces it
+and the set of stages that read it — a producer→consumer topology, written down rather than
+approximated. It was used to assemble prompts, and for nothing else.
+
+Meanwhile staleness was decided by arithmetic: a rollback to stage *N* marked every stage
+numbered above *N*. That is the same approximation the channel layer was introduced to
+remove one level up — "who needs this" approximated by "everyone from here on" — still
+deciding whose approval survives a change.
+
+It fails in a direction arithmetic cannot see. `research_rounds` is produced at Stage 06 and
+read from Stage 02 onward, because Stages 03–06 repeat as a round: **information genuinely
+flows backwards.** A change at Stage 06 leaves every earlier consumer's approval standing,
+because 2 is not greater than 6.
+
+### 4.2 Committed view and current view
+
+At approval, a stage records a digest per declared input — its **committed view**. At any
+later point the same digests can be taken again — the **current view**. The stage is stale
+exactly when they differ, and the channels that differ are the reason, which the declared
+topology turns into the name of the stage that caused it.
+
+Three properties of the choice:
+
+**The view is over what the stage reads, not over the files behind it.** A channel is a
+rendered block, and that block is what the stage actually saw. Going through files instead
+would require a second declaration of which file backs which channel, and two spellings of
+one mapping is how they drift apart. It also gives the comparison the right grain: *two
+states of the run are the same, for this stage, exactly when no channel it reads can tell
+them apart.*
+
+**Only channels with a producer are in the view.** Run configuration, project context and
+the artifact index come from outside the stage graph. They are the environment the run sits
+in, not a dependency on another stage's work, and a withdrawal does not touch them.
+
+**One producer channel is excluded by name, with a measurement behind it.** The experiment
+manifest is the framework's own inventory, and rendering it rewrites it with a fresh
+timestamp — so its digest moves on research that did not. Left in the view it would mark
+four stages stale at every boundary. A test renders every producer channel across a boundary
+and requires it to be either stable or named in the exclusion list, so the list cannot grow
+by assertion.
+
+### 4.3 The rule, and why it is additive
+
+> A stage is stale when its own output was withdrawn, **or** when its committed view no
+> longer matches.
+
+The first clause is the old stage-number rule and it is kept, because above the withdrawal
+target the stage's own artifacts are gone and its approval is void whatever it reads.
+Replacing it would leave stages approved with their outputs deleted. The second clause is
+the new one, and it catches what numbering cannot: an approval below the target that was
+given against something the withdrawal moved.
+
+The mechanism is not only for withdrawals. Drift can be asked at any point, which makes the
+same machinery answer a question the run could not previously ask: *has any approved stage's
+input changed under it?*
+
+---
+
+## 5. Which withdrawals may be selective
+
+Reverse-order withdrawal always works. Withdrawing *one* stage and leaving the later ones
+standing is what the graph is actually for, and it needs a condition.
+
+Two writes to different shared locations never interfere. Two writes to the same location
+interfere unless the location is one where they cannot. So we classify each shared location:
+
+| Kind | Example | Withdrawable out of order? |
+| --- | --- | --- |
+| **Commutative** — a collection whose entries are added and removed independently | the source set, the hypothesis set, the results directory | yes |
+| **Ordered** — a sequence whose entries see each other | the manuscript draft, the run log | no |
+
+Two registrations into a table, in either order, leave a table that answers every read
+alike, and either can be withdrawn while the other stands. A paragraph written after another
+reads differently without it, and neither order can be withdrawn without disturbing the
+rest.
+
+Ordered locations are not a defect to be engineered away. They are where the
+order-sensitive part of the run lives, and naming them is what licenses reordering
+everywhere else. The design guidance that falls out is concrete: **anything you want to be
+selectively withdrawable belongs in a collection keyed by identifier, not in a narrative.**
+
+A location in neither class is treated as ordered and *reported as unclassified*. The two
+are different findings — the first is a fact about the research, the second is a fact about
+the codebase — and reporting them alike hides the one that has a fix.
+
+---
+
+## 6. The system boundary: what an inverse cannot reach
+
+An inverse works because the run owns the location: it can change it exclusively and it can
+put the previous state back. Not everything a stage does is like that.
+
+- An **acquisition** installs a record the run owns — a file it created, a handle it holds.
+  It is withdrawable.
+- An **emission** pushes data where other parties can already read it — a pull request, a
+  spent quota, a row in a shared leaderboard. No inverse the run holds takes it back.
+
+The boundary is drawn **per location, not per medium**. The same directory holds a
+two-kilobyte results table the run can rewind and a four-gigabyte checkpoint it cannot, and
+the honest record says so per file rather than per directory.
+
+There are two ways to recover from an emission, and we implement the first: **withhold it**
+until the state that produced it is settled. A stage registers the intent; the intent is
+released when the stage is approved and dropped when the stage is withdrawn. The second —
+emit now, compensate later — is available to a caller that needs it and is not free: a
+compensating action restores the world only up to an equivalence the application supplies,
+coarser than the one the rest of the system reasons in, and nothing in the framework can
+check it.
+
+---
+
+## 7. The asymmetry: state is reverted, evidence is retained
+
+Everything in §3–§6 pushes toward one limit: a run whose dynamic history leaves no trace,
+that quiesces wherever a run which had gone straight there would have. For a plugin host
+that is the goal. For a research run it is half of one, and the wrong half to stop at.
+
+A run that withdraws Stage 04's design and then re-enters Stage 04 with no record of what
+was withdrawn has bought itself the right to make the same mistake again — cheaply, and as
+many times as its visit budget allows. Recovery so complete that it erases the reason for
+the recovery makes a withdrawal indistinguishable from never having tried, and a system
+that cannot tell those apart will try the same thing again.
+
+So the run context divides in two, and the division is the design rather than an
+implementation detail:
+
+| | Behaviour under withdrawal | What it holds |
+| --- | --- | --- |
+| **Workspace** | reverted | the state the run stands behind |
+| **Ledger** | monotone — only grows | what was tried, what it cost, why it was taken back |
+
+The second is what makes the first safe to use. And it has to *reach* the stage that could
+repeat the decision, or it is an archive: the record is delivered as a typed information
+channel to every stage a backward edge can land on. That readership is read off the graph's
+own backward edges rather than listed by hand, so a new backward edge brings its target into
+the readership with it. A stage re-entered after a withdrawal is told what was withdrawn
+from it and why, in the same prompt that asks it to try again.
+
+The ledger sits outside the workspace, which puts it beyond every recovery path *by
+construction* rather than by an exclusion somebody has to maintain. A withdrawal that could
+edit it could withdraw the record of itself.
+
+**What this buys that a purely revertible system does not have.** The convergence argument
+for a graph walk is that dead ends leave no residue in the state. The learning argument is
+that they leave residue somewhere else. A system with only the first wanders efficiently; a
+system with only the second accumulates junk it cannot clean up. The split is what lets a
+run explore a backward edge without either consequence.
+
+---
+
+## 8. The ratchet: a backward move that made the run worse is itself taken back
+
+Everything in §3–§7 is about **state**, and none of it says the run gets better. A withdrawal
+can be exact, an approval can be retired for the right reason, and the walk can still spend
+its budget going in a circle. Keeping the two apart matters, because a system that withdraws
+perfectly and wanders is easy to mistake for one that is working.
+
+The graph exists so that a late finding can send the run back. Nothing checked whether going
+back *helped*. A run could leave Stage 06 for Stage 03, rebuild the design, walk forward and
+arrive at a Stage 06 scoring lower than the one it abandoned — and that outcome was recorded,
+promoted and built on exactly like an improvement, because "later" was the only ordering the
+walk had.
+
+### 8.1 The excursion
+
+An **excursion** is the interval between leaving a stage by a backward edge and getting back
+to it. It opens when the walk leaves stage *S* for something earlier; it closes the next time
+the walk leaves a stage numbered *S* or above — the point at which the run has recovered the
+ground it gave up and the two states are comparable.
+
+A backward move taken while an excursion is already open **extends the outer one** rather
+than nesting inside it. The outer baseline is the state before the run started going
+backwards at all, and that is the comparison worth keeping: judging an inner excursion
+against a state which is itself under review would let two bad moves ratify each other.
+
+### 8.2 What it is compared on, and why there is no noise band
+
+The excursion was taken to improve *S*'s situation, so *S*'s own score is the measure — the
+same stage, before and after. Both numbers are already recorded per visit by the walk, so
+nothing is re-scored.
+
+The score is mechanical. It reads the run off disk and never calls a model, so the same
+workspace scores the same number twice, and **any drop is a real drop**. The margin is
+therefore zero. This is a property of the measure, not an omission: a judged score would
+need a margin wider than its own sampling dispersion before two draws could be compared at
+all. The margin exists as a named constant precisely so that swapping in a judged score is a
+change to a value with an argument attached, rather than a silent reintroduction of the
+problem.
+
+This is also why the ratchet belongs at the walk level rather than only inside a stage. A
+mechanical score is cheap enough to take at every stage boundary, which is what makes an
+excursion judgeable at all.
+
+### 8.3 Where the run goes back to
+
+A **snapshot** of the version pointers in the provenance ledger, taken when the excursion
+opened. Restoring it uses the same applier a stage-range withdrawal uses; only the choice of
+target version differs — by stage number there, by recorded identifier here. The bytes are
+already in the content-addressed store, so a snapshot costs a dictionary rather than a copy
+of the workspace, which is what makes it affordable at every departure.
+
+A file whose version has not moved is not in the restore plan. A file created since the
+snapshot is deleted. A file that has moved is rewound to the version the snapshot names — and
+where an intervening withdrawal has trimmed that version out of the chain, the honest answer
+is to delete rather than to leave a later version in place and call it restored.
+
+### 8.4 One rewind per stage
+
+A rewind puts the run back exactly where it was before the backward move — which is also the
+state that made the backward move look attractive. Uncapped, the ratchet becomes the loop it
+exists to detect.
+
+So a stage may be overruled once. A second excursion from the same stage that also comes back
+worse is recorded, and allowed to stand. The run has been told, in the withdrawal ledger and
+in the prompt that reaches the stage; a mechanism that keeps overruling the same decision has
+stopped being a ratchet and become a wall.
+
+### 8.5 Five verdicts
+
+| Verdict | Meaning |
+| --- | --- |
+| `improved` | came back higher — what the backward edge is for |
+| `held` | came back equal; left standing |
+| `rewound` | came back lower; the workspace is put back to the snapshot |
+| `worse_but_capped` | came back lower, but this stage has been overruled already |
+| `unjudgeable` | one end was never scored, so the excursion is recorded rather than judged |
+
+The distribution over these verdicts is the number a graph-versus-pipeline comparison
+actually needs. Not *how many backward edges were taken* — a pipeline takes none and that
+says nothing — but **how many of them ended better than they started**.
+
+---
+
+## 9. What is guaranteed, and what is not
+
+Sections 3 to 7 are about **state**; §8 is the only one that speaks to whether the run gets
+better. Keeping them apart matters: a system can withdraw perfectly and still wander.
+
+What the mechanisms above do support:
+
+1. **Withdrawal exactness.** Applying a stage's accumulator yields the state the same
+   sequence would have produced had the stage never run — up to the equivalence in §4.2, and
+   up to the boundary in §6.
+2. **No torn approvals.** A stage's approval either stands against the inputs it was given,
+   or is marked stale naming the input that moved.
+3. **Fail-open on absence.** Anything the ledger has no record of still counts. A run
+   started before the ledger existed, a resumed run whose ledger did not survive, a file
+   written outside any stage's window — all of these behave as they did before. A
+   precondition no real run can meet is not a strict gate; this repository has shipped that
+   mistake once and the rule is a response to it.
+
+---
+
+## 10. Not yet implemented
+
+Listed here rather than omitted, because the difference between a design and a system is
+which parts are running.
+
+| Piece | Status |
+| --- | --- |
+| Attribution, version chains, withdrawal plan | implemented |
+| Per-stage accumulator, reverse-order withdrawal, blob store | implemented |
+| Commutativity classification, independence check, reported on withdrawal | implemented |
+| Emission withholding | implemented |
+| Committed view, drift, topology-derived staleness | implemented |
+| Withdrawal ledger, delivered to every backward-edge target | implemented |
+| Snapshot/restore of version pointers | implemented |
+| Excursions and the walk-level ratchet | implemented |
+| Walk-level ratchet: excursions judged, and rewound when they lose | implemented |
+| **Selective withdrawal as an action** | precondition computed and reported; *deliberately* not wired — see below |
+| **A write surface the stage agent writes through** | pending |
+| **Intra-stage checkpoints** | pending |
+
+### On selective withdrawal
+
+The precondition is computed and reported at every withdrawal: whether the target stage
+could have gone on its own, and if not, which ordered location both it and the stages after
+it wrote. The *action* is not wired, and that is a finding rather than an omission. In this
+stage topology, reverse-order withdrawal is almost always the correct answer — the stages
+after a withdrawn one were reading what it produced, so keeping them would leave them
+standing on a state that no longer exists. Selective withdrawal becomes valuable exactly
+when stages are more independent than they are here, which is the direction the design
+points and not the state it is in. Wiring it now would mean inventing a caller, and a
+mechanism with an invented caller is one nobody has checked.

--- a/src/manager.py
+++ b/src/manager.py
@@ -59,6 +59,12 @@ from .emissions import (
     withhold as withhold_emission,
 )
 from .provenance import format_withdrawal_plan, observe as observe_artifacts, plan_withdrawal
+from .walk_ratchet import (
+    begin as ratchet_begin,
+    settle as ratchet_settle,
+    outcomes,
+    summarise as summarise_excursions,
+)
 from .withdrawal_ledger import load_withdrawals, summarise as summarise_withdrawals
 from .experiment_manifest import write_experiment_manifest
 from .hypothesis_manifest import write_hypothesis_manifest
@@ -597,11 +603,25 @@ class ResearchManager:
             # `REVISIT_EDGES` has no such edge to attribute it to.
             if self._jump_target_stage is not None:
                 target = self._jump_target_stage
+                backwards = target.number <= stage.number
+                # Settle before opening. A departure both closes the excursion the run was
+                # already on -- if it has climbed back to where that one started -- and may
+                # open a new one, and doing them in the other order would judge the new
+                # excursion against its own opening state.
+                self._settle_excursion(paths, state, stage, None)
+                if backwards:
+                    ratchet_begin(
+                        paths,
+                        state,
+                        stage,
+                        target,
+                        self._jump_reason or "The run was redirected to an earlier stage.",
+                    )
                 graph_leave(
                     paths,
                     state,
                     chose=target.slug,
-                    kind="revisit" if target.number <= stage.number else "advance",
+                    kind="revisit" if backwards else "advance",
                     reason=self._jump_reason or "The run was redirected to an earlier stage.",
                     default_choice="",
                     agent_directed=False,
@@ -668,6 +688,18 @@ class ResearchManager:
     def _complete_run(self, paths: RunPaths, state: "GraphState | None" = None) -> bool:
         route = format_route(state) if state is not None else ""
         self._record_block_census(paths, state)
+
+        # What every backward move bought, in one block. The count a graph-versus-pipeline
+        # comparison needs is not how many backward edges were taken -- `format_route`
+        # already carries that -- but how many of them ended better than they started.
+        # Written on every way out, because a halted run's excursions are as informative
+        # as a finished one's -- but only when there were any. A run that took no backward
+        # move has nothing to say here, and an entry saying so is noise in a log other
+        # readers scan by position: it displaced the disclosure
+        # `test_the_run_banner_names_a_stage_that_was_never_attacked` reads out of that
+        # test's window, on a run with no excursions at all.
+        if outcomes(paths):
+            append_log_entry(paths.logs, "excursions", summarise_excursions(paths))
 
         # Written on every way out, not only the clean one: a halted or abandoned run
         # still publishes the stage files whose validity reviews never ran, and "no
@@ -851,6 +883,11 @@ class ResearchManager:
                     f"not: {decision.refusal or 'the move was not available'}.",
                     level="warn",
                 )
+        self._settle_excursion(paths, state, stage, score.total if score is not None else None)
+        if decision.kind == "revisit":
+            target_stage = stage_for_slug(decision.target)
+            if target_stage is not None:
+                ratchet_begin(paths, state, stage, target_stage, decision.reason)
         graph_leave(
             paths,
             state,
@@ -3770,6 +3807,44 @@ class ResearchManager:
             + "\n".join(FIXED_STAGE_OPTIONS)
             + "\n"
         )
+
+    def _settle_excursion(
+        self,
+        paths: RunPaths,
+        state: "GraphState",
+        stage: StageSpec,
+        score: float | None,
+    ) -> None:
+        """Judge the backward move the run is on, if this departure closes it.
+
+        Called at both departure seams rather than at one, because the two are where the
+        walk leaves a stage and an excursion closes when the run has climbed back to where
+        it started going backwards -- which can happen on either path. Best-effort: a
+        ratchet that raised would turn a scoring question into a run-ending one, and the
+        walk's job is to keep going.
+        """
+
+        try:
+            outcome = ratchet_settle(paths, state, stage, score)
+        except OSError as error:
+            append_log_entry(paths.logs, "walk_ratchet_failed", str(error))
+            return
+        if outcome is None:
+            return
+        append_log_entry(paths.logs, f"{stage.slug} excursion_closed", outcome.render())
+        if outcome.verdict == "rewound":
+            self.ui.show_status(
+                f"The move back to {outcome.to_stage} left {outcome.from_stage} worse than "
+                f"it found it ({outcome.baseline} -> {outcome.closed_at_score}); the "
+                "workspace has been returned to where the move started.",
+                level="warn",
+            )
+        elif outcome.verdict == "worse_but_capped":
+            self.ui.show_status(
+                f"The move back to {outcome.to_stage} left {outcome.from_stage} worse "
+                "again, and it has already been rewound once. Recorded, and left standing.",
+                level="warn",
+            )
 
     def _format_rollback_preview(self, paths: RunPaths, rollback_stage: StageSpec) -> str:
         manifest = ensure_run_manifest(paths)

--- a/src/provenance.py
+++ b/src/provenance.py
@@ -563,6 +563,86 @@ def plan_withdrawal(paths: RunPaths, stage: StageSpec) -> list[Withdrawal]:
     return plan
 
 
+def snapshot(paths: RunPaths) -> dict[str, str]:
+    """Where every tracked file stands right now, as a version identifier per path.
+
+    Not a copy of the workspace. The blobs behind those versions are already in the
+    content-addressed store, so a snapshot is a set of pointers into it — cheap enough to
+    take whenever the walk leaves a stage, which is what makes it usable as the boundary of
+    an excursion.
+
+    A path absent from a snapshot is a path that did not exist at that moment, which is
+    what :func:`plan_restore` reads as "delete this on the way back".
+    """
+
+    ledger = load_ledger(paths)
+    return {
+        rel_path: entry.version_uid
+        for rel_path, entry in ledger.entries.items()
+        if entry.live and entry.version_uid
+    }
+
+
+def plan_restore(paths: RunPaths, marks: Mapping[str, str]) -> list[Withdrawal]:
+    """What it takes to put the workspace back to a snapshot. Read-only.
+
+    Expressed as the same :class:`Withdrawal` list a stage-range withdrawal produces, so
+    one applier serves both. The difference is only in how the target version is chosen:
+    by stage number there, by recorded identifier here.
+
+    A file whose version has not moved is not in the plan. A file created since the
+    snapshot is deleted. A file that has moved is rewound to the version the snapshot
+    names, if that version is still in the chain — a chain trimmed by an intervening
+    withdrawal may no longer carry it, and the honest answer then is to delete rather than
+    to leave a later version in place and call it restored.
+    """
+
+    ledger = load_ledger(paths)
+    plan: list[Withdrawal] = []
+    for rel_path, entry in sorted(ledger.entries.items()):
+        wanted = marks.get(rel_path)
+        if wanted is not None and entry.version_uid == wanted:
+            continue
+        target = (
+            next((version for version in entry.versions if version.version_uid == wanted), None)
+            if wanted is not None
+            else None
+        )
+        plan.append(Withdrawal(entry=entry, restore_to=target))
+    return plan
+
+
+def trim_to_snapshot(paths: RunPaths, marks: Mapping[str, str]) -> None:
+    """Cut every version chain back to the version the snapshot names.
+
+    Called after the files have moved, so the ledger describes the workspace the restore
+    leaves rather than the one it found. Rows whose path is not in the snapshot are dropped
+    outright: :func:`plan_restore` deleted the file, and a row for a path that is not on
+    disk would make the next :func:`observe` read the next creation as a rewrite of
+    something that was never there.
+    """
+
+    ledger = load_ledger(paths)
+    entries: dict[str, ArtifactProvenance] = {}
+    for rel_path, entry in ledger.entries.items():
+        wanted = marks.get(rel_path)
+        if wanted is None:
+            continue
+        kept: list[ArtifactVersion] = []
+        for version in entry.versions:
+            kept.append(version)
+            if version.version_uid == wanted:
+                break
+        if kept:
+            entries[rel_path] = replace(
+                entry,
+                versions=tuple(kept),
+                invalidated_by_stage=None,
+                invalidated_reason="",
+            )
+    save_ledger(paths, ProvenanceLedger(next_uid=ledger.next_uid, entries=entries))
+
+
 def invalidate_from(
     paths: RunPaths,
     stage: StageSpec,

--- a/src/walk_ratchet.py
+++ b/src/walk_ratchet.py
@@ -1,0 +1,347 @@
+"""A backward move that made the run worse is itself taken back.
+
+The graph exists so a late finding can send the run back. Nothing checked whether going
+back helped. A run could leave Stage 06 for Stage 03, rebuild the design, walk forward
+again and arrive at a Stage 06 that scored *lower* than the one it abandoned — and that
+outcome was recorded, promoted and built on exactly like an improvement, because "later"
+was the only ordering the walk had.
+
+:mod:`src.evolution` already solved this one level down. Within a stage, a polish round
+that scores worse is reverted and the champion is restored. The walk had no equivalent: the
+ratchet stopped at the stage boundary, and the moves the graph was added for were the ones
+outside it.
+
+**What an excursion is.** The interval between leaving a stage by a backward edge and
+getting back to it. It opens when the walk leaves stage *S* for something earlier, and
+closes the next time the walk leaves a stage numbered *S* or above — the point at which it
+has recovered the ground it gave up and the two states are comparable.
+
+**What it is compared on.** The score of *the same stage*, before and after. The excursion
+was taken to improve S's situation, so S's own rubric total is the measure, and both numbers
+are already recorded per visit in ``stage_graph.json``. No new scoring runs.
+
+**Why there is no noise band.** :mod:`src.rubric` reads the run off disk and never calls a
+backend, so the same workspace scores the same number twice. A judged score would need a
+margin wider than its sampling noise before a comparison of two draws meant anything; a
+mechanical one does not, and :data:`RATCHET_MARGIN` is 0.0 for that reason rather than by
+omission. It exists as a named constant so that swapping in a judged score is a change to a
+value with an argument attached rather than a silent reintroduction of the problem.
+
+**Where the run goes back to.** A snapshot of the provenance ledger's version pointers,
+taken when the excursion opened. Restoring it is the same applier a stage-range withdrawal
+uses, with the target version chosen by recorded identifier instead of by stage number. The
+blobs are already in the content-addressed store, so the snapshot costs a dictionary rather
+than a copy of the workspace.
+
+**One rewind per stage.** A rewind puts the run back exactly where it was before the
+backward move, which is also the state that made the backward move look attractive. The
+per-stage cap is what stops the ratchet from becoming the loop it exists to detect. A second
+excursion from the same stage that also comes back worse is recorded and allowed to stand:
+the run has been told once, in the withdrawal ledger and in the prompt, and a mechanism that
+keeps overruling the same decision has stopped being a ratchet and become a wall.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from .utils import RunPaths, StageSpec
+
+#: How much worse an excursion has to end before it is taken back. Zero because the rubric
+#: is mechanical: it reads the run off disk, never calls a backend, and scores the same
+#: workspace identically twice, so any drop is a real drop. A judged score would need a
+#: margin wider than its own sampling dispersion before two draws could be compared at all.
+RATCHET_MARGIN = 0.0
+
+#: How many times the ratchet may overrule excursions from one stage. See the module note:
+#: a rewind restores the state that made the backward move look attractive in the first
+#: place, so an uncapped ratchet is a loop.
+MAX_REWINDS_PER_STAGE = 1
+
+
+@dataclass(frozen=True)
+class Excursion:
+    """A backward move in flight: where it left from, and what the run looked like then."""
+
+    from_stage: str
+    to_stage: str
+    opened_at: str
+    reason: str
+    #: The departing stage's rubric total at the moment it was left. ``None`` when the
+    #: stage had never been scored, which makes the excursion unjudgeable rather than
+    #: judged favourably.
+    baseline: float | None
+    #: Version pointer per workspace path, from :func:`src.provenance.snapshot`.
+    marks: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "from_stage": self.from_stage,
+            "to_stage": self.to_stage,
+            "opened_at": self.opened_at,
+            "reason": self.reason,
+            "baseline": self.baseline,
+            "marks": dict(self.marks),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "Excursion":
+        baseline = payload.get("baseline")
+        return cls(
+            from_stage=str(payload.get("from_stage") or ""),
+            to_stage=str(payload.get("to_stage") or ""),
+            opened_at=str(payload.get("opened_at") or ""),
+            reason=str(payload.get("reason") or ""),
+            baseline=float(baseline) if isinstance(baseline, (int, float)) else None,
+            marks={str(k): str(v) for k, v in dict(payload.get("marks") or {}).items()},
+        )
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """What the ratchet decided when an excursion closed."""
+
+    from_stage: str
+    to_stage: str
+    baseline: float | None
+    closed_at_score: float | None
+    #: ``improved`` | ``held`` | ``rewound`` | ``worse_but_capped`` | ``unjudgeable``
+    verdict: str
+    detail: str = ""
+
+    def render(self) -> str:
+        span = f"{self.from_stage} -> {self.to_stage} -> {self.from_stage}"
+        scores = f"{_fmt(self.baseline)} -> {_fmt(self.closed_at_score)}"
+        body = f"excursion {span}: {scores} ({self.verdict})"
+        return f"{body}\n{self.detail}" if self.detail else body
+
+
+def _fmt(value: float | None) -> str:
+    return "unscored" if value is None else f"{value:.1f}"
+
+
+def _now() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def state_path(paths: RunPaths) -> Path:
+    return paths.evolution_dir / "excursions.json"
+
+
+def _load(paths: RunPaths) -> dict[str, Any]:
+    path = state_path(paths)
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _save(paths: RunPaths, payload: Mapping[str, Any]) -> None:
+    path = state_path(paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(payload), indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def open_excursion(paths: RunPaths) -> Excursion | None:
+    raw = _load(paths).get("open")
+    return Excursion.from_dict(raw) if isinstance(raw, dict) else None
+
+
+def rewinds_so_far(paths: RunPaths, stage_slug: str) -> int:
+    counts = _load(paths).get("rewinds")
+    if not isinstance(counts, dict):
+        return 0
+    return int(counts.get(stage_slug, 0) or 0)
+
+
+def outcomes(paths: RunPaths) -> list[Outcome]:
+    raw = _load(paths).get("outcomes")
+    if not isinstance(raw, list):
+        return []
+    return [
+        Outcome(
+            from_stage=str(item.get("from_stage") or ""),
+            to_stage=str(item.get("to_stage") or ""),
+            baseline=item.get("baseline") if isinstance(item.get("baseline"), (int, float)) else None,
+            closed_at_score=(
+                item.get("closed_at_score")
+                if isinstance(item.get("closed_at_score"), (int, float))
+                else None
+            ),
+            verdict=str(item.get("verdict") or ""),
+            detail=str(item.get("detail") or ""),
+        )
+        for item in raw
+        if isinstance(item, dict)
+    ]
+
+
+def last_score_for(state: Any, stage_slug: str) -> float | None:
+    """The most recent rubric total recorded for a stage, from the walk's own record.
+
+    Read backwards off ``state.path`` rather than recomputed. The rollback paths call
+    ``graph_leave`` with ``score_total=None`` — the move was already made by the time the
+    walk saw it — so the departing score is not on the visit that opens an excursion, and
+    the last one that *was* measured is the honest baseline.
+    """
+
+    for visit in reversed(getattr(state, "path", []) or []):
+        if visit.stage == stage_slug and visit.score_total is not None:
+            return float(visit.score_total)
+    return None
+
+
+def begin(
+    paths: RunPaths,
+    state: Any,
+    from_stage: StageSpec,
+    to_stage: StageSpec,
+    reason: str = "",
+) -> Excursion | None:
+    """Open an excursion, unless one is already open.
+
+    A backward move taken while an excursion is in flight extends the outer one rather than
+    nesting inside it. The outer baseline is the state before the run started going
+    backwards at all, which is the comparison worth keeping: judging an inner excursion
+    against a state that is itself under review would let two bad moves ratify each other.
+    """
+
+    from .provenance import snapshot
+
+    payload = _load(paths)
+    if isinstance(payload.get("open"), dict):
+        return None
+
+    excursion = Excursion(
+        from_stage=from_stage.slug,
+        to_stage=to_stage.slug,
+        opened_at=_now(),
+        reason=reason.strip(),
+        baseline=last_score_for(state, from_stage.slug),
+        marks=snapshot(paths),
+    )
+    payload["open"] = excursion.to_dict()
+    _save(paths, payload)
+    return excursion
+
+
+def settle(
+    paths: RunPaths,
+    state: Any,
+    stage: StageSpec,
+    score: float | None = None,
+) -> Outcome | None:
+    """Close the open excursion if the walk has recovered its ground, and judge it.
+
+    Called where the walk leaves a stage. Returns ``None`` while no excursion is open or the
+    run has not yet climbed back to the stage it left, so the caller can invoke it at every
+    departure without deciding when an excursion ends.
+
+    ``score`` may be omitted, and is on the paths where the move was already made by the
+    time the walk saw it — a rollback, a ``/back``, a round decision — which call
+    ``graph_leave`` with no score at all. The closing figure then comes from the same place
+    the baseline does, the last total the walk recorded for this stage, so both ends of the
+    comparison are read the same way.
+    """
+
+    from .effects import apply_withdrawal
+    from .provenance import plan_restore, trim_to_snapshot
+    from .utils import STAGES
+
+    excursion = open_excursion(paths)
+    if excursion is None:
+        return None
+
+    by_slug = {item.slug: item for item in STAGES}
+    origin = by_slug.get(excursion.from_stage)
+    if origin is None or stage.number < origin.number:
+        return None
+
+    payload = _load(paths)
+    payload.pop("open", None)
+    if score is None:
+        score = last_score_for(state, stage.slug)
+
+    if excursion.baseline is None or score is None:
+        outcome = Outcome(
+            excursion.from_stage,
+            excursion.to_stage,
+            excursion.baseline,
+            score,
+            "unjudgeable",
+            "one end of the comparison was never scored, so the excursion is recorded "
+            "rather than judged",
+        )
+    elif score >= excursion.baseline - RATCHET_MARGIN:
+        verdict = "improved" if score > excursion.baseline else "held"
+        outcome = Outcome(
+            excursion.from_stage, excursion.to_stage, excursion.baseline, score, verdict
+        )
+    elif rewinds_so_far(paths, excursion.from_stage) >= MAX_REWINDS_PER_STAGE:
+        outcome = Outcome(
+            excursion.from_stage,
+            excursion.to_stage,
+            excursion.baseline,
+            score,
+            "worse_but_capped",
+            f"{excursion.from_stage} has already been rewound "
+            f"{MAX_REWINDS_PER_STAGE} time(s); a ratchet that keeps overruling the same "
+            "decision is a wall, so this one is recorded and left standing",
+        )
+    else:
+        plan = plan_restore(paths, excursion.marks)
+        report = apply_withdrawal(paths, plan)
+        trim_to_snapshot(paths, excursion.marks)
+        counts = dict(payload.get("rewinds") or {})
+        counts[excursion.from_stage] = counts.get(excursion.from_stage, 0) + 1
+        payload["rewinds"] = counts
+        outcome = Outcome(
+            excursion.from_stage,
+            excursion.to_stage,
+            excursion.baseline,
+            score,
+            "rewound",
+            report.render(),
+        )
+
+    recorded = list(payload.get("outcomes") or [])
+    recorded.append(
+        {
+            "from_stage": outcome.from_stage,
+            "to_stage": outcome.to_stage,
+            "baseline": outcome.baseline,
+            "closed_at_score": outcome.closed_at_score,
+            "verdict": outcome.verdict,
+            "detail": outcome.detail,
+            "at": _now(),
+        }
+    )
+    payload["outcomes"] = recorded
+    _save(paths, payload)
+    return outcome
+
+
+def summarise(paths: RunPaths) -> str:
+    """What every backward move in this run bought, in one block.
+
+    The number a graph-versus-pipeline comparison actually needs: not how many backward
+    edges were taken, but how many of them ended better than they started.
+    """
+
+    settled = outcomes(paths)
+    if not settled:
+        return "No backward move has closed yet."
+    counts: dict[str, int] = {}
+    for outcome in settled:
+        counts[outcome.verdict] = counts.get(outcome.verdict, 0) + 1
+    parts = ", ".join(f"{verdict} x{count}" for verdict, count in sorted(counts.items()))
+    lines = [f"{len(settled)} backward move(s) closed: {parts}"]
+    lines.extend(f"- {outcome.render()}" for outcome in settled)
+    return "\n".join(lines)

--- a/tests/test_walk_ratchet.py
+++ b/tests/test_walk_ratchet.py
@@ -1,0 +1,244 @@
+"""A backward move that made the run worse is itself taken back.
+
+Two halves. :class:`SnapshotTests` covers the mechanism the rewind is built on — version
+pointers into the blob store, cheap enough to take at every departure. :class:`RatchetTests`
+covers the judgement: an excursion is compared on the score of the stage it left and
+returned to, and only a drop is acted on.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.effects import apply_withdrawal
+from src.provenance import load_ledger, observe, plan_restore, snapshot, trim_to_snapshot
+from src.stage_graph import GraphState, Visit
+from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+from src.walk_ratchet import (
+    MAX_REWINDS_PER_STAGE,
+    RATCHET_MARGIN,
+    begin,
+    last_score_for,
+    open_excursion,
+    outcomes,
+    rewinds_so_far,
+    settle,
+    summarise,
+)
+
+STAGE_03, STAGE_04, STAGE_05, STAGE_06 = STAGES[2], STAGES[3], STAGES[4], STAGES[5]
+
+
+class RatchetTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+
+    def visited(self, *pairs: tuple[str, float | None]) -> GraphState:
+        state = GraphState()
+        for slug, score in pairs:
+            state.path.append(Visit(stage=slug, entered_at="t", score_total=score))
+        return state
+
+
+class SnapshotTests(RatchetTestCase):
+    def test_a_snapshot_is_pointers_rather_than_a_copy(self) -> None:
+        write_text(self.paths.data_dir / "counts.csv", "one\n")
+        observe(self.paths, STAGE_03)
+
+        marks = snapshot(self.paths)
+        self.assertEqual(list(marks), ["data/counts.csv"])
+        self.assertEqual(marks["data/counts.csv"], load_ledger(self.paths).entries["data/counts.csv"].version_uid)
+
+    def test_an_unchanged_file_is_not_in_the_restore_plan(self) -> None:
+        write_text(self.paths.data_dir / "counts.csv", "one\n")
+        observe(self.paths, STAGE_03)
+        marks = snapshot(self.paths)
+
+        self.assertEqual(plan_restore(self.paths, marks), [])
+
+    def test_a_file_created_after_the_snapshot_is_planned_for_deletion(self) -> None:
+        marks = snapshot(self.paths)
+        write_text(self.paths.data_dir / "later.csv", "later\n")
+        observe(self.paths, STAGE_05)
+
+        plan = plan_restore(self.paths, marks)
+        self.assertEqual([item.rel_path for item in plan], ["data/later.csv"])
+        self.assertTrue(plan[0].deletes)
+
+    def test_a_file_changed_after_the_snapshot_is_rewound_to_the_marked_version(self) -> None:
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "before\n")
+        observe(self.paths, STAGE_03)
+        marks = snapshot(self.paths)
+        write_text(target, "after\n")
+        observe(self.paths, STAGE_05)
+
+        apply_withdrawal(self.paths, plan_restore(self.paths, marks))
+
+        self.assertEqual(target.read_text(encoding="utf-8"), "before\n")
+
+    def test_trimming_leaves_the_ledger_describing_what_the_restore_left(self) -> None:
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "before\n")
+        observe(self.paths, STAGE_03)
+        marks = snapshot(self.paths)
+        write_text(target, "after\n")
+        observe(self.paths, STAGE_05)
+
+        apply_withdrawal(self.paths, plan_restore(self.paths, marks))
+        trim_to_snapshot(self.paths, marks)
+
+        entry = load_ledger(self.paths).entries["data/counts.csv"]
+        self.assertEqual(entry.version_uid, marks["data/counts.csv"])
+        self.assertEqual(entry.last_written_by_stage, STAGE_03.slug)
+        self.assertEqual(
+            entry.content_hash,
+            load_ledger(self.paths).entries["data/counts.csv"].content_hash,
+        )
+
+    def test_a_uid_is_still_never_reissued_after_a_rewind(self) -> None:
+        """The counter is monotone across a rewind, or a consumer could not tell the
+        rewound state from the state it was rewound out of."""
+
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "before\n")
+        observe(self.paths, STAGE_03)
+        marks = snapshot(self.paths)
+        write_text(target, "after\n")
+        observe(self.paths, STAGE_05)
+        before_uid = load_ledger(self.paths).next_uid
+
+        apply_withdrawal(self.paths, plan_restore(self.paths, marks))
+        trim_to_snapshot(self.paths, marks)
+
+        self.assertEqual(load_ledger(self.paths).next_uid, before_uid)
+        write_text(target, "third\n")
+        observe(self.paths, STAGE_03)
+        self.assertGreaterEqual(load_ledger(self.paths).next_uid, before_uid + 1)
+
+
+class ExcursionLifecycleTests(RatchetTestCase):
+    def test_a_backward_move_opens_an_excursion_with_the_departing_score(self) -> None:
+        state = self.visited((STAGE_06.slug, 71.0))
+
+        excursion = begin(self.paths, state, STAGE_06, STAGE_03, "the design was wrong")
+
+        assert excursion is not None
+        self.assertEqual(excursion.baseline, 71.0)
+        self.assertEqual(excursion.from_stage, STAGE_06.slug)
+        self.assertEqual(open_excursion(self.paths).from_stage, STAGE_06.slug)
+
+    def test_a_second_backward_move_extends_the_outer_one_rather_than_nesting(self) -> None:
+        """Judging an inner excursion against a state that is itself under review would
+        let two bad moves ratify each other."""
+
+        state = self.visited((STAGE_06.slug, 71.0), (STAGE_05.slug, 60.0))
+        begin(self.paths, state, STAGE_06, STAGE_03, "first")
+
+        self.assertIsNone(begin(self.paths, state, STAGE_05, STAGE_04, "second"))
+        self.assertEqual(open_excursion(self.paths).from_stage, STAGE_06.slug)
+
+    def test_the_excursion_does_not_close_before_the_ground_is_recovered(self) -> None:
+        state = self.visited((STAGE_06.slug, 71.0))
+        begin(self.paths, state, STAGE_06, STAGE_03, "the design was wrong")
+
+        self.assertIsNone(settle(self.paths, state, STAGE_04, 50.0))
+        self.assertIsNotNone(open_excursion(self.paths))
+
+    def test_settle_is_a_no_op_with_no_excursion_open(self) -> None:
+        self.assertIsNone(settle(self.paths, self.visited(), STAGE_06, 71.0))
+
+    def test_the_closing_score_falls_back_to_the_last_one_recorded(self) -> None:
+        """The rollback paths leave with no score; both ends must be read the same way."""
+
+        state = self.visited((STAGE_06.slug, 71.0))
+        begin(self.paths, state, STAGE_06, STAGE_03, "x")
+        state.path.append(Visit(stage=STAGE_06.slug, entered_at="t", score_total=80.0))
+
+        outcome = settle(self.paths, state, STAGE_06, None)
+
+        assert outcome is not None
+        self.assertEqual(outcome.closed_at_score, 80.0)
+        self.assertEqual(last_score_for(state, STAGE_06.slug), 80.0)
+
+
+class RatchetTests(RatchetTestCase):
+    def _excursion_scoring(self, before: float | None, after: float | None):
+        state = self.visited((STAGE_06.slug, before))
+        write_text(self.paths.data_dir / "kept.csv", "before\n")
+        observe(self.paths, STAGE_06)
+        begin(self.paths, state, STAGE_06, STAGE_03, "the design was wrong")
+        write_text(self.paths.data_dir / "excursion.csv", "made during the excursion\n")
+        observe(self.paths, STAGE_04)
+        return state, settle(self.paths, state, STAGE_06, after)
+
+    def test_an_excursion_that_improved_is_kept(self) -> None:
+        _, outcome = self._excursion_scoring(71.0, 78.0)
+
+        assert outcome is not None
+        self.assertEqual(outcome.verdict, "improved")
+        self.assertTrue((self.paths.data_dir / "excursion.csv").exists())
+
+    def test_an_excursion_that_held_is_kept(self) -> None:
+        _, outcome = self._excursion_scoring(71.0, 71.0)
+
+        assert outcome is not None
+        self.assertEqual(outcome.verdict, "held")
+        self.assertTrue((self.paths.data_dir / "excursion.csv").exists())
+
+    def test_an_excursion_that_made_the_run_worse_is_taken_back(self) -> None:
+        """The whole point: a backward move is not exempt from the ordering it exists to fix."""
+
+        _, outcome = self._excursion_scoring(71.0, 64.0)
+
+        assert outcome is not None
+        self.assertEqual(outcome.verdict, "rewound")
+        self.assertFalse((self.paths.data_dir / "excursion.csv").exists())
+        self.assertTrue((self.paths.data_dir / "kept.csv").exists())
+
+    def test_an_unscored_end_is_recorded_rather_than_judged(self) -> None:
+        _, outcome = self._excursion_scoring(None, 64.0)
+
+        assert outcome is not None
+        self.assertEqual(outcome.verdict, "unjudgeable")
+        self.assertTrue((self.paths.data_dir / "excursion.csv").exists())
+
+    def test_the_margin_is_zero_because_the_rubric_is_mechanical(self) -> None:
+        """Named so that swapping in a judged score is a change to an argued value."""
+
+        self.assertEqual(RATCHET_MARGIN, 0.0)
+
+    def test_the_ratchet_overrules_one_stage_only_so_many_times(self) -> None:
+        """A rewind restores the state that made the move look attractive; uncapped, that
+        is the loop the ratchet exists to detect."""
+
+        for _ in range(MAX_REWINDS_PER_STAGE):
+            self._excursion_scoring(71.0, 64.0)
+        self.assertEqual(rewinds_so_far(self.paths, STAGE_06.slug), MAX_REWINDS_PER_STAGE)
+
+        _, outcome = self._excursion_scoring(71.0, 64.0)
+
+        assert outcome is not None
+        self.assertEqual(outcome.verdict, "worse_but_capped")
+        self.assertTrue((self.paths.data_dir / "excursion.csv").exists())
+
+    def test_every_closed_excursion_is_on_the_record(self) -> None:
+        self._excursion_scoring(71.0, 78.0)
+        self._excursion_scoring(71.0, 64.0)
+
+        self.assertEqual([item.verdict for item in outcomes(self.paths)], ["improved", "rewound"])
+        block = summarise(self.paths)
+        self.assertIn("2 backward move(s) closed", block)
+        self.assertIn("improved x1", block)
+
+    def test_a_run_with_no_backward_move_says_so(self) -> None:
+        self.assertIn("No backward move has closed", summarise(self.paths))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The gap

`src.evolution` ratchets **inside** a stage: a polish round that scores worse is reverted and the champion restored. The walk had no equivalent — so the moves the graph was *added* for, the thirteen backward edges, were the only ones nothing checked.

A run could leave Stage 06 for Stage 03, rebuild the design, walk forward, and arrive at a Stage 06 scoring **lower** than the one it abandoned. That outcome was recorded, promoted and built on exactly like an improvement, because "later" was the only ordering the walk had.

Everything in #218, #229 and #231 is about *state*: withdrawal is exact, approvals retire for the right reason, evidence survives. None of it says the run gets **better**. This does.

## The excursion

The interval between leaving a stage by a backward edge and getting back to it. Opens when the walk leaves stage *S* for something earlier; closes the next time the walk leaves a stage numbered *S* or above — the point at which the run has recovered the ground it gave up and the two states are comparable.

A backward move taken while an excursion is open **extends the outer one** rather than nesting. Judging an inner excursion against a state that is itself under review would let two bad moves ratify each other.

Compared on the same stage's own rubric total, before and after — both already recorded per visit in `stage_graph.json`. Nothing is re-scored.

## Why the margin is zero

`RATCHET_MARGIN = 0.0`, and that is a property of the measure rather than an omission.

`src.rubric` reads the run off disk and **never calls a backend**, so the same workspace scores the same number twice and any drop is a real drop. A judged score would need a margin wider than its own sampling dispersion before two draws could be compared at all. The constant is named so that swapping in a judged score is a change to a value with an argument attached, rather than a silent reintroduction of the problem.

## Where a losing excursion goes back to

A snapshot of the provenance ledger's **version pointers**, taken when the excursion opened. Restoring it is the same applier a stage-range withdrawal uses — only the choice of target version differs, by recorded identifier here instead of by stage number. `plan_restore` and `trim_to_snapshot` sit alongside the existing `plan_withdrawal`.

The bytes are already in the content-addressed store from #218, so a snapshot costs a dictionary rather than a copy of the workspace. That is what makes it affordable at every departure.

## One rewind per stage

`MAX_REWINDS_PER_STAGE = 1`. A rewind restores the state that made the backward move look attractive in the first place, so an uncapped ratchet **is the loop it exists to detect**.

A second excursion from the same stage that also comes back worse is recorded as `worse_but_capped` and left standing. The run has already been told — in the withdrawal ledger and in the prompt that reaches the stage — and a mechanism that keeps overruling the same decision has stopped being a ratchet and become a wall.

## Five verdicts

| Verdict | Meaning |
| --- | --- |
| `improved` | came back higher — what the backward edge is for |
| `held` | came back equal; left standing |
| `rewound` | came back lower; workspace put back to the snapshot |
| `worse_but_capped` | came back lower, but this stage has been overruled already |
| `unjudgeable` | one end was never scored, so it is recorded rather than judged |

The distribution over these is the number a **graph-versus-pipeline** comparison actually needs. Not how many backward edges were taken — a pipeline answers zero and that says nothing — but how many ended better than they started.

## One existing test moved

The end-of-run summary was written on every way out, including runs with no excursion at all, and `test_the_run_banner_names_a_stage_that_was_never_attacked` reads the log **by position**: a block saying *"No backward move has closed yet"* displaced the disclosure it looks for. Now written only when something closed — which is also the right behaviour, since a log line reporting that nothing happened is noise.

## Docs

`docs/iclr/composable-stage-graphs.md` gains §8 on the ratchet, and was **silently untracked**: `.gitignore` ignores `docs/*` and allows markdown back with `!docs/*.md`, which reaches files directly under `docs/` and not a subdirectory — exactly the failure the comment above those lines warns about, met by the next directory added. `docs/ui-design/` already carries the two-line remedy; this follows it.

## Testing

17 new tests. Suite **2665 → 2682, green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)