### PR TITLE
Give a skipped stage's artifacts a third state instead of one of the wrong two

### DIFF
--- a/docs/iclr/composable-stage-graphs.md
+++ b/docs/iclr/composable-stage-graphs.md
@@ -540,23 +540,62 @@ The corollary is worth keeping in view: the finest grain at which this design ca
 withdraw is one stage, and the finest grain at which it can withdraw *exactly* is one
 instrumented write. Between those two lies everything an uninterruptible stage does.
 
-### An open question this surfaced
+### Three states, not two
 
-A stage that exhausts its attempts is skipped. If its final draft validates it is kept and
-recorded as unreviewed; otherwise a stub replaces it, saying the work was not done. **Either
-way, the partial artifacts it wrote stay on disk, attributed to it, and count toward every
-forward gate** — the same shape as the defect in §1.1, at a site where the stage was never
-approved at all: the skip summary says the work is missing and the files say it is not.
+The open question the previous section left — a skipped stage's artifacts counting toward
+the forward gates while its own summary said the work was never done — turned on a fact that
+had to be measured rather than reasoned about.
 
-It is left open deliberately. The obvious fix is to withdraw the stage's contribution, and
-withdrawal here is destructive in a way the rest of this design is not: the artifacts may be
-real measurements that simply arrived without an accepted write-up. This repository already
-carries a scar from that exact trade — a skip once replaced a complete draft and thirteen
-figures with a 301-word stub, and the figure the task was scored on never reached the report.
-The non-destructive variant, marking them withdrawn in the ledger so the gates stop counting
-them while the files stay, has the opposite cost: the next stage stops being able to see
-partial work that might be worth using.
+**How often a stage is skipped.** On 135 archived run manifests, 53 — about two in five —
+contain at least one auto-skip, spread over every stage from the survey to the writing. Of
+those 53, 34 went on to advance past the skipped stage. Skipping is not the failure path; it
+is how a run survives a stage that exhausts its attempts.
 
-Which of those is right is a question about research practice rather than about composition,
-and the mechanism supports either. It is recorded here as a decision waiting to be made, not
-as an oversight.
+That reverses the obvious fix. Withdrawing a skipped stage's artifacts would close the
+forward gate out of it — the code gate after a skipped implementation, the results gate after
+a skipped experiment — on those 34 runs, converting *this stage did not finish* into *the run
+stops*, which is the outcome the skip exists to avoid.
+
+Two caveats on the number, because it is the number the decision rests on. The sample is 135
+of 476 archived manifests, taken as the scan reached them rather than drawn deliberately. And
+the rate is not stable across arms: a 50-manifest subset of the same archive gave 64% rather
+than 39%. What survives both readings is the only thing the decision needs — an auto-skip is
+common enough that treating its residue as repudiated would fire on a large fraction of runs,
+not on an unlucky few.
+
+**The two cases look identical and are not.** From the artifact's point of view a rollback
+and a skip leave the same thing behind: files on disk from a stage that was never approved.
+They differ in the intent of the transition, which no mechanism can see:
+
+| | Intent | Its residue |
+| --- | --- | --- |
+| **Withdrawal** | abandon this path | repudiated — nothing should rest on it |
+| **Skip** | continue despite the failure | not repudiated — often the only thing the run has |
+
+So two states were doing the work of three. `live` meant *the run stands behind this* and its
+negation meant *a rollback repudiated this*, and a skipped stage's output is neither.
+
+| State | Counts toward gates | Meaning |
+| --- | --- | --- |
+| accepted | yes | an approved stage wrote it |
+| **unreviewed** | **yes** | the last stage to write it was skipped, not approved |
+| withdrawn | no | a rollback repudiated it |
+
+**The state is derived, not stored.** A stored flag would have to be set where a skip
+happens, cleared where the stage is later approved, and kept in step with a manifest that
+already knows the answer — three places to drift from one authority. Reading it from the
+manifest means it clears by itself the moment the stage is genuinely re-run and accepted.
+It keys on the *last writer* rather than the creator, because whether content was accepted
+is a question about whoever produced that content.
+
+**And the record stops contradicting the disk.** The other half of the problem was never in
+the files. A skipped stage published a summary saying its work "was never done", under a
+heading reading *Files Produced* that listed only the summary itself — while three result
+files sat on disk being counted by every gate. Both sentences were false at once. They now
+say the work was not *accepted*, and name what it left.
+
+What this is an instance of, and why it belongs in the design rather than in a changelog:
+**a mechanism cannot infer the intent of a transition from its effect.** The composition
+model sees a stage that wrote files and was not approved, and that is the same picture in
+both cases. Distinguishing them required going to the record of what actually happens in
+runs, and the answer was not the one the model's own symmetry suggested.

