### PR TITLE
Show the routing agent what the move costs against what is left

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -377,6 +377,7 @@ class ResearchManager:
             mode=routing_mode,
             fake_mode=bool(getattr(operator, "fake_mode", False)),
             archive=archive,
+            skip_budget=self._auto_skip_budget,
         )
         # Measuring is on unless a caller turns it off: scoring a draft and running
         # the ratchet spends no backend call, and the property it buys — the draft
@@ -3438,6 +3439,29 @@ class ResearchManager:
             if choice == "3":
                 return False
             self.ui.show_status("Invalid choice. Enter 1, 2, or 3.", level="warn")
+
+    def _auto_skip_budget(self) -> tuple[int, int | None]:
+        """The auto-skip pool, for the router to *show*. Nothing routes on it.
+
+        Deliberately the same two values `_handle_unattended_stage_exhaustion` tests
+        against each other — `len(self.auto_skipped_stages)` and `self.max_auto_skips`
+        — so the figure in the routing prompt cannot disagree with the figure that
+        ends the run. Two consequences, both wanted:
+
+        * `_route_to_deliverable` extends `auto_skipped_stages` with the stages it
+          bypasses and never writes an `auto_skip_used:` line, so a tally recovered
+          from `logs.txt` reads zero where this reads four. This reads the enforcer.
+        * A resumed run starts the list empty because the manager does, and the
+          allowance it will actually enforce is the fresh one. Reporting the
+          pre-resume spend would be reporting a budget nothing consults.
+
+        `None` for attended runs: the allowance is only ever consulted in unattended
+        mode, and a number no path can spend is not a balance. `describe_budget_for_prompt`
+        says "not declared" rather than filling one in.
+        """
+        if not self.unattended:
+            return len(self.auto_skipped_stages), None
+        return len(self.auto_skipped_stages), self.max_auto_skips
 
     def _handle_unattended_stage_exhaustion(
         self,

--- a/src/manager.py
+++ b/src/manager.py
@@ -3450,7 +3450,11 @@ class ResearchManager:
 
         * `_route_to_deliverable` extends `auto_skipped_stages` with the stages it
           bypasses and never writes an `auto_skip_used:` line, so a tally recovered
-          from `logs.txt` reads zero where this reads four. This reads the enforcer.
+          from `logs.txt` reads zero where this reads one per stage from the aborting
+          one up to the deliverable. How many that is depends on where the abort
+          landed, not on the branch: four from Stage 03, which is the case
+          `TheSkipPoolComesFromTheEnforcerTest` pins, and six from Stage 01. The log
+          says nothing in either. This reads the enforcer.
         * A resumed run starts the list empty because the manager does, and the
           allowance it will actually enforce is the fresh one. Reporting the
           pre-resume spend would be reporting a budget nothing consults.

--- a/src/router.py
+++ b/src/router.py
@@ -20,6 +20,22 @@ would be the more obvious design and it is the wrong one: an agent that can see
 that would fix it, while an agent shown only the open moves picks the best of them
 without ever learning what it was missing.
 
+**And what the run has left to spend.** The same argument reaches one step further
+than it used to. The prompt showed every move and what each one discards, and then
+told the agent in as many words not to weigh the cost — right in the abstract, and
+wrong under a budget the agent could not see. Measured on the first live paired
+trial: the step budget never bound, and the auto-skip allowance did. Three skips
+went, the next exhaustion landed at the stage that writes the deliverable, and the
+run ended `cancelled` with the deliverable truncated. A backward move re-runs
+stages and a re-run stage can exhaust its attempts like any other, so revisiting
+and reaching the deliverable were drawing on one allowance while the routing prompt
+named neither. :class:`src.stage_graph.WalkBudget` now puts all three pools next to
+the menu — the graph's own two off :class:`~src.stage_graph.GraphState`, and the
+auto-skip pool from ``skip_budget``, the counters the manager enforces it with — so
+"an expensive correction is worth it" has a denominator. It is still not a price
+list: what changed is that "cost is not the criterion" is now said to an agent that
+can tell whether it can afford to finish.
+
 **The refusal that carries the weight.** A revisit whose justification repeats one
 already on the path is refused. Returning to Stage 05 a third time because "more
 repeats are needed" is not iteration; the run has been there twice with that exact
@@ -32,6 +48,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -40,7 +57,15 @@ from .approval_agent import extract_json_payload
 from .obligations import load_ledger
 from .preregistration import load_hypothesis_outcomes
 from .rubric import StageScore, format_score_for_prompt
-from .stage_graph import FINISH, GraphState, Move, StageGraph, block_census
+from .stage_graph import (
+    FINISH,
+    GraphState,
+    Move,
+    StageGraph,
+    WalkBudget,
+    block_census,
+    describe_budget_for_prompt,
+)
 from .utils import (
     RunPaths,
     StageSpec,
@@ -58,6 +83,12 @@ from .utils import (
 #: ``auto`` asks only where the answer can differ, which is any node with more than
 #: one live move; on a linear graph that is never, so ``auto`` costs nothing there.
 ROUTING_MODES = ("off", "auto", "agent")
+
+
+#: Auto-skips spent and allowed, supplied by whoever enforces them. ``None`` for the
+#: allowance means "nobody declared one", which the prompt says in those words rather
+#: than filling in a default — see :func:`src.stage_graph.describe_budget_for_prompt`.
+SkipBudget = Callable[[], tuple[int, int | None]]
 
 
 @dataclass(frozen=True)
@@ -94,6 +125,7 @@ class StageRouter:
         mode: str = "auto",
         fake_mode: bool = False,
         archive: Any | None = None,
+        skip_budget: SkipBudget | None = None,
     ) -> None:
         if mode not in ROUTING_MODES:
             raise ValueError(f"Unknown routing mode: {mode!r}. Expected one of {', '.join(ROUTING_MODES)}.")
@@ -105,6 +137,21 @@ class StageRouter:
         # not `default_move`, not a guard, not a recommendation. The archive knows
         # about other research questions; the agent can see this one.
         self.archive = archive
+        # The auto-skip pool, from the party that spends it. The router cannot compute
+        # it: the allowance is a `ResearchManager` setting that reaches no file and no
+        # `RunPaths` field, and the tally lives in memory beside it.
+        #
+        # Reading it back out of `logs.txt` was the other candidate and is wrong twice
+        # over. `logs.txt` sits at the run root and the operator runs at `cwd=run_root`
+        # with `bypassPermissions`, so it is a file the displayed party can write; and
+        # it is incomplete — `_route_to_deliverable` extends the tally the budget test
+        # reads without writing an `auto_skip_used:` line, so a run routed off the
+        # approval gate reports four skips consumed in memory and none on the record.
+        # A provider asks the enforcer, which cannot disagree with itself.
+        #
+        # Optional because the router runs without a manager in tests and in
+        # `tools/`; absent, the prompt says the pool was never declared.
+        self.skip_budget = skip_budget
 
     def choose(
         self,
@@ -429,6 +476,10 @@ class StageRouter:
         score: StageScore | None,
     ) -> str:
         graph = StageGraph(tuple(move.edge for move in moves))
+        skips_spent, max_skips = self.skip_budget() if self.skip_budget else (0, None)
+        budget = WalkBudget.of(
+            state, stage.slug, skips_spent=skips_spent, max_skips=max_skips
+        )
         route = " → ".join(f"{visit.stage}" for visit in state.path) or "(this is the first stage)"
         revisits = [
             f"- went back to `{visit.chose}` after `{visit.stage}`: {visit.reason}"
@@ -449,17 +500,30 @@ class StageRouter:
             "",
             "## Moves out of this node",
             "",
-            graph.describe_for_prompt(moves),
+            graph.describe_for_prompt(moves, budget),
             "",
             "A move marked unavailable cannot be chosen. The reason it is unavailable is usually "
             "actionable — if the writing stage is closed because a hypothesis has no verdict, the "
             "move that opens it is the one to take.",
             "",
-            "**Discards** is how many stages the move throws away and the run has to redo. It is "
-            "there so the choice is informed, not so you make the cheap one: a correct expensive "
-            "correction beats a wrong cheap one every time, and a run that shops on price writes "
-            "up around the flaw it should have gone back for. Use it only to break a tie between "
-            "two moves that would fix the same thing.",
+            "**Discards** is how many stages the move throws away and the run has to redo. "
+            "**Worst case** is what that comes to against what is left: one stage execution per "
+            "discarded stage, and — because a re-run stage can exhaust its attempts like any "
+            "other — up to one auto-skip each. Both are ceilings; a re-run stage that passes "
+            "first time costs a step and no skip.",
+            "",
+            "## What this run has left",
+            "",
+            describe_budget_for_prompt(budget),
+            "",
+            "Cost is not the criterion. A correct expensive correction beats a wrong cheap one, "
+            "and a run that shops on price writes up around the flaw it should have gone back "
+            "for. But a correction the run cannot afford to finish is not a correction: if the "
+            "worst case of the move you want does not fit in the numbers above, the run does not "
+            "come back from it — it stops part-way and writes up from wherever it stopped, which "
+            "is the outcome going back was supposed to prevent. So spend on the move that fixes "
+            "the research, and where two moves would fix the same thing, break a tie with the "
+            "one the run can finish.",
             "",
             "## Route so far",
             "",

--- a/src/router.py
+++ b/src/router.py
@@ -23,14 +23,18 @@ without ever learning what it was missing.
 **And what the run has left to spend.** The same argument reaches one step further
 than it used to. The prompt showed every move and what each one discards, and then
 told the agent in as many words not to weigh the cost — right in the abstract, and
-wrong under a budget the agent could not see. Measured on the first live paired
-trial: the step budget never bound, and the auto-skip allowance did. Three skips
-went, the next exhaustion landed at the stage that writes the deliverable, and the
-run ended `cancelled` with the deliverable truncated. A backward move re-runs
-stages and a re-run stage can exhaust its attempts like any other, so revisiting
-and reaching the deliverable were drawing on one allowance while the routing prompt
-named neither. :class:`src.stage_graph.WalkBudget` now puts all three pools next to
-the menu — the graph's own two off :class:`~src.stage_graph.GraphState`, and the
+wrong under a budget the agent could not see. Measured on every finished run of the
+first live paired trial — the population and the figures are pinned in the module
+docstring of ``tests/test_router_budget.py`` — the step budget never bound and the
+auto-skip allowance did. On `Astronomy_000_20260814_175426` three skips went, the
+next exhaustion landed at the stage that writes the deliverable, and the run ended
+`cancelled`: its manifest has `07_writing` as `failed`, its `stages/` holds a
+`07_writing.tmp.md` and no `07_writing.md`, and one stage of the eight is `approved`.
+A backward move re-runs stages and a re-run stage can exhaust its attempts like any
+other, so revisiting and reaching the deliverable were drawing on one allowance while
+the routing prompt named neither. :class:`src.stage_graph.WalkBudget` now puts all
+three pools next to the menu — the graph's own two off
+:class:`~src.stage_graph.GraphState`, and the
 auto-skip pool from ``skip_budget``, the counters the manager enforces it with — so
 "an expensive correction is worth it" has a denominator. It is still not a price
 list: what changed is that "cost is not the criterion" is now said to an agent that
@@ -146,7 +150,9 @@ class StageRouter:
         # with `bypassPermissions`, so it is a file the displayed party can write; and
         # it is incomplete — `_route_to_deliverable` extends the tally the budget test
         # reads without writing an `auto_skip_used:` line, so a run routed off the
-        # approval gate reports four skips consumed in memory and none on the record.
+        # approval gate reports every stage from the aborting one up to the deliverable
+        # as consumed in memory — four when it aborts at Stage 03, six at Stage 01 —
+        # and none of them on the record.
         # A provider asks the enforcer, which cannot disagree with itself.
         #
         # Optional because the router runs without a manager in tests and in

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -1018,6 +1018,28 @@ def worst_case(move: Move, budget: WalkBudget) -> str:
     It is a ceiling and it says so. A re-run stage that passes first time spends a
     step and no skip, which is the ordinary case and the reason this is not
     presented as a price.
+
+    The skip half saturates once the pool is low, and a reader should know that
+    before reading the column. ``min(runs, skips_left)`` is ``skips_left`` for every
+    move that re-runs at least that many stages, so with one skip left every row of
+    the adaptive menu out of `06_analysis` — the advance and every revisit alike —
+    reads `up to 1 of the 1 auto-skip left`, and only `finish` differs. That is the
+    honest number, because the run really can lose its last skip to any of them; it
+    does mean the column tells moves apart through its step term and not its skip
+    term. `WorstCaseTest.test_the_skip_ceiling_saturates_once_the_pool_is_low` in
+    ``tests/test_router_budget.py`` is where that is pinned rather than asserted here.
+
+    "Does not fit" is said about the step pool and about nothing else, and the
+    narrowness is deliberate rather than missed. :attr:`Move.stage_runs` counts what
+    the move commits to "before the run is back here", and the run may also fail to
+    get back here because this node is at its own visit cap — that wall is the second
+    of the three lines :func:`describe_budget_for_prompt` prints, in the section the
+    prompt puts under this table, and folding it into a per-row verdict would restate
+    one number in as many rows as the menu has. The cap on the *target* is not silent
+    either: :meth:`StageGraph.moves` has already marked the move unavailable, with its
+    own reason and its own block kind, before the row is rendered. So the omission
+    here is one arithmetic the reader has to do across two lines, not a wall nobody
+    named.
     """
     runs = move.stage_runs
     if runs == 0:

--- a/src/stage_graph.py
+++ b/src/stage_graph.py
@@ -34,6 +34,14 @@ expensive to take *twice for the same reason*: a node carries a visit budget, an
 since the last time it was taken. A loop that keeps returning to Stage 05 with the
 same complaint is not iterating, it is stuck, and the difference is measurable.
 
+They are cheap, not free, and :class:`WalkBudget` is what says so before the wall
+rather than at it. A block is what a budget looks like once it has already bitten;
+:func:`describe_budget_for_prompt` and :func:`worst_case` are the same arithmetic
+addressed to the party about to spend — how much of the walk is left, how much of
+this node is left, how much of the unattended auto-skip allowance is left, and how
+much of each the move under consideration can take. Neither refuses anything: the
+refusals are :meth:`StageGraph.moves`'s and stay there.
+
 The path is recorded in ``evolution/stage_graph.json`` — every visit, the move out
 of it, whether the agent's choice matched what AutoR would have picked, and the
 rubric total at the time. :mod:`src.archive` reads those across runs to learn
@@ -896,12 +904,163 @@ class Move:
         return replay_cost(self.edge.source, self.edge.target)
 
     @property
+    def stage_runs(self) -> int:
+        """Stage executions the move commits to before the run is back here.
+
+        The same quantity as :attr:`replay_cost` for a backward move — the stages
+        it throws away are exactly the stages it has to run again — but not the
+        same *statement*, and the difference is what a budget reads. An advance
+        discards nothing and still runs a stage; a finish discards nothing and
+        runs none. Presenting all three as ``0`` is how a menu can show cost and
+        still say nothing about what the run is about to spend.
+        """
+        if self.edge.kind == "finish":
+            return 0
+        return self.replay_cost or 1
+
+    @property
     def admissible(self) -> bool:
         return not self.blocked_because
 
     @property
     def target(self) -> str:
         return self.edge.target
+
+
+# ----------------------------------------------------------------------------
+# What the walk has left
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WalkBudget:
+    """What the run has already spent, against what it was given.
+
+    Three pools, and they are not one pool. :data:`DEFAULT_MAX_STEPS` bounds the
+    whole walk, :data:`DEFAULT_MAX_VISITS` bounds one node, and the unattended
+    auto-skip allowance bounds how many stages may exhaust their attempts before
+    the run is sent to write up whatever it holds. Only the first two are the
+    graph's own; the third is the manager's, and it arrives from the caller rather
+    than as a constant repeated here — a second copy of a budget is a second
+    answer to "how much is left".
+
+    The auto-skip pool is the one that matters to a routing decision and the one
+    the router could not see. A backward move re-runs stages, a re-run stage can
+    exhaust its attempts like any other, and an exhausted stage spends a skip. So
+    a revisit and reaching the deliverable draw on the same allowance, and an
+    agent shown only the moves is choosing without the denominator.
+
+    Nothing here refuses anything. :meth:`StageGraph.moves` already blocks a move
+    the step and visit budgets have closed, with its own reason and its own block
+    kind; this is the same arithmetic said *before* the wall rather than at it.
+    ``max_skips`` is deliberately optional for the same reason: a display may say
+    "nobody declared one" and be honest, where a gate that fell back to a guess
+    would be refusing on a number nobody wrote.
+    """
+
+    #: Stage executions already made, including the one being routed out of, and
+    #: the cap on the whole walk.
+    steps_taken: int
+    max_steps: int
+    #: The node being routed out of, how many times the run has entered it, and
+    #: the per-stage cap.
+    node: str
+    node_visits: int
+    max_visits: int
+    #: Stages the harness auto-skipped after they exhausted their attempts.
+    skips_spent: int = 0
+    #: The cap on those. ``None`` when no allowance was declared: an attended run
+    #: has none in play, because a person chooses what happens when a stage
+    #: exhausts its attempts, and a caller with no manager behind it has nothing
+    #: to declare.
+    max_skips: int | None = None
+
+    @classmethod
+    def of(
+        cls,
+        state: GraphState,
+        node: str,
+        *,
+        skips_spent: int = 0,
+        max_skips: int | None = None,
+    ) -> "WalkBudget":
+        """Read the graph's own two pools off ``state``; take the third from the caller."""
+        return cls(
+            steps_taken=state.steps,
+            max_steps=state.max_steps,
+            node=node,
+            node_visits=state.visits(node),
+            max_visits=state.max_visits,
+            skips_spent=skips_spent,
+            max_skips=max_skips,
+        )
+
+    @property
+    def steps_left(self) -> int:
+        return max(self.max_steps - self.steps_taken, 0)
+
+    @property
+    def skips_left(self) -> int | None:
+        if self.max_skips is None:
+            return None
+        return max(self.max_skips - self.skips_spent, 0)
+
+
+def worst_case(move: Move, budget: WalkBudget) -> str:
+    """What taking ``move`` can cost, in one cell, against what is left.
+
+    Worst case rather than expected: the number that decides whether a correction
+    is affordable is the one where every stage it re-runs goes badly, because that
+    is the run that does not come back. Each re-run stage is a step, and each can
+    exhaust its attempts and spend an auto-skip, so the ceiling on both is the
+    same :attr:`Move.stage_runs`.
+
+    It is a ceiling and it says so. A re-run stage that passes first time spends a
+    step and no skip, which is the ordinary case and the reason this is not
+    presented as a price.
+    """
+    runs = move.stage_runs
+    if runs == 0:
+        return "—"
+    steps = f"{runs} step{'s' if runs != 1 else ''} of {budget.steps_left} left"
+    if runs > budget.steps_left:
+        steps += " — does not fit"
+    skips_left = budget.skips_left
+    if skips_left is None:
+        return f"{steps}; up to {runs} auto-skip{'s' if runs != 1 else ''}"
+    at_risk = min(runs, skips_left)
+    return (
+        f"{steps}; up to {at_risk} of the {skips_left} "
+        f"auto-skip{'s' if skips_left != 1 else ''} left"
+    )
+
+
+def describe_budget_for_prompt(budget: WalkBudget) -> str:
+    """The three pools, in the words the routing prompt shows them.
+
+    Written as what is *left* rather than as what was configured. "20 steps" is a
+    setting; "eleven left" is the thing a decision divides by.
+    """
+    if budget.max_skips is None:
+        skips = (
+            f"{budget.skips_spent} spent so far, against no declared allowance — treat this "
+            "pool as unknown rather than as empty or as unlimited"
+        )
+    else:
+        skips = f"{budget.skips_spent} of {budget.max_skips} spent, {budget.skips_left} left"
+    return "\n".join(
+        [
+            f"- **Steps**: {budget.steps_taken} of {budget.max_steps} spent, "
+            f"{budget.steps_left} left. Every stage execution is one, and a stage this "
+            "run has already done counts again when it is re-run.",
+            f"- **Visits to `{budget.node}`**: {budget.node_visits} of {budget.max_visits}. "
+            "A stage entered that many times is closed to any further move into it.",
+            f"- **Auto-skips**: {skips}. A stage that exhausts its attempts spends one and "
+            "is promoted as a stub saying its work was not done; when they are gone, the "
+            "next exhaustion sends the run straight to the deliverable with whatever it "
+            "holds, or ends it if the run is already there.",
+        ]
+    )
 
 
 class StageGraph:
@@ -1113,8 +1272,8 @@ class StageGraph:
             return False
         return normalized in state.revisit_reasons(target)
 
-    def describe_for_prompt(self, moves: Sequence[Move]) -> str:
-        """The menu, with what each move costs.
+    def describe_for_prompt(self, moves: Sequence[Move], budget: WalkBudget) -> str:
+        """The menu, with what each move costs and what the run has to spend.
 
         Cost is shown because it is real and invisible otherwise: two backward
         moves out of Stage 07 differ by 3.5x in the work they discard, and an
@@ -1122,18 +1281,25 @@ class StageGraph:
         framed as a reason to prefer the cheap move — a correct expensive
         correction beats a wrong cheap one, and a router that shops on price
         writes up around the flaw it should have gone back for.
+
+        ``Discards`` alone was not enough to make that framing honest. A price with
+        no balance beside it cannot be weighed at all, so an agent told to ignore
+        it was being told the only thing it could do with the column. ``Worst
+        case`` is the same number divided by what is left, and ``budget`` is
+        required rather than optional because a menu rendered without one is the
+        state this method spent its whole life in.
         """
         lines = [
-            "| Move | Target | Kind | Discards | Available | Why this move exists |",
-            "| --- | --- | --- | --- | --- | --- |",
+            "| Move | Target | Kind | Discards | Worst case | Available | Why this move exists |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
         ]
         for index, move in enumerate(moves, start=1):
             availability = "yes" if move.admissible else f"**no** — {move.blocked_because}"
             cost = move.replay_cost
             discards = "—" if cost == 0 else f"{cost} stage{'s' if cost != 1 else ''}"
             lines.append(
-                f"| {index} | `{move.edge.target}` | {move.edge.kind} | {discards} | {availability} | "
-                f"{move.edge.rationale} |"
+                f"| {index} | `{move.edge.target}` | {move.edge.kind} | {discards} | "
+                f"{worst_case(move, budget)} | {availability} | {move.edge.rationale} |"
             )
         return "\n".join(lines)
 

--- a/tests/test_graph_cost.py
+++ b/tests/test_graph_cost.py
@@ -9,7 +9,9 @@ ordering*: a per-edge constant sitting beside a derivable one is where drift
 starts, and this repo has already been bitten by hand-copied constants that were
 stale. Second, cost is shown as information, not as a reason to be thrifty — a
 correct expensive correction beats a wrong cheap one, and a router that shops on
-price writes up around the flaw it should have gone back for.
+price writes up around the flaw it should have gone back for. The second property
+grew a balance to weigh the price against; ``tests/test_router_budget.py`` holds
+that half, and the two assertions here keep both halves of the sentence at once.
 """
 
 from __future__ import annotations
@@ -19,7 +21,9 @@ import unittest
 from src.stage_graph import (
     FINISH,
     REVISIT_EDGES,
+    GraphState,
     StageGraph,
+    WalkBudget,
     _advance_edges,
     replay_cost,
 )
@@ -76,7 +80,7 @@ class ReplayCostTest(unittest.TestCase):
 class CostOnTheMenuTest(unittest.TestCase):
     def test_the_move_table_has_a_discards_column(self) -> None:
         graph = StageGraph.named("adaptive")
-        rendered = graph.describe_for_prompt([])
+        rendered = graph.describe_for_prompt([], WalkBudget.of(GraphState(), "06_analysis"))
         self.assertIn("Discards", rendered)
 
     def test_the_router_says_cost_is_not_a_reason_to_be_cheap(self) -> None:
@@ -87,6 +91,24 @@ class CostOnTheMenuTest(unittest.TestCase):
         self.assertIn("**Discards**", text, "the router never explains the column")
         self.assertIn("correct expensive", text)
         self.assertIn("break a tie", text)
+
+    def test_it_no_longer_says_that_without_saying_what_is_left(self) -> None:
+        """The other half of the same sentence, and the half that was false.
+
+        "A correct expensive correction beats a wrong cheap one" was addressed to an
+        agent with no idea what it had left to spend, and the paragraph went on to tell
+        it not to look. Keeping only the first assertion above would let the paragraph
+        revert to that: it is the sentence the reverted version also contains.
+        """
+        from pathlib import Path
+
+        text = (Path(__file__).resolve().parent.parent / "src" / "router.py").read_text(encoding="utf-8")
+        self.assertIn("afford to finish", text, "cost is weighed against nothing")
+        self.assertNotIn(
+            "Use it only to break a tie",
+            text,
+            "the column is still presented as tie-break-only, with no balance beside it",
+        )
 
 
 class NewBackwardEdgesTest(unittest.TestCase):

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -7,14 +7,20 @@ the stage summary — and no budget of any kind. Then it told the agent not to w
 on price writes up around the flaw it should have gone back for."
 
 That is right in the abstract and it was addressed to an agent that could not see the
-balance. Measured on the four runs of the first live paired trial, by reading
-`evolution/stage_graph.json` and `logs.txt` under
-`/rmeng_data/robtang/rcb-trial-graph/workspaces/*/.autor/*/`: every run was given
-twenty steps and the longest walk took nine of them, so the step budget never bound;
-the auto-skip allowance was three on all four and two runs spent all three. On the run
-that spent them, the next exhaustion landed at Stage 07, which is already the stage
-that writes the deliverable, so there was nowhere left to route and the run ended
-`cancelled`.
+balance. Measured by reading `evolution/stage_graph.json`, `run_manifest.json` and
+`logs.txt` under `/rmeng_data/robtang/rcb-trial-graph/workspaces/*/.autor/*/`, over the
+runs of the first live paired trial that had *finished* —
+`Astronomy_000_20260814_175426`, `Astronomy_000_20260815_074118` and
+`Chemistry_000_20260816_011751`. A fourth, `Chemistry_000_20260816_173127`, still reads
+`run_status: running` and is out of every count below on purpose: its walk was four
+steps when this branch was written and when it was reviewed, and five when this
+paragraph was, and a number that moves under the reader is not evidence.
+
+Of the three: each was given twenty steps and the longest walk took nine of them, so
+the step budget never bound; every `auto_skip_used:` line in all three has denominator
+three, and two of the three reached `3/3`. On one that spent them, the next exhaustion
+landed at Stage 07, which is already the stage that writes the deliverable, so there
+was nowhere left to route and the run ended `cancelled`.
 
 A backward move re-runs stages. A re-run stage can exhaust its attempts like any other,
 and an exhausted stage spends a skip. So revisiting and reaching the deliverable draw on
@@ -163,9 +169,27 @@ class WorstCaseTest(unittest.TestCase):
         self.assertIn("up to 2 of the 2 auto-skips left", cell)
 
     def test_the_skips_at_risk_are_capped_by_the_skips_that_remain(self) -> None:
-        """Four re-runs cannot spend five skips out of an allowance of two."""
+        """Four re-runs cannot spend four skips out of the one that is left.
+
+        The move re-runs four stages, `_budget(skips_spent=2)` leaves one of the three,
+        and the ceiling shown is one. A cell reading "up to 4" would be quoting the
+        move's cost where the balance is what the reader needs.
+        """
         cell = worst_case(self._move("06_analysis", "03_study_design"), _budget(skips_spent=2))
         self.assertIn("up to 1 of the 1 auto-skip left", cell)
+
+    def test_a_cheap_move_risks_fewer_skips_than_the_pool_holds(self) -> None:
+        """The other side of that cap, and it needed its own test.
+
+        Every other case in this class has the move re-running at least as many stages
+        as there are skips left, where `min(runs, skips_left)` and a bare `skips_left`
+        agree. An advance risks one skip out of three and the two come apart: a cell
+        reading "up to 3" would be telling the agent that stepping forward one stage
+        can cost the whole allowance.
+        """
+        cell = worst_case(self._move("06_analysis", "07_writing"), _budget(skips_spent=0))
+        self.assertIn("1 step of 11 left", cell)
+        self.assertIn("up to 1 of the 3 auto-skips left", cell)
 
     def test_a_move_the_walk_cannot_finish_says_so(self) -> None:
         cell = worst_case(self._move("06_analysis", "02_hypothesis_generation"), _budget(steps_taken=18))
@@ -181,6 +205,30 @@ class WorstCaseTest(unittest.TestCase):
 
     def test_finishing_costs_nothing_and_is_shown_as_nothing(self) -> None:
         self.assertEqual(worst_case(self._move("06_analysis", "finish"), _budget()), "—")
+
+    def test_the_skip_ceiling_saturates_once_the_pool_is_low(self) -> None:
+        """What the column stops discriminating, said out loud so nobody over-reads it.
+
+        With one skip left, `min(runs, skips_left)` is 1 for every move that re-runs a
+        stage at all, so the whole menu out of `06_analysis` carries the same skip term
+        and only the step term still separates the rows. Honest — the run can lose its
+        last skip to any of them — and the reason `worst_case` documents it.
+        """
+        budget = _budget(skips_spent=2)
+        self.assertEqual(budget.skips_left, 1)
+        cells = {
+            move.target: worst_case(move, budget)
+            for move in self.graph.moves(self.paths, "06_analysis", GraphState())
+        }
+        spending = {target: cell for target, cell in cells.items() if cell != "—"}
+        self.assertGreater(len(spending), 1, "one row cannot show saturation")
+        self.assertEqual(
+            {cell.split("; ", 1)[1] for cell in spending.values()},
+            {"up to 1 of the 1 auto-skip left"},
+        )
+        # The step term is what still tells them apart.
+        self.assertGreater(len({cell.split("; ", 1)[0] for cell in spending.values()}), 1)
+        self.assertEqual(cells["finish"], "—")
 
 
 class BudgetBlockTest(unittest.TestCase):
@@ -216,10 +264,15 @@ class TheSkipPoolComesFromTheEnforcerTest(unittest.TestCase):
     log reader can report an untouched pool to the very next routing decision after the
     pool has been emptied and overdrawn.
 
-    Measured on the trial, not just constructed here: on
-    `workspaces/Astronomy_000_20260814_175426/.autor/20260814_175429/logs.txt` the last
-    `auto_skip_used:` line reads `3/3` while the `already_skipped:` list in the same
-    file's `routed_to_deliverable` entry names five stages.
+    Measured on the trial, not just constructed here. That file is
+    `workspaces/Astronomy_000_20260814_175426/.autor/20260814_175429/logs.txt`, and it
+    carries three `auto_skip_used:` lines — `1/3`, `2/3`, `3/3` — then, later in the
+    file, its one `routed_to_deliverable` entry, whose `already_skipped:` list names
+    four stages: `02_hypothesis_generation`, `03_study_design`, `04_implementation`,
+    `06_analysis`. The published tally stopped at three and the list the budget test
+    reads had already gone past it. (The five-name list, those four plus
+    `05_experimentation`, is in the `07_writing unattended_abort` entry later still —
+    a different entry, and the pool was overdrawn before it was written.)
 
     Asking the enforcer cannot disagree with the enforcer. The second half — `logs.txt`
     is at the run root, where the operator runs `bypassPermissions` — is why it would
@@ -396,6 +449,86 @@ class RoutingPromptTest(unittest.TestCase):
         self.assertIn("4 steps of 2 left — does not fit", prompt)
         # `06 -> 05` re-runs two and still fits.
         self.assertIn("| 2 steps of 2 left; up to 2 auto-skips |", prompt)
+
+
+class TheVisitDenominatorIsTheCapThatBlocksTest(unittest.TestCase):
+    """The visit line divides by this run's cap, not by the constant.
+
+    Every other state in this file sits at :data:`DEFAULT_MAX_VISITS`, so
+    :meth:`WalkBudget.of` reading the constant instead of ``state.max_visits`` is
+    invisible to all of them and to the rest of the suite with it. The two numbers do
+    come apart: `--graph-max-visits` overrides the constant and `load_graph_state`
+    writes the override onto the state, which is why `WalkBudget.of` departs from the
+    wording that asked for "visits to this node of `DEFAULT_MAX_VISITS`".
+
+    The failure that departure removes is the one this whole item is about — a
+    denominator shown to the routing agent that is not the number
+    :meth:`StageGraph.moves` refuses at. Showing "1 of 3" to a run configured for five
+    would understate what it has left, which is the same error as showing no
+    denominator at all, only harder to notice.
+    """
+
+    CAP = DEFAULT_MAX_VISITS + 2
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.stage_file(STAGE_06), "# Stage 06: Analysis\n\nBody.\n")
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        write_text(self.paths.results_dir / "metrics.json", json.dumps({"acc": 0.7}))
+        write_text(self.paths.experiment_manifest, json.dumps({"result_artifacts": ["metrics.json"]}))
+        self.graph = StageGraph.adaptive()
+
+    def _state(self, visits_to_05: int = 1) -> GraphState:
+        """A walk out of `06_analysis` that has entered `05_experimentation` N times."""
+        slugs = [stage.slug for stage in STAGES[:6]]
+        slugs += ["05_experimentation", "06_analysis"] * (visits_to_05 - 1)
+        state = GraphState(
+            path=[Visit(stage=slug, entered_at="t") for slug in slugs], max_visits=self.CAP
+        )
+        self.assertEqual(state.visits("05_experimentation"), visits_to_05)
+        self.assertLess(state.steps, state.max_steps, "the step pool must not decide this")
+        return state
+
+    def _move_into_05(self, visits_to_05: int):
+        state = self._state(visits_to_05)
+        return next(
+            move
+            for move in self.graph.moves(self.paths, STAGE_06.slug, state)
+            if move.target == "05_experimentation"
+        )
+
+    def test_walk_budget_takes_the_cap_from_the_state_it_was_given(self) -> None:
+        self.assertNotEqual(self.CAP, DEFAULT_MAX_VISITS)
+        self.assertEqual(WalkBudget.of(self._state(), STAGE_06.slug).max_visits, self.CAP)
+
+    def test_the_prompt_divides_by_this_runs_cap_and_not_by_the_constant(self) -> None:
+        state = self._state()
+        prompt = StageRouter(None, mode="agent").build_prompt(
+            paths=self.paths,
+            stage=STAGE_06,
+            moves=self.graph.moves(self.paths, STAGE_06.slug, state),
+            state=state,
+            score=None,
+        )
+        self.assertIn(f"Visits to `06_analysis`**: 1 of {self.CAP}", prompt)
+        self.assertNotIn(f"Visits to `06_analysis`**: 1 of {DEFAULT_MAX_VISITS}", prompt)
+
+    def test_that_denominator_is_the_number_the_graph_refuses_at(self) -> None:
+        """Shown and enforced have to be one number or the display misinforms.
+
+        One entry below the cap the move into `05_experimentation` is live; at the cap
+        `StageGraph.moves` closes it with block kind `visits`. Both read the same
+        ``max_visits`` the line above prints, so the prompt's denominator is the wall.
+        """
+        self.assertTrue(self._move_into_05(self.CAP - 1).admissible)
+        at_cap = self._move_into_05(self.CAP)
+        self.assertFalse(at_cap.admissible)
+        self.assertEqual(at_cap.blocked_kind, "visits")
+        self.assertIn(f"entered {self.CAP} times", at_cap.blocked_because)
 
 
 class TheBudgetIsShownAndNotEnforcedTest(unittest.TestCase):

--- a/tests/test_router_budget.py
+++ b/tests/test_router_budget.py
@@ -1,0 +1,524 @@
+"""What the move costs, against what the run has left.
+
+The routing prompt showed every move, what each one discards, the route so far, the
+backward moves already taken, the finished stage's score, archive evidence, the goal and
+the stage summary — and no budget of any kind. Then it told the agent not to weigh cost:
+"a correct expensive correction beats a wrong cheap one every time, and a run that shops
+on price writes up around the flaw it should have gone back for."
+
+That is right in the abstract and it was addressed to an agent that could not see the
+balance. Measured on the four runs of the first live paired trial, by reading
+`evolution/stage_graph.json` and `logs.txt` under
+`/rmeng_data/robtang/rcb-trial-graph/workspaces/*/.autor/*/`: every run was given
+twenty steps and the longest walk took nine of them, so the step budget never bound;
+the auto-skip allowance was three on all four and two runs spent all three. On the run
+that spent them, the next exhaustion landed at Stage 07, which is already the stage
+that writes the deliverable, so there was nowhere left to route and the run ended
+`cancelled`.
+
+A backward move re-runs stages. A re-run stage can exhaust its attempts like any other,
+and an exhausted stage spends a skip. So revisiting and reaching the deliverable draw on
+one allowance, and the prompt named neither. These tests hold four things:
+
+* the three pools reach the prompt, with numbers;
+* the worst case of each move reaches the prompt, divided by what is left;
+* the auto-skip figures come from the counters that *enforce* the budget, not from a
+  reconstruction of them — see :class:`TheSkipPoolComesFromTheEnforcerTest`, which pins
+  the case a reconstruction gets wrong;
+* **none of it refuses anything.** A move whose worst case does not fit is still on the
+  menu and is still taken when it is chosen. The refusal is somebody else's item, and a
+  display that quietly became a gate would be the more expensive mistake: the run that
+  cannot afford to go back is exactly the run that most needs to be able to.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.manager import ResearchManager
+from src.router import StageRouter
+from src.stage_graph import (
+    DEFAULT_MAX_STEPS,
+    DEFAULT_MAX_VISITS,
+    GraphState,
+    StageGraph,
+    Visit,
+    WalkBudget,
+    describe_budget_for_prompt,
+    worst_case,
+)
+from src.terminal_ui import TerminalUI
+from src.utils import (
+    STAGES,
+    WRITING_STAGE,
+    build_run_paths,
+    ensure_run_layout,
+    read_text,
+    write_text,
+)
+
+
+STAGE_06 = next(stage for stage in STAGES if stage.number == 6)
+
+
+def _budget(**overrides: object) -> WalkBudget:
+    fields: dict[str, object] = {
+        "steps_taken": 9,
+        "max_steps": 20,
+        "node": "06_analysis",
+        "node_visits": 2,
+        "max_visits": 3,
+        "skips_spent": 1,
+        "max_skips": 3,
+    }
+    fields.update(overrides)
+    return WalkBudget(**fields)  # type: ignore[arg-type]
+
+
+class WalkBudgetArithmeticTest(unittest.TestCase):
+    def test_what_is_left_is_what_was_given_minus_what_was_spent(self) -> None:
+        budget = _budget()
+        self.assertEqual(budget.steps_left, 11)
+        self.assertEqual(budget.skips_left, 2)
+
+    def test_an_overspent_pool_reads_as_empty_rather_than_negative(self) -> None:
+        """A run resumed with a smaller cap than it has already spent is a real state.
+
+        `--graph-max-steps` is re-read on resume and `load_graph_state` overwrites the
+        stored cap with it, so a walk of nine steps resumed at `--graph-max-steps 4` is
+        reachable from the CLI. "-5 left" is not a quantity a reader can act on.
+        """
+        self.assertEqual(_budget(max_steps=4).steps_left, 0)
+        self.assertEqual(_budget(skips_spent=5).skips_left, 0)
+
+    def test_an_unrecorded_allowance_is_none_rather_than_a_guess(self) -> None:
+        self.assertIsNone(_budget(max_skips=None).skips_left)
+
+    def test_it_reads_the_graphs_two_pools_off_the_state(self) -> None:
+        state = GraphState(
+            path=[
+                Visit(stage="05_experimentation", entered_at="t"),
+                Visit(stage="06_analysis", entered_at="t"),
+                Visit(stage="05_experimentation", entered_at="t"),
+            ]
+        )
+        budget = WalkBudget.of(state, "05_experimentation")
+        self.assertEqual(budget.steps_taken, 3)
+        self.assertEqual(budget.max_steps, DEFAULT_MAX_STEPS)
+        self.assertEqual(budget.node_visits, 2)
+        self.assertEqual(budget.max_visits, DEFAULT_MAX_VISITS)
+        # Not the graph's to know, and not invented.
+        self.assertEqual(budget.skips_spent, 0)
+        self.assertIsNone(budget.max_skips)
+
+
+class StageRunsTest(unittest.TestCase):
+    """`Discards` is zero for three different situations and they cost differently."""
+
+    def setUp(self) -> None:
+        self.graph = StageGraph.adaptive()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+
+    def _move(self, source: str, target: str):
+        moves = self.graph.moves(self.paths, source, GraphState())
+        return next(move for move in moves if move.target == target)
+
+    def test_an_advance_discards_nothing_and_still_runs_a_stage(self) -> None:
+        move = self._move("06_analysis", "07_writing")
+        self.assertEqual(move.replay_cost, 0)
+        self.assertEqual(move.stage_runs, 1)
+
+    def test_a_finish_runs_nothing(self) -> None:
+        move = self._move("06_analysis", "finish")
+        self.assertEqual(move.stage_runs, 0)
+
+    def test_a_revisit_re_runs_everything_it_threw_away(self) -> None:
+        move = self._move("06_analysis", "03_study_design")
+        self.assertEqual(move.replay_cost, 4)
+        self.assertEqual(move.stage_runs, 4)
+
+
+class WorstCaseTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.graph = StageGraph.adaptive()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+
+    def _move(self, source: str, target: str):
+        moves = self.graph.moves(self.paths, source, GraphState())
+        return next(move for move in moves if move.target == target)
+
+    def test_it_divides_the_cost_by_what_is_left(self) -> None:
+        cell = worst_case(self._move("06_analysis", "03_study_design"), _budget())
+        self.assertIn("4 steps of 11 left", cell)
+        self.assertIn("up to 2 of the 2 auto-skips left", cell)
+
+    def test_the_skips_at_risk_are_capped_by_the_skips_that_remain(self) -> None:
+        """Four re-runs cannot spend five skips out of an allowance of two."""
+        cell = worst_case(self._move("06_analysis", "03_study_design"), _budget(skips_spent=2))
+        self.assertIn("up to 1 of the 1 auto-skip left", cell)
+
+    def test_a_move_the_walk_cannot_finish_says_so(self) -> None:
+        cell = worst_case(self._move("06_analysis", "02_hypothesis_generation"), _budget(steps_taken=18))
+        self.assertIn("5 steps of 2 left", cell)
+        self.assertIn("does not fit", cell)
+
+    def test_a_move_that_fits_does_not_say_it_does_not(self) -> None:
+        self.assertNotIn("does not fit", worst_case(self._move("06_analysis", "05_experimentation"), _budget()))
+
+    def test_an_unrecorded_allowance_gives_a_ceiling_without_a_denominator(self) -> None:
+        cell = worst_case(self._move("06_analysis", "03_study_design"), _budget(max_skips=None))
+        self.assertEqual(cell, "4 steps of 11 left; up to 4 auto-skips")
+
+    def test_finishing_costs_nothing_and_is_shown_as_nothing(self) -> None:
+        self.assertEqual(worst_case(self._move("06_analysis", "finish"), _budget()), "—")
+
+
+class BudgetBlockTest(unittest.TestCase):
+    def test_all_three_pools_are_named_with_what_is_left(self) -> None:
+        block = describe_budget_for_prompt(_budget())
+        self.assertIn("9 of 20 spent, 11 left", block)
+        self.assertIn("Visits to `06_analysis`**: 2 of 3", block)
+        self.assertIn("1 of 3 spent, 2 left", block)
+
+    def test_an_unrecorded_allowance_is_declared_missing_rather_than_filled_in(self) -> None:
+        block = describe_budget_for_prompt(_budget(skips_spent=0, max_skips=None))
+        skip_line = next(line for line in block.splitlines() if "Auto-skips" in line)
+        self.assertIn("0 spent so far", skip_line)
+        self.assertIn("against no declared allowance", skip_line)
+        # The two shapes a fabricated denominator would take.
+        self.assertNotIn(" left", skip_line)
+        self.assertNotIn(" of ", skip_line.split(".")[0])
+
+
+class TheSkipPoolComesFromTheEnforcerTest(unittest.TestCase):
+    """Where the auto-skip figures come from, and the case that decided it.
+
+    The obvious source is `logs.txt`: the manager writes `auto_skip_used: N/M` beside
+    every stage it auto-skips, both halves on one line, and a regex over the run's own
+    record needs no new parameter anywhere. It is also wrong twice, and this class pins
+    the more serious half.
+
+    `_route_to_deliverable` extends `auto_skipped_stages` — the list the budget test
+    `len(self.auto_skipped_stages) >= self.max_auto_skips` reads — with every stage it
+    bypasses, and writes a `routed_to_deliverable` entry that carries no
+    `auto_skip_used:` line. It is reachable with the pool untouched: the approval-gate
+    abort branch calls it in unattended mode without consulting the budget at all. So a
+    log reader can report an untouched pool to the very next routing decision after the
+    pool has been emptied and overdrawn.
+
+    Measured on the trial, not just constructed here: on
+    `workspaces/Astronomy_000_20260814_175426/.autor/20260814_175429/logs.txt` the last
+    `auto_skip_used:` line reads `3/3` while the `already_skipped:` list in the same
+    file's `routed_to_deliverable` entry names five stages.
+
+    Asking the enforcer cannot disagree with the enforcer. The second half — `logs.txt`
+    is at the run root, where the operator runs `bypassPermissions` — is why it would
+    have been the wrong source even if it were complete.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        self.paths = build_run_paths(self.root / "runs" / "run_0001")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.memory, "# Memory\n\n## Approved Stage Summaries\n\n_None yet._\n")
+
+    def _manager(self, *, max_auto_skips: int = 3, unattended: bool = True) -> ResearchManager:
+        class StubOperator:
+            model = "stub-model"
+            backend_name = "claude"
+
+        return ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=self.root / "runs",
+            operator=StubOperator(),
+            ui=TerminalUI(output_stream=io.StringIO(), input_stream=io.StringIO(), interactive=False),
+            unattended=unattended,
+            max_auto_skips=max_auto_skips,
+        )
+
+    def test_an_untouched_pool_reads_as_spent_nothing_of_the_allowance(self) -> None:
+        self.assertEqual(self._manager()._auto_skip_budget(), (0, 3))
+
+    def test_a_spent_skip_moves_it(self) -> None:
+        manager = self._manager()
+        self.assertTrue(
+            manager._handle_stage_exhaustion(
+                paths=self.paths,
+                stage=STAGES[1],
+                attempt_no=8,
+                last_validation_errors=["Missing 'Key Results' section"],
+            )
+        )
+        self.assertEqual(manager._auto_skip_budget(), (1, 3))
+        self.assertEqual(len(manager.auto_skipped_stages), 1)
+
+    def test_it_tracks_the_spend_across_several_skips(self) -> None:
+        manager = self._manager()
+        for stage in STAGES[:2]:
+            manager._handle_stage_exhaustion(
+                paths=self.paths, stage=stage, attempt_no=8, last_validation_errors=[]
+            )
+        self.assertEqual(manager._auto_skip_budget(), (2, 3))
+
+    def test_a_non_default_allowance_is_reported_rather_than_assumed(self) -> None:
+        """The one thing a constant kept in `src/router.py` could not have got right."""
+        self.assertEqual(self._manager(max_auto_skips=7)._auto_skip_budget(), (0, 7))
+
+    def test_a_human_skip_does_not_draw_on_the_unattended_pool(self) -> None:
+        """`/skip` costs the run a stage and costs the unattended allowance nothing."""
+        manager = self._manager()
+        manager._skip_stage(
+            paths=self.paths,
+            stage=STAGES[0],
+            attempt_no=1,
+            reason="Human operator skipped this stage via /skip.",
+            kind="human",
+        )
+        self.assertIn("skipped", read_text(self.paths.logs))
+        self.assertEqual(manager._auto_skip_budget(), (0, 3))
+
+    def test_an_attended_run_reports_no_allowance_because_none_is_in_play(self) -> None:
+        self.assertEqual(self._manager(unattended=False)._auto_skip_budget(), (0, None))
+
+    def test_a_route_to_the_deliverable_spends_the_pool_and_writes_no_tally(self) -> None:
+        """The case a `logs.txt` reader gets wrong, both halves in one test.
+
+        Reachable with the budget untouched: `_route_to_deliverable` is called from the
+        approval-gate abort branch without a budget check. Four stages land in the
+        tally, and the words `auto_skip_used` never reach the log — so a reader of the
+        record would tell the next routing decision that nothing had been spent.
+        """
+        manager = self._manager()
+        self.assertTrue(
+            manager._route_to_deliverable(
+                paths=self.paths,
+                stage=STAGES[2],
+                attempt_no=1,
+                because="the approval gate aborted with no human to ask",
+                errors_note="- (the stage was aborted rather than failing validation)",
+            )
+        )
+        self.assertEqual(manager._auto_skip_budget(), (4, 3))
+        self.assertNotIn("auto_skip_used", read_text(self.paths.logs))
+
+    def test_the_manager_hands_the_router_that_very_method(self) -> None:
+        """Wiring, not shape. A provider nothing passes shows the same "not declared"
+        line as no provider at all, and the whole block would go quietly blank."""
+        manager = self._manager()
+        self.assertEqual(manager.router.skip_budget, manager._auto_skip_budget)
+
+    def test_a_router_with_no_provider_declares_no_allowance_rather_than_guessing(self) -> None:
+        self.assertIsNone(StageRouter(None, mode="agent").skip_budget)
+
+
+class RoutingPromptTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.stage_file(STAGE_06), "# Stage 06: Analysis\n\nBody.\n")
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        write_text(self.paths.results_dir / "metrics.json", json.dumps({"acc": 0.7}))
+        write_text(self.paths.experiment_manifest, json.dumps({"result_artifacts": ["metrics.json"]}))
+        self.graph = StageGraph.adaptive()
+
+    def _state(self, steps: int = 6) -> GraphState:
+        return GraphState(
+            path=[Visit(stage=stage.slug, entered_at="t") for stage in STAGES[:steps]]
+        )
+
+    def _prompt(
+        self,
+        state: GraphState | None = None,
+        skip_budget: object | None = None,
+    ) -> str:
+        state = state or self._state()
+        moves = self.graph.moves(self.paths, STAGE_06.slug, state)
+        return StageRouter(None, mode="agent", skip_budget=skip_budget).build_prompt(  # type: ignore[arg-type]
+            paths=self.paths, stage=STAGE_06, moves=moves, state=state, score=None
+        )
+
+    def test_the_prompt_carries_the_three_pools(self) -> None:
+        prompt = self._prompt(skip_budget=lambda: (1, 3))
+        self.assertIn("## What this run has left", prompt)
+        self.assertIn("6 of 20 spent, 14 left", prompt)
+        self.assertIn("Visits to `06_analysis`**: 1 of 3", prompt)
+        self.assertIn("1 of 3 spent, 2 left", prompt)
+
+    def test_the_menu_carries_a_worst_case_per_move(self) -> None:
+        prompt = self._prompt(skip_budget=lambda: (1, 3))
+        self.assertIn("| Worst case |", prompt)
+        # `06 -> 03` discards four stages; four of the fourteen steps left, and it can
+        # spend both of the two skips left.
+        self.assertIn("4 steps of 14 left; up to 2 of the 2 auto-skips left", prompt)
+
+    def test_the_prompt_says_what_a_re_run_stage_can_cost(self) -> None:
+        """The sentence that connects a backward edge to the allowance it competes with."""
+        prompt = self._prompt()
+        self.assertIn("a re-run stage can exhaust its attempts", prompt)
+        self.assertIn("up to one auto-skip each", prompt)
+
+    def test_cost_is_still_not_the_criterion(self) -> None:
+        prompt = self._prompt()
+        self.assertIn("Cost is not the criterion", prompt)
+        self.assertIn("A correct expensive correction beats a wrong cheap one", prompt)
+
+    def test_and_an_unaffordable_correction_is_no_longer_recommended(self) -> None:
+        prompt = self._prompt()
+        self.assertIn("cannot afford to finish is not a correction", prompt)
+
+    def test_it_does_not_invent_an_allowance_it_was_never_told(self) -> None:
+        prompt = self._prompt()
+        self.assertIn("against no declared allowance", prompt)
+        self.assertNotIn("auto-skips left", prompt)
+
+    def test_a_run_out_of_steps_is_told_the_move_does_not_fit(self) -> None:
+        state = self._state()
+        state.max_steps = 8
+        prompt = self._prompt(state)
+        self.assertIn("6 of 8 spent, 2 left", prompt)
+        # `06 -> 03` re-runs four stages and the walk has two left.
+        self.assertIn("4 steps of 2 left — does not fit", prompt)
+        # `06 -> 05` re-runs two and still fits.
+        self.assertIn("| 2 steps of 2 left; up to 2 auto-skips |", prompt)
+
+
+class TheBudgetIsShownAndNotEnforcedTest(unittest.TestCase):
+    """The line this item is not allowed to cross.
+
+    A refusal on cost grounds belongs to the budget-separation work and to the
+    supervisor above it. What is added here is a number on a page. These tests fail if
+    it ever becomes a gate — which is the accident this shape invites, because the
+    arithmetic for the display and the arithmetic for a refusal are the same arithmetic.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        write_text(self.paths.stage_file(STAGE_06), "# Stage 06: Analysis\n\nBody.\n")
+        write_text(self.paths.code_dir / "run.py", "print(1)\n")
+        write_text(self.paths.results_dir / "metrics.json", json.dumps({"acc": 0.7}))
+        write_text(self.paths.experiment_manifest, json.dumps({"result_artifacts": ["metrics.json"]}))
+        self.graph = StageGraph.adaptive()
+
+    def _choose(self, response: str, state: GraphState, skip_budget: object | None = None):
+        class FakeOperator:
+            fake_mode = False
+
+            def __init__(self) -> None:
+                self.prompts: list[str] = []
+
+            def _prepare_invocation(self, prompt_path, session_id, *, paths, resume):
+                self.prompts.append(read_text(prompt_path))
+                return (["fake-backend"], paths.run_root, None)
+
+            def _run_streaming_command(self, **kwargs):
+                return (0, response, "", None, {})
+
+        operator = FakeOperator()
+        decision = StageRouter(operator, mode="agent", skip_budget=skip_budget).choose(  # type: ignore[arg-type]
+            paths=self.paths, stage=STAGE_06, graph=self.graph, state=state
+        )
+        return decision, operator
+
+    def test_the_dearest_move_is_taken_with_the_allowance_spent(self) -> None:
+        state = GraphState(path=[Visit(stage=stage.slug, entered_at="t") for stage in STAGES[:6]])
+        decision, operator = self._choose(
+            json.dumps(
+                {
+                    "target": "02_hypothesis_generation",
+                    "reason": "The evidence refutes H1 and points at a different mechanism.",
+                }
+            ),
+            state,
+            skip_budget=lambda: (3, 3),
+        )
+        self.assertIn("3 of 3 spent, 0 left", operator.prompts[0])
+        self.assertEqual(decision.target, "02_hypothesis_generation")
+        self.assertTrue(decision.agent_directed)
+        self.assertEqual(decision.refusal, "")
+
+    def test_a_move_that_does_not_fit_the_step_budget_is_still_on_the_menu(self) -> None:
+        state = GraphState(
+            path=[Visit(stage=stage.slug, entered_at="t") for stage in STAGES[:6]], max_steps=7
+        )
+        decision, operator = self._choose(
+            json.dumps(
+                {
+                    "target": "02_hypothesis_generation",
+                    "reason": "The evidence refutes H1 and points at a different mechanism.",
+                }
+            ),
+            state,
+        )
+        self.assertIn("does not fit", operator.prompts[0])
+        self.assertEqual(decision.target, "02_hypothesis_generation")
+        self.assertEqual(decision.refusal, "")
+
+    def test_the_router_source_records_no_refusal_on_a_budget_it_only_displays(self) -> None:
+        """A grep, deliberately. The reader after the supervisor lands will be looking
+        for whether this module ever learned to say no, and the answer has to be no."""
+        text = (Path(__file__).resolve().parent.parent / "src" / "router.py").read_text(encoding="utf-8")
+        body = text.split("def choose(", 1)[1].split("def _refuse(", 1)[0]
+        for symbol in ("skips_left", "steps_left", "skip_budget", "WalkBudget"):
+            self.assertNotIn(symbol, body, f"`choose` reads {symbol}; a display became a gate")
+
+
+class WritingStageHasNowhereToRouteTest(unittest.TestCase):
+    """Why the auto-skip pool is the one worth showing.
+
+    The chain the trial walked: a stage burns its attempts, an auto-skip fires, repeat
+    until the allowance is spent, and then the next exhaustion happens at the stage that
+    writes the deliverable — where `_route_to_deliverable` has nowhere to send it. This
+    pins the last link, which is the one that turns a spent allowance into a cancelled
+    run rather than into a shorter one.
+    """
+
+    def test_an_exhaustion_at_the_writing_stage_with_no_allowance_left_aborts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            paths = build_run_paths(root / "runs" / "run_0001")
+            ensure_run_layout(paths)
+            write_text(paths.user_input, "goal")
+            write_text(paths.memory, "# Memory\n\n## Approved Stage Summaries\n\n_None yet._\n")
+
+            class StubOperator:
+                model = "stub-model"
+                backend_name = "claude"
+
+            manager = ResearchManager(
+                project_root=Path(__file__).resolve().parent.parent,
+                runs_dir=root / "runs",
+                operator=StubOperator(),
+                ui=TerminalUI(output_stream=io.StringIO(), input_stream=io.StringIO(), interactive=False),
+                unattended=True,
+                max_auto_skips=0,
+            )
+            self.assertFalse(
+                manager._handle_stage_exhaustion(
+                    paths=paths, stage=WRITING_STAGE, attempt_no=8, last_validation_errors=[]
+                )
+            )
+            self.assertIn("unattended_abort", read_text(paths.logs))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stage_graph.py
+++ b/tests/test_stage_graph.py
@@ -26,6 +26,7 @@ from src.stage_graph import (
     Move,
     StageGraph,
     Visit,
+    WalkBudget,
     block_census,
     enter,
     format_block_census,
@@ -230,9 +231,10 @@ class AdaptiveTopologyTests(unittest.TestCase):
     def test_a_blocked_move_is_still_shown_to_the_router(self) -> None:
         """Hiding it would be the obvious design and it is the wrong one: an agent
         that can see why writing is closed routes to what opens it."""
-        moves = self.graph.moves(self.paths, "06_analysis", GraphState())
+        state = GraphState()
+        moves = self.graph.moves(self.paths, "06_analysis", state)
         self.assertIn("07_writing", {move.target for move in moves})
-        rendered = self.graph.describe_for_prompt(moves)
+        rendered = self.graph.describe_for_prompt(moves, WalkBudget.of(state, "06_analysis"))
         self.assertIn("07_writing", rendered)
         self.assertIn("**no**", rendered)
 


### PR DESCRIPTION
Review of `routing/what-the-move-costs` returned three must-fix items. All three
were right; each is corrected against a command run in this pass, not against
memory of the trial.

**1. A count read from the wrong log entry.** `TheSkipPoolComesFromTheEnforcerTest`
said the `already_skipped:` list in the `routed_to_deliverable` entry of
`Astronomy_000_20260814_175426` "names five stages". Parsed with `re.finditer` over
the 12 MB file (`grep` treats it as binary — it has NUL bytes): that entry, at byte
10386451, names four — `02_hypothesis_generation`, `03_study_design`,
`04_implementation`, `06_analysis`. The five-name list is a different entry,
`07_writing unattended_abort`, at byte 12348135. The point the docstring was making
survives and is now attributed to the entry that carries it.

**2. Numbers in a docstring derivable from nothing.**
`test_the_skips_at_risk_are_capped_by_the_skips_that_remain` claimed "four re-runs
cannot spend five skips out of an allowance of two" against a call with
`max_skips=3`, `skips_spent=2`, four re-runs and an assertion of `up to 1 of the 1
auto-skip left`. Restated against the fixture.

**3. `max_visits=state.max_visits` was unpinned.** Replacing it with
`DEFAULT_MAX_VISITS` survived the entire suite — reproduced here at 2770 tests, OK
— because every state in the module already sits at the default.
`TheVisitDenominatorIsTheCapThatBlocksTest` uses `DEFAULT_MAX_VISITS + 2` and
asserts both halves that have to agree: the prompt divides by the run's cap, and
that same cap is the number `StageGraph.moves` refuses at, live one entry below it
and `blocked_kind == "visits"` at it. Both new tests fail under the mutant.

**The population was still moving.** The module docstring counted "the four runs of
the first live paired trial". `Chemistry_000_20260816_173127` still reads
`run_status: running`; its walk was four steps for the author and the reviewer and
is five now. The docstring now names the three finished runs, states its figures
over those, and says why the fourth is excluded. Re-measured over the three:
`max_steps` 20 on each, path lengths 6/9/7, every `auto_skip_used:` denominator 3,
two of the three reaching `3/3`.

**Reviewer's non-blocking notes, all taken.** "Reports four skips" was written as a
property of the path; measured from every stage, the pool it leaves is
`WRITING_STAGE.number - stage.number` — six from Stage 01, four from Stage 03 —
so both copies now name where the four comes from. "The deliverable truncated"
is replaced by what the manifest and `stages/` actually hold. `worst_case` now
says that its skip term saturates once the pool is low, with
`test_the_skip_ceiling_saturates_once_the_pool_is_low` pinning it, and that "does
not fit" is about the step pool only.

That saturation work found a fourth gap the review did not: with
`min(runs, skips_left)`, every existing case had `runs >= skips_left`, so replacing
the expression with a bare `skips_left` survived.
`test_a_cheap_move_risks_fewer_skips_than_the_pool_holds` uses an advance against a
full pool and kills it.

21 mutants applied via /tmp/mut-rb/mutate.py, 21 killed, baseline asserted green
first and every file restored in a `finally` (`git status --short` clean after).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



🤖 Generated with [Claude Code](https://claude.com/claude-code)
