### PR TITLE
The tenth of the weight nobody can score is not headroom, it is a missing paper

### DIFF
--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -866,6 +866,48 @@ will do — which is the cheapest way to see what the adapter writes where.
 
 ---
 
+## About a tenth of the weight asks about a paper the workspace does not contain
+
+A task-by-task study of the 2026-08-16 arm found 16 criteria, **4.00 of 40.0 total weight
+(10.0%)**, where AutoR's new code, AutoR's pre-fix code and a bare agent all score at or
+below 10. The study called that the remaining headroom. It is not headroom, and the
+correction is worth more than the original claim.
+
+Every one of those criteria names something specific — an analysis (`SHAP`), a dataset
+(`TextVQA`), a model (`Qwen2.5-3B`), a tool (`HADDOCK3`), an event (CAPRI round 57,
+target 268), a pipeline (`FlyWire`, `FAFB`). Those names come from the **target paper**,
+and the benchmark does not ship it. `related_work/` holds *other* papers. Searching only
+what the agent is given — `related_work/` and `data/`, nothing the run wrote —
+**2 of 30 distinctive identifiers from these criteria appear anywhere**:
+
+| task | supplied text | absent from it |
+|:---|---:|:---|
+| Neuroscience_000 #1–#3 | 3,463,517 chars | `SHAP`, `Lab1`, `Lab2`, `CSDS` |
+| Chemistry_002 #3–#4 | 1,602,208 chars | `CAPRI`, `HADDOCK3`, `VoroIF` |
+| Life_001 #0, #3 | 2,462,557 chars | `NeoAgDT`, `NetMHCpan` |
+| Information_001 #2 | **0 chars** | `Qwen2.5-3B`, `TextVQA` |
+| Neuroscience_002 #0, #4 | **0 chars** | `FlyWire`, `FAFB`, `FFN`, `EmbedNet` |
+| Information_003 #4 | **0 chars** | `DIDS`, `MFL` |
+
+Four of those tasks supply no readable text at all: their `related_work/` and `data/` are
+tensors and images. Three and a half million characters of Neuroscience_000's supplied
+papers contain the string "SHAP" zero times.
+
+So this is not a gap a skill or a gate can close. It is the benchmark's floor for an agent
+that is not given the document it is graded against, and any claim about how much of
+ResearchClawBench is reachable should be quoted against **90%**, not 100%.
+
+The one route that would reach it is fetching the target paper from the web and reading
+its methods section. That is a research-integrity question rather than an engineering one
+— on a reproduction benchmark, reading the target's results and restating them is close to
+copying the answer — and it is recorded here rather than taken.
+
+`python tools/unreachable_criteria.py --arms <score dirs> --runs <workspace root>`
+re-derives all of it. Two earlier attempts at this measurement were wrong in the same
+direction: one searched the criterion's words in a corpus that included `_score.json`, the
+judge's own output, which contains the criteria verbatim, and got 30 of 30 "present". A
+search for a criterion's words that includes the criterion answers yes by construction.
+
 ## Measuring a change against the benchmark score
 
 AutoR's own rubric cannot answer "did this PR make the research better" — it is AutoR

