### PR TITLE
Give the stage's agent writes that already carry their inverse

### DIFF
--- a/docs/iclr/composable-stage-graphs.md
+++ b/docs/iclr/composable-stage-graphs.md
@@ -160,6 +160,37 @@ does — and a consumer comparing values could not tell the re-run from the orig
 consumer that recorded `a000007` and now reads `a000019` knows its input changed without
 comparing anything about the content.
 
+### 3.7 Two grains of attribution, and a tool that offers the finer one
+
+Observation gives attribution at the grain of a stage boundary. That is enough to withdraw a
+stage, and it is weaker than instrumentation in two ways the ledger has to record: a change
+is attributed to whichever boundary next observes it, so a write and its attribution are
+separated by everything in between; and a version whose bytes were never held can be deleted
+on the way back but not rewound to.
+
+So the framework also *offers* the finer grain, as tools in the agent's own tool list rather
+than as an instruction in its prompt. A write that comes through a tool is attributed at the
+moment it happens, to the stage the run's manifest says is running, with the previous bytes
+stored before the new ones land — the inverse is exact rather than reconstructed. Table
+writes get their own tools, so one source or one hypothesis can be withdrawn without
+rewriting the file that holds it.
+
+Three properties make this safe to offer on every stage:
+
+- **Nothing depends on it being used.** A stage that writes files directly is attributed at
+  the next boundary exactly as before. The tool adds exactness where it is used and takes
+  nothing away where it is not.
+- **A failure degrades rather than breaks.** A server that will not start leaves the run in
+  the prior behaviour, which is a working behaviour.
+- **Refusals are answers, not errors.** A write that cannot be attributed comes back as a
+  result the model can read — *"the manifest names no stage as running; write the file
+  directly instead"* — rather than as a protocol error that ends the call with nothing it
+  can act on.
+
+The stage is resolved per call rather than captured at start-up: the tool server outlives
+any one stage, and a captured value would attribute Stage 05's writes to Stage 01 for the
+rest of the run.
+
 ---
 
 ## 4. Spatial composability: staleness as a comparison, not as arithmetic
@@ -436,7 +467,7 @@ which parts are running.
 | Excursions and the walk-level ratchet | implemented |
 | Walk-level ratchet: excursions judged, and rewound when they lose | implemented |
 | **Selective withdrawal as an action** | precondition computed and reported; *deliberately* not wired — see below |
-| **A write surface the stage agent writes through** | pending |
+| Write surface: revertible write tools in the agent's tool list | implemented |
 | **Intra-stage checkpoints** | pending |
 
 ### On selective withdrawal

--- a/src/effects.py
+++ b/src/effects.py
@@ -26,18 +26,27 @@ stage runs, so a crash mid-stage leaves a partial accumulator that still withdra
 everything the stage had done up to the crash.
 
 **Undo is unconditional.** No inverse here has a precondition it can fail: deleting a path
-that is already gone succeeds, and restoring bytes creates the parent directories it needs.
-An undo that can refuse is not an undo — it turns a rollback into a state the run has no
+that is already gone succeeds, restoring bytes creates the parent directories it needs, and
+removing a collection entry that is not there succeeds. An undo that can refuse is not an
+undo — it turns a rollback into a state the run has no
 rule for, and the recovery it was supposed to perform into a partial one nobody records.
 
