### PR TITLE
A figure that reproduces the source is not exploratory

### DIFF
--- a/src/prompts/03_study_design.md
+++ b/src/prompts/03_study_design.md
@@ -124,9 +124,17 @@ Rules:
 - `filename` is the bare filename, with its image extension, that the figure will be published
   under — no directory, no path. It is the join key between this plan and the published report,
   so two slots may not share one.
-- `supports` names the claim the figure settles: an id from the Stage 02 hypotheses, or
-  `exploratory:<slug>`. **Every figure must carry at least one claim no other figure carries.**
-  Two slots answering the same question is one slot spent twice.
+- `supports` names the claim the figure settles: an id from the Stage 02 hypotheses,
+  `reproduces:<slug>` for a result the source study published, or `exploratory:<slug>` for a
+  question the run did not preregister. **Every figure must carry at least one claim no other
+  figure carries.** Two slots answering the same question is one slot spent twice.
+- **A result the source published claims its slot before any hypothesis does.** Use
+  `reproduces:<slug>` and give it a low slot number. A reproduction panel is not exploratory —
+  it is the most committed claim in this plan — and it does not have to win a competition
+  against your own hypotheses to exist. One run reproduced a theory to 110 of 111 published
+  values, bound all eight of its slots to its own hypotheses, discharged the source's first
+  result as a headline number, and scored 18.7 where an agent that simply drew the paper's
+  figures scored 53.4.
 - `shows` is what a reader should see in it, naming both axes and their units.
 - `if_supported` and `if_refuted` are what the figure looks like each way. They may not be the
   same sentence: a figure that cannot say what refutation would look like is decoration, not

--- a/src/report_plan.py
+++ b/src/report_plan.py
@@ -96,6 +96,26 @@ SOURCE_ARTIFACT_ROOTS = ("results", "data", "outputs")
 #: distinct from every other slot's, so "exploratory" cannot be a wildcard used
 #: five times.
 EXPLORATORY_PREFIX = "exploratory:"
+
+#: A figure that redraws a result the source study published. Its own prefix because
+#: `exploratory:` was the only escape and it is the wrong word: a reproduction panel is
+#: the most committed claim in the plan, not an unpreregistered aside, and a schema that
+#: makes an author call it exploratory is telling them it ranks below their hypotheses.
+#:
+#: Observed on Physics_000. The run reproduced a packing theory to 110 of 111 published
+#: values — more of the source than either comparator managed — and scored 18.7 against a
+#: bare agent's 53.4. Every one of its eight slots was bound to one of its own six
+#: preregistered hypotheses plus two `exploratory:` ids; the source's first result was
+#: discharged as a headline number; the two magic-number series it turns on were on disk
+#: and neither was drawn. There was nothing wrong with the plan under this schema. There
+#: was no row in it for "the figure the paper published", so the figure had to displace a
+#: hypothesis to exist, and it lost that competition eight times.
+REPRODUCTION_PREFIX = "reproduces:"
+
+#: Both prefixes take a slug, and it is held to the same floor: a claim id that is only a
+#: prefix is a wildcard, and the distinctness rule below is what stops one claim owning
+#: five slots.
+CLAIM_PREFIXES = (EXPLORATORY_PREFIX, REPRODUCTION_PREFIX)
 MIN_EXPLORATORY_SLUG_CHARS = 3
 
 #: Floors under "a sentence was written". See the module docstring: these are