--- a/tools/unreachable_criteria.py
+++ b/tools/unreachable_criteria.py
@@ -1,0 +1,131 @@
+"""How much of the benchmark asks about a paper the workspace does not contain.
+
+The claim this exists to keep honest. A task-by-task study of the 2026-08-16 arm
+reported that "10.0% of total weight sits on 16 criteria where all three arms score at
+or below 10" and called it the remaining headroom. It is not headroom. Every one of
+those criteria names something specific -- an analysis (SHAP), a dataset (TextVQA), a
+model (Qwen2.5-3B), a tool (HADDOCK3), an event (CAPRI round 57) -- and those names are
+in the *target paper*, which ResearchClawBench does not ship. `related_work/` holds
+other papers: 3.4 million characters of them for Neuroscience_000, containing the string
+"SHAP" zero times.
+
+Measured here rather than asserted, because the first two attempts at this measurement
+were both wrong in ways that flattered the conclusion. The first read only the top level
+of two directories and undercounted. The second recursed and got 30 of 30 identifiers
+"present" -- because it was reading `_score.json`, the judge's own output, which contains
+the criteria verbatim, and `outputs/`, which the agent wrote. **A search for a criterion's
+words that includes the criterion, or anything downstream of it, answers yes by
+construction.** Only `related_work/` and `data/` are read here.
+
+Usage::
+
+    python tools/unreachable_criteria.py --arm /path/to/scores --runs /path/to/runs
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+#: A token that identifies a specific thing rather than describing one: an acronym, a
+#: model or version string, a CamelCase name. "comparison", "features" and "importance"
+#: are in every paper ever written and matching on them is how the second attempt at this
+#: got 30 of 30.
+_IDENTIFIER = re.compile(
+    r"\b(?:[A-Z]{3,}[0-9]*|[A-Za-z]+[0-9][A-Za-z0-9.\-]*|[A-Z][a-z]+[A-Z][A-Za-z]*)\b"
+)
+
+#: Acronyms too common to identify anything, plus the judge's own vocabulary.
+_GENERIC = frozenset({"AI", "The", "This", "Mode", "ROC", "AUC"})
+
+#: Only what the benchmark hands the agent. Never `outputs/`, `code/` or `report/`, which
+#: the run writes; never `_score.json` or `INSTRUCTIONS.md`, which carry the criteria.
+_SUPPLIED_DIRS = ("related_work", "data")
+
+_TEXT_SUFFIXES = {".txt", ".md", ".json", ".csv", ".tsv", ".yaml", ".yml", ".html", ".xml"}
+_MAX_TEXT_BYTES = 20_000_000
+
+#: Below this, every arm has effectively failed the criterion.
+_FLOOR = 10
+
+
+def supplied_text(workspace: Path) -> str:
+    parts: list[str] = []
+    for sub in _SUPPLIED_DIRS:
+        for path in sorted((workspace / sub).rglob("*")):
+            if not path.is_file():
+                continue
+            try:
+                if path.suffix.lower() == ".pdf":
+                    parts.append(
+                        subprocess.run(  # noqa: S603
+                            ["pdftotext", str(path), "-"],
+                            capture_output=True, text=True, timeout=120, check=False,
+                        ).stdout
+                    )
+                elif path.suffix.lower() in _TEXT_SUFFIXES and path.stat().st_size < _MAX_TEXT_BYTES:
+                    parts.append(path.read_text(encoding="utf-8", errors="replace"))
+            except (OSError, subprocess.SubprocessError):
+                continue
+    return "\n".join(parts)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arms", nargs="+", required=True, help="score directories, one per arm")
+    parser.add_argument("--runs", required=True, help="workspace root of any one arm")
+    args = parser.parse_args()
+
+    per_arm = []
+    for arm in args.arms:
+        per_arm.append({
+            os.path.basename(p)[:-5]: json.load(open(p, encoding="utf-8"))
+            for p in glob.glob(f"{arm}/*.json")
+        })
+    tasks = sorted(set.intersection(*(set(a) for a in per_arm)))
+
+    total_weight = sum(i["weight"] for t in tasks for i in per_arm[0][t]["items"])
+    hard: list[tuple[float, str, int]] = []
+    for task in tasks:
+        for index in range(len(per_arm[0][task]["items"])):
+            scores = [a[task]["items"][index].get("score") or 0 for a in per_arm]
+            if max(scores) <= _FLOOR:
+                hard.append((per_arm[0][task]["items"][index]["weight"], task, index))
+    hard.sort(reverse=True)
+
+    hard_weight = sum(w for w, _, _ in hard)
+    print(f"{len(hard)} criteria no arm scores above {_FLOOR}: "
+          f"{hard_weight:.2f} of {total_weight:.1f} weight ({hard_weight / total_weight:.1%})\n")
+
+    present = absent = 0
+    for weight, task, index in hard:
+        matches = glob.glob(f"{args.runs}/{task}_*/")
+        if not matches:
+            continue
+        text = supplied_text(Path(matches[0])).lower()
+        content = per_arm[0][task]["items"][index]["content"]
+        terms = [w for w in dict.fromkeys(_IDENTIFIER.findall(content)) if w not in _GENERIC][:8]
+        if not terms:
+            print(f"  w={weight:.2f} {task}#{index}: names nothing specific enough to look for")
+            continue
+        missing = [w for w in terms if w.lower() not in text]
+        present += len(terms) - len(missing)
+        absent += len(missing)
+        print(f"  w={weight:.2f} {task}#{index}: supplied text {len(text):,} chars, "
+              f"{len(terms) - len(missing)}/{len(terms)} present"
+              + (f", absent: {', '.join(missing[:5])}" if missing else ""))
+
+    print(f"\n{present}/{present + absent} of these criteria's distinctive identifiers appear "
+          f"anywhere in what the benchmark supplies.")
+    print("The rest name things that exist only in the target paper, which is not shipped.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**Fix 3 of 3** from the study in #235 — except it is not a fix. It is a retraction of the claim, with the measurement that settles it.

#235 reported that **10.0% of total benchmark weight** sits on 16 criteria where AutoR's new code, AutoR's pre-fix code and a bare agent all score ≤10, and called it *"where the headroom is"*. That was my claim and it is wrong.

## What those criteria actually ask for

Every one names something specific — an analysis (`SHAP`), a dataset (`TextVQA`), a model (`Qwen2.5-3B`), a tool (`HADDOCK3`), an event (CAPRI round 57, target 268), a pipeline (`FlyWire`, `FAFB`). Those names come from the **target paper**, and the benchmark does not ship it. `related_work/` holds *other* papers.

Searching only what the agent is handed — `related_work/` and `data/`, nothing the run wrote — **2 of 30 distinctive identifiers appear anywhere**:

| task | supplied text | absent from it |
|:---|---:|:---|
| Neuroscience_000 #1–#3 | 3,463,517 chars | `SHAP`, `Lab1`, `Lab2`, `CSDS` |
| Chemistry_002 #3–#4 | 1,602,208 chars | `CAPRI`, `HADDOCK3`, `VoroIF` |
| Life_001 #0, #3 | 2,462,557 chars | `NeoAgDT`, `NetMHCpan` |
| Information_001 #2 | **0 chars** | `Qwen2.5-3B`, `TextVQA` |
| Neuroscience_002 #0, #4 | **0 chars** | `FlyWire`, `FAFB`, `FFN`, `EmbedNet` |
| Information_003 #4 | **0 chars** | `DIDS`, `MFL` |

Four of those tasks supply **no readable text at all** — their inputs are tensors and images. Three and a half million characters of Neuroscience_000's supplied papers contain "SHAP" zero times.

## What follows

- No skill and no gate reaches this. It is the benchmark's floor for an agent not given the document it is graded against.
- Any claim about how much of ResearchClawBench is reachable should be quoted against **90%**, not 100%.
- The one route that would reach it — fetch the target paper and read its methods — is a **research-integrity question, not an engineering one**. On a reproduction benchmark, reading the target's results and restating them is close to copying the answer. Recorded here rather than taken.

## The measurement has a script, because I got it wrong twice first

`tools/unreachable_criteria.py` re-derives all of it. Both earlier attempts erred in the direction that flattered the conclusion:

1. read only the top level of two directories → undercounted;
2. recursed the whole workspace → **30 of 30 identifiers "present"** — because it was reading `_score.json`, the judge's own output, **which contains the criteria verbatim**, and `outputs/`, which the agent wrote.

A search for a criterion's words in a corpus that includes the criterion answers yes by construction. The tool reads `related_work/` and `data/` and nothing else, and its docstring says why.

2733 tests pass, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)