-**What the primitives cover, and what they do not.** A stage's real work is done by an
-agent CLI writing files directly, and those writes do not come through here; they are
-picked up by :func:`src.provenance.observe` at the stage boundary, which stores the bytes
-it can and marks the rest ``restorable=False``. So the recovery this module offers is
-layered: writes made through a primitive are withdrawn exactly, observed writes are
-withdrawn to the previous bytes when the ledger holds them and deleted when it does not,
-and a file too large for the ledger is deleted with the fact recorded rather than silently
-half-restored.
+**Two grains, because two kinds of write reach here.** A whole-file write inverts to a
+delete or to the bytes that were there. An entry appended to a collection inverts to the
+removal of *that entry by identifier*, which is the finer grain and the one that matters:
+two stages appending sources to the same table are independent exactly because either
+append can be taken back while the other stands, and an inverse that restored the whole
+file would take back both.
+
+**What the primitives cover, and what they do not.** A stage's work is done by an agent CLI,
+which reaches these through the MCP server in :mod:`src.mcp_write` when it uses them and
+writes files directly when it does not. What does not come through here is picked up by
+:func:`src.provenance.observe` at the stage boundary, which stores the bytes it can and
+marks the rest ``restorable=False``. So the recovery this module offers is layered: writes
+made through a primitive are withdrawn exactly and at the grain they were made, observed
+writes are withdrawn to the previous bytes when the ledger holds them and deleted when it
+does not, and a file too large for the ledger is deleted with the fact recorded rather than
+silently half-restored.
 """
 
 from __future__ import annotations
@@ -216,6 +225,94 @@ def _invert_restore_blob(paths: RunPaths, payload: Mapping[str, Any]) -> str:
     return f"restored {rel_path}"
 
 
+def _read_collection(path: Path, collection: str) -> tuple[Any, list[Any]]:
+    """The document and the list inside it, tolerating both shapes these files take.
+
+    ``sources.json`` and the hypothesis manifest wrap their entries in an object; a
+    hand-written one may be a bare list. Reading both here keeps the two shapes out of the
+    inverse handlers, which have to work on whatever is on disk at recovery time rather
+    than on whatever was there when the effect was applied.
+    """
+
+    if not path.exists():
+        return {collection: []}, []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return {collection: []}, []
+    if isinstance(payload, list):
+        return payload, list(payload)
+    if isinstance(payload, dict):
+        entries = payload.get(collection)
+        return payload, list(entries) if isinstance(entries, list) else []
+    return {collection: []}, []
+
+
+def _write_collection(path: Path, payload: Any, collection: str, entries: list[Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, list):
+        body: Any = entries
+    else:
+        body = dict(payload) if isinstance(payload, dict) else {}
+        body[collection] = entries
+    path.write_text(json.dumps(body, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+
+
+def _invert_remove_entry(paths: RunPaths, payload: Mapping[str, Any]) -> str:
+    """Take one entry back out of a collection, by identifier.
+
+    By identifier rather than by position, because the entries around it may have moved
+    since: another stage appends to the same table, and an inverse that removed "the third
+    one" would take back somebody else's work.
+    """
+
+    rel_path = str(payload.get("rel_path", "")).strip()
+    collection = str(payload.get("collection", "")).strip()
+    id_field = str(payload.get("id_field", "id")).strip() or "id"
+    entry_id = str(payload.get("entry_id", "")).strip()
+    target = _resolve(paths, rel_path)
+    document, entries = _read_collection(target, collection)
+    kept = [
+        entry
+        for entry in entries
+        if not (isinstance(entry, dict) and str(entry.get(id_field, "")).strip() == entry_id)
+    ]
+    if len(kept) == len(entries):
+        return f"{collection}[{entry_id}] was already absent"
+    _write_collection(target, document, collection, kept)
+    return f"removed {collection}[{entry_id}] from {rel_path}"
+
+
+def _invert_restore_entry(paths: RunPaths, payload: Mapping[str, Any]) -> str:
+    """Put back the entry an overwrite replaced, at the identifier it had."""
+
+    rel_path = str(payload.get("rel_path", "")).strip()
+    collection = str(payload.get("collection", "")).strip()
+    id_field = str(payload.get("id_field", "id")).strip() or "id"
+    entry_id = str(payload.get("entry_id", "")).strip()
+    blob = load_blob(paths, str(payload.get("blob_hash", "")).strip())
+    if blob is None:
+        return _invert_remove_entry(paths, payload) + " (no stored entry to restore)"
+    try:
+        prior = json.loads(blob.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return _invert_remove_entry(paths, payload) + " (stored entry unreadable)"
+    target = _resolve(paths, rel_path)
+    document, entries = _read_collection(target, collection)
+    rebuilt: list[Any] = []
+    replaced = False
+    for entry in entries:
+        if isinstance(entry, dict) and str(entry.get(id_field, "")).strip() == entry_id:
+            rebuilt.append(prior)
+            replaced = True
+        else:
+            rebuilt.append(entry)
+    if not replaced:
+        rebuilt.append(prior)
+    _write_collection(target, document, collection, rebuilt)
+    return f"restored {collection}[{entry_id}] in {rel_path}"
+
+
 def _invert_noop(paths: RunPaths, payload: Mapping[str, Any]) -> str:
     return str(payload.get("note", "")).strip() or "nothing to undo"
 
@@ -226,6 +323,8 @@ def _invert_noop(paths: RunPaths, payload: Mapping[str, Any]) -> str:
 INVERSE_HANDLERS: dict[str, Callable[[RunPaths, Mapping[str, Any]], str]] = {
     "delete_path": _invert_delete_path,
     "restore_blob": _invert_restore_blob,
+    "remove_entry": _invert_remove_entry,
+    "restore_entry": _invert_restore_entry,
     "noop": _invert_noop,
 }
 
@@ -610,3 +709,119 @@ def set_artifact(
             at=_now(),
         ),
     )
+
+
+def _append_to_collection(
+    paths: RunPaths,
+    stage: StageSpec,
+    rel_path: str,
+    collection: str,
+    entry: Mapping[str, Any],
+    key: str,
+    id_field: str = "id",
+) -> EffectRecord:
+    target = _resolve(paths, rel_path)
+    entry_id = str(entry.get(id_field, "")).strip()
+    if not entry_id:
+        raise ValueError(
+            f"an entry appended to {collection} needs a non-empty {id_field!r}: the inverse "
+            "removes it by that identifier, and an entry without one cannot be withdrawn "
+            "on its own"
+        )
+
+    document, entries = _read_collection(target, collection)
+    prior = next(
+        (
+            item
+            for item in entries
+            if isinstance(item, dict) and str(item.get(id_field, "")).strip() == entry_id
+        ),
+        None,
+    )
+
+    if prior is None:
+        inverse = Inverse(
+            "remove_entry",
+            {
+                "rel_path": rel_path,
+                "collection": collection,
+                "id_field": id_field,
+                "entry_id": entry_id,
+            },
+        )
+        entries.append(dict(entry))
+    else:
+        inverse = Inverse(
+            "restore_entry",
+            {
+                "rel_path": rel_path,
+                "collection": collection,
+                "id_field": id_field,
+                "entry_id": entry_id,
+                "blob_hash": store_blob(paths, json.dumps(prior, ensure_ascii=True).encode("utf-8")),
+            },
+        )
+        entries = [
+            dict(entry)
+            if isinstance(item, dict) and str(item.get(id_field, "")).strip() == entry_id
+            else item
+            for item in entries
+        ]
+
+    _write_collection(target, document, collection, entries)
+    return record_effect(
+        paths,
+        EffectRecord(
+            stage=stage.slug,
+            key=key,
+            action="append" if prior is None else "replace",
+            rel_path=rel_path,
+            inverse=inverse,
+            at=_now(),
+        ),
+    )
+
+
+def append_source(paths: RunPaths, stage: StageSpec, source: Mapping[str, Any]) -> EffectRecord:
+    """Add one literature source, withdrawable on its own."""
+
+    rel_path = paths.literature_dir.relative_to(paths.workspace_root).as_posix() + "/sources.json"
+    return _append_to_collection(paths, stage, rel_path, "sources", source, key="literature.sources")
+
+
+def append_claim(paths: RunPaths, stage: StageSpec, claim: Mapping[str, Any]) -> EffectRecord:
+    """Add one literature claim, withdrawable on its own."""
+
+    rel_path = paths.literature_dir.relative_to(paths.workspace_root).as_posix() + "/claims.json"
+    return _append_to_collection(paths, stage, rel_path, "claims", claim, key="literature.claims")
+
+
+def register_hypothesis(
+    paths: RunPaths, stage: StageSpec, hypothesis: Mapping[str, Any]
+) -> EffectRecord:
+    """Add one empirical hypothesis to the manifest, withdrawable on its own."""
+
+    rel_path = paths.hypothesis_manifest.relative_to(paths.workspace_root).as_posix()
+    return _append_to_collection(
+        paths, stage, rel_path, "empirical_hypotheses", hypothesis, key="hypotheses"
+    )
+
+
+def record_result(
+    paths: RunPaths, stage: StageSpec, rel_path: str, content: str | bytes
+) -> EffectRecord:
+    """Write a result artifact under ``workspace/results`` with its inverse.
+
+    The path is forced under the results directory rather than trusted: this is reached
+    from a tool the stage's agent calls, and a write that escaped the directory would land
+    outside the family the gates count and the withdrawal plan reaches.
+    """
+
+    results_root = paths.results_dir.relative_to(paths.workspace_root).as_posix()
+    normalised = str(rel_path).strip().replace("\\", "/").lstrip("/")
+    normalised = "/".join(part for part in normalised.split("/") if part not in ("", ".", ".."))
+    if not normalised:
+        raise ValueError("record_result needs a file name under workspace/results")
+    if not normalised.startswith(f"{results_root}/"):
+        normalised = f"{results_root}/{normalised}"
+    return set_artifact(paths, stage, normalised, content, key="results")

--- a/src/mcp_write.py
+++ b/src/mcp_write.py
@@ -1,0 +1,351 @@
+"""An MCP server that hands the stage's agent writes which already carry their inverse.
+
+:mod:`src.provenance` attributes what a stage wrote by *comparing* the workspace across a
+stage boundary, because the agent writes files directly and AutoR cannot intercept it. That
+works, and it is weaker than instrumentation in two ways the ledger has to record. A change
+is attributed to whichever stage's boundary next observes it, so a write and its attribution
+are separated by everything that happens in between; and a version whose bytes were never
+held can be deleted on the way back but not rewound to.
+
+This closes both, for the writes that come through it. A tool call is attributed to the
+stage the manifest says is running, at the moment it happens, and the previous bytes go into
+the content-addressed store before the new ones land -- so the inverse is exact rather than
+reconstructed. It is the difference between a runtime that observes effects and one that
+tracks them.
+
+**A paragraph is not a tool.** The same argument :mod:`src.mcp_web_search` makes: an
+instruction to "record sources through the helper" competes with everything else in a long
+prompt, whereas a tool in the model's actual tool list gets reached for. It also puts each
+write in the trace as a named call with structured arguments rather than as an opaque shell
+invocation, which is what makes "what did Stage 01 actually record" answerable without
+parsing shell strings.
+
+**Nothing depends on the agent using it.** A stage that writes files directly is still
+attributed at the next boundary and still withdrawable -- just to observation granularity.
+That is what makes the server safe to run on every stage: it adds exactness where it is
+used and takes nothing away where it is not, so a server that fails to start degrades to the
+behaviour that was there before rather than breaking the run.
+
+**The stage is read from the manifest, not passed in.** The config is written once per run
+and the server outlives any one stage, so the current stage has to be resolved per call.
+``run_manifest.json`` already carries ``current_stage_slug``, set where the stage starts
+running, and reading it there means the attribution follows the authority rather than a copy
+of it that can go stale.
+
+The transport is newline-delimited JSON-RPC 2.0 on stdin/stdout, standard library only.
+
+Run directly for a protocol smoke test::
+
+    AUTOR_RUN_ROOT=runs/<id> echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+        | python3 -m src.mcp_write
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, TextIO
+
+if __package__ in (None, ""):  # pragma: no cover - direct `python3 src/mcp_write.py`
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.effects import (  # noqa: E402
+    append_claim,
+    append_source,
+    record_result,
+    register_hypothesis,
+    set_artifact,
+)
+from src.utils import STAGES, RunPaths, StageSpec, build_run_paths  # noqa: E402
+
+SERVER_NAME = "autor-write"
+SERVER_VERSION = "1.0.0"
+
+#: Names the run this server writes into. Set in the ``--mcp-config`` env block rather than
+#: passed as an argument, so the same module entry point serves every run.
+RUN_ROOT_ENV = "AUTOR_RUN_ROOT"
+
+FALLBACK_PROTOCOL_VERSION = "2025-06-18"
+
+METHOD_NOT_FOUND = -32601
+INTERNAL_ERROR = -32603
+
+_WHY = (
+    " Writing through this tool rather than directly is what lets a later rollback take "
+    "this exact change back; a direct write is still recovered, but only to the state the "
+    "previous stage boundary observed."
+)
+
+TOOLS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "autor_record_result",
+        "description": (
+            "Write a machine-readable result artifact under workspace/results/." + _WHY
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "File name under workspace/results, e.g. 'metrics.json'.",
+                },
+                "content": {"type": "string", "description": "The file's full contents."},
+            },
+            "required": ["path", "content"],
+        },
+    },
+    {
+        "name": "autor_set_artifact",
+        "description": (
+            "Write any workspace file -- data, code, notes, figures metadata." + _WHY
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path relative to workspace/, e.g. 'data/counts.csv'.",
+                },
+                "content": {"type": "string", "description": "The file's full contents."},
+            },
+            "required": ["path", "content"],
+        },
+    },
+    {
+        "name": "autor_append_source",
+        "description": (
+            "Add one literature source to workspace/literature/sources.json. Needs an 'id'; "
+            "re-using an existing id replaces that entry." + _WHY
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "object",
+                    "description": "The source record. Must carry a non-empty 'id'.",
+                }
+            },
+            "required": ["source"],
+        },
+    },
+    {
+        "name": "autor_append_claim",
+        "description": (
+            "Add one literature claim to workspace/literature/claims.json. Needs an 'id'."
+            + _WHY
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "claim": {
+                    "type": "object",
+                    "description": "The claim record. Must carry a non-empty 'id'.",
+                }
+            },
+            "required": ["claim"],
+        },
+    },
+    {
+        "name": "autor_register_hypothesis",
+        "description": (
+            "Add one empirical hypothesis to workspace/notes/hypothesis_manifest.json. "
+            "Needs an 'id'." + _WHY
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "hypothesis": {
+                    "type": "object",
+                    "description": "The hypothesis record. Must carry a non-empty 'id'.",
+                }
+            },
+            "required": ["hypothesis"],
+        },
+    },
+)
+
+TOOLS_BY_NAME = {tool["name"]: tool for tool in TOOLS}
+
+
+def _text_result(text: str, *, is_error: bool = False) -> dict[str, Any]:
+    return {"content": [{"type": "text", "text": text}], "isError": is_error}
+
+
+def resolve_run_root(environ: dict[str, str] | None = None) -> Path | None:
+    value = (environ if environ is not None else dict(os.environ)).get(RUN_ROOT_ENV, "")
+    return Path(value) if value.strip() else None
+
+
+def current_stage(paths: RunPaths) -> StageSpec | None:
+    """Which stage the manifest says is running, or ``None``.
+
+    Read per call rather than captured at start-up. The config is written once per run and
+    this process outlives any one stage, so a captured value would attribute Stage 05's
+    writes to Stage 01 for the rest of the run.
+    """
+
+    from .manifest import load_run_manifest
+
+    manifest = load_run_manifest(paths.run_manifest)
+    if manifest is None or not manifest.current_stage_slug:
+        return None
+    return next((stage for stage in STAGES if stage.slug == manifest.current_stage_slug), None)
+
+
+def call_tool(name: str, arguments: dict[str, Any], *, run_root: Path | None) -> dict[str, Any]:
+    """Perform one write, or say why it could not happen.
+
+    Every failure comes back as ``isError`` on a normal result rather than as a protocol
+    error: the model can act on "that needs an id" and retry, whereas a protocol error ends
+    the call with nothing it can use. A refusal here also has to leave the agent a way
+    forward, and the way forward is the ordinary file write -- still attributed, still
+    withdrawable, just less exactly.
+    """
+
+    if run_root is None:
+        return _text_result(
+            f"{RUN_ROOT_ENV} is not set, so this server does not know which run to write "
+            "into. Write the file directly instead.",
+            is_error=True,
+        )
+
+    paths = build_run_paths(run_root)
+    stage = current_stage(paths)
+    if stage is None:
+        return _text_result(
+            "The run manifest names no stage as running, so this write could not be "
+            "attributed. Write the file directly instead.",
+            is_error=True,
+        )
+
+    try:
+        if name == "autor_record_result":
+            record = record_result(
+                paths, stage, str(arguments.get("path") or ""), str(arguments.get("content") or "")
+            )
+        elif name == "autor_set_artifact":
+            record = set_artifact(
+                paths, stage, str(arguments.get("path") or ""), str(arguments.get("content") or "")
+            )
+        elif name == "autor_append_source":
+            record = append_source(paths, stage, dict(arguments.get("source") or {}))
+        elif name == "autor_append_claim":
+            record = append_claim(paths, stage, dict(arguments.get("claim") or {}))
+        elif name == "autor_register_hypothesis":
+            record = register_hypothesis(paths, stage, dict(arguments.get("hypothesis") or {}))
+        else:  # pragma: no cover - guarded by the caller
+            return _text_result(f"Unknown tool: {name}", is_error=True)
+    except ValueError as error:
+        return _text_result(str(error), is_error=True)
+    except OSError as error:
+        return _text_result(f"The write failed: {error}", is_error=True)
+    except Exception as error:  # noqa: BLE001 - never take the agent's session down
+        return _text_result(f"The write failed unexpectedly: {error}", is_error=True)
+
+    return _text_result(
+        f"Wrote {record.rel_path} ({record.action}) as {stage.slug}. "
+        "Its inverse is accumulated, so a rollback past this stage takes it back exactly."
+    )
+
+
+def handle_message(
+    message: dict[str, Any], *, run_root: Path | None = None
+) -> dict[str, Any] | None:
+    """Answer one JSON-RPC message, or None when it is a notification."""
+
+    method = message.get("method")
+    message_id = message.get("id")
+    is_notification = "id" not in message
+
+    if method == "initialize":
+        params = message.get("params") or {}
+        result: dict[str, Any] = {
+            "protocolVersion": params.get("protocolVersion") or FALLBACK_PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+        }
+    elif method == "tools/list":
+        result = {"tools": list(TOOLS)}
+    elif method == "tools/call":
+        params = message.get("params") or {}
+        name = str(params.get("name") or "")
+        if name not in TOOLS_BY_NAME:
+            return _error(message_id, METHOD_NOT_FOUND, f"Unknown tool: {name}")
+        result = call_tool(name, params.get("arguments") or {}, run_root=run_root)
+    elif is_notification:
+        return None
+    elif method == "ping":
+        result = {}
+    else:
+        return _error(message_id, METHOD_NOT_FOUND, f"Unknown method: {method}")
+
+    if is_notification:
+        return None
+    return {"jsonrpc": "2.0", "id": message_id, "result": result}
+
+
+def _error(message_id: Any, code: int, text: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": message_id, "error": {"code": code, "message": text}}
+
+
+def serve(
+    stdin: TextIO | None = None,
+    stdout: TextIO | None = None,
+    *,
+    run_root: Path | None = None,
+) -> int:
+    """Read newline-delimited JSON-RPC from stdin until EOF."""
+
+    stdin = stdin if stdin is not None else sys.stdin
+    stdout = stdout if stdout is not None else sys.stdout
+    if run_root is None:
+        run_root = resolve_run_root()
+
+    for line in stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(message, dict):
+            continue
+        try:
+            response = handle_message(message, run_root=run_root)
+        except Exception as exc:  # noqa: BLE001 - a crash here kills the agent's whole stage
+            response = _error(message.get("id"), INTERNAL_ERROR, str(exc))
+        if response is None:
+            continue
+        stdout.write(json.dumps(response, ensure_ascii=False) + "\n")
+        stdout.flush()
+    return 0
+
+
+def build_mcp_server_entry(paths: RunPaths, *, repo_root: Path | None = None) -> dict[str, Any]:
+    """This server's block for the agent's ``--mcp-config``.
+
+    Launched with AutoR's own interpreter and PYTHONPATH, like the search server, so the
+    child resolves ``src.effects`` the way the parent already verified rather than through
+    whatever ``python3`` the agent's PATH finds.
+    """
+
+    root = (repo_root or Path(__file__).resolve().parent.parent).resolve()
+    return {
+        SERVER_NAME: {
+            "command": sys.executable or "python3",
+            "args": ["-m", "src.mcp_write"],
+            "env": {"PYTHONPATH": str(root), RUN_ROOT_ENV: str(paths.run_root.resolve())},
+            "cwd": str(root),
+        }
+    }
+
+
+def main() -> int:  # pragma: no cover - process entry point
+    return serve()
+
+
+if __name__ == "__main__":  # pragma: no cover - process entry point
+    raise SystemExit(main())

--- a/src/operator.py
+++ b/src/operator.py
@@ -1525,17 +1525,29 @@ Original stderr:
         )
 
     def _mcp_config_path(self, paths: RunPaths) -> Path | None:
-        """Materialize the search server's config inside the run, or None if unused.
+        """Materialize the MCP servers' config inside the run.
 
         Written into `operator_state/` rather than a temp file so it sits with the prompts
         and session IDs: a run should be able to say what tools its agent was given, not
         only what it was told.
-        """
-        if not self.web_search_mcp:
-            return None
-        from .web_search import write_mcp_config
 
-        return write_mcp_config(paths.operator_state_dir / "mcp_config.json")
+        Two servers, composed here rather than by either of them. The search server is
+        conditional -- it replaces a built-in that only some deployments disable. The
+        workspace server is not: it hands the agent the revertible write primitives, which
+        are additive (a stage that ignores them writes files as before, and those writes
+        are still attributed at the boundary) and are the only way a write can be withdrawn
+        at the grain it was made rather than as a whole file at the end of a stage.
+        """
+        from .mcp_write import build_mcp_server_entry
+        from .web_search import build_mcp_config, write_mcp_config
+
+        servers: dict[str, object] = dict(build_mcp_server_entry(paths))
+        if self.web_search_mcp:
+            servers.update(build_mcp_config().get("mcpServers", {}))
+
+        return write_mcp_config(
+            paths.operator_state_dir / "mcp_config.json", servers=servers
+        )
 
     def _build_cli_command(
         self,

--- a/src/web_search.py
+++ b/src/web_search.py
@@ -26,7 +26,7 @@ import shlex
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Mapping
 from urllib.parse import urlsplit
 
 
@@ -775,12 +775,29 @@ def build_mcp_config(*, repo_root: Path | None = None) -> dict[str, object]:
     }
 
 