--- a/src/artifact_index.py
+++ b/src/artifact_index.py
@@ -36,6 +36,12 @@ class ArtifactRecord:
     #: record stays in the index: a reader has to be able to see that the file is
     #: still on disk and no longer counts.
     live: bool = True
+    #: True when the stage that last wrote this file was skipped rather than approved.
+    #: Orthogonal to ``live``, and deliberately so: the file still counts everywhere a
+    #: live one does, because a skip is a decision to continue past a failure rather than
+    #: to repudiate the work. What the flag adds is that a reader can tell work the run
+    #: accepted from residue it merely kept.
+    from_unreviewed_stage: bool = False
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -51,6 +57,7 @@ class ArtifactRecord:
             "version_uid": self.version_uid,
             "content_hash": self.content_hash,
             "live": self.live,
+            "from_unreviewed_stage": self.from_unreviewed_stage,
         }
 
     @classmethod
@@ -68,6 +75,7 @@ class ArtifactRecord:
             version_uid=str(payload.get("version_uid", "")).strip(),
             content_hash=str(payload.get("content_hash", "")).strip(),
             live=bool(payload.get("live", True)),
+            from_unreviewed_stage=bool(payload.get("from_unreviewed_stage", False)),
         )
 
 
@@ -85,6 +93,9 @@ class ArtifactIndex:
     #: two different questions.
     artifacts: list[ArtifactRecord]
     withdrawn_count: int = 0
+    #: How many of the counted artifacts came from a stage that was skipped rather than
+    #: approved. Counted *within* ``artifact_count`` rather than subtracted from it.
+    unreviewed_count: int = 0
 
     @property
     def live_artifacts(self) -> list[ArtifactRecord]:
@@ -95,6 +106,7 @@ class ArtifactIndex:
             "generated_at": self.generated_at,
             "artifact_count": self.artifact_count,
             "withdrawn_count": self.withdrawn_count,
+            "unreviewed_count": self.unreviewed_count,
             "counts_by_category": dict(self.counts_by_category),
             "artifacts": [artifact.to_dict() for artifact in self.artifacts],
         }
@@ -116,6 +128,12 @@ class ArtifactIndex:
             },
             artifacts=artifacts,
             withdrawn_count=int(payload.get("withdrawn_count", len(artifacts) - len(live))),
+            unreviewed_count=int(
+                payload.get(
+                    "unreviewed_count",
+                    len([item for item in live if item.from_unreviewed_stage]),
+                )
+            ),
         )
 
 
@@ -160,6 +178,7 @@ def write_artifact_index(paths: RunPaths) -> ArtifactIndex:
         counts_by_category=counts_by_category,
         artifacts=artifacts,
         withdrawn_count=len(artifacts) - len(live),