@@ -784,23 +804,30 @@ def validate_report_plan(
         if not item.supports:
             problems.append(
                 f"{label} names no claim it supports. Cite a hypothesis id from "
-                f"hypothesis_manifest.json, or `{EXPLORATORY_PREFIX}<slug>` for a question "
+                f"hypothesis_manifest.json, `{REPRODUCTION_PREFIX}<slug>` for a result the "
+                f"source study published, or `{EXPLORATORY_PREFIX}<slug>` for a question "
                 "the run did not preregister."
             )
         else:
             for identifier in item.supports:
-                if identifier.startswith(EXPLORATORY_PREFIX):
-                    slug = identifier[len(EXPLORATORY_PREFIX) :].strip()
+                prefix = next(
+                    (p for p in CLAIM_PREFIXES if identifier.startswith(p)), None
+                )
+                if prefix is not None:
+                    slug = identifier[len(prefix) :].strip()
                     if len(slug) < MIN_EXPLORATORY_SLUG_CHARS:
+                        kind = "reproduced result" if prefix == REPRODUCTION_PREFIX \
+                            else "exploratory question"
                         problems.append(
                             f"{label} supports `{identifier}`, whose slug is shorter than "
-                            f"{MIN_EXPLORATORY_SLUG_CHARS} characters. Name the exploratory "
-                            "question, so a second slot cannot quietly claim the same one."
+                            f"{MIN_EXPLORATORY_SLUG_CHARS} characters. Name the {kind}, so a "
+                            "second slot cannot quietly claim the same one."
                         )
                 elif known_ids is not None and identifier not in known_ids:
                     problems.append(
                         f"{label} supports `{identifier}`, which is not an id in "
-                        f"hypothesis_manifest.json. Cite a declared hypothesis, or label the "
+                        f"hypothesis_manifest.json. Cite a declared hypothesis, label a result "
+                        f"the source published `{REPRODUCTION_PREFIX}<slug>`, or label the "
                         f"question `{EXPLORATORY_PREFIX}<slug>`."
                     )
             if all(claimed[identifier] > 1 for identifier in item.supports):

--- a/tests/test_report_plan.py
+++ b/tests/test_report_plan.py
@@ -1046,6 +1046,34 @@ class TaskOutputCoverageTest(ReportPlanTestCase):
         self.assertIn("show it in the report", rendered)
         self.assertIn("NOT ATTEMPTED", rendered)
 
+    def test_a_source_result_is_a_first_class_claim(self) -> None:
+        """`exploratory:` was the only escape, and it is the wrong word for a reproduction.
+
+        Physics_000 bound all eight slots to its own six hypotheses plus two exploratory
+        ids, discharged the source's first result as a headline number, and scored 18.7
+        against a bare agent's 53.4. Nothing in the schema was violated — there was no row
+        for "the figure the paper published", so it had to displace a hypothesis to exist.
+        """
+        self.write_plan(figures=[figure(1, supports=["reproduces:magic-number-series"])])
+        self.assertEqual(self.problems(), [])
+
+    def test_a_reproduction_slug_is_held_to_the_same_floor(self) -> None:
+        """A bare prefix is a wildcard, which is what the distinctness rule stops."""
+        self.write_plan(figures=[figure(1, supports=["reproduces:x"])])
+        self.assertTrue(any("shorter than" in p for p in self.problems()), self.problems())
+        self.assertTrue(any("reproduced result" in p for p in self.problems()), self.problems())
+
+    def test_the_refusal_offers_the_reproduction_label(self) -> None:
+        """A claim id nobody declared should be told where a source result goes."""
+        self.write_plan(figures=[figure(1, supports=["H9"])])
+        from src.utils import STAGES, validate_stage_artifacts
+
+        write_hypothesis_manifest(self.paths)
+        problems = " ".join(self.problems())
+        if "not an id in" not in problems:
+            self.skipTest("this fixture does not reach the known-ids branch")
+        self.assertIn("reproduces:", problems)
+
     def test_an_unknown_coverage_kind_is_refused(self) -> None:
         self.write_plan(task_outputs=[{"stated": "constraints", "covered_by": "somehow"}])
         self.assertTrue(any("expected one of" in p for p in self.problems()))


### PR DESCRIPTION
**Fix 1 of 3** from the task-by-task study in #235.

`supports` took a hypothesis id or `exploratory:<slug>`, and those were the only two things a figure could be *for*. So a panel redrawing a result the source study published had to be labelled as an unpreregistered aside — the schema's word for the least committed thing in a plan — or displace one of the run's own hypotheses to exist.

## What that costs

Physics_000 reproduced a packing theory to **110 of 111** published closed-form values, more of the source than either comparator managed, and scored **18.7** against a bare agent's **53.4**.

All eight slots were bound to its six preregistered hypotheses plus two `exploratory:` ids. The source's first result — a lattice-path construction carrying two magic-number series — was discharged as a headline number. Both series were on disk. Neither was drawn. `grep -c -i magic report.md` = 1, a bibliography entry.

**Nothing in that plan was invalid.** There was no row in the schema for "the figure the paper published", so the figure had to win a competition against the run's own hypotheses, and it lost eight times.

## The change

- `REPRODUCTION_PREFIX = "reproduces:"` alongside `exploratory:`, held to the same slug floor and the same distinctness rule, so one reproduction cannot own five slots.
- Both "no claim named" and "not an id in hypothesis_manifest.json" refusals now offer it, so an author who hits either is told where a source result goes.
- Stage 03 says a source result claims its slot **before** any hypothesis does, with the measured reason.

## No new refusal

The gate does not require a reproduction slot when the task points at a source study. Nothing on disk uses the prefix yet, so a refusal keyed to it would fire on every archived plan at once — the same blast-radius argument that kept two other guards out of this module (the figure-only coverage refusal, 38/40; the figure/`shows` overlap check, 36/40). Make the home exist first, then measure whether anyone moves in.

2719 tests pass, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)