-def write_mcp_config(destination: Path, *, repo_root: Path | None = None) -> Path:
-    """Write the MCP config into the run, where it is auditable alongside the prompts."""
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    destination.write_text(
-        json.dumps(build_mcp_config(repo_root=repo_root), indent=2) + "\n", encoding="utf-8"
+def write_mcp_config(
+    destination: Path,
+    *,
+    repo_root: Path | None = None,
+    servers: Mapping[str, object] | None = None,
+) -> Path:
+    """Write the MCP config into the run, where it is auditable alongside the prompts.
+
+    ``servers`` overrides the block this module would build on its own. There is more than
+    one server now -- :mod:`src.mcp_write` hands the agent revertible writes alongside
+    search -- and the caller is the only place that knows which of them this run wants.
+    Kept as one writer rather than one per server so a run has a single file answering
+    "what tools was this agent given", which is the reason the config lives under
+    ``operator_state/`` in the first place.
+    """
+
+    payload = (
+        {"mcpServers": dict(servers)}
+        if servers is not None
+        else build_mcp_config(repo_root=repo_root)
     )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     return destination
 
 

--- a/tests/test_mcp_web_search.py
+++ b/tests/test_mcp_web_search.py
@@ -298,9 +298,47 @@ class OperatorWiringTest(unittest.TestCase):
         written = Path(command[command.index("--mcp-config") + 1])
         self.assertEqual(written.parent, paths.operator_state_dir)
 
-    def test_no_flag_when_search_is_not_active(self) -> None:
+    def test_the_search_server_is_the_conditional_one_not_the_flag(self) -> None:
+        """The flag is unconditional now, and the config's contents are what vary.
+
+        The write server in ``src.mcp_write`` runs on every stage: it is additive, and a
+        stage that ignores its tools is where it was before. Search replaces a built-in
+        that only some deployments disable, so it is the part that comes and goes. The
+        earlier version of this test asserted the *flag* was absent without search, which
+        stopped being the invariant the moment a second server existed.
+        """
+
+        from src.mcp_write import SERVER_NAME as WRITE_SERVER_NAME
+
         command, _ = self._command(web_search_mcp=False)
-        self.assertNotIn("--mcp-config", command)
+        self.assertIn("--mcp-config", command)
+        servers = json.loads(
+            Path(command[command.index("--mcp-config") + 1]).read_text(encoding="utf-8")
+        )["mcpServers"]
+        self.assertIn(WRITE_SERVER_NAME, servers)
+        self.assertNotIn(MCP_SERVER_NAME, servers)
+
+    def test_both_servers_are_offered_when_search_is_active(self) -> None:
+        from src.mcp_write import SERVER_NAME as WRITE_SERVER_NAME
+
+        command, _ = self._command(web_search_mcp=True)
+        servers = json.loads(
+            Path(command[command.index("--mcp-config") + 1]).read_text(encoding="utf-8")
+        )["mcpServers"]
+        self.assertEqual(sorted(servers), sorted({WRITE_SERVER_NAME, MCP_SERVER_NAME}))
+
+    def test_the_write_server_is_told_which_run_to_write_into(self) -> None:
+        """A server that could not resolve the run would attribute writes to nothing."""
+
+        from src.mcp_write import RUN_ROOT_ENV, SERVER_NAME as WRITE_SERVER_NAME
+
+        command, paths = self._command(web_search_mcp=False)
+        servers = json.loads(
+            Path(command[command.index("--mcp-config") + 1]).read_text(encoding="utf-8")
+        )["mcpServers"]
+        self.assertEqual(
+            servers[WRITE_SERVER_NAME]["env"][RUN_ROOT_ENV], str(paths.run_root.resolve())
+        )
 
     def test_the_config_lands_in_the_run_for_audit(self) -> None:
         """A run should be able to say what tools its agent was given, not only what it

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -1,0 +1,203 @@
+"""The write surface, and the two things that make it safe to offer on every stage.
+
+`src.provenance` attributes a stage's writes by comparing the workspace across a boundary,
+because the agent writes files directly. This server closes the gap for writes that come
+through it: attributed at the moment they happen, to the stage the manifest says is
+running, with the previous bytes stored before the new ones land.
+
+The tests that matter most are the refusals. A tool that fails has to leave the agent a way
+forward, and the way forward is the ordinary file write -- still attributed, still
+withdrawable, just less exactly. A refusal that reads as a protocol error instead would end
+the call with nothing the model can act on.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.effects import load_accumulator
+from src.manifest import ensure_run_manifest, mark_stage_running_manifest
+from src.mcp_write import (
+    RUN_ROOT_ENV,
+    TOOLS,
+    build_mcp_server_entry,
+    call_tool,
+    current_stage,
+    handle_message,
+    resolve_run_root,
+    serve,
+)
+from src.utils import STAGES, build_run_paths, ensure_run_layout
+
+STAGE_01, STAGE_05 = STAGES[0], STAGES[4]
+
+
+class WriteServerTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+        ensure_run_manifest(self.paths)
+        self.run_root = self.paths.run_root
+
+    def running(self, stage) -> None:
+        mark_stage_running_manifest(self.paths, stage, 1)
+
+    def call(self, name: str, arguments: dict) -> dict:
+        return call_tool(name, arguments, run_root=self.run_root)
+
+
+class ProtocolTests(WriteServerTestCase):
+    def test_tools_list_answers_with_every_tool(self) -> None:
+        response = handle_message({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+        assert response is not None
+        self.assertEqual(len(response["result"]["tools"]), len(TOOLS))
+
+    def test_initialize_echoes_the_client_protocol_version(self) -> None:
+        """MCP negotiates down; a server that insists on its favourite stops working the
+        next time the CLI updates."""
+
+        response = handle_message(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": "2099-01-01"},
+            }
+        )
+
+        assert response is not None
+        self.assertEqual(response["result"]["protocolVersion"], "2099-01-01")
+
+    def test_a_notification_is_answered_with_silence(self) -> None:
+        """Answering a notification is itself a protocol error."""
+
+        self.assertIsNone(handle_message({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+
+    def test_an_unknown_tool_is_a_protocol_error(self) -> None:
+        response = handle_message(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "rm_rf"}}
+        )
+
+        assert response is not None
+        self.assertIn("error", response)
+
+    def test_unparseable_input_does_not_take_the_session_down(self) -> None:
+        import io
+
+        out = io.StringIO()
+        code = serve(io.StringIO("not json\n\n"), out, run_root=self.run_root)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(out.getvalue(), "")
+
+
+class AttributionTests(WriteServerTestCase):
+    def test_the_stage_is_read_from_the_manifest_at_call_time(self) -> None:
+        """The config is written once per run and this process outlives any one stage, so a
+        captured value would attribute Stage 05's writes to Stage 01 for the rest of the
+        run."""
+
+        self.running(STAGE_01)
+        self.assertEqual(current_stage(self.paths), STAGE_01)
+
+        self.running(STAGE_05)
+        self.assertEqual(current_stage(self.paths), STAGE_05)
+
+    def test_a_write_is_attributed_to_the_stage_that_is_running(self) -> None:
+        self.running(STAGE_05)
+        result = self.call("autor_record_result", {"path": "metrics.json", "content": "{}\n"})
+
+        self.assertFalse(result["isError"])
+        self.assertEqual(
+            [record.rel_path for record in load_accumulator(self.paths, STAGE_05)],
+            ["results/metrics.json"],
+        )
+
+    def test_the_write_lands_and_carries_its_inverse(self) -> None:
+        self.running(STAGE_05)
+        self.call("autor_set_artifact", {"path": "data/counts.csv", "content": "id\n1\n"})
+
+        self.assertTrue((self.paths.data_dir / "counts.csv").exists())
+        inverse = load_accumulator(self.paths, STAGE_05)[0].inverse
+        self.assertEqual(inverse.kind, "delete_path")
+
+    def test_a_table_entry_is_withdrawable_on_its_own(self) -> None:
+        self.running(STAGE_01)
+        self.call("autor_append_source", {"source": {"id": "S1", "title": "one"}})
+        self.call("autor_append_source", {"source": {"id": "S2", "title": "two"}})
+
+        records = load_accumulator(self.paths, STAGE_01)
+        self.assertEqual([record.inverse.payload["entry_id"] for record in records], ["S1", "S2"])
+        self.assertEqual({record.key for record in records}, {"literature.sources"})
+
+
+class RefusalTests(WriteServerTestCase):
+    def test_a_refusal_is_a_result_the_model_can_act_on_not_a_protocol_error(self) -> None:
+        self.running(STAGE_01)
+        result = self.call("autor_append_source", {"source": {"title": "no id"}})
+
+        self.assertTrue(result["isError"])
+        self.assertIn("id", result["content"][0]["text"])
+
+    def test_no_running_stage_refuses_and_names_the_way_forward(self) -> None:
+        """A write with no stage cannot be attributed, and a refusal that leaves the agent
+        stuck is worse than one that tells it to write the file directly."""
+
+        result = self.call("autor_record_result", {"path": "m.json", "content": "{}"})
+
+        self.assertTrue(result["isError"])
+        self.assertIn("directly", result["content"][0]["text"])
+
+    def test_no_run_root_refuses_rather_than_writing_somewhere(self) -> None:
+        result = call_tool("autor_set_artifact", {"path": "a", "content": "b"}, run_root=None)
+
+        self.assertTrue(result["isError"])
+        self.assertIn(RUN_ROOT_ENV, result["content"][0]["text"])
+
+    def test_a_result_path_cannot_escape_the_results_directory(self) -> None:
+        self.running(STAGE_05)
+        result = self.call(
+            "autor_record_result", {"path": "../../../etc/passwd", "content": "x"}
+        )
+
+        self.assertFalse(result["isError"], "the traversal is normalised away, not refused")
+        written = [record.rel_path for record in load_accumulator(self.paths, STAGE_05)]
+        self.assertEqual(written, ["results/etc/passwd"])
+        self.assertTrue(str(self.paths.results_dir) in str((self.paths.workspace_root / written[0])))
+
+
+class ConfigTests(WriteServerTestCase):
+    def test_the_server_block_names_the_run_it_writes_into(self) -> None:
+        entry = build_mcp_server_entry(self.paths)
+        block = next(iter(entry.values()))
+
+        self.assertEqual(block["args"], ["-m", "src.mcp_write"])
+        self.assertEqual(block["env"][RUN_ROOT_ENV], str(self.run_root.resolve()))
+
+    def test_the_run_root_comes_from_the_environment(self) -> None:
+        self.assertEqual(resolve_run_root({RUN_ROOT_ENV: "/tmp/x"}), Path("/tmp/x"))
+        self.assertIsNone(resolve_run_root({}))
+        self.assertIsNone(resolve_run_root({RUN_ROOT_ENV: "   "}))
+
+    def test_the_operator_hands_the_agent_both_servers(self) -> None:
+        """Search is conditional on the deployment; the write surface is not."""
+
+        from src.operator import ClaudeOperator
+
+        operator = ClaudeOperator.__new__(ClaudeOperator)
+        operator.web_search_mcp = False
+        destination = operator._mcp_config_path(self.paths)
+
+        assert destination is not None
+        servers = json.loads(destination.read_text(encoding="utf-8"))["mcpServers"]
+        self.assertIn("autor-write", servers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What observation cannot do

Attribution has been observed since #218: the agent writes files directly, so AutoR compares the workspace across a stage boundary and attributes whatever moved. That works, and it is weaker than instrumentation in two ways the ledger has to record:

- a change is attributed to whichever boundary **next** observes it, so a write and its attribution are separated by everything in between;
- a version whose bytes were never held can be deleted on the way back but **not rewound to**.

`src/mcp_write.py` closes both, for the writes that come through it. Five tools over JSON-RPC on stdio, standard library only, in the shape `mcp_web_search.py` already established.

A write through a tool is attributed **at the moment it happens**, to the stage the manifest says is running, and the previous bytes go into the content-addressed store **before** the new ones land — so the inverse is exact rather than reconstructed. The table primitives (`append_source`, `append_claim`, `register_hypothesis`) withdraw one entry without rewriting the file that holds it, which is what a commutative key is *for*.

## A paragraph is not a tool

The argument `mcp_web_search.py` already makes for search. An instruction to "record sources through the helper" competes with everything else in a long prompt; a tool in the model's own tool list gets reached for. It also puts each write in the trace as a named call with structured arguments rather than as an opaque shell invocation.

## Why this one is unconditional

Search is conditional on the deployment. The write surface is not, and three properties are why:

1. **Nothing depends on the agent using it.** A stage that writes files directly is attributed at the next boundary exactly as before. The tool adds exactness where it is used and takes nothing away where it is not.
2. **A failure degrades rather than breaks.** A server that will not start leaves the run in the prior behaviour — which is a working behaviour.
3. **Refusals are answers.** *"The manifest names no stage as running; write the file directly instead"* comes back as a result the model can act on, not a protocol error that ends the call with nothing usable. Most of the new tests are the refusals.

## The stage is resolved per call

From `run_manifest.json`, not captured at start-up. The config is written once per run and the server outlives any one stage, so a captured value would attribute Stage 05's writes to Stage 01 for the rest of the run. Reading the manifest means attribution follows the authority rather than a copy of it that can go stale.

`test_the_stage_is_read_from_the_manifest_at_call_time` pins it.

## One writer for the config

`write_mcp_config` grows a `servers` override rather than each server writing its own file. A run should be able to answer *"what tools was this agent given"* from one file — which is why the config lives under `operator_state/` beside the prompts in the first place.

## Docs

`docs/iclr/composable-stage-graphs.md` gains §3.7 on the two grains of attribution, and the status table loses another **pending** row.

## Testing

16 new tests. Suite **2684 → 2700, green**.

## Still not in

`revert_only` — selective withdrawal as an *action*. The precondition is computed and reported on every rollback preview (#218); the natural caller is `--redo-stage`, which today re-runs a stage without withdrawing its previous contribution at all. That is its own defect and its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)