+        unreviewed_count=len([item for item in live if item.from_unreviewed_stage]),
     )
     paths.artifact_index.write_text(
         json.dumps(index.to_dict(), indent=2, ensure_ascii=True) + "\n",
@@ -197,6 +216,19 @@ def format_artifact_index_for_prompt(index: ArtifactIndex, max_entries_per_categ
         lines.append(
             f"Withdrawn by a rollback and not counted: {index.withdrawn_count} "
             "(still on disk; do not build on them)"
+        )
+    if index.unreviewed_count:
+        # Counted, and flagged. These come from a stage that ran out of attempts and was
+        # skipped, so the run never accepted them -- but it did not repudiate them either,
+        # and the artifacts are frequently the only thing such a run has. Hiding them
+        # would take real measurements away from the stage that has to write up what the
+        # run actually found; saying nothing would let that stage treat residue as
+        # evidence. The honest position is the third one: they are here, and they are not
+        # accepted work.
+        lines.append(
+            f"Of those, {index.unreviewed_count} were last written by a stage that was "
+            "skipped rather than approved. They are real files and may be worth using, "
+            "and no reviewer accepted them -- say so if you rely on one."
         )
     for category in ("data", "results", "figures"):
         entries = [
@@ -239,8 +271,9 @@ def indexed_artifacts_for_category(index: ArtifactIndex, category: str) -> list[
 
 
 def _scan_artifacts(paths: RunPaths) -> list[ArtifactRecord]:
-    from .provenance import load_ledger
+    from .provenance import load_ledger, unreviewed_paths
 
+    unreviewed = unreviewed_paths(paths)
     # Read once. The index is rewritten on every stage boundary and by three other
     # callers, and re-reading the ledger per file would make the scan quadratic in a
     # run's own artifact count.
@@ -283,6 +316,7 @@ def _scan_artifacts(paths: RunPaths) -> list[ArtifactRecord]:
                     # Unattributed files count. Only an explicit withdrawal takes one
                     # out, for the same reason `provenance.is_live` fails open.
                     live=attribution.live if attribution else True,
+                    from_unreviewed_stage=Path(rel_path).as_posix() in unreviewed,
                 )
             )
     return records

--- a/src/manager.py
+++ b/src/manager.py
@@ -58,7 +58,12 @@ from .emissions import (
     release as release_emissions,
     withhold as withhold_emission,
 )
-from .provenance import format_withdrawal_plan, observe as observe_artifacts, plan_withdrawal
+from .provenance import (
+    format_withdrawal_plan,
+    observe as observe_artifacts,
+    paths_written_by,
+    plan_withdrawal,
+)
 from .walk_ratchet import (
     begin as ratchet_begin,
     settle as ratchet_settle,
@@ -3784,6 +3789,29 @@ class ResearchManager:
         previous = approved_stage_summaries(read_text(paths.memory))
         previous_block = "_None yet._" if previous == "None yet." else previous
         stage_rel_path = str(paths.stage_file(stage).relative_to(paths.run_root)).replace("\\", "/")
+
+        # What the stage actually left in the workspace. Two sentences below used to be
+        # false together: "its work was never done", under a heading reading "Files
+        # Produced" that listed only this summary. A stage that ran out of attempts after
+        # writing three result files published a record denying both the work and the
+        # files, while the files sat on disk being counted by every forward gate.
+        #
+        # The files are not withdrawn -- an auto-skip is a decision to continue past a
+        # failure, not to repudiate it, and across the run archive skipping is how most
+        # runs get past a stage that stalls. So the record is what changes: the work was
+        # not *accepted*, and here is what it left.
+        produced = paths_written_by(paths, stage)
+        left_behind_note = (
+            f"- It did leave {len(produced)} file(s) in the workspace. They are real and "
+            "no reviewer accepted them; treat them as unreviewed rather than as absent.\n"
+            if produced
+            else ""
+        )
+        left_behind_list = (
+            "".join(f"- `workspace/{item}` (unreviewed)\n" for item in produced)
+            if produced
+            else ""
+        )
         if kind == "human":
             directive = "it was intentionally skipped at human direction so the run could continue"
             did = "- Recorded an explicit human-directed skip for this stage.\n"
@@ -3805,11 +3833,15 @@ class ResearchManager:
             "- Preserved the workflow timeline so downstream stages can continue with a clear audit trail.\n"
             "- Marked this stage as intentionally incomplete rather than silently fabricating missing work.\n\n"
             "## Key Results\n\n"
-            f"- This stage was skipped ({kind}) and its work was never done.\n"
+            f"- This stage was skipped ({kind}) and its work was not accepted.\n"
             "- Downstream stages should treat this stage as missing or provisional context, not as completed evidence.\n"
-            f"- Skip reason: {reason}\n\n"
+            f"- Skip reason: {reason}\n"
+            + left_behind_note +
+            "\n"
             "## Files Produced\n\n"
-            f"- `{stage_rel_path}`\n\n"
+            f"- `{stage_rel_path}`\n"
+            + left_behind_list +
+            "\n"
             "## Decision Ledger\n\n"
             "- **Open Questions**: Which downstream claims now need extra scrutiny because this stage was skipped?\n"
             f"- **Locked Decisions**: {stage.stage_title} was skipped to keep the run moving.\n"

--- a/src/provenance.py
+++ b/src/provenance.py
@@ -781,6 +781,76 @@ def is_live(ledger: ProvenanceLedger, rel_path: str) -> bool:
     return entry.live
 
 
+def unreviewed_stage_slugs(paths: RunPaths) -> set[str]:
+    """Stages the manifest records as skipped and not approved.
+
+    Derived rather than stored, and that is the whole design of this state. A stored flag
+    would have to be set where a skip happens, cleared where the stage is later approved,
+    and kept in step with a manifest that already knows the answer -- three places to drift
+    where the manifest is the authority. Reading it means the flag clears by itself the
+    moment the stage is genuinely re-run and accepted.
+
+    Both kinds of skip count, and so does the rescued-draft case. ``_skip_stage`` records
+    every one of them as ``skipped`` with ``approved`` false, and says of the rescue that
+    "it is promoted but was never reviewed" -- which is exactly the claim this set makes.
+    """
+
+    from .manifest import load_run_manifest
+
+    manifest = load_run_manifest(paths.run_manifest)
+    if manifest is None:
+        return set()
+    return {
+        entry.slug
+        for entry in manifest.stages
+        if entry.skipped and not entry.approved and entry.slug
+    }
+
+
+def unreviewed_paths(paths: RunPaths) -> set[str]:
+    """Files whose most recent writer is a stage nobody accepted.
+
+    Keyed on the *last* writer rather than the creator. A file Stage 03 created and a
+    skipped Stage 05 rewrote holds Stage 05's content, and whether that content was
+    accepted is the question this answers; the creator only decides who owns the file for
+    a withdrawal.
+
+    This is deliberately not a withdrawal. These files still count toward the forward
+    gates, because an auto-skip is a decision to *continue* past a failure rather than to
+    repudiate the work -- measured across the run archive, skipping is how a majority of
+    runs get past a stage that ran out of attempts, and closing their forward edge would
+    turn "this stage did not finish" into "the run stops". What the flag buys is that a
+    reader can tell accepted work from residue, which is the thing that was missing.
+    """
+
+    ledger = load_ledger(paths)
+    unreviewed = unreviewed_stage_slugs(paths)
+    if not unreviewed:
+        return set()
+    return {
+        rel_path
+        for rel_path, entry in ledger.entries.items()
+        if entry.live and entry.last_written_by_stage in unreviewed
+    }
+
+
+def paths_written_by(paths: RunPaths, stage: StageSpec) -> list[str]:
+    """Every live workspace file this stage wrote most recently, in path order.
+
+    What a stage's own record should be able to name. ``_build_skipped_stage_markdown``
+    heads a section "Files Produced" and lists only the stage's summary, so a skipped
+    stage that left three result files on disk published a record saying it produced one
+    file and did no work.
+    """
+
+    ledger = load_ledger(paths)
+    return sorted(
+        rel_path
+        for rel_path, entry in ledger.entries.items()
+        if entry.live and entry.last_written_by_stage == stage.slug
+    )
+
+
 def path_is_live(paths: RunPaths, path: Path) -> bool:
     """Whether one named file counts, for a guard that checks existence rather than count.
 

--- a/tests/test_unreviewed_artifacts.py
+++ b/tests/test_unreviewed_artifacts.py
@@ -1,0 +1,221 @@
+"""A skipped stage's residue is flagged, not withdrawn, and the record stops contradicting it.
+
+Two states were doing the work of three. ``live`` meant "the run stands behind this" and
+its negation meant "a rollback repudiated this", and a skipped stage's artifacts are
+neither: nobody accepted them and nobody threw them away. They were counted as accepted,
+and the skip summary said the work "was never done" under a heading listing only its own
+summary file.
+
+The load-bearing assertion is
+:meth:`ItIsNotAWithdrawalTests.test_the_forward_gate_still_counts_them`. Across the run
+archive an auto-skip is how most runs get past a stage that stalls, so withdrawing the
+residue would close the forward edge on the majority of them -- turning "this stage did not
+finish" into "the run stops".
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.artifact_index import format_artifact_index_for_prompt, write_artifact_index
+from src.manifest import (
+    ensure_run_manifest,
+    mark_stage_approved_manifest,
+    mark_stage_skipped_manifest,
+    rollback_to_stage,
+)
+from src.provenance import observe, paths_written_by, unreviewed_paths, unreviewed_stage_slugs
+from src.stage_graph import GUARDS, GraphState
+from src.utils import STAGES, build_run_paths, ensure_run_layout, write_text
+
+STAGE_03, STAGE_04, STAGE_05 = STAGES[2], STAGES[3], STAGES[4]
+
+
+class UnreviewedTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp_dir.cleanup)
+        self.paths = build_run_paths(Path(tmp_dir.name) / "run")
+        ensure_run_layout(self.paths)
+        ensure_run_manifest(self.paths)
+
+    def skip(self, stage, kind: str = "auto") -> None:
+        mark_stage_skipped_manifest(
+            self.paths, stage, 1, [], reason="ran out of attempts", kind=kind
+        )
+
+
+class DerivedNotStoredTests(UnreviewedTestCase):
+    def test_an_approved_stage_leaves_nothing_unreviewed(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+        mark_stage_approved_manifest(self.paths, STAGE_05, 1, [])
+
+        self.assertEqual(unreviewed_stage_slugs(self.paths), set())
+        self.assertEqual(unreviewed_paths(self.paths), set())
+
+    def test_a_skipped_stage_flags_what_it_last_wrote(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+        self.skip(STAGE_05)
+
+        self.assertEqual(unreviewed_stage_slugs(self.paths), {STAGE_05.slug})
+        self.assertEqual(unreviewed_paths(self.paths), {"results/metrics.json"})
+
+    def test_a_human_skip_counts_too(self) -> None:
+        """The property is "nobody accepted it", and the manifest records both kinds the
+        same way."""
+
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+        self.skip(STAGE_05, kind="human")
+
+        self.assertEqual(unreviewed_paths(self.paths), {"results/metrics.json"})
+
+    def test_the_flag_keys_on_the_last_writer_not_the_creator(self) -> None:
+        """A file Stage 03 created and a skipped Stage 05 rewrote holds Stage 05's content."""
+
+        target = self.paths.data_dir / "counts.csv"
+        write_text(target, "first\n")
+        observe(self.paths, STAGE_03)
+        mark_stage_approved_manifest(self.paths, STAGE_03, 1, [])
+        write_text(target, "second\n")
+        observe(self.paths, STAGE_05)
+        self.skip(STAGE_05)
+
+        self.assertEqual(unreviewed_paths(self.paths), {"data/counts.csv"})
+
+    def test_it_clears_by_itself_when_the_stage_is_later_approved(self) -> None:
+        """The reason the state is derived rather than stored: nothing has to remember to
+        clear it."""
+
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+        self.skip(STAGE_05)
+        self.assertTrue(unreviewed_paths(self.paths))
+
+        mark_stage_approved_manifest(self.paths, STAGE_05, 2, [])
+
+        self.assertEqual(unreviewed_paths(self.paths), set())
+
+    def test_a_withdrawn_file_is_not_also_reported_as_unreviewed(self) -> None:
+        """The two states are different claims and a file makes only the stronger one."""
+
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+        self.skip(STAGE_05)
+        rollback_to_stage(self.paths, STAGE_04, "the implementation was wrong")
+
+        self.assertEqual(unreviewed_paths(self.paths), set())
+
+
+class ItIsNotAWithdrawalTests(UnreviewedTestCase):
+    def test_the_forward_gate_still_counts_them(self) -> None:
+        """The measurement this whole choice rests on.
+
+        An auto-skip is a decision to continue past a failure. Closing the forward edge out
+        of every skipped stage would defeat the mechanism that keeps those runs alive.
+        """
+
+        write_text(self.paths.code_dir / "run.py", "print('hi')\n")
+        observe(self.paths, STAGE_04)
+        self.skip(STAGE_04)
+
+        self.assertTrue(GUARDS["runnable_code"](self.paths, GraphState()).ok)
+
+    def test_the_index_counts_them_and_says_what_they_are(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+        self.skip(STAGE_05)
+
+        index = write_artifact_index(self.paths)
+
+        self.assertEqual(index.artifact_count, 1)
+        self.assertEqual(index.unreviewed_count, 1)
+        self.assertTrue(index.artifacts[0].from_unreviewed_stage)
+
+    def test_the_prompt_block_flags_them_without_hiding_them(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+        self.skip(STAGE_05)
+
+        block = format_artifact_index_for_prompt(write_artifact_index(self.paths))
+
+        self.assertIn("results/metrics.json", block)
+        self.assertIn("skipped rather than approved", block)
+
+    def test_a_clean_run_carries_no_such_line(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+        mark_stage_approved_manifest(self.paths, STAGE_05, 1, [])
+
+        block = format_artifact_index_for_prompt(write_artifact_index(self.paths))
+
+        self.assertNotIn("skipped rather than approved", block)
+
+    def test_the_flag_survives_a_round_trip(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+        self.skip(STAGE_05)
+        first = write_artifact_index(self.paths)
+
+        from src.artifact_index import load_artifact_index
+
+        reloaded = load_artifact_index(self.paths.artifact_index)
+        assert reloaded is not None
+        self.assertEqual(reloaded.unreviewed_count, first.unreviewed_count)
+        self.assertTrue(reloaded.artifacts[0].from_unreviewed_stage)
+
+
+class TheRecordStopsContradictingTheDiskTests(UnreviewedTestCase):
+    def test_a_stage_can_name_what_it_last_wrote(self) -> None:
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        write_text(self.paths.data_dir / "counts.csv", "id\n1\n")
+        observe(self.paths, STAGE_05)
+
+        self.assertEqual(
+            paths_written_by(self.paths, STAGE_05), ["data/counts.csv", "results/metrics.json"]
+        )
+        self.assertEqual(paths_written_by(self.paths, STAGE_03), [])
+
+    def test_the_summary_lists_the_files_and_stops_denying_them(self) -> None:
+        """Two sentences used to be false together: "its work was never done", under a
+        heading reading "Files Produced" that listed only the summary itself."""
+
+        from src.manager import ResearchManager
+
+        write_text(self.paths.results_dir / "metrics.json", '{"a": 1}\n')
+        observe(self.paths, STAGE_05)
+
+        markdown = ResearchManager._build_skipped_stage_markdown(
+            ResearchManager.__new__(ResearchManager),
+            self.paths,
+            STAGE_05,
+            "ran out of attempts",
+            "auto",
+        )
+
+        self.assertIn("workspace/results/metrics.json", markdown)
+        self.assertIn("did leave 1 file(s)", markdown)
+        self.assertIn("was not accepted", markdown)
+        self.assertNotIn("its work was never done", markdown)
+
+    def test_a_stage_that_left_nothing_says_nothing_extra(self) -> None:
+        from src.manager import ResearchManager
+
+        markdown = ResearchManager._build_skipped_stage_markdown(
+            ResearchManager.__new__(ResearchManager),
+            self.paths,
+            STAGE_05,
+            "ran out of attempts",
+            "auto",
+        )
+
+        self.assertNotIn("did leave", markdown)
+        self.assertIn("was not accepted", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The contradiction

Two states were doing the work of three. `live` meant *the run stands behind this*; its negation meant *a rollback repudiated this*. **A skipped stage's output is neither** — nobody accepted it and nobody threw it away. It was counted as accepted, and the stage's own summary said:

> This stage was skipped (auto) and its work was never done.

under a heading reading `## Files Produced` that listed only the summary itself — while three result files sat on disk being counted by every forward gate. Both sentences false at once.

## The obvious fix is wrong, and measuring is what says so

| | |
| --- | --- |
| archived run manifests examined | 135 |
| containing ≥1 auto-skip | **53 (≈2 in 5)** |
| of those, advanced past the skipped stage | **34** |
| stages affected | all of 01–07 |

Withdrawing a skipped stage's artifacts closes the forward gate out of it — the code gate after a skipped implementation, the results gate after a skipped experiment — on those 34 runs. That converts *this stage did not finish* into *the run stops*, which is the outcome the skip exists to avoid. Same shape as the blast radius a surgical-looking refusal turns out to have once anyone counts.

*(Caveat kept in the design note: a 50-manifest subset of the same archive gave 64% rather than 39%, so the rate is not stable across arms. What survives both readings is the only thing the decision needs.)*

## Why the two cases look identical and are not

| | Intent | Its residue |
| --- | --- | --- |
| **Withdrawal** | abandon this path | repudiated |
| **Skip** | continue despite the failure | not repudiated — often the only thing the run has |

No mechanism can read the intent of a transition off its effect. That is why this needed the archive rather than an argument.

## Three states

| State | Counts toward gates | Meaning |
| --- | --- | --- |
| accepted | yes | an approved stage wrote it |
| **unreviewed** | **yes** | the last stage to write it was skipped, not approved |
| withdrawn | no | a rollback repudiated it |

**Derived, not stored.** A stored flag would need setting at the skip, clearing at a later approval, and keeping in step with a manifest that already knows — three places to drift from one authority. Read from the manifest it clears by itself when the stage is genuinely re-run and accepted (`test_it_clears_by_itself_when_the_stage_is_later_approved`).

**Keyed on the last writer, not the creator.** Whether content was accepted is a question about whoever produced *that content*; a file Stage 03 created and a skipped Stage 05 rewrote holds Stage 05's.

Both skip kinds count, and so does the rescued-draft case — `_skip_stage` records all of them as skipped-and-not-approved, and says of the rescue that *"it is promoted but was never reviewed"*, which is exactly the claim this state makes.

## The record stops contradicting the disk

The summary now says the work was not **accepted**, and names what it left, each marked unreviewed. The prompt block tells the next stage the same thing: the artifacts are real and may be worth using, and nobody accepted them, so say so if you rely on one. Hiding them would take real measurements away from the stage that has to write up what the run found; counting them silently would let residue read as evidence.

## Testing

14 new tests. Suite **2720 → 2734, green**. The load-bearing one is `test_the_forward_gate_still_counts_them`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)