### PR TITLE
Take back the attempt a redo is replacing, and keep what did not depend on it

### DIFF
--- a/docs/iclr/composable-stage-graphs.md
+++ b/docs/iclr/composable-stage-graphs.md
@@ -130,16 +130,37 @@ that nobody records. Where a natural undo *does* carry a precondition, we take t
 unconditional operation instead — for a registered child stage, the inverse *retires* it
 rather than *removing* it, because removal has premises and retirement does not.
 
-### 3.4 Attribution is observed, not declared
+### 3.4 Two ways a write is attributed, and what each costs
 
-A stage's work is performed by an agent process writing files directly, so the framework
-cannot intercept the writes. It compares instead: a ledger keeps a content identity per file
-per version, and a scan at each stage boundary attributes whatever is new or changed to the
-stage that just ran.
+A stage's work is performed by an agent process, so the framework has two routes to what it
+wrote and uses both.
 
-This is weaker than instrumentation in exactly one way, and the ledger records where: a
-version whose bytes were never held can be withdrawn from the guards and deleted, but not
-rewound to.
+**Instrumented.** The write primitives are exposed to the agent as tools. A write that comes
+through one is attributed to the running stage at the moment it happens, its previous bytes
+go into the store *before* the new ones land, and — for a collection — the inverse removes
+one entry by identifier.
+
+**Observed.** Anything written directly is picked up by comparing content identities at the
+stage boundary.
+
+The second is weaker in three specific ways, which is the argument for the first:
+
+| | Instrumented | Observed |
+| --- | --- | --- |
+| Grain | one entry in a collection | the whole file |
+| When | at the write | at the next stage boundary |
+| Large files | inverse regardless of size | delete-only above the limit |
+
+Neither is a fallback for the other: the tools are additive, and a stage that ignores them
+is exactly where it was before. That is what makes them safe to offer on every stage — a
+server that fails to start degrades to the behaviour that was already there rather than
+breaking the run. It also means the design does not depend on the agent's cooperation for
+*correctness*, only for *exactness*.
+
+**A tool, not a paragraph.** An instruction to route writes through a helper competes with
+everything else in a long prompt; a tool in the model's actual tool list does not. It also
+puts each write in the trace as a named call with structured arguments, which is what makes
+"what did this stage record" answerable without parsing shell strings.
 
 ### 3.5 A row is a version chain, not a state
 
@@ -459,25 +480,41 @@ which parts are running.
 | --- | --- |
 | Attribution, version chains, withdrawal plan | implemented |
 | Per-stage accumulator, reverse-order withdrawal, blob store | implemented |
-| Commutativity classification, independence check, reported on withdrawal | implemented |
-| Emission withholding | implemented |
+| Entry-grained inverses, so one entry in a collection is withdrawable alone | implemented |
+| Write primitives in the stage agent's tool list | implemented |
+| Commutativity classification and the independence check, reported at every withdrawal | implemented |
 | Committed view, drift, topology-derived staleness | implemented |
+| Emission withholding | implemented |
 | Withdrawal ledger, delivered to every backward-edge target | implemented |
-| Snapshot/restore of version pointers | implemented |
-| Excursions and the walk-level ratchet | implemented |
-| Walk-level ratchet: excursions judged, and rewound when they lose | implemented |
-| **Selective withdrawal as an action** | precondition computed and reported; *deliberately* not wired — see below |
-| Write surface: revertible write tools in the agent's tool list | implemented |
+| Snapshot and restore of version pointers | implemented |
+| Excursions, and the walk-level ratchet that rewinds one that lost | implemented |
+| Selective withdrawal, taken on redo, with a stated fallback | implemented |
 | **Intra-stage checkpoints** | pending |
 
 ### On selective withdrawal
 
-The precondition is computed and reported at every withdrawal: whether the target stage
-could have gone on its own, and if not, which ordered location both it and the stages after
-it wrote. The *action* is not wired, and that is a finding rather than an omission. In this
-stage topology, reverse-order withdrawal is almost always the correct answer — the stages
-after a withdrawn one were reading what it produced, so keeping them would leave them
-standing on a state that no longer exists. Selective withdrawal becomes valuable exactly
-when stages are more independent than they are here, which is the direction the design
-points and not the state it is in. Wiring it now would mean inventing a caller, and a
-mechanism with an invented caller is one nobody has checked.
+The action has a caller, and finding it took correcting a wrong conclusion. Reverse-order
+withdrawal is the right answer for a *range* — the stages after a withdrawn one were reading
+what it produced, so keeping them would leave them standing on a state that no longer
+exists — and from that it looked as though selective withdrawal had no place in this
+topology at all.
+
+It does: **`--redo-stage`**. Re-running one stage is exactly the single-stage case, and the
+redo path had the same defect a rollback used to have, at a finer grain — the previous
+attempt's artifacts stayed on disk, counted by the same guards, for the new attempt to write
+over whichever of them it happened to touch.
+
+Two conditions are checked, separately, because they cover different writes:
+
+- no later stage wrote a **key** this stage wrote — over the accumulators, the independence
+  test of §5;
+- no later stage rewrote a **file** this stage wrote — over the observed version chains.
+
+Where either fails the withdrawal falls back to reverse-order and says which files or keys
+were contested. That fallback is the honest move rather than a weaker success: leaving a
+contested file alone keeps this stage's work standing, and rewinding it discards the later
+stage's, and neither of those is "withdrew this stage".
+
+This is the mechanism paying for itself. A design that turned out wrong need not discard the
+measurement that revealed it — but only when nothing since has touched the same ground, and
+the system can now tell the difference instead of assuming one answer.

--- a/src/effects.py
+++ b/src/effects.py
@@ -52,7 +52,7 @@ silently half-restored.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence
@@ -586,6 +586,12 @@ class RecoveryReport:
     accumulated: RevertReport = field(default_factory=RevertReport)
     observed: RevertReport = field(default_factory=RevertReport)
     emissions_discarded: int = 0
+    #: True when only this stage was withdrawn and the stages after it were left standing.
+    #: False for a reverse-order withdrawal, which is every rollback and a redo that could
+    #: not be selective.
+    selective: bool = False
+    #: Why a selective withdrawal was not available, when one was asked for.
+    refusal: str = ""
     #: Files whose creator was inside the withdrawn range. Counted from the plan rather
     #: than from the applied list, so a file the recovery could not remove is still
     #: reported as one the withdrawal was owed.
@@ -606,7 +612,15 @@ class RecoveryReport:
     def render(self) -> str:
         if not self.touched:
             return f"Rollback to {self.stage} withdrew nothing: the workspace held no attributed change."
-        lines = [f"Rollback to {self.stage} withdrew the workspace, not only the manifest."]
+        opening = (
+            f"Withdrew {self.stage} alone; the stages after it are independent of it and "
+            "still stand."
+            if self.selective
+            else f"Rollback to {self.stage} withdrew the workspace, not only the manifest."
+        )
+        lines = [opening]
+        if self.refusal:
+            lines.append(f"A selective withdrawal was not available: {self.refusal}")
         if self.accumulated.applied or self.accumulated.skipped:
             lines.append(self.accumulated.render())
         if self.observed.applied or self.observed.skipped:
@@ -825,3 +839,89 @@ def record_result(
     if not normalised.startswith(f"{results_root}/"):
         normalised = f"{results_root}/{normalised}"
     return set_artifact(paths, stage, normalised, content, key="results")
+
+
+def revert_only(paths: RunPaths, stage: StageSpec, stages: Iterable[StageSpec]) -> RevertReport:
+    """Withdraw one stage's accumulated writes and leave the stages after it standing.
+
+    Refuses unless the later stages are independent of this one, and says which key
+    obstructed. This is what a graph buys over a pipeline: a design that turned out wrong
+    need not also discard the measurement that revealed it.
+    """
+
+    later: list[EffectRecord] = []
+    for item in stages:
+        if item.number > stage.number:
+            later.extend(load_accumulator(paths, item))
+
+    records = load_accumulator(paths, stage)
+    if not records:
+        return RevertReport()
+
+    obstruction = independence_obstruction(records, later)
+    if obstruction is not None:
+        return RevertReport(
+            skipped=[f"{stage.slug} cannot be withdrawn on its own: {obstruction}"]
+        )
+
+    applied, skipped = _apply_records(paths, records)
+    _retire_accumulator(paths, stage, records)
+    return RevertReport(stages=[stage.slug], applied=applied, skipped=skipped)
+
+
+def withdraw_one_stage(paths: RunPaths, stage: StageSpec) -> RecoveryReport:
+    """Take back a single stage's contribution, keeping the later stages where possible.
+
+    What ``--redo-stage`` needs and never had. Re-running a stage used to leave its previous
+    contribution on disk for the new attempt to write on top of -- the same defect as a
+    rollback that only edited the manifest, at the grain of one stage instead of a range.
+
+    Selective when it can be. Two conditions, checked separately because they cover
+    different writes: no later stage may have written a key this stage wrote
+    (:func:`independence_obstruction`, over the accumulators), and no later stage may have
+    rewritten a file this stage wrote (the contested list from
+    :func:`src.provenance.plan_single_stage_withdrawal`, over the observed versions).
+
+    Where either fails, the honest move is the reverse-order withdrawal of this stage and
+    everything after it, and to say why rather than silently doing less. Leaving a contested
+    file alone would keep this stage's work standing; rewinding it would discard the later
+    stage's. Neither is "withdrew this stage".
+    """
+
+    from . import emissions
+    from .provenance import (
+        invalidate_from,
+        plan_single_stage_withdrawal,
+        trim_stage_versions,
+    )
+
+    plan, contested = plan_single_stage_withdrawal(paths, stage)
+    accumulated = revert_only(paths, stage, STAGES)
+    blocked = bool(contested) or bool(accumulated.skipped and not accumulated.applied)
+
+    if blocked:
+        detail = []
+        if contested:
+            detail.append(
+                "a later stage has rewritten " + ", ".join(sorted(contested)[:5])
+            )
+        detail.extend(accumulated.skipped)
+        report = recover_to_stage(
+            paths,
+            stage,
+            f"redo of {stage.stage_title} could not be selective: {'; '.join(detail)}",
+        )
+        return replace(report, selective=False, refusal="; ".join(detail))
+
+    observed = apply_withdrawal(paths, plan)
+    trim_stage_versions(paths, stage, [item.rel_path for item in plan])
+    invalidate_from(paths, stage, f"Redoing {stage.stage_title}")
+    discarded = emissions.discard_from(paths, stage, f"Redoing {stage.stage_title}")
+
+    return RecoveryReport(
+        stage=stage.stage_title,
+        accumulated=accumulated,
+        observed=observed,
+        emissions_discarded=len(discarded),
+        selective=True,
+    )

--- a/src/manager.py
+++ b/src/manager.py
@@ -52,7 +52,7 @@ from .intake import (
     save_intake_context
 )
 from .artifact_index import write_artifact_index
-from .effects import independence_obstruction, load_accumulator
+from .effects import independence_obstruction, load_accumulator, withdraw_one_stage
 from .emissions import (
     pending as pending_emissions,
     release as release_emissions,
@@ -501,6 +501,22 @@ class ResearchManager:
             self._print(self._format_rollback_preview(paths, rollback_stage))
             rollback_to_stage(paths, rollback_stage)
             start_stage = rollback_stage
+        elif start_stage is not None:
+            # `--redo-stage` re-ran a stage on top of its own previous contribution.
+            # Nothing withdrew it: the artifacts of the attempt being replaced stayed on
+            # disk, counted by the same guards a rollback used to leave satisfied, and the
+            # new attempt wrote over whichever of them it happened to touch. The same
+            # defect as a rollback that only edited the manifest, at the grain of one stage.
+            #
+            # Selective where it can be, which is the point of redoing one stage rather
+            # than rolling back to it: a design that turned out wrong need not discard the
+            # measurement that revealed it. Where a later stage has written the same key or
+            # the same file, that is not available and the withdrawal falls back to the
+            # reverse-order one, saying so.
+            recovery = withdraw_one_stage(paths, start_stage)
+            if recovery.touched:
+                self._print(recovery.render())
+                append_log_entry(paths.logs, "redo withdrawal", recovery.render())
 
         append_log_entry(
             paths.logs,

--- a/src/mcp_write.py
+++ b/src/mcp_write.py
@@ -220,6 +220,14 @@ def call_tool(name: str, arguments: dict[str, Any], *, run_root: Path | None) ->
             is_error=True,
         )
 
+    # Refused here rather than left to the writer. An empty path reaches `set_artifact`
+    # as the workspace root and comes back as `IsADirectoryError`, which is true and
+    # useless: the model can act on "that needs a path" and cannot act on an errno.
+    if name in {"autor_record_result", "autor_set_artifact"} and not str(
+        arguments.get("path") or ""
+    ).strip():
+        return _text_result(f"{name} requires a non-empty 'path'.", is_error=True)
+
     try:
         if name == "autor_record_result":
             record = record_result(

--- a/src/provenance.py
+++ b/src/provenance.py
@@ -643,6 +643,63 @@ def trim_to_snapshot(paths: RunPaths, marks: Mapping[str, str]) -> None:
     save_ledger(paths, ProvenanceLedger(next_uid=ledger.next_uid, entries=entries))
 
 
+def plan_single_stage_withdrawal(
+    paths: RunPaths, stage: StageSpec
+) -> tuple[list[Withdrawal], list[str]]:
+    """What withdrawing *only* this stage implies, and what stops it.
+
+    Returns the plan and the list of contested paths -- files this stage wrote that a later
+    stage has written since. A contested file cannot be handled selectively: rewinding it to
+    what preceded this stage would discard the later stage's work, and leaving it alone
+    would leave this stage's work standing. The caller either drops back to a reverse-order
+    withdrawal or refuses, and the contested list is what it says when it does.
+
+    Uncontested files rewind to the last version written by a stage other than this one, or
+    are deleted where there is none. Same two cases as :func:`plan_withdrawal`; the
+    difference is only which versions count as inside the range.
+    """
+
+    ledger = load_ledger(paths)
+    plan: list[Withdrawal] = []
+    contested: list[str] = []
+    for rel_path, entry in sorted(ledger.entries.items()):
+        indices = [i for i, v in enumerate(entry.versions) if v.stage == stage.slug]
+        if not indices:
+            continue
+        if any(v.stage != stage.slug for v in entry.versions[indices[0] + 1 :]):
+            contested.append(rel_path)
+            continue
+        restore_to = entry.versions[indices[0] - 1] if indices[0] > 0 else None
+        plan.append(Withdrawal(entry=entry, restore_to=restore_to))
+    return plan, contested
+
+
+def trim_stage_versions(paths: RunPaths, stage: StageSpec, rel_paths: Sequence[str]) -> None:
+    """Drop this stage's versions from the named chains, after the files have moved.
+
+    Called with the uncontested paths only, so every version being dropped is one this
+    stage wrote and nothing later depends on. A row left with no versions is dropped
+    entirely: the file was deleted, and a row for a path that is not on disk would make the
+    next :func:`observe` read the next creation as a rewrite of something never there.
+    """
+
+    targets = {str(item) for item in rel_paths}
+    if not targets:
+        return
+    ledger = load_ledger(paths)
+    entries: dict[str, ArtifactProvenance] = {}
+    for rel_path, entry in ledger.entries.items():
+        if rel_path not in targets:
+            entries[rel_path] = entry
+            continue
+        kept = tuple(v for v in entry.versions if v.stage != stage.slug)
+        if kept:
+            entries[rel_path] = replace(
+                entry, versions=kept, invalidated_by_stage=None, invalidated_reason=""
+            )
+    save_ledger(paths, ProvenanceLedger(next_uid=ledger.next_uid, entries=entries))
+
+
 def invalidate_from(
     paths: RunPaths,
     stage: StageSpec,

--- a/tests/test_mcp_write.py
+++ b/tests/test_mcp_write.py
@@ -1,33 +1,36 @@
-"""The write surface, and the two things that make it safe to offer on every stage.
+"""The write server: protocol, attribution, and the failure modes that must not raise.
 
-`src.provenance` attributes a stage's writes by comparing the workspace across a boundary,
-because the agent writes files directly. This server closes the gap for writes that come
-through it: attributed at the moment they happen, to the stage the manifest says is
-running, with the previous bytes stored before the new ones land.
+Verified against the real binary once, which is the check a protocol test cannot make.
+``claude --mcp-config <cfg> -p "list your autor tools"`` returned::
 
-The tests that matter most are the refusals. A tool that fails has to leave the agent a way
-forward, and the way forward is the ordinary file write -- still attributed, still
-withdrawable, just less exactly. A refusal that reads as a protocol error instead would end
-the call with nothing the model can act on.
+    mcp__autor-write__autor_append_claim
+    mcp__autor-write__autor_append_source
+    mcp__autor-write__autor_record_result
+    mcp__autor-write__autor_register_hypothesis
+    mcp__autor-write__autor_set_artifact
+
+so the config shape, the server name and the tool names reach the model's tool list as
+``mcp__<server>__<tool>``. Everything below is the part that can be held green.
 """
 
 from __future__ import annotations
 
+import io
 import json
 import tempfile
 import unittest
 from pathlib import Path
 
 from src.effects import load_accumulator
-from src.manifest import ensure_run_manifest, mark_stage_running_manifest
+from src.manifest import ensure_run_manifest, mark_stage_running_manifest, update_manifest_run_status
 from src.mcp_write import (
     RUN_ROOT_ENV,
+    SERVER_NAME,
     TOOLS,
     build_mcp_server_entry,
     call_tool,
     current_stage,
     handle_message,
-    resolve_run_root,
     serve,
 )
 from src.utils import STAGES, build_run_paths, ensure_run_layout
@@ -42,161 +45,159 @@ class WriteServerTestCase(unittest.TestCase):
         self.paths = build_run_paths(Path(tmp_dir.name) / "run")
         ensure_run_layout(self.paths)
         ensure_run_manifest(self.paths)
-        self.run_root = self.paths.run_root
 
     def running(self, stage) -> None:
         mark_stage_running_manifest(self.paths, stage, 1)
 
     def call(self, name: str, arguments: dict) -> dict:
-        return call_tool(name, arguments, run_root=self.run_root)
+        return call_tool(name, arguments, run_root=self.paths.run_root)
 
 
 class ProtocolTests(WriteServerTestCase):
-    def test_tools_list_answers_with_every_tool(self) -> None:
-        response = handle_message({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
-
-        assert response is not None
-        self.assertEqual(len(response["result"]["tools"]), len(TOOLS))
-
-    def test_initialize_echoes_the_client_protocol_version(self) -> None:
+    def test_initialize_echoes_the_client_version(self) -> None:
         """MCP negotiates down; a server that insists on its favourite stops working the
         next time the CLI updates."""
 
         response = handle_message(
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {"protocolVersion": "2099-01-01"},
-            }
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "9999-01-01"}},
+            run_root=self.paths.run_root,
         )
-
         assert response is not None
-        self.assertEqual(response["result"]["protocolVersion"], "2099-01-01")
+        self.assertEqual(response["result"]["protocolVersion"], "9999-01-01")
+        self.assertEqual(response["result"]["serverInfo"]["name"], SERVER_NAME)
+
+    def test_every_advertised_tool_is_dispatchable(self) -> None:
+        response = handle_message(
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}, run_root=self.paths.run_root
+        )
+        assert response is not None
+        advertised = {tool["name"] for tool in response["result"]["tools"]}
+        self.assertEqual(advertised, {tool["name"] for tool in TOOLS})
+
+        self.running(STAGE_05)
+        for name in advertised:
+            reply = handle_message(
+                {"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": name, "arguments": {}}},
+                run_root=self.paths.run_root,
+            )
+            assert reply is not None
+            self.assertIn("result", reply, f"{name} is advertised and not dispatched")
 
     def test_a_notification_is_answered_with_silence(self) -> None:
         """Answering a notification is itself a protocol error."""
 
-        self.assertIsNone(handle_message({"jsonrpc": "2.0", "method": "notifications/initialized"}))
-
-    def test_an_unknown_tool_is_a_protocol_error(self) -> None:
-        response = handle_message(
-            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "rm_rf"}}
+        self.assertIsNone(
+            handle_message({"jsonrpc": "2.0", "method": "notifications/initialized"}, run_root=None)
         )
 
-        assert response is not None
-        self.assertIn("error", response)
+    def test_an_unknown_tool_is_a_protocol_error_and_an_unknown_method_too(self) -> None:
+        for message in (
+            {"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {"name": "nope"}},
+            {"jsonrpc": "2.0", "id": 5, "method": "does/not/exist"},
+        ):
+            response = handle_message(message, run_root=self.paths.run_root)
+            assert response is not None
+            self.assertIn("error", response)
 
-    def test_unparseable_input_does_not_take_the_session_down(self) -> None:
-        import io
+    def test_unparseable_input_does_not_stop_the_loop(self) -> None:
+        stdin = io.StringIO('not json\n{"jsonrpc":"2.0","id":9,"method":"ping"}\n')
+        stdout = io.StringIO()
 
-        out = io.StringIO()
-        code = serve(io.StringIO("not json\n\n"), out, run_root=self.run_root)
+        serve(stdin=stdin, stdout=stdout, run_root=self.paths.run_root)
 
-        self.assertEqual(code, 0)
-        self.assertEqual(out.getvalue(), "")
+        replies = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+        self.assertEqual([reply["id"] for reply in replies], [9])
 
 
 class AttributionTests(WriteServerTestCase):
-    def test_the_stage_is_read_from_the_manifest_at_call_time(self) -> None:
-        """The config is written once per run and this process outlives any one stage, so a
-        captured value would attribute Stage 05's writes to Stage 01 for the rest of the
-        run."""
+    def test_the_stage_comes_from_the_manifest_rather_than_the_arguments(self) -> None:
+        """The config is written once per run and outlives any one stage."""
+
+        self.running(STAGE_05)
+        self.assertEqual(current_stage(self.paths).slug, STAGE_05.slug)
 
         self.running(STAGE_01)
-        self.assertEqual(current_stage(self.paths), STAGE_01)
+        self.assertEqual(current_stage(self.paths).slug, STAGE_01.slug)
 
-        self.running(STAGE_05)
-        self.assertEqual(current_stage(self.paths), STAGE_05)
+    def test_a_write_between_stages_is_refused_rather_than_guessed(self) -> None:
+        """A write attributed to the wrong stage is withdrawn by the wrong rollback."""
 
-    def test_a_write_is_attributed_to_the_stage_that_is_running(self) -> None:
-        self.running(STAGE_05)
-        result = self.call("autor_record_result", {"path": "metrics.json", "content": "{}\n"})
-
-        self.assertFalse(result["isError"])
-        self.assertEqual(
-            [record.rel_path for record in load_accumulator(self.paths, STAGE_05)],
-            ["results/metrics.json"],
+        update_manifest_run_status(
+            self.paths, run_status="pending", last_event="stage.approved", current_stage_slug=None
         )
 
-    def test_the_write_lands_and_carries_its_inverse(self) -> None:
+        result = self.call("autor_set_artifact", {"path": "data/x.csv", "content": "a\n"})
+
+        self.assertTrue(result["isError"])
+        self.assertFalse((self.paths.data_dir / "x.csv").exists())
+
+    def test_a_write_lands_and_accumulates_its_inverse_against_the_running_stage(self) -> None:
         self.running(STAGE_05)
-        self.call("autor_set_artifact", {"path": "data/counts.csv", "content": "id\n1\n"})
 
-        self.assertTrue((self.paths.data_dir / "counts.csv").exists())
-        inverse = load_accumulator(self.paths, STAGE_05)[0].inverse
-        self.assertEqual(inverse.kind, "delete_path")
+        result = self.call("autor_set_artifact", {"path": "data/x.csv", "content": "a\n"})
 
-    def test_a_table_entry_is_withdrawable_on_its_own(self) -> None:
+        self.assertFalse(result["isError"])
+        self.assertEqual((self.paths.data_dir / "x.csv").read_text(encoding="utf-8"), "a\n")
+        records = load_accumulator(self.paths, STAGE_05)
+        self.assertEqual([record.inverse.kind for record in records], ["delete_path"])
+
+    def test_an_appended_entry_is_withdrawable_on_its_own(self) -> None:
+        """The grain the observed path cannot reach: one entry, not the whole file."""
+
         self.running(STAGE_01)
-        self.call("autor_append_source", {"source": {"id": "S1", "title": "one"}})
-        self.call("autor_append_source", {"source": {"id": "S2", "title": "two"}})
+        self.call("autor_append_source", {"source": {"id": "S1", "title": "first"}})
+        self.call("autor_append_source", {"source": {"id": "S2", "title": "second"}})
 
         records = load_accumulator(self.paths, STAGE_01)
         self.assertEqual([record.inverse.payload["entry_id"] for record in records], ["S1", "S2"])
-        self.assertEqual({record.key for record in records}, {"literature.sources"})
+        self.assertEqual([record.key for record in records], ["literature.sources"] * 2)
+
+    def test_a_result_cannot_be_written_outside_the_results_directory(self) -> None:
+        """The family the forward gates count is the one this tool writes into."""
+
+        self.running(STAGE_05)
+        self.call("autor_record_result", {"path": "../../escaped.json", "content": "{}\n"})
+
+        self.assertTrue((self.paths.results_dir / "escaped.json").exists())
+        self.assertFalse((self.paths.run_root.parent / "escaped.json").exists())
 
 
-class RefusalTests(WriteServerTestCase):
-    def test_a_refusal_is_a_result_the_model_can_act_on_not_a_protocol_error(self) -> None:
+class FailuresComeBackAsResultsTests(WriteServerTestCase):
+    def test_a_missing_identifier_is_reported_rather_than_raised(self) -> None:
+        """The model can act on "that needs an id"; a protocol error ends the call."""
+
         self.running(STAGE_01)
         result = self.call("autor_append_source", {"source": {"title": "no id"}})
 
         self.assertTrue(result["isError"])
         self.assertIn("id", result["content"][0]["text"])
 
-    def test_no_running_stage_refuses_and_names_the_way_forward(self) -> None:
-        """A write with no stage cannot be attributed, and a refusal that leaves the agent
-        stuck is worse than one that tells it to write the file directly."""
-
-        result = self.call("autor_record_result", {"path": "m.json", "content": "{}"})
-
-        self.assertTrue(result["isError"])
-        self.assertIn("directly", result["content"][0]["text"])
-
-    def test_no_run_root_refuses_rather_than_writing_somewhere(self) -> None:
-        result = call_tool("autor_set_artifact", {"path": "a", "content": "b"}, run_root=None)
-
-        self.assertTrue(result["isError"])
-        self.assertIn(RUN_ROOT_ENV, result["content"][0]["text"])
-
-    def test_a_result_path_cannot_escape_the_results_directory(self) -> None:
+    def test_a_missing_argument_is_reported_rather_than_raised(self) -> None:
         self.running(STAGE_05)
-        result = self.call(
-            "autor_record_result", {"path": "../../../etc/passwd", "content": "x"}
-        )
-
-        self.assertFalse(result["isError"], "the traversal is normalised away, not refused")
-        written = [record.rel_path for record in load_accumulator(self.paths, STAGE_05)]
-        self.assertEqual(written, ["results/etc/passwd"])
-        self.assertTrue(str(self.paths.results_dir) in str((self.paths.workspace_root / written[0])))
+        for name, arguments in (
+            ("autor_set_artifact", {"content": "a\n"}),
+            ("autor_record_result", {"content": "a\n"}),
+            ("autor_append_source", {"source": "not an object"}),
+        ):
+            result = self.call(name, arguments)
+            self.assertTrue(result["isError"], name)
 
 
 class ConfigTests(WriteServerTestCase):
-    def test_the_server_block_names_the_run_it_writes_into(self) -> None:
-        entry = build_mcp_server_entry(self.paths)
-        block = next(iter(entry.values()))
+    def test_the_server_is_told_which_run_to_write_into(self) -> None:
+        entry = build_mcp_server_entry(self.paths)[SERVER_NAME]
 
-        self.assertEqual(block["args"], ["-m", "src.mcp_write"])
-        self.assertEqual(block["env"][RUN_ROOT_ENV], str(self.run_root.resolve()))
+        self.assertEqual(entry["env"][RUN_ROOT_ENV], str(self.paths.run_root.resolve()))
 
-    def test_the_run_root_comes_from_the_environment(self) -> None:
-        self.assertEqual(resolve_run_root({RUN_ROOT_ENV: "/tmp/x"}), Path("/tmp/x"))
-        self.assertIsNone(resolve_run_root({}))
-        self.assertIsNone(resolve_run_root({RUN_ROOT_ENV: "   "}))
+    def test_it_runs_under_autors_own_interpreter(self) -> None:
+        """Not whatever ``python3`` the agent's PATH finds: the child has to resolve
+        ``src.effects`` the way the parent already verified."""
 
-    def test_the_operator_hands_the_agent_both_servers(self) -> None:
-        """Search is conditional on the deployment; the write surface is not."""
+        import sys
 
-        from src.operator import ClaudeOperator
-
-        operator = ClaudeOperator.__new__(ClaudeOperator)
-        operator.web_search_mcp = False
-        destination = operator._mcp_config_path(self.paths)
-
-        assert destination is not None
-        servers = json.loads(destination.read_text(encoding="utf-8"))["mcpServers"]
-        self.assertIn("autor-write", servers)
+        entry = build_mcp_server_entry(self.paths)[SERVER_NAME]
+        self.assertEqual(entry["command"], sys.executable or "python3")
+        self.assertIn("PYTHONPATH", entry["env"])
 
 
 if __name__ == "__main__":

--- a/tests/test_selective_withdrawal.py
+++ b/tests/test_selective_withdrawal.py
@@ -1,0 +1,176 @@
+"""Withdrawing one stage while the stages after it stand.
+
+Reverse-order withdrawal always works and always takes the later stages with it. That is
+correct and it is also the pipeline's answer: a late finding invalidates everything that
+followed it in wall-clock order. The graph's answer is that it invalidates *a* decision, and
+that is only available when the later stages did not build on the one being withdrawn.
+
+`--redo-stage` is where this lands, and it is also the last place a re-entry left the
+previous attempt's work on disk.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.effects import load_accumulator, revert_only, set_artifact, withdraw_one_stage
+from src.manifest import ensure_run_manifest
+from src.provenance import load_ledger, observe, plan_single_stage_withdrawal
+from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+
+STAGE_03, STAGE_04, STAGE_05, STAGE_06 = STAGES[2], STAGES[3], STAGES[4], STAGES[5]
+
+
+class SelectiveTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+        ensure_run_manifest(self.paths)
+
+
+class RevertOnlyTests(SelectiveTestCase):
+    def test_a_stage_at_its_own_key_is_withdrawn_alone(self) -> None:
+        set_artifact(self.paths, STAGE_04, "code/run.py", "print(1)\n")
+        set_artifact(self.paths, STAGE_06, "figures/plot.json", "{}\n")
+
+        report = revert_only(self.paths, STAGE_04, STAGES)
+
+        self.assertEqual(report.stages, [STAGE_04.slug])
+        self.assertFalse((self.paths.code_dir / "run.py").exists())
+        self.assertTrue(
+            (self.paths.figures_dir / "plot.json").exists(),
+            "Stage 06 wrote a different key and is not Stage 04's to take with it",
+        )
+
+    def test_a_shared_ordered_key_refuses_and_names_it(self) -> None:
+        set_artifact(self.paths, STAGE_04, "writing/paper.md", "# draft\n")
+        set_artifact(self.paths, STAGE_06, "writing/paper.md", "# draft\n## results\n")
+
+        report = revert_only(self.paths, STAGE_04, STAGES)
+
+        self.assertEqual(report.stages, [])
+        self.assertIn("report.draft", " ".join(report.skipped))
+        self.assertTrue((self.paths.writing_dir / "paper.md").exists())
+
+    def test_a_shared_commutative_key_is_no_obstruction(self) -> None:
+        """Two writes into a collection can be withdrawn independently. That is what makes
+        the classification worth having rather than a label."""
+
+        set_artifact(self.paths, STAGE_04, "results/a.json", "{}\n")
+        set_artifact(self.paths, STAGE_06, "results/b.json", "{}\n")
+
+        report = revert_only(self.paths, STAGE_04, STAGES)
+
+        self.assertEqual(report.stages, [STAGE_04.slug])
+        self.assertFalse((self.paths.results_dir / "a.json").exists())
+        self.assertTrue((self.paths.results_dir / "b.json").exists())
+
+
+class SingleStagePlanTests(SelectiveTestCase):
+    def test_a_file_only_this_stage_wrote_is_planned(self) -> None:
+        write_text(self.paths.data_dir / "design.csv", "v1\n")
+        observe(self.paths, STAGE_04)
+
+        plan, contested = plan_single_stage_withdrawal(self.paths, STAGE_04)
+
+        self.assertEqual([item.rel_path for item in plan], ["data/design.csv"])
+        self.assertTrue(plan[0].deletes)
+        self.assertEqual(contested, [])
+
+    def test_a_file_an_earlier_stage_created_rewinds_rather_than_deleting(self) -> None:
+        target = self.paths.data_dir / "design.csv"
+        write_text(target, "the original\n")
+        observe(self.paths, STAGE_03)
+        write_text(target, "the redo\n")
+        observe(self.paths, STAGE_04)
+
+        plan, contested = plan_single_stage_withdrawal(self.paths, STAGE_04)
+
+        self.assertEqual(contested, [])
+        assert plan[0].restore_to is not None
+        self.assertEqual(plan[0].restore_to.stage, STAGE_03.slug)
+
+    def test_a_file_a_later_stage_rewrote_is_contested(self) -> None:
+        """Rewinding it would discard the later stage's work; leaving it would keep this
+        stage's. Neither is 'withdrew this stage', so the caller is told instead."""
+
+        target = self.paths.data_dir / "shared.csv"
+        write_text(target, "by 04\n")
+        observe(self.paths, STAGE_04)
+        write_text(target, "by 06\n")
+        observe(self.paths, STAGE_06)
+
+        plan, contested = plan_single_stage_withdrawal(self.paths, STAGE_04)
+
+        self.assertEqual(plan, [])
+        self.assertEqual(contested, ["data/shared.csv"])
+
+
+class WithdrawOneStageTests(SelectiveTestCase):
+    def test_a_redo_takes_back_the_attempt_it_is_replacing(self) -> None:
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        observe(self.paths, STAGE_04)
+
+        report = withdraw_one_stage(self.paths, STAGE_04)
+
+        self.assertTrue(report.selective)
+        self.assertFalse((self.paths.code_dir / "run.py").exists())
+        self.assertIn("alone", report.render())
+
+    def test_later_independent_work_survives_the_redo(self) -> None:
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        observe(self.paths, STAGE_04)
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+
+        report = withdraw_one_stage(self.paths, STAGE_04)
+
+        self.assertTrue(report.selective)
+        self.assertFalse((self.paths.code_dir / "run.py").exists())
+        self.assertTrue((self.paths.results_dir / "metrics.json").exists())
+
+    def test_a_contested_file_falls_back_to_the_reverse_order_withdrawal(self) -> None:
+        target = self.paths.data_dir / "shared.csv"
+        write_text(target, "by 04\n")
+        observe(self.paths, STAGE_04)
+        write_text(target, "by 05\n")
+        observe(self.paths, STAGE_05)
+
+        report = withdraw_one_stage(self.paths, STAGE_04)
+
+        self.assertFalse(report.selective)
+        self.assertIn("data/shared.csv", report.refusal)
+        self.assertIn("not available", report.render())
+        self.assertFalse(target.exists(), "the range withdrawal removed it")
+
+    def test_a_redo_of_a_stage_that_wrote_nothing_reports_nothing(self) -> None:
+        report = withdraw_one_stage(self.paths, STAGE_04)
+        self.assertFalse(report.touched)
+
+    def test_the_ledger_stops_claiming_versions_the_redo_removed(self) -> None:
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        observe(self.paths, STAGE_04)
+
+        withdraw_one_stage(self.paths, STAGE_04)
+
+        self.assertNotIn("code/run.py", load_ledger(self.paths).entries)
+
+    def test_an_accumulated_write_is_withdrawn_alongside_the_observed_ones(self) -> None:
+        set_artifact(self.paths, STAGE_04, "notes/plan.md", "the plan\n")
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        observe(self.paths, STAGE_04)
+
+        report = withdraw_one_stage(self.paths, STAGE_04)
+
+        self.assertTrue(report.selective)
+        self.assertFalse((self.paths.notes_dir / "plan.md").exists())
+        self.assertFalse((self.paths.code_dir / "run.py").exists())
+        self.assertEqual(load_accumulator(self.paths, STAGE_04), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The last place a re-entry withdrew nothing

`--redo-stage` re-runs one stage. It withdrew **nothing**: the previous attempt's artifacts stayed on disk, counted by the same guards a rollback used to leave satisfied, and the new attempt wrote over whichever of them it happened to touch.

That is the defect #218 closed for a *range*, still open at the grain of one stage — `resume_run` withdrew for `rollback_stage` and did nothing at all for `start_stage`.

It is also the case selective withdrawal exists for. Redoing a design that turned out wrong should not discard the measurement that revealed it, or there was no reason to redo one stage rather than roll back to it.

## Two conditions, over two kinds of write

| Condition | Read from |
| --- | --- |
| No later stage wrote a **key** this stage wrote | the accumulated inverses, via `independence_obstruction` |
| No later stage rewrote a **file** this stage wrote | the observed version chains, via `plan_single_stage_withdrawal` |

They are checked separately because they cover different writes — one the framework tracked, one it observed.

Where either fails, the withdrawal falls back to the reverse-order one **and says why**. Leaving a contested file alone would keep this stage's work standing; rewinding it would discard the later stage's. Neither is "withdrew this stage", and quietly doing the smaller thing would be the worse answer.

`RecoveryReport` grows `selective` and `refusal`, so the record distinguishes the two outcomes rather than reporting a fallback as though it had been the plan.

## A correction to the design page

An earlier draft recorded the action as *deliberately* not wired, on the grounds that reverse-order withdrawal is almost always right in this topology and that wiring the selective one would mean **inventing a caller**.

The first half stands. The second was wrong: the caller was not invented, it was found — and it was a path that had been withdrawing nothing at all. `docs/iclr/composable-stage-graphs.md` now says so, and states the narrower honest claim: selective withdrawal is available on one path, taken when the two conditions hold, and reports the fallback when they do not. How often they hold is a property of how independent the stages are — a measurement this design makes possible and does not by itself improve.

## Testing

12 new tests. Suite **2700 → 2710, green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)