### PR TITLE
Make the paired trial able to reach a conclusion

### DIFF
--- a/src/rcb_trial.py
+++ b/src/rcb_trial.py
@@ -584,14 +584,40 @@ class RcbTrial:
     """A finished (or interrupted) paired trial and everything a reader needs to argue."""
 
     result: TrialResult
-    #: Admitted evidence, keyed ``(task_id, arm)``.
+    #: Admitted evidence, keyed ``(task_id, arm)``. The population *under* the number:
+    #: every arm here is in a pair or in ``result.excluded``, and nothing else is.
     evidence: Mapping[tuple[str, str], ArmEvidence]
+    #: Every arm a judge produced a score for, keyed the same way — admitted *and*
+    #: refused by :func:`admit_arm`. A separate field and not a filter over ``evidence``,
+    #: because refusing an arm is the one operation that removes it from ``evidence``,
+    #: and the sample-composition section is the reader's only view of what was removed.
+    #: Reporting the composition of a sample off the survivors is the shape this branch
+    #: was sent back for: ``_run_status_lines`` read ``evidence``, so on the live
+    #: stage-graph trial — three scored runs, two of them ``cancelled`` and both refused
+    #: by ``pipeline_completed`` — it printed "all 1 scored runs ended `completed`", a
+    #: positive clean-sample claim over a sample that was two thirds truncated.
+    #:
+    #: Driver refusals are *not* here and cannot be: a run killed by quota, by the
+    #: watchdog or by the scorer never became an :class:`ArmEvidence` and has no score
+    #: for the section to be about. They are in ``refusals`` and in the ledger above it.
+    scored: Mapping[tuple[str, str], ArmEvidence]
     refusals: tuple[Refusal, ...]
     planned_pairs: int
 
     @property
     def interim(self) -> bool:
         return self.result.n != self.planned_pairs
+
+    def refused_clauses_by_arm(self) -> dict[tuple[str, str], tuple[str, ...]]:
+        """``(task, arm) -> the clauses that refused it``, for the arms that were refused.
+
+        Both refusal populations at once, because the caller asking is asking whether a
+        given arm is in the difference, and an arm refused by the driver and an arm
+        refused by a clause are equally out of it.
+        """
+        return {
+            (refusal.task_id, refusal.arm): refusal.clauses for refusal in self.refusals
+        }
 
     def refusals_by_clause(self) -> dict[str, int]:
         """Every admission clause at its count, then every driver refusal that happened.
@@ -656,8 +682,13 @@ def collect_rcb_pairs(
     measure that is not in ``trials.DECLARED_OUTCOMES``.
     """
     admitted: dict[tuple[str, str], ArmEvidence] = {}
+    # Every arm that reached the gate, whichever way it came out. `admitted` is what the
+    # difference is computed over; this is what the difference's *sample* is, and the two
+    # differ by exactly the runs a reader most needs told about.
+    scored: dict[tuple[str, str], ArmEvidence] = {}
     refusals: list[Refusal] = []
     for evidence in evidences:
+        scored[(evidence.task_id, evidence.arm)] = evidence
         ok, failed = admit_arm(evidence)
         if ok:
             admitted[(evidence.task_id, evidence.arm)] = evidence
@@ -728,6 +759,7 @@ def collect_rcb_pairs(
     return RcbTrial(
         result=replace(result, excluded=tuple(sorted(excluded.items()))),
         evidence=admitted,
+        scored=scored,
         refusals=tuple(refusals),
         planned_pairs=planned_pairs,
     )
@@ -997,26 +1029,43 @@ def _run_status_lines(trial: RcbTrial) -> list[str]:
     """How each scored run ended, above the difference rather than inside it.
 
     Every number in this report is a judge's reading of a deliverable, and a truncated
-    deliverable is a different object from a finished one. Two of the three finished runs
+    deliverable is a different object from a finished one. Two of the three scored runs
     of the live stage-graph trial ended ``cancelled`` — auto-skip budget spent, routed to
     the writing stage to produce what it had — and neither said so anywhere in the
     report: a reader had to open ``runs/<task>.<arm>.a1.json`` to find out that the
-    majority of the finished sample was truncated.
+    majority of the scored sample was truncated.
 
-    Not a refusal and not a caveat under the total. The runs are scored on purpose, so
-    what a reader needs is the composition of the sample, in the same voice as the
-    refusal ledger above it.
+    The population is :attr:`RcbTrial.scored` and not :attr:`RcbTrial.evidence`, and that
+    is the whole of this function's history. Both of those live ``cancelled`` runs also
+    carry ``_meta.pipeline_completed: false``, so the ``pipeline_completed`` clause
+    refuses them and they are absent from ``evidence`` — the first version of this
+    section read ``evidence``, saw the one surviving run, and printed "all 1 scored runs
+    ended ``completed``" over a sample two thirds of which was cut off. A disclosure
+    computed over the survivors of the thing it is disclosing states the opposite of the
+    truth exactly when the truth is worst, and reads as an all-clear while doing it.
+    ``tests.test_rcb_trial.RunStatusSeesRefusedRunsTests`` is that sample as a fixture.
+
+    Refused rows are marked and counted separately rather than dropped, because "the
+    sample the difference is over" and "the sample the judge scored" are two different
+    populations and a reader needs both: a trial that refused its way to a clean-looking
+    mean has produced a result, and it is not the mean.
+
+    Not a refusal and not a caveat under the total. The admitted runs are scored on
+    purpose, so what a reader needs is the composition of the sample, in the same voice
+    as the refusal ledger above it.
 
     Three headlines and not two, because a run that recorded no status at all is neither
     truncated nor clean. Folding silence into the clean branch would print "all N scored
     runs ended `completed`" over a sample nothing had measured the ending of, which is
     the same fabrication in the other direction.
     """
-    rows = sorted(trial.evidence.items())
+    rows = sorted(trial.scored.items())
     if not rows:
         return ["- no run was scored."]
+    refused = trial.refused_clauses_by_arm()
     cut = [key for key, evidence in rows if truncated(evidence)]
     silent = [key for key, evidence in rows if not run_status_of(evidence)]
+    out = [key for key, _ in rows if key in refused]
     if cut:
         headline = f"- **{len(cut)} of {len(rows)} scored runs did not end `{RUN_COMPLETED}`.**"
     elif silent:
@@ -1027,12 +1076,31 @@ def _run_status_lines(trial: RcbTrial) -> list[str]:
     else:
         headline = f"- all {len(rows)} scored runs ended `{RUN_COMPLETED}`."
     lines = [headline]
-    lines += ["", "| task | arm | run status | stages the run scored |", "| --- | --- | --- | --- |"]
-    for (task, arm_label), evidence in rows:
+    # The split, always, and above the table. Every count in the headline is over runs a
+    # judge scored; the difference below is over a subset of them, and how big a subset
+    # is the number that decides whether the difference is about the code under test.
+    lines.append(
+        f"- of those {len(rows)}, **{len(rows) - len(out)} reached the difference below** "
+        f"and **{len(out)} were refused** by the gate above. Driver refusals are not "
+        "counted here: a run that died before the judge has no score for this section to "
+        "be about, and is in the ledger above."
+    )
+    lines += [
+        "",
+        "| task | arm | run status | in the difference | stages the run scored |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for key, evidence in rows:
+        task, arm_label = key
         status = run_status_of(evidence) or "<unrecorded>"
         mark = f"**{status}**" if truncated(evidence) else status
+        clauses = refused.get(key)
+        seat = "yes"
+        if clauses:
+            seat = "no — refused (" + ", ".join(f"`{name}`" for name in clauses) + ")"
         lines.append(
-            f"| `{task}` | `{arm_label}` | {mark} | {len(evidence.autor_stages_scored)} |"
+            f"| `{task}` | `{arm_label}` | {mark} | {seat} | "
+            f"{len(evidence.autor_stages_scored)} |"
         )
     if cut:
         lines += [
@@ -1040,10 +1108,21 @@ def _run_status_lines(trial: RcbTrial) -> list[str]:
             "A run reads `cancelled` when a stage burned its attempts, the unattended "
             "auto-skip fired, the auto-skip budget ran out, and the next failure landed at "
             "the stage that writes the deliverable, where there is nowhere left to route. "
-            "The report it produced is the report it managed to write, and it is scored as "
-            "one: the alternative is a sample of only the runs that finished, which is a "
-            "sample of the runs that had the easier time. `run_status` comes off the run's "
-            "own manifest inside the run root, so it is reported here and read by no gate.",
+            "The report it produced is the report it managed to write, and an admitted one "
+            "is scored as one: the alternative is a sample of only the runs that finished, "
+            "which is a sample of the runs that had the easier time. `run_status` comes off "
+            "the run's own manifest inside the run root, so it is reported here and read by "
+            "no gate.",
+        ]
+    if cut and out:
+        lines += [
+            "",
+            "**A truncated run and a refused run are not the same event and they arrive "
+            "together.** A run that spends its auto-skip budget tends to leave the "
+            "workspace marks the gate refuses — `_meta.pipeline_completed` is false on a "
+            "run the writing stage was routed to rather than reached — so the runs most "
+            "worth disclosing are the ones the difference no longer contains. That is why "
+            "this table is over every scored run and not over the admitted ones.",
         ]
     return lines
 

--- a/src/rcb_trial.py
+++ b/src/rcb_trial.py
@@ -682,6 +682,16 @@ def collect_rcb_pairs(
         control_arm=control_arm,
         treatment_arm=treatment_arm,
         outcome=RCB_TOTAL,
+        # The composition the benchmark seam is blind to, declared by the producer that
+        # can see it. `stage_fitness` here is one key by construction, so `same_shape`
+        # compared two single-element sets that pairing has already forced to be equal —
+        # true of every pair and empty of content. The first live pair is the refutation:
+        # four stages against seven, one arm cancelled and one completed, both scored
+        # against the same checklist and averaged into one mean.
+        composition={
+            (item.task_id, item.arm): item.autor_stages_scored
+            for item in admitted.values()
+        },
     )
 
     named: dict[str, list[str]] = {}
@@ -802,6 +812,46 @@ def stratum_rollup(control: ArmEvidence, treatment: ArmEvidence) -> dict[str, An
 # ---------------------------------------------------------------------------
 
 
+#: What ``run_manifest.run_status`` reads on a run that finished the way it meant to.
+#: Anything else — ``cancelled``, ``failed``, ``halted``, ``abandoned`` — is a run whose
+#: deliverable is what it managed to write, not what it set out to write.
+RUN_COMPLETED = "completed"
+
+
+def run_status_of(evidence: ArmEvidence) -> str:
+    """The run's own verdict on how it ended, or ``""`` when nothing recorded one.
+
+    Read off ``run_manifest.json``, which is inside the run root and therefore writable
+    by the party every admission clause constrains. So this is printed and never gated:
+    no clause in :data:`ADMISSION_CLAUSES` reads ``run_status`` and none may, because a
+    run that could clear a gate by rewriting one word of its own manifest is not gated at
+    all. What it is good for is the opposite direction — a run that *admits* it was
+    truncated, in the artifact a reader would otherwise have to go and open.
+    """
+    return str(_fact(evidence, "run_status", "") or "")
+
+
+def truncated(evidence: ArmEvidence) -> bool:
+    """Whether this arm's deliverable is what the run managed to write.
+
+    ``run_status: cancelled`` is the end of a measured chain: a stage burns eight
+    consecutive attempts, the unattended auto-skip fires, that repeats until
+    ``--max-auto-skips`` is spent, and the next failure at the stage that writes the
+    deliverable has nowhere left to route. Two of the three finished runs of the live
+    stage-graph trial ended there — counted off ``run_status`` in that trial's own
+    ``runs/*.json``, one per (task, arm). Scoring them is right: a truncated report is
+    what the run produced, and refusing them would throw away most of the sample the
+    capability is being measured on. But a reader must not have to open the state files
+    to find out how much of the sample is truncated.
+
+    Empty reads as not truncated, deliberately: a state file written before the driver
+    recorded the field says nothing, and inventing a truncation from silence would put a
+    warning on runs nobody has evidence about.
+    """
+    status = run_status_of(evidence)
+    return bool(status) and status != RUN_COMPLETED
+
+
 #: The single largest hole, and it goes directly under the total rather than in a
 #: caveats section nobody reaches. Every (task, arm) ran once, so the apparatus has no
 #: observation at all of AutoR's own run-to-run variance, which is almost certainly
@@ -918,6 +968,8 @@ def format_rcb_trial_report(
     if trial.refusals or trial.interim:
         lines += ["", _REFUSAL_BIAS]
 
+    lines += ["", "## Runs scored, and how they ended", ""] + _run_status_lines(trial)
+
     lines += ["", "## The difference", "", format_trial_report(result, unit=unit)]
 
     for pair in result.pairs:
@@ -939,6 +991,61 @@ def format_rcb_trial_report(
         "read by any criterion.",
     ]
     return "\n".join(lines)
+
+
+def _run_status_lines(trial: RcbTrial) -> list[str]:
+    """How each scored run ended, above the difference rather than inside it.
+
+    Every number in this report is a judge's reading of a deliverable, and a truncated
+    deliverable is a different object from a finished one. Two of the three finished runs
+    of the live stage-graph trial ended ``cancelled`` — auto-skip budget spent, routed to
+    the writing stage to produce what it had — and neither said so anywhere in the
+    report: a reader had to open ``runs/<task>.<arm>.a1.json`` to find out that the
+    majority of the finished sample was truncated.
+
+    Not a refusal and not a caveat under the total. The runs are scored on purpose, so
+    what a reader needs is the composition of the sample, in the same voice as the
+    refusal ledger above it.
+
+    Three headlines and not two, because a run that recorded no status at all is neither
+    truncated nor clean. Folding silence into the clean branch would print "all N scored
+    runs ended `completed`" over a sample nothing had measured the ending of, which is
+    the same fabrication in the other direction.
+    """
+    rows = sorted(trial.evidence.items())
+    if not rows:
+        return ["- no run was scored."]
+    cut = [key for key, evidence in rows if truncated(evidence)]
+    silent = [key for key, evidence in rows if not run_status_of(evidence)]
+    if cut:
+        headline = f"- **{len(cut)} of {len(rows)} scored runs did not end `{RUN_COMPLETED}`.**"
+    elif silent:
+        headline = (
+            f"- **{len(silent)} of {len(rows)} scored runs recorded no run status at "
+            "all**, so how they ended is unknown here rather than clean."
+        )
+    else:
+        headline = f"- all {len(rows)} scored runs ended `{RUN_COMPLETED}`."
+    lines = [headline]
+    lines += ["", "| task | arm | run status | stages the run scored |", "| --- | --- | --- | --- |"]
+    for (task, arm_label), evidence in rows:
+        status = run_status_of(evidence) or "<unrecorded>"
+        mark = f"**{status}**" if truncated(evidence) else status
+        lines.append(
+            f"| `{task}` | `{arm_label}` | {mark} | {len(evidence.autor_stages_scored)} |"
+        )
+    if cut:
+        lines += [
+            "",
+            "A run reads `cancelled` when a stage burned its attempts, the unattended "
+            "auto-skip fired, the auto-skip budget ran out, and the next failure landed at "
+            "the stage that writes the deliverable, where there is nowhere left to route. "
+            "The report it produced is the report it managed to write, and it is scored as "
+            "one: the alternative is a sample of only the runs that finished, which is a "
+            "sample of the runs that had the easier time. `run_status` comes off the run's "
+            "own manifest inside the run root, so it is reported here and read by no gate.",
+        ]
+    return lines
 
 
 def _images_shown_lines(control: ArmEvidence, treatment: ArmEvidence) -> list[str]:
@@ -993,7 +1100,23 @@ def _format_pair(task_id: str, control: ArmEvidence, treatment: ArmEvidence) -> 
         f"- judge draws: control **{control.replicates}**, treatment "
         f"**{treatment.replicates}**, of "
         f"{control.replicates_requested or treatment.replicates_requested or '?'} planned",
+        # Beside the totals, not only in the sample table above: this is the line a reader
+        # takes the delta off, and "35.1 against 26.6" reads differently once one of the
+        # two is a report the run was cut off in the middle of writing.
+        f"- run status: control **{run_status_of(control) or '<unrecorded>'}**, treatment "
+        f"**{run_status_of(treatment) or '<unrecorded>'}**",
     ]
+    if truncated(control) or truncated(treatment):
+        cut = " and ".join(
+            name
+            for name, arm in (("control", control), ("treatment", treatment))
+            if truncated(arm)
+        )
+        lines.append(
+            f"- **The {cut} arm's deliverable was truncated.** The run spent its auto-skip "
+            "budget and wrote what it had. The score is a real score of a real report and "
+            "the delta is partly a difference in how much report there was."
+        )
     if resolution_is_measured(control, treatment):
         lines.append(
             f"- judge resolution on this pair: **±{resolution:.2f}** total points"
@@ -1021,10 +1144,13 @@ def _format_pair(task_id: str, control: ArmEvidence, treatment: ArmEvidence) -> 
             "",
             f"- **the arms' own runs did not score the same stages** "
             f"(control {len(control.autor_stages_scored)}, treatment "
-            f"{len(treatment.autor_stages_scored)}). The benchmark seam cannot see this: "
-            "both arms are scored against the same checklist whatever their internal "
-            "composition, so `shape_changes` is structurally zero here. That a revision "
-            "changes how far a run gets is a separate result and is not in the delta.",
+            f"{len(treatment.autor_stages_scored)}). The benchmark seam cannot see this "
+            "by itself: both arms are scored against the same checklist whatever their "
+            "internal composition, so `stage_fitness` is one key per arm and "
+            "`Pair.same_shape` read as true. `collect_rcb_pairs` now declares this "
+            "composition to `collect_pairs`, so the pair is set aside from the mean and "
+            "counted in `shape_changes` instead. That a revision changes how far a run "
+            "gets is a separate result and is not in the delta.",
         ]
 
     lines += [
@@ -1393,6 +1519,50 @@ def count_quota_hits(log_text: str) -> int:
     return sum(len(re.findall(re.escape(marker), log_text)) for marker in _QUOTA_MARKERS)
 
 
+def draws_in_payload(payload: Mapping[str, Any]) -> int:
+    """How many judge passes one score file is the mean of.
+
+    ``score_rcb_run.aggregate_draws`` writes ``draws`` into every file it produces, and
+    it is the only honest reader of a file's draw count: a file is a checkpoint, not a
+    draw, so counting files is right only while every file holds exactly one. Absent —
+    a file written before the field existed — reads as 1, which is what a scorer with a
+    default of ``--draws 1`` produced.
+    """
+    try:
+        return max(1, int(payload.get("draws") or 1))
+    except (TypeError, ValueError):
+        return 1
+
+
+def judge_draws_in(payloads: Sequence[Mapping[str, Any]]) -> int:
+    """Total judge draws across a set of score files for one arm.
+
+    The count :attr:`RunEnvironment.judge_replicates` is meant to hold, and the number
+    ``resolution_is_measured`` refuses a stated uncertainty below. It was ``len(payloads)``
+    at the only call site, which is the same number only under the final pass's own
+    layout of one draw per file. Hand that reader one file the scorer wrote with
+    ``--draws 3`` and it reports one draw over an item vector whose spreads are real —
+    the two encodings of a single count disagreeing in the direction that publishes,
+    because an arm the report calls single-draw is an arm whose measured band the report
+    then declines to state.
+    """
+    return sum(draws_in_payload(payload) for payload in payloads)
+
+
+def _scores_of(row: Mapping[str, Any]) -> tuple[int, ...]:
+    """Every draw's score for one item, from a row ``aggregate_draws`` may have folded.
+
+    ``scores`` is the per-draw list the aggregator writes and ``score`` is their mean, so
+    reading ``score`` alone throws away exactly the dispersion the draws were bought for.
+    The fallback is not defensive padding: a row from a single-draw file has no ``scores``
+    key at all, and one draw is one score.
+    """
+    raw = row.get("scores")
+    if isinstance(raw, (list, tuple)) and raw:
+        return tuple(int(round(float(value))) for value in raw)
+    return (int(round(float(row.get("score", 0) or 0))),)
+
+
 def items_from_score_payloads(payloads: Sequence[Mapping[str, Any]]) -> tuple[ScoredItem, ...]:
     """Zip N replicate scorings of one workspace into one item vector.
 
@@ -1400,6 +1570,12 @@ def items_from_score_payloads(payloads: Sequence[Mapping[str, Any]]) -> tuple[Sc
     file order, the serial executor preserves order by construction, and ``content[:200]``
     is unique inside every one of the forty shipped checklists — so the content key is
     asserted equal across replicates rather than trusted.
+
+    A payload may itself hold several draws — ``aggregate_draws`` leaves the per-draw
+    list on each item as ``scores`` — so the vector is flattened over files *and* over
+    the draws inside them. Reading one score per file was correct for the final pass,
+    which writes one draw per file, and silently discarded two thirds of the in-loop
+    score's draws the moment that path started asking for three.
     """
     if not payloads:
         return ()
@@ -1416,17 +1592,16 @@ def items_from_score_payloads(payloads: Sequence[Mapping[str, Any]]) -> tuple[Sc
                 )
     items: list[ScoredItem] = []
     for position, row in enumerate(base):
-        scores = tuple(
-            int((list(payload.get("items") or [])[position]).get("score", 0))
-            for payload in payloads
-        )
+        scores: list[int] = []
+        for payload in payloads:
+            scores.extend(_scores_of(list(payload.get("items") or [])[position]))
         items.append(
             ScoredItem(
                 index=int(row.get("index", position)),
                 kind=str(row.get("type", "text")),
                 weight=float(row.get("weight", 0.0)),
                 content_key=str(row.get("content", "")),
-                scores=scores,
+                scores=tuple(scores),
             )
         )
     return tuple(items)

--- a/src/trials.py
+++ b/src/trials.py
@@ -26,9 +26,21 @@ fitness is not one measurement of two configurations — later stages are scored
 strictly more criteria, so the arm that stopped early scores higher for stopping
 early. That is the same bias :func:`src.archive.comparability_basis` exists to
 remove, and it reappears inside a pair. The difference is taken over the stages
-*both* arms measured, and pairs whose shapes differed are counted and reported
-separately, because a capability that changes how far runs get has done something
-worth knowing about and it is not a score.
+*both* arms measured, and pairs whose shapes differed are set aside from the mean
+and reported on their own line with their own count and their own mean, because a
+capability that changes how far runs get has done something worth knowing about
+and it is not a score.
+
+Two things had to change for that sentence to be true of this module rather than
+of its intentions. The mean, the p-value, the floor and the decomposition run over
+:attr:`TrialResult.comparable_pairs`; they used to run over every pair while the
+report printed the shape-change count underneath, so a shape-differing pair was
+counted and averaged in at once. And a producer whose outcome measure cannot see
+the composition — a benchmark total is one key per pair by construction — declares
+it, through ``collect_pairs(composition=...)``. Without that, ``same_shape`` on the
+benchmark path was a comparison of two single-element key sets that are equal for
+every pair that survives pairing at all: structurally true, and empty in exactly
+the trial it was written for.
 
 **It does not report a total without the criterion decomposition.** The outcome
 measure is a rubric, and a rubric can be gamed. A capability that writes more files
@@ -280,6 +292,22 @@ class Pair:
     trial_id: str
     control: RunRecord
     treatment: RunRecord
+    #: How far each arm's run actually got, when the producer knows and the outcome
+    #: measure cannot see it. Empty is the ordinary case and means "ask the measure",
+    #: which is what an archived rubric row supports: its ``stage_fitness`` has one key
+    #: per stage the run scored, so the key set *is* the composition.
+    #:
+    #: A benchmark total has one key by construction — :mod:`src.rcb_trial` builds
+    #: ``"<task_id>|<env_digest>"`` so that an unweighted mean over one element is the
+    #: weighted total — so on that path the key sets are equal for every pair that
+    #: survives at all and :attr:`same_shape` was structurally true. The first live
+    #: paired trial is exactly the pair that refutes: the control arm skipped four stages
+    #: and was cancelled after scoring four of eight, the treatment arm skipped none and
+    #: completed at seven of eight, and both were scored against the same checklist, so
+    #: the strongest refusal in this module was true and empty over the one comparison it
+    #: was written for.
+    control_composition: tuple[str, ...] = ()
+    treatment_composition: tuple[str, ...] = ()
 
     @property
     def shared_stages(self) -> tuple[str, ...]:
@@ -287,6 +315,16 @@ class Pair:
 
     @property
     def same_shape(self) -> bool:
+        """Both arms measured the same stages *and* their runs got equally far.
+
+        Two questions, one answer, because the consequence is the same: a difference
+        between two depths of run is not a difference between two configurations. Which
+        of the two can see it depends on the measure — the rubric's key set carries the
+        composition and a benchmark total cannot — so a declared composition is checked
+        first and the key sets are checked always.
+        """
+        if set(self.control_composition) != set(self.treatment_composition):
+            return False
         return set(self.control.stage_fitness) == set(self.treatment.stage_fitness)
 
     def _mean_over(self, record: RunRecord, stages: Sequence[str]) -> float:
@@ -369,16 +407,54 @@ class TrialResult:
             )
 
     @property
+    def comparable_pairs(self) -> tuple[Pair, ...]:
+        """The pairs the result is a mean over: both arms got the same distance.
+
+        Every statistic below reads this and not :attr:`pairs`. The mean, the p-value and
+        the floor have to be over one population or the report states a p from one sample
+        beside a floor from another — the crack this module's header already records at
+        ``MAX_EXACT_PAIRS`` and which is worth exactly one instance.
+        """
+        return tuple(pair for pair in self.pairs if pair.same_shape)
+
+    @property
+    def shape_changed_pairs(self) -> tuple[Pair, ...]:
+        """Pairs whose arms did not get equally far. Reported, never averaged in.
+
+        Not a failure and not an exclusion: a capability that changes how far a run gets
+        has done something real, and it is the most interesting thing this apparatus has
+        seen. It is simply not a score, and putting it in the mean makes the number a
+        comparison of two depths of run wearing the label of a comparison of two
+        configurations.
+        """
+        return tuple(pair for pair in self.pairs if not pair.same_shape)
+
+    @property
     def n(self) -> int:
-        return len(self.pairs)
+        return len(self.comparable_pairs)
 
     @property
     def differences(self) -> list[float]:
-        return [pair.difference for pair in self.pairs]
+        return [pair.difference for pair in self.comparable_pairs]
+
+    @property
+    def shape_changed_differences(self) -> list[float]:
+        return [pair.difference for pair in self.shape_changed_pairs]
 
     @property
     def mean_difference(self) -> float:
         values = self.differences
+        return sum(values) / len(values) if values else 0.0
+
+    @property
+    def shape_changed_mean(self) -> float:
+        """The mean over the shape-differing pairs, on its own line and its own count.
+
+        Printed rather than withheld. A reader who is told a count and not a number will
+        estimate one, and the sign of what was set aside is the first thing anybody wants
+        to know about a set-aside.
+        """
+        values = self.shape_changed_differences
         return sum(values) / len(values) if values else 0.0
 
     @property
@@ -395,13 +471,15 @@ class TrialResult:
 
     @property
     def shape_changes(self) -> int:
-        """Pairs whose two arms did not measure the same stages.
+        """Pairs whose two arms did not measure the same stages, or did not get as far.
 
-        Not folded into the score. A capability that changes how far a run gets has
-        done something, and averaging it into a mean over shared stages would hide
-        exactly the thing worth reporting.
+        Not folded into the score, and — since the split above — not folded into the
+        mean either. Counting them while averaging them was the state this left behind:
+        the report printed "1 pair(s) whose arms did not reach the same stages" one line
+        under a mean difference that pair was half of, and the sentence "the score above
+        is over the stages both measured" was true of the stages and false of the pairs.
         """
-        return sum(1 for pair in self.pairs if not pair.same_shape)
+        return len(self.shape_changed_pairs)
 
     @property
     def p_value(self) -> float:
@@ -440,9 +518,14 @@ class TrialResult:
         criterion mechanically — writing more files raises ``artifact_breadth``
         whether or not the work improved — produces a real total and a fake result.
         A win concentrated in a single criterion is a flag.
+
+        Over :attr:`comparable_pairs`, like every other statistic here. The decomposition
+        is the total's decomposition — the column sums to the scalar on the benchmark
+        path — so a table built over a different population than the scalar above it
+        would break the one identity that makes ``concentration`` readable.
         """
         totals: dict[str, list[float]] = {}
-        for pair in self.pairs:
+        for pair in self.comparable_pairs:
             for key, value in pair.criterion_differences().items():
                 totals.setdefault(key, []).append(value)
         return {
@@ -463,7 +546,7 @@ class TrialResult:
         between an anecdote and a measurement.
         """
         counts: dict[str, int] = {}
-        for pair in self.pairs:
+        for pair in self.comparable_pairs:
             for key in pair.criterion_differences():
                 counts[key] = counts.get(key, 0) + 1
         return counts
@@ -488,6 +571,7 @@ def collect_pairs(
     control_arm: str,
     treatment_arm: str,
     outcome: Outcome = RUBRIC_TOTAL,
+    composition: Mapping[tuple[str, str], Sequence[str]] | None = None,
 ) -> TrialResult:
     """Group tagged runs into pairs and say why any were dropped.
 
@@ -497,7 +581,15 @@ def collect_pairs(
     holds nothing else, and a producer that fills the dicts from another instrument
     passes its own — :func:`src.rcb_trial.collect_rcb_pairs` passes
     :data:`RCB_TOTAL`. Only a measure in :data:`DECLARED_OUTCOMES` is accepted.
+
+    ``composition`` is the same shape of declaration for how far each run got, keyed
+    ``(trial_id, arm)`` and read into :attr:`Pair.control_composition`. Keyed on the pair
+    rather than on ``run_id`` because that is the identity this function already groups
+    by, and two arms of one trial that happened to share a run id would otherwise be one
+    entry. Omitted, every pair keeps the shape its ``stage_fitness`` keys give it, which
+    is what the archive's rubric rows support and all this module ever had.
     """
+    declared = dict(composition or {})
     by_trial: dict[str, dict[str, RunRecord]] = {}
     for record in records:
         if not record.trial_id or record.capability != capability:
@@ -518,7 +610,13 @@ def collect_pairs(
         if not (control.usable and treatment.usable):
             excluded.append((trial_id, "an arm is a fake run or a stale rubric version"))
             continue
-        pair = Pair(trial_id, control, treatment)
+        pair = Pair(
+            trial_id,
+            control,
+            treatment,
+            control_composition=tuple(declared.get((trial_id, control_arm), ())),
+            treatment_composition=tuple(declared.get((trial_id, treatment_arm), ())),
+        )
         if not pair.shared_stages:
             excluded.append((trial_id, "the two arms measured no stage in common"))
             continue
@@ -598,7 +696,8 @@ def format_trial_report(result: TrialResult, *, unit: str | None = None) -> str:
     lines = [
         header,
         "",
-        f"- pairs: **{result.n}**"
+        f"- pairs: **{result.n}** same-shape"
+        + (f" (+{result.shape_changes} shape-differing)" if result.shape_changes else "")
         + (f" ({len(result.excluded)} excluded)" if result.excluded else ""),
         measure,
         f"- mean difference: **{result.mean_difference:+.4f}** {unit}",
@@ -613,10 +712,23 @@ def format_trial_report(result: TrialResult, *, unit: str | None = None) -> str:
             "capability."
         )
     if result.shape_changes:
+        # Its own line, its own count and its own mean, under the result rather than
+        # inside it. The count alone was printed here for as long as the mean above it
+        # included the pairs being counted, which is the reading a reader cannot recover
+        # from: "1 pair did not reach the same stages" over a mean of one pair.
         lines.append(
-            f"- {result.shape_changes} pair(s) whose arms did not reach the same stages. The score "
-            "above is over the stages both measured; that a capability changes how far a run gets "
-            "is a separate result and is not in this number."
+            f"- **set aside: {result.shape_changes} shape-differing pair(s)**, mean "
+            f"**{result.shape_changed_mean:+.4f}** {unit} among them. Their arms did not "
+            "reach the same stages or did not get equally far, so their difference is "
+            "between two depths of run and not between two configurations. That a "
+            "capability changes how far a run gets is a real result and it is not a "
+            "score; it is not in the number above and must not be read as one."
+        )
+    if result.n == 0 and result.shape_changes:
+        lines.append(
+            "- **there is no same-shape pair yet, so the mean above is over nothing.** "
+            "The whole sample is shape-differing. Read the set-aside line, not the "
+            f"{result.mean_difference:+.4f} above it."
         )
     for trial_id, reason in result.excluded:
         lines.append(f"  - excluded `{trial_id}`: {reason}")

--- a/tests/test_declared_symbols_are_wired.py
+++ b/tests/test_declared_symbols_are_wired.py
@@ -25,7 +25,7 @@ place the product actually starts from, including ``studio.py``, without which t
 ``src/backend/`` package would read as dead.
 
 ``tests/`` and ``tools/`` are deliberately *not* roots. A test is the thing that keeps a
-dead symbol green -- nineteen of the twenty-nine symbols listed below have one -- so counting
+dead symbol green -- twenty of the thirty symbols listed below have one -- so counting
 a test as wiring would make the gate assert nothing. An instrument is not evidence:
 ``archive_sample_complexity`` was importing ``RunRecord`` and crashing on it at the same
 time. A symbol that only ``tools/`` reaches is still exempt, but by a line somebody wrote,
@@ -64,14 +64,15 @@ the answer, when it happens, is an allowlist entry naming the framework that cal
 
 Measured precision
 ------------------
-1319 public definitions over 1184 distinct names in ``src/``, and 31 referenced by nothing
-outside ``tests/`` and ``tools/``. It was 32 before this landed: ``DATA_DIRNAME`` had a
-one-line wiring fix and got it, so reverting that one line in ``src/rcb.py`` is how the 32
-comes back.
+1326 public definitions over 1190 distinct names in ``src/``, and 30 referenced by nothing
+outside ``tests/`` and ``tools/``. One of them was ``DATA_DIRNAME`` until a one-line wiring
+fix in ``src/rcb.py`` took it off the list, so reverting that line puts the population back
+up by one -- stated as a delta rather than as the absolute it used to be, because the
+absolute drifts with the tree and the sentence outlived two of them.
 
-Each of those 31 has exactly one *executable* occurrence of its name across ``main.py``,
+Each of those 30 has exactly one *executable* occurrence of its name across ``main.py``,
 ``studio.py``, ``rcb_agent.py`` and ``src/`` -- its own definition -- and every other
-textual hit is a comment or a docstring. **False-positive rate 0/31.** That is not the scan
+textual hit is a comment or a docstring. **False-positive rate 0/30.** That is not the scan
 marking its own homework. :func:`code_lines_naming` re-reads the roots with ``tokenize``,
 which cannot see inside a string or a comment and knows nothing about reference units;
 :func:`accusations_with_a_second_code_line` is where the two readers are made to agree, and
@@ -83,7 +84,7 @@ The census prints the rate and the evidence under it, every occurrence labelled 
 
     python3 -m tests.test_declared_symbols_are_wired --census
 
-Its header carries 1319, 1184, 31, 20 and the rate, so those drift with the tree and none of
+Its header carries 1326, 1190, 30, 20 and the rate, so those drift with the tree and none of
 them has to be believed. The 32 is the only figure here that is not in the header, because
 it is the population before the fix in ``src/rcb.py``.
 :meth:`AllowlistIsHonestTests.test_the_allowlist_is_exactly_what_the_scan_finds` keeps the

--- a/tests/test_declared_symbols_are_wired.py
+++ b/tests/test_declared_symbols_are_wired.py
@@ -31,7 +31,7 @@ a test as wiring would make the gate assert nothing. An instrument is not eviden
 time. A symbol that only ``tools/`` reaches is still exempt, but by a line somebody wrote,
 and :attr:`Exempt.reached_from` makes that line checkable.
 
-That nineteen is :func:`allowlisted_symbols_with_a_test`, printed by the census and pinned
+That twenty is :func:`allowlisted_symbols_with_a_test`, printed by the census and pinned
 against this sentence by
 :meth:`AllowlistIsHonestTests.test_the_stated_count_of_tested_symbols_is_the_measured_one`,
 because the first version of the sentence said twenty-one and no instrument could
@@ -64,7 +64,7 @@ the answer, when it happens, is an allowlist entry naming the framework that cal
 
 Measured precision
 ------------------
-1111 public definitions over 1011 distinct names in ``src/``, and 31 referenced by nothing
+1260 public definitions over 1142 distinct names in ``src/``, and 31 referenced by nothing
 outside ``tests/`` and ``tools/``. It was 32 before this landed: ``DATA_DIRNAME`` had a
 one-line wiring fix and got it, so reverting that one line in ``src/rcb.py`` is how the 32
 comes back.
@@ -83,7 +83,7 @@ The census prints the rate and the evidence under it, every occurrence labelled 
 
     python3 -m tests.test_declared_symbols_are_wired --census
 
-Its header carries 1111, 1011, 31, 20 and the rate, so those drift with the tree and none of
+Its header carries 1260, 1142, 31, 20 and the rate, so those drift with the tree and none of
 them has to be believed. The 32 is the only figure here that is not in the header, because
 it is the population before the fix in ``src/rcb.py``.
 :meth:`AllowlistIsHonestTests.test_the_allowlist_is_exactly_what_the_scan_finds` keeps the
@@ -168,6 +168,7 @@ ALLOWLIST: dict[str, Exempt] = {
     "src/rcb_trial.py::driver_clause": Exempt(_DRIVER_ONLY, ("tools/rcb_trial.py",)),
     "src/rcb_trial.py::format_rcb_trial_report": Exempt(_DRIVER_ONLY, ("tools/rcb_trial.py",)),
     "src/rcb_trial.py::items_from_score_payloads": Exempt(_DRIVER_ONLY, ("tools/rcb_trial.py",)),
+    "src/rcb_trial.py::judge_draws_in": Exempt(_DRIVER_ONLY, ("tools/rcb_trial.py",)),
     "src/rcb_trial.py::next_action": Exempt(_DRIVER_ONLY, ("tools/rcb_trial.py",)),
     # -- called by the operator, not by AutoR ---------------------------------------------
     #

--- a/tests/test_declared_symbols_are_wired.py
+++ b/tests/test_declared_symbols_are_wired.py
@@ -64,7 +64,7 @@ the answer, when it happens, is an allowlist entry naming the framework that cal
 
 Measured precision
 ------------------
-1260 public definitions over 1142 distinct names in ``src/``, and 31 referenced by nothing
+1319 public definitions over 1184 distinct names in ``src/``, and 31 referenced by nothing
 outside ``tests/`` and ``tools/``. It was 32 before this landed: ``DATA_DIRNAME`` had a
 one-line wiring fix and got it, so reverting that one line in ``src/rcb.py`` is how the 32
 comes back.
@@ -83,7 +83,7 @@ The census prints the rate and the evidence under it, every occurrence labelled 
 
     python3 -m tests.test_declared_symbols_are_wired --census
 
-Its header carries 1260, 1142, 31, 20 and the rate, so those drift with the tree and none of
+Its header carries 1319, 1184, 31, 20 and the rate, so those drift with the tree and none of
 them has to be believed. The 32 is the only figure here that is not in the header, because
 it is the population before the fix in ``src/rcb.py``.
 :meth:`AllowlistIsHonestTests.test_the_allowlist_is_exactly_what_the_scan_finds` keeps the

--- a/tests/test_rcb_trial.py
+++ b/tests/test_rcb_trial.py
@@ -30,11 +30,14 @@ from src.rcb_trial import (
     count_quota_hits,
     format_rcb_trial_report,
     items_from_score_payloads,
+    judge_draws_in,
     next_action,
     pair_resolution,
     resolution_is_measured,
+    run_status_of,
     stratum_rollup,
     to_run_record,
+    truncated,
 )
 
 # Private on purpose — it is one rule shared by the classifier and the admission clause,
@@ -752,18 +755,44 @@ class ReportTests(unittest.TestCase):
         self.assertIn("ran **once**", text)
         self.assertIn("zero observations", text)
 
-    def test_a_stage_composition_difference_is_reported_outside_the_score(self) -> None:
-        """``shape_changes`` is structurally zero here, so it is re-armed by hand.
+    def test_a_stage_composition_difference_is_set_aside_from_the_score(self) -> None:
+        """``shape_changes`` used to be structurally zero here. It is not any more.
 
         Both arms are scored against the same checklist whatever their internal
-        composition, so the strongest refusal in :mod:`src.trials` is true and empty on
-        this outcome measure.
+        composition, so ``stage_fitness`` carries one key each and the strongest refusal
+        in :mod:`src.trials` was true and empty on this outcome measure — over exactly
+        the pair it was written for. The first live pair is four stages against seven,
+        one arm cancelled and one completed, and its totals were averaged as if they
+        were two configurations of the same depth of run.
         """
-        control = arm(stages=("01_s", "02_s"))
-        treatment = arm(label="47f3fbf", stages=tuple(f"0{n}_s" for n in range(1, 9)))
+        control = arm(stages=("01_s", "02_s", "03_s", "04_s"), scores=(40, 30, 20))
+        treatment = arm(
+            label="47f3fbf",
+            stages=tuple(f"0{n}_s" for n in range(1, 8)),
+            scores=(20, 30, 20),
+        )
+        outcome = trial(control, treatment)
         text = self.report(control, treatment)
+
         self.assertIn("did not score the same stages", text)
-        self.assertEqual(trial(control, treatment).result.shape_changes, 0)
+        self.assertEqual((outcome.result.n, outcome.result.shape_changes), (0, 1))
+        self.assertIn("set aside: 1 shape-differing pair(s)", text)
+        self.assertIn("there is no same-shape pair yet", text)
+        # The delta is real and is reported as a set-aside, not as the result.
+        self.assertAlmostEqual(outcome.result.shape_changed_mean, -10.0, places=6)
+        self.assertAlmostEqual(outcome.result.mean_difference, 0.0, places=9)
+
+    def test_two_arms_that_got_equally_far_are_still_one_pair(self) -> None:
+        """The control on the change above: only the composition may move the verdict.
+
+        A declaration that set every pair aside would look identical from the report's
+        one shape-differing line, and would silently empty the trial.
+        """
+        outcome = trial(arm(stages=("01_s", "02_s")), arm(label="47f3fbf", stages=("01_s", "02_s")))
+        self.assertEqual((outcome.result.n, outcome.result.shape_changes), (1, 0))
+        self.assertNotIn(
+            "set aside", format_rcb_trial_report(outcome)
+        )
 
     def test_the_contrast_is_printed_verbatim(self) -> None:
         text = self.report(arm(), arm(label="47f3fbf"), contrast_log="47f3fbf one commit (#175)")
@@ -1074,6 +1103,176 @@ class ReplicateTests(unittest.TestCase):
         with self.assertRaises(ValueError) as caught:
             items_from_score_payloads(payloads)
         self.assertIn("item identity", str(caught.exception))
+
+
+class DrawsInsideOneFileTests(unittest.TestCase):
+    """A file is a checkpoint. A draw is a judge pass. They were the same number once.
+
+    ``final_pass`` writes one draw per file, so ``len(payloads)`` was the draw count and
+    reading ``item["score"]`` was reading the draw. Both stop being true the moment the
+    scorer is asked for ``--draws N``, which is what the in-loop score now does — and
+    they stop being true silently and in the direction that publishes: an arm the report
+    calls single-draw is an arm whose measured spread the report then declines to state.
+    """
+
+    def folded(self, *draws: tuple[int, ...]) -> dict:
+        """One score file as ``score_rcb_run.aggregate_draws`` actually writes it."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "score_rcb_run", REPO_ROOT / "tools" / "score_rcb_run.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module.aggregate_draws(
+            [
+                {
+                    "items": [
+                        {"index": i, "type": "text", "weight": 0.5, "content": f"c{i}", "score": s}
+                        for i, s in enumerate(scores)
+                    ],
+                    "total_score": sum(0.5 * s for s in scores),
+                    "judge_calls": len(scores),
+                    "judge_failures": [],
+                }
+                for scores in draws
+            ]
+        )
+
+    def test_one_file_of_three_draws_counts_as_three(self) -> None:
+        payload = self.folded((40, 20), (60, 20), (50, 20))
+        self.assertEqual(payload["draws"], 3)
+        self.assertEqual(judge_draws_in([payload]), 3)
+
+    def test_three_files_of_one_draw_still_count_as_three(self) -> None:
+        """The two ways the driver spends the same budget have to agree."""
+        payloads = [self.folded((40, 20)), self.folded((60, 20)), self.folded((50, 20))]
+        self.assertEqual([p["draws"] for p in payloads], [1, 1, 1])
+        self.assertEqual(judge_draws_in(payloads), 3)
+
+    def test_a_file_written_before_the_field_existed_reads_as_one_draw(self) -> None:
+        self.assertEqual(judge_draws_in([{"items": []}]), 1)
+        self.assertEqual(judge_draws_in([{"draws": None}]), 1)
+
+    def test_the_spread_inside_one_file_survives_into_the_item_vector(self) -> None:
+        """The half that made the count wrong in the direction that publishes.
+
+        ``aggregate_draws`` leaves the per-draw list on each item and the mean in
+        ``score``. Reading ``score`` alone gave a one-element ``ScoredItem.scores``, so
+        ``spread`` was 0 over a first item the judge had actually moved 20 points on —
+        and ``pair_resolution`` then reported ±0.00, which reads as a judge that
+        resolved every item exactly, off the one file where the judge's noise *was*
+        observed.
+        """
+        payload = self.folded((40, 20), (60, 20), (50, 20))
+        scored = items_from_score_payloads([payload])
+        self.assertEqual(scored[0].scores, (40, 60, 50))
+        self.assertEqual(scored[0].spread, 20)
+        self.assertEqual(scored[1].spread, 0)
+
+    def test_a_replicated_arm_in_one_file_can_state_its_resolution(self) -> None:
+        """End to end: one file of three draws is a pair with a measured band."""
+        payload = self.folded((40, 20), (60, 20), (50, 20))
+        scored = items_from_score_payloads([payload])
+        both = ArmEvidence(
+            task_id="Energy_001",
+            arm="621566b",
+            run_id="r",
+            workspace="/ws",
+            env=env(judge_replicates=judge_draws_in([payload])),
+            items=scored,
+            published_total=float(payload["total_score"]),
+            replicates_requested=3,
+            checklist_items_expected=len(scored),
+            facts=dict(GOOD_FACTS),
+        )
+        self.assertEqual(both.replicates, 3)
+        self.assertTrue(resolution_is_measured(both, both))
+        self.assertAlmostEqual(pair_resolution(both, both), 0.5 * 20, places=9)
+
+
+class RunStatusIsVisibleTests(unittest.TestCase):
+    """A truncated deliverable is a different object from a finished one.
+
+    ``run_status: cancelled`` is what the manifest records when a stage burned its
+    attempts, the auto-skip budget ran out, and the next failure landed at the stage
+    that writes the deliverable. Two of the three finished runs of the live stage-graph
+    trial ended that way and the report said so nowhere: a reader had to open
+    ``runs/<task>.<arm>.a1.json``.
+    """
+
+    def report(self, *evidences, **kwargs) -> str:
+        return format_rcb_trial_report(trial(*evidences, **kwargs))
+
+    def cut(self, **kwargs):
+        return arm(facts={"run_status": "cancelled"}, **kwargs)
+
+    def test_a_cancelled_run_is_named_in_the_sample_table(self) -> None:
+        text = self.report(self.cut(), arm(label="47f3fbf", facts={"run_status": "completed"}))
+        self.assertIn("Runs scored, and how they ended", text)
+        self.assertIn("1 of 2 scored runs did not end `completed`", text)
+        self.assertIn("| `Energy_001` | `621566b` | **cancelled** | 2 |", text)
+        self.assertIn("| `Energy_001` | `47f3fbf` | completed | 2 |", text)
+
+    def test_the_sample_table_sits_above_the_difference(self) -> None:
+        """Same argument as the refusal ledger: the composition of a sample is not a
+        footnote to the number the sample produced."""
+        text = self.report(self.cut(), arm(label="47f3fbf", facts={"run_status": "completed"}))
+        self.assertLess(text.index("Runs scored, and how they ended"), text.index("## The difference"))
+
+    def test_the_truncation_is_named_beside_the_pair_delta(self) -> None:
+        text = self.report(self.cut(), arm(label="47f3fbf", facts={"run_status": "completed"}))
+        self.assertIn("- run status: control **cancelled**, treatment **completed**", text)
+        self.assertIn("The control arm's deliverable was truncated", text)
+
+    def test_both_arms_truncated_are_both_named(self) -> None:
+        text = self.report(self.cut(), self.cut(label="47f3fbf"))
+        self.assertIn("2 of 2 scored runs did not end `completed`", text)
+        self.assertIn("The control and treatment arm's deliverable was truncated", text)
+
+    def test_a_finished_pair_is_not_disclaimed(self) -> None:
+        text = self.report(
+            arm(facts={"run_status": "completed"}),
+            arm(label="47f3fbf", facts={"run_status": "completed"}),
+        )
+        self.assertIn("all 2 scored runs ended `completed`", text)
+        self.assertNotIn("was truncated", text)
+
+    def test_an_unrecorded_status_is_printed_as_unrecorded_and_not_as_truncated(self) -> None:
+        """Silence is not evidence of truncation, and it is not evidence of completion.
+
+        A state file written before the driver carried the field says nothing, and
+        inventing either reading from it would put a claim on runs nobody measured.
+        Folding it into the clean branch is the tempting half: "all 2 scored runs ended
+        `completed`" over two runs whose ending nothing observed is a fabrication with
+        the report's own voice behind it.
+        """
+        control, treatment = arm(), arm(label="47f3fbf")
+        self.assertEqual((run_status_of(control), truncated(control)), ("", False))
+        text = self.report(control, treatment)
+        self.assertIn("2 of 2 scored runs recorded no run status at all", text)
+        self.assertNotIn("all 2 scored runs ended `completed`", text)
+        self.assertNotIn("was truncated", text)
+        self.assertIn("| <unrecorded> |", text)
+        self.assertIn("- run status: control **<unrecorded>**", text)
+
+    def test_one_silent_run_beside_one_clean_one_is_not_reported_as_two_clean(self) -> None:
+        """The mixed case, which the two-branch version got wrong in the same direction."""
+        text = self.report(arm(), arm(label="47f3fbf", facts={"run_status": "completed"}))
+        self.assertIn("1 of 2 scored runs recorded no run status at all", text)
+        self.assertNotIn("all 2 scored runs ended `completed`", text)
+
+    def test_no_admission_clause_reads_the_run_status(self) -> None:
+        """It comes off the run's own manifest inside the run root, which the operator
+        writes with `bypassPermissions`. A gate on it would be a gate the party it
+        constrains can clear with one word."""
+        for status in ("cancelled", "completed", "failed", "halted", ""):
+            with self.subTest(status=status):
+                self.assertEqual(
+                    admit_arm(arm(facts={"run_status": status})),
+                    admit_arm(arm()),
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_rcb_trial.py
+++ b/tests/test_rcb_trial.py
@@ -1212,8 +1212,9 @@ class RunStatusIsVisibleTests(unittest.TestCase):
         text = self.report(self.cut(), arm(label="47f3fbf", facts={"run_status": "completed"}))
         self.assertIn("Runs scored, and how they ended", text)
         self.assertIn("1 of 2 scored runs did not end `completed`", text)
-        self.assertIn("| `Energy_001` | `621566b` | **cancelled** | 2 |", text)
-        self.assertIn("| `Energy_001` | `47f3fbf` | completed | 2 |", text)
+        self.assertIn("| `Energy_001` | `621566b` | **cancelled** | yes | 2 |", text)
+        self.assertIn("| `Energy_001` | `47f3fbf` | completed | yes | 2 |", text)
+        self.assertIn("of those 2, **2 reached the difference below** and **0 were refused**", text)
 
     def test_the_sample_table_sits_above_the_difference(self) -> None:
         """Same argument as the refusal ledger: the composition of a sample is not a
@@ -1263,6 +1264,19 @@ class RunStatusIsVisibleTests(unittest.TestCase):
         self.assertIn("1 of 2 scored runs recorded no run status at all", text)
         self.assertNotIn("all 2 scored runs ended `completed`", text)
 
+    def test_the_table_is_over_the_scored_runs_and_says_which_reached_the_mean(self) -> None:
+        """Two populations, one table, and the difference between them printed.
+
+        With nothing refused the two are the same set, and a test written only on this
+        fixture cannot tell ``trial.scored`` from ``trial.evidence`` — which is exactly
+        how the first version of this section shipped reading the wrong one.
+        ``RunStatusSeesRefusedRunsTests`` below is the fixture where they differ.
+        """
+        result = trial(self.cut(), arm(label="47f3fbf", facts={"run_status": "completed"}))
+        self.assertEqual(len(result.scored), 2)
+        self.assertEqual(set(result.scored), set(result.evidence))
+        self.assertEqual(result.refused_clauses_by_arm(), {})
+
     def test_no_admission_clause_reads_the_run_status(self) -> None:
         """It comes off the run's own manifest inside the run root, which the operator
         writes with `bypassPermissions`. A gate on it would be a gate the party it
@@ -1273,6 +1287,163 @@ class RunStatusIsVisibleTests(unittest.TestCase):
                     admit_arm(arm(facts={"run_status": status})),
                     admit_arm(arm()),
                 )
+
+
+class RunStatusSeesRefusedRunsTests(unittest.TestCase):
+    """The live stage-graph trial's own three scored runs, as a fixture.
+
+    Read off ``/rmeng_data/robtang/rcb-trial-graph`` — ``runs/*.json`` for the statuses
+    and stage lists, each workspace's ``_meta.json`` for ``pipeline_completed``:
+
+    ==============  ========  ===========  ====================  ======
+    task            arm       run_status   pipeline_completed    stages
+    ==============  ========  ===========  ====================  ======
+    Astronomy_000   a13cd7d   completed    true                  7
+    Astronomy_000   a3bcae6   cancelled    false                 4
+    Chemistry_000   a13cd7d   cancelled    false                 6
+    ==============  ========  ===========  ====================  ======
+
+    Both truncated runs are refused by ``pipeline_completed``, so ``trial.evidence``
+    holds one of the three. That is not an accident of this sample and it is why the
+    section cannot be computed over the admitted runs: a run that spends its auto-skip
+    budget is routed to the writing stage rather than reaching it, and that is the same
+    event that leaves ``pipeline_completed`` false. Reading ``evidence`` here printed
+    "all 1 scored runs ended ``completed``" — a positive clean-sample claim, in the
+    report's own voice, over a sample two thirds of which was cut off.
+    """
+
+    CONTROL = "a3bcae6"
+    TREATMENT = "a13cd7d"
+    HEADING = "## Runs scored, and how they ended"
+
+    def section(self, result) -> str:
+        """Just the sample-composition section, so "absent from it" is assertable."""
+        text = format_rcb_trial_report(result)
+        self.assertIn(self.HEADING, text)
+        return text.split(self.HEADING, 1)[1].split("\n## ", 1)[0]
+
+    def live(self):
+        """The three runs above, with everything not under test held at the good value."""
+        return collect_rcb_pairs(
+            [
+                arm(
+                    task="Astronomy_000",
+                    label=self.TREATMENT,
+                    facts={"run_status": "completed"},
+                    stages=tuple(f"{n:02d}_s" for n in range(1, 8)),
+                ),
+                arm(
+                    task="Astronomy_000",
+                    label=self.CONTROL,
+                    facts={"run_status": "cancelled", "meta_pipeline_completed": False},
+                    stages=tuple(f"{n:02d}_s" for n in range(1, 5)),
+                ),
+                arm(
+                    task="Chemistry_000",
+                    label=self.TREATMENT,
+                    facts={"run_status": "cancelled", "meta_pipeline_completed": False},
+                    stages=tuple(f"{n:02d}_s" for n in range(1, 7)),
+                ),
+            ],
+            capability="stage_graph",
+            control_arm=self.CONTROL,
+            treatment_arm=self.TREATMENT,
+            planned_pairs=6,
+        )
+
+    def test_the_two_populations_really_do_differ_on_this_fixture(self) -> None:
+        """Without this the rest of the class would pass on either collection."""
+        result = self.live()
+        self.assertEqual(len(result.scored), 3)
+        self.assertEqual(len(result.evidence), 1)
+        self.assertEqual(
+            sorted(result.refused_clauses_by_arm()),
+            [("Astronomy_000", self.CONTROL), ("Chemistry_000", self.TREATMENT)],
+        )
+        for clauses in result.refused_clauses_by_arm().values():
+            self.assertEqual(clauses, ("pipeline_completed",))
+
+    def test_the_headline_counts_every_scored_run_not_only_the_admitted_one(self) -> None:
+        text = format_rcb_trial_report(self.live())
+        self.assertIn("**2 of 3 scored runs did not end `completed`.**", text)
+        self.assertNotIn("all 1 scored runs ended `completed`", text)
+        self.assertNotIn("scored runs ended `completed`", text)
+
+    def test_both_truncated_runs_are_in_the_table_with_their_status(self) -> None:
+        text = format_rcb_trial_report(self.live())
+        self.assertIn(
+            "| `Astronomy_000` | `a3bcae6` | **cancelled** | no — refused "
+            "(`pipeline_completed`) | 4 |",
+            text,
+        )
+        self.assertIn(
+            "| `Chemistry_000` | `a13cd7d` | **cancelled** | no — refused "
+            "(`pipeline_completed`) | 6 |",
+            text,
+        )
+        self.assertIn("| `Astronomy_000` | `a13cd7d` | completed | yes | 7 |", text)
+
+    def test_the_split_between_the_sample_and_the_mean_is_stated(self) -> None:
+        text = format_rcb_trial_report(self.live())
+        self.assertIn(
+            "of those 3, **1 reached the difference below** and **2 were refused**", text
+        )
+
+    def test_the_word_a_reader_would_search_for_is_in_the_report(self) -> None:
+        """The reviewer's own test: replaying these artifacts produced a report with no
+        occurrence of `cancelled` or `truncated` anywhere in it."""
+        text = format_rcb_trial_report(self.live())
+        self.assertGreaterEqual(text.count("cancelled"), 2)
+        self.assertIn("truncated", text)
+
+    def test_a_sample_that_is_entirely_refused_still_discloses(self) -> None:
+        """Zero admitted is the reading the old code could not make at all: with
+        ``evidence`` empty it printed "no run was scored" over runs that were scored."""
+        text = format_rcb_trial_report(
+            collect_rcb_pairs(
+                [
+                    arm(
+                        task="Astronomy_000",
+                        label=self.CONTROL,
+                        facts={"run_status": "cancelled", "meta_pipeline_completed": False},
+                    )
+                ],
+                capability="stage_graph",
+                control_arm=self.CONTROL,
+                treatment_arm=self.TREATMENT,
+                planned_pairs=6,
+            )
+        )
+        self.assertNotIn("no run was scored", text)
+        self.assertIn("**1 of 1 scored runs did not end `completed`.**", text)
+        self.assertIn("**0 reached the difference below** and **1 were refused**", text)
+
+    def test_a_driver_refusal_is_not_counted_as_a_scored_run(self) -> None:
+        """It never became evidence and has no score, so it belongs to the ledger above.
+
+        Chemistry_000's control arm was still `launched` when this trial was read, and a
+        run in flight or dead before the judge must not inflate the denominator of a
+        sentence about what the judge saw.
+        """
+        result = collect_rcb_pairs(
+            [arm(task="Astronomy_000", label=self.TREATMENT, facts={"run_status": "completed"})],
+            capability="stage_graph",
+            control_arm=self.CONTROL,
+            treatment_arm=self.TREATMENT,
+            planned_pairs=6,
+            driver_refusals=(Refusal("Chemistry_000", self.CONTROL, ("driver:quota",)),),
+        )
+        self.assertEqual(len(result.scored), 1)
+        section = self.section(result)
+        self.assertIn("all 1 scored runs ended `completed`.", section)
+        self.assertIn(
+            "of those 1, **1 reached the difference below** and **0 were refused**", section
+        )
+        self.assertNotIn("| `Chemistry_000` |", section)
+        # It is in the ledger above instead, which is the half of the record it belongs to.
+        self.assertIn(
+            "`Chemistry_000` / `a3bcae6`: driver:quota", format_rcb_trial_report(result)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_rcb_trial_driver.py
+++ b/tests/test_rcb_trial_driver.py
@@ -706,6 +706,106 @@ class DeclaredDrawCountArrivesTests(unittest.TestCase):
         self.assertEqual(per_file.value, 1)
 
 
+class FakeJudgeDrawsAreDistinctTests(unittest.TestCase):
+    """``fake_score``'s N draws are N draws, asserted on a seed that cannot drift.
+
+    The fake judge's jitter is ``sha256(task|index|workspace|out|draw)[0] % 5``, so with
+    the workspace directory name and the output file name pinned the whole fold is a
+    fixed function of this file's ``CHECKLIST`` and ``FAKE_QUALITY``. That is the point
+    of doing it here rather than only through the driver, whose workspace name carries a
+    wall-clock second: the property "these are three draws and not one draw three times"
+    is the thing the end-to-end test could not assert without a failure rate that depends
+    on when the suite ran.
+
+    The defect this replaces was an ``assertIsNotNone`` on ``total_spread``. Removing
+    ``|{draw_no}`` from the seed makes every draw identical, ``aggregate_draws`` folds
+    them to ``total_spread == 0.0``, and ``0.0 is not None`` — so the assertion that
+    existed to refuse "a stochastic judge that resolved every item perfectly" passed on
+    exactly that. Every assertion below is one the identical-draws fold fails.
+    """
+
+    QUALITY = 20.0
+    #: Pinned, because it is a seed input. Any other value is a different measurement.
+    WORKSPACE = "Energy_001_20260101_000000"
+    OUT = "Energy_001.621566b.a1.early.r0.json"
+
+    def setUp(self) -> None:
+        self.tool = load_tool()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        self.bench = make_bench(self.root)
+
+    def fold(self, draws: int) -> dict:
+        from src.rcb_trial import ArmSpec, TrialPlan
+
+        plan = TrialPlan(
+            capability="pr175",
+            bench=str(self.bench),
+            tasks=("Energy_001",),
+            control=ArmSpec("621566b", "/wt/c", "621566b"),
+            treatment=ArmSpec("47f3fbf", "/wt/t", "47f3fbf"),
+            state_dir=str(self.root / "state"),
+            judge_kind="fake",
+            judge_model="fake-judge",
+            replicates=draws,
+        )
+        workspace = self.root / "workspaces" / self.WORKSPACE
+        (workspace / "report").mkdir(parents=True, exist_ok=True)
+        (workspace / "_meta.json").write_text(
+            json.dumps({"task_id": "Energy_001", "run_id": "20260101_000000"}),
+            encoding="utf-8",
+        )
+        (workspace / "report" / "report.md").write_text(
+            f"FAKE_QUALITY: {self.QUALITY}\n", encoding="utf-8"
+        )
+        out = self.root / "state" / "scores" / self.OUT
+        out.parent.mkdir(parents=True, exist_ok=True)
+        self.assertTrue(self.tool.fake_score(plan, workspace, out, draws=draws))
+        return json.loads(out.read_text(encoding="utf-8"))
+
+    def test_three_draws_are_three_different_readings_of_one_workspace(self) -> None:
+        """The assertion the reviewer's mutation has to fail, and the reason it is safe
+        to state it as an equality: the seed is pinned, so ``[42.2, 41.8, 42.6]`` is a
+        fact about sha256 and this file's checklist, not about the wall clock."""
+        payload = self.fold(3)
+        self.assertEqual(payload["draws"], 3)
+        self.assertEqual(payload["total_scores"], [42.2, 41.8, 42.6])
+        self.assertEqual(len(set(payload["total_scores"])), 3)
+
+    def test_the_fold_states_a_spread_a_repeated_draw_could_not_produce(self) -> None:
+        payload = self.fold(3)
+        self.assertAlmostEqual(payload["total_spread"], 0.8, places=9)
+        self.assertGreater(
+            payload["total_spread"],
+            0.0,
+            "0.0 is the identical-draws reading and it is not None, which is how an "
+            "assertIsNotNone here held nothing",
+        )
+
+    def test_no_item_carries_the_same_score_on_every_draw(self) -> None:
+        """Per item, not only in the total: ``pair_resolution`` sums per-item spreads, so
+        a fold whose items never move publishes ±0.00 over a judge nobody varied."""
+        payload = self.fold(3)
+        for item in payload["items"]:
+            with self.subTest(index=item["index"]):
+                self.assertEqual(len(item["scores"]), 3)
+                self.assertGreater(len(set(item["scores"])), 1, item["scores"])
+                self.assertGreater(item["spread"], 0.0)
+
+    def test_one_draw_still_states_an_unmeasured_spread_and_not_zero(self) -> None:
+        """The other direction, and the reason ``None`` cannot simply be banned: one draw
+        has measured no dispersion at all, and ``0.0`` there would claim it measured
+        perfect agreement."""
+        payload = self.fold(1)
+        self.assertEqual(payload["draws"], 1)
+        self.assertIsNone(payload["total_spread"])
+
+    def test_the_fold_is_reproducible_from_the_pinned_seed(self) -> None:
+        """What makes the equalities above assertions rather than a sample."""
+        self.assertEqual(self.fold(3)["total_scores"], self.fold(3)["total_scores"])
+
+
 class EvidenceTests(unittest.TestCase):
     """That the environment is *read off the run*, which nothing tested.
 
@@ -1022,6 +1122,18 @@ class EndToEndDryRunTests(unittest.TestCase):
         Both paths are asserted from the plan rather than from a hand-passed argument,
         because "the knob is forwarded when you pass it" is the assertion that was
         already true.
+
+        What the draw assertions have to distinguish is *three draws that agreed* from
+        *one draw written down three times*, and ``assertIsNotNone(total_spread)`` — what
+        was here — cannot: ``aggregate_draws`` writes ``0.0`` for the first and ``None``
+        only for a genuinely single-draw file, so deleting ``|{draw_no}`` from
+        ``fake_score``'s seed made every draw identical and left this green. The
+        distinctness check below is pooled over both arms' files and every item in them,
+        because the fake judge's jitter is a hash of the workspace name and the driver's
+        workspace name carries a wall-clock second: whether one file's three draws happen
+        to land on one number is a property of when the suite ran, and over six item
+        vectors it is not. :class:`FakeJudgeDrawsAreDistinctTests` is the same property
+        with the seed pinned, where the spread itself can be asserted exactly.
         """
         from src.rcb_trial import judge_draws_in
 
@@ -1034,17 +1146,32 @@ class EndToEndDryRunTests(unittest.TestCase):
         # the file states rather than reports as `null`.
         early = sorted(scores.glob("*.early.*.json"))
         self.assertEqual(len(early), 2, [p.name for p in early])
+        varied: list[bool] = []
         for path in early:
             payload = json.loads(path.read_text(encoding="utf-8"))
             with self.subTest(score=path.name):
                 self.assertEqual(payload["draws"], 3)
                 self.assertEqual(len(payload["total_scores"]), 3)
-                self.assertIsNotNone(
+                # `float` and not `is not None`: `None` is the single-draw reading and
+                # `0.0` is the identical-draws reading, and only the first of the two is
+                # what a missing `--draws` produces. Both have to be excluded here.
+                self.assertIsInstance(
                     payload["total_spread"],
-                    "three draws of a stochastic judge that resolved every item "
-                    "identically is the reading the spread exists to keep off the page",
+                    float,
+                    "a fold of three draws states a spread; `None` is what one draw "
+                    "states, which is the knob not having arrived",
                 )
                 self.assertEqual(judge_draws_in([payload]), 3)
+                for item in payload["items"]:
+                    self.assertEqual(len(item["scores"]), 3, item)
+                    varied.append(len(set(item["scores"])) > 1)
+        self.assertTrue(
+            any(varied),
+            "every item of both arms carries the same score on all three draws: that is "
+            "one draw recorded three times, and a spread of 0.0 over it reads as a judge "
+            "that resolved every item exactly — the one reading `aggregate_draws` and "
+            "`resolution_is_measured` exist to keep off the page",
+        )
 
         # The final pass: the same count spent as separately checkpointed files, so a
         # judge flake costs one draw rather than the arm's whole replication.

--- a/tests/test_rcb_trial_driver.py
+++ b/tests/test_rcb_trial_driver.py
@@ -14,6 +14,7 @@ judge's bill are fake.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 import os
@@ -541,7 +542,7 @@ class RealScorerArgvTests(unittest.TestCase):
         self.root = Path(self.tmp.name)
         self.addCleanup(self.tmp.cleanup)
 
-    def _capture(self, plan, out: Path) -> dict:
+    def _capture(self, plan, out: Path, *, draws: int = 1) -> dict:
         seen: dict = {}
         real = self.tool.subprocess.run
 
@@ -555,21 +556,23 @@ class RealScorerArgvTests(unittest.TestCase):
         self.tool.subprocess.run = spy
         try:
             seen["ok"] = self.tool.score_once(
-                plan, {"workspace": str(self.root / "ws")}, out
+                plan, {"workspace": str(self.root / "ws")}, out, draws=draws
             )
         finally:
             self.tool.subprocess.run = real
         return seen
 
-    def plan(self):
+    def plan(self, **overrides):
         from src.rcb_trial import ArmSpec, TrialPlan
 
-        return TrialPlan(
+        base = dict(
             capability="pr175", bench=str(self.root / "bench"), tasks=("Energy_001",),
             control=ArmSpec("c", "/wt/c", "c"), treatment=ArmSpec("t", "/wt/t", "t"),
             judge_kind="reference", judge_model="gpt-5.1",
             state_dir=str(self.root / "state"),
         )
+        base.update(overrides)
+        return TrialPlan(**base)
 
     def test_the_scorer_is_told_which_judge_to_use(self) -> None:
         """Without it ``score_rcb_run.py`` falls back to its own default model, and the
@@ -603,10 +606,104 @@ class RealScorerArgvTests(unittest.TestCase):
         try:
             self.assertFalse(
                 self.tool.score_once(plan, {"workspace": str(self.root / "ws")},
-                                     self.root / "state" / "scores" / "s.json")
+                                     self.root / "state" / "scores" / "s.json",
+                                     draws=1)
             )
         finally:
             self.tool.subprocess.run = real
+
+    def test_the_draw_count_reaches_the_scorers_argv(self) -> None:
+        """The knob that did not arrive, at the one boundary that spends the money.
+
+        ``score_rcb_run.py`` declares ``--draws`` and defaults it to 1, and the driver
+        built a command line that never mentioned it, so the plan's ``replicates`` could
+        say anything and the judge was asked once. Every score file the live stage-graph
+        trial has produced records ``"draws": 1`` and ``"total_spread": null``; the pair
+        those files carry is 35.1 against 26.6.
+        """
+        seen = self._capture(self.plan(), self.root / "state" / "scores" / "s.json", draws=3)
+        argv = seen["argv"]
+        self.assertIn("--draws", argv)
+        self.assertEqual(argv[argv.index("--draws") + 1], "3")
+
+
+class DeclaredDrawCountArrivesTests(unittest.TestCase):
+    """A knob declared in the plan and not passed at the boundary that spends it.
+
+    ``replicates: 3`` sat in the frozen plan of the live stage-graph trial and every
+    score file it produced records ``"draws": 1`` and ``"total_spread": null``. The
+    count was plumbed as far as :func:`final_pass`'s file loop and no further, so the
+    only path that trial actually took — the in-loop early score — asked the judge once
+    and published a total whose sampling band it then declined to state.
+
+    The shape of the defect is a call site that says nothing and a callee that has a
+    default to say it with. Both halves are refused here, off the driver's own syntax,
+    because the behavioural test below can only cover the call sites a test reaches.
+    """
+
+    SOURCE = ast.parse(TOOL.read_text(encoding="utf-8"))
+
+    def _def(self, name: str) -> ast.FunctionDef:
+        for node in ast.walk(self.SOURCE):
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                return node
+        raise AssertionError(f"tools/rcb_trial.py no longer defines {name}()")
+
+    def _calls_in(self, node: ast.AST, name: str) -> list[ast.Call]:
+        return [
+            child
+            for child in ast.walk(node)
+            if isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Name)
+            and child.func.id == name
+        ]
+
+    def test_score_once_gives_the_draw_count_no_default_to_hide_behind(self) -> None:
+        """A default is what let a silent call site look complete.
+
+        ``draws`` is keyword-only with no default, so a call that does not name it is a
+        ``TypeError`` at import-adjacent time rather than a judge asked once.
+        """
+        signature = self._def("score_once").args
+        self.assertIn("draws", [arg.arg for arg in signature.kwonlyargs])
+        index = [arg.arg for arg in signature.kwonlyargs].index("draws")
+        self.assertIsNone(
+            signature.kw_defaults[index],
+            "score_once(draws=...) has a default again; a call site that says nothing "
+            "about how many times to pay the judge would compile",
+        )
+
+    def test_every_call_site_of_score_once_names_the_draw_count(self) -> None:
+        calls = self._calls_in(self.SOURCE, "score_once")
+        self.assertGreaterEqual(len(calls), 2, "the two scoring paths are one call each")
+        for call in calls:
+            with self.subTest(line=call.lineno):
+                self.assertIn(
+                    "draws",
+                    [keyword.arg for keyword in call.keywords],
+                    "a score_once call that does not say how many draws it is buying",
+                )
+
+    def test_the_two_scoring_paths_spend_the_budget_the_two_declared_ways(self) -> None:
+        """One file of ``replicates`` draws in the loop, ``replicates`` files of one after.
+
+        Not interchangeable, and the split is the reason each is what it is. The final
+        pass checkpoints per file, so one draw per file makes a judge flake cost one
+        draw instead of the arm's whole replication. The in-loop score is thrown away by
+        the final pass and has nothing to salvage, so it buys the plan's whole count at
+        once — and it is the number an operator reads for days.
+        """
+        in_loop = self._calls_in(self._def("cmd_run"), "score_once")
+        self.assertEqual(len(in_loop), 1)
+        drawn = next(kw.value for kw in in_loop[0].keywords if kw.arg == "draws")
+        self.assertIsInstance(drawn, ast.Attribute)
+        self.assertEqual(drawn.attr, "replicates")
+
+        final = self._calls_in(self._def("final_pass"), "score_once")
+        self.assertEqual(len(final), 1)
+        per_file = next(kw.value for kw in final[0].keywords if kw.arg == "draws")
+        self.assertIsInstance(per_file, ast.Constant)
+        self.assertEqual(per_file.value, 1)
 
 
 class EvidenceTests(unittest.TestCase):
@@ -718,6 +815,50 @@ class EvidenceTests(unittest.TestCase):
         self.assertEqual(evidence.env.judge_replicates, 2)
         self.assertEqual(evidence.replicates_requested, 2)
         self.assertEqual((evidence.images_shown, evidence.images_available), (1, 1))
+
+    def test_the_recorded_draw_count_counts_draws_and_not_files(self) -> None:
+        """``len(payloads)`` and the draw count are the same number on one layout only.
+
+        The final pass writes one draw per file, so counting files was right for as long
+        as that was the only writer. The in-loop score asks the scorer for the plan's
+        whole count in one invocation, and ``aggregate_draws`` records it as ``draws``
+        inside that file — so a reader that counts files reports two where the judge was
+        paid six times. The disagreement runs in the direction that publishes: an arm the
+        report calls single-draw is an arm whose measured band the report then declines
+        to state.
+        """
+        plan = self.plan()
+        self.write_scores(
+            plan, "621566b", 20,
+            draws=3,
+            total_scores=[18.0, 20.0, 22.0],
+            items=[
+                {"index": index, "type": entry["type"], "weight": entry["weight"],
+                 "content": entry["content"], "score": 20, "scores": [18, 20, 22]}
+                for index, entry in enumerate(CHECKLIST)
+            ],
+        )
+        evidence = self.tool.evidence_for(plan, self.state("621566b"))
+        self.assertEqual(evidence.env.judge_replicates, 6)
+        self.assertEqual(evidence.items[0].scores, (18, 20, 22, 18, 20, 22))
+
+    def test_a_cancelled_run_carries_its_status_into_the_evidence(self) -> None:
+        """The producer half of the truncation report: ``run_manifest.run_status``.
+
+        ``harvest`` already read the field and ``evidence_for`` dropped it, so the whole
+        reporting path could be correct and have nothing to report. Two of the three
+        finished runs of the live stage-graph trial read ``cancelled`` here.
+        """
+        from src.rcb_trial import run_status_of, truncated
+
+        plan = self.plan()
+        self.write_scores(plan, "621566b", 20)
+        cut = self.tool.evidence_for(plan, self.state("621566b", run_status="cancelled"))
+        clean = self.tool.evidence_for(plan, self.state("621566b", run_status="completed"))
+
+        self.assertEqual(run_status_of(cut), "cancelled")
+        self.assertTrue(truncated(cut))
+        self.assertFalse(truncated(clean))
 
     def test_two_arms_run_on_different_models_are_not_a_pair(self) -> None:
         """Fact one's exact confound, through the real producer.
@@ -837,6 +978,56 @@ class EndToEndDryRunTests(unittest.TestCase):
         # must show a signed, non-zero, correctly-directed difference. Two identical
         # columns would let a broken seam pass.
         self.assertIn("won 1, lost 0", report)
+
+    def test_the_plans_replicate_count_reaches_the_judge_on_both_paths(self) -> None:
+        """The knob that did not arrive, from the frozen plan to the file on disk.
+
+        This is the test the live stage-graph trial needed and did not have. Its plan
+        declares ``replicates: 3``; the driver's in-loop score built a scorer command
+        line with no ``--draws`` on it, so the judge was asked once and every score file
+        in that trial's ``scores/`` records ``"draws": 1`` and ``"total_spread": null``.
+        Nothing was red, because the count was checked where it was *declared* and never
+        where it was *spent*.
+
+        Both paths are asserted from the plan rather than from a hand-passed argument,
+        because "the knob is forwarded when you pass it" is the assertion that was
+        already true.
+        """
+        from src.rcb_trial import judge_draws_in
+
+        plan_path = self._plan(replicates=3)
+        self.assertEqual(self.tool.main(["plan", "--plan", str(plan_path)]), 0)
+        self.assertEqual(self.tool.main(["run", "--plan", str(plan_path)]), 0)
+        scores = self.root / "state" / "scores"
+
+        # The in-loop score: one file, the plan's whole count inside it, and a spread
+        # the file states rather than reports as `null`.
+        early = sorted(scores.glob("*.early.*.json"))
+        self.assertEqual(len(early), 2, [p.name for p in early])
+        for path in early:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            with self.subTest(score=path.name):
+                self.assertEqual(payload["draws"], 3)
+                self.assertEqual(len(payload["total_scores"]), 3)
+                self.assertIsNotNone(
+                    payload["total_spread"],
+                    "three draws of a stochastic judge that resolved every item "
+                    "identically is the reading the spread exists to keep off the page",
+                )
+                self.assertEqual(judge_draws_in([payload]), 3)
+
+        # The final pass: the same count spent as separately checkpointed files, so a
+        # judge flake costs one draw rather than the arm's whole replication.
+        for label in (self.control_arm, self.treatment_arm):
+            final = sorted(scores.glob(f"*.{label}.*.final.*.json"))
+            with self.subTest(arm=label):
+                self.assertEqual(len(final), 3, [p.name for p in final])
+                payloads = [json.loads(p.read_text(encoding="utf-8")) for p in final]
+                self.assertEqual([p["draws"] for p in payloads], [1, 1, 1])
+                self.assertEqual(judge_draws_in(payloads), 3)
+
+        report = (self.root / "state" / "report.md").read_text(encoding="utf-8")
+        self.assertIn("judge draws: control **3**, treatment **3**, of 3 planned", report)
 
     def test_the_recovered_difference_is_the_benchmark_total_difference(self) -> None:
         plan_path = self._plan()

--- a/tests/test_rcb_trial_driver.py
+++ b/tests/test_rcb_trial_driver.py
@@ -841,6 +841,10 @@ class EvidenceTests(unittest.TestCase):
         evidence = self.tool.evidence_for(plan, self.state("621566b"))
         self.assertEqual(evidence.env.judge_replicates, 6)
         self.assertEqual(evidence.items[0].scores, (18, 20, 22, 18, 20, 22))
+        # The count is the half that gates; this is the half the count is *for*. Reading
+        # one score per file left `spread` at 0 over an item the judge had moved, and
+        # `resolution_is_measured` then declined to state a band that was measured.
+        self.assertEqual(evidence.items[0].spread, 4)
 
     def test_a_cancelled_run_carries_its_status_into_the_evidence(self) -> None:
         """The producer half of the truncation report: ``run_manifest.run_status``.
@@ -856,9 +860,35 @@ class EvidenceTests(unittest.TestCase):
         cut = self.tool.evidence_for(plan, self.state("621566b", run_status="cancelled"))
         clean = self.tool.evidence_for(plan, self.state("621566b", run_status="completed"))
 
+        silent = self.tool.evidence_for(plan, self.state("621566b"))
+
         self.assertEqual(run_status_of(cut), "cancelled")
         self.assertTrue(truncated(cut))
         self.assertFalse(truncated(clean))
+        # Silence is the third reading and the producer has to carry it as one: a state
+        # file written before the driver recorded the field says nothing, and neither
+        # "truncated" nor "clean" is a claim anything measured.
+        self.assertEqual((run_status_of(silent), truncated(silent)), ("", False))
+
+    def test_no_admission_clause_reads_the_run_status(self) -> None:
+        """The same refusal as the report-side test, through the real producer.
+
+        ``run_manifest.json`` is inside the run root, which the operator writes with
+        ``bypassPermissions``, so a gate on this field would be a gate its subject clears
+        by rewriting one word. The report-side test builds its evidence by hand; this one
+        makes ``evidence_for`` build it, which is the path a real run takes.
+        """
+        from src.rcb_trial import admit_arm
+
+        plan = self.plan()
+        self.write_scores(plan, "621566b", 20)
+        verdicts = {
+            status: admit_arm(
+                self.tool.evidence_for(plan, self.state("621566b", run_status=status))
+            )
+            for status in ("cancelled", "completed", "failed", "")
+        }
+        self.assertEqual(len(set(map(repr, verdicts.values()))), 1, verdicts)
 
     def test_two_arms_run_on_different_models_are_not_a_pair(self) -> None:
         """Fact one's exact confound, through the real producer.

--- a/tests/test_trials.py
+++ b/tests/test_trials.py
@@ -133,23 +133,160 @@ class PairTests(unittest.TestCase):
         self.assertAlmostEqual(pair.difference, 0.05, places=6)
         self.assertFalse(pair.same_shape)
 
-    def test_a_shape_change_is_counted_rather_than_folded_in(self) -> None:
-        """That a capability changes how far a run gets is a result. Averaging it
-        into a mean over shared stages would hide the thing worth reporting."""
+    def test_a_shape_change_is_set_aside_rather_than_folded_in(self) -> None:
+        """That a capability changes how far a run gets is a result, and not a score.
+
+        The shape-differing pair used to be *counted* and *averaged at the same time*:
+        `shape_changes` said one and the mean above it was taken over both pairs. The
+        two pairs here disagree in sign on purpose — the same-shape pair is +0.05 and
+        the shape-differing one is -0.20 — so a mean that still included the second one
+        would come out negative and a reader would take the sign of the thing that was
+        supposed to have been set aside.
+        """
         result = collect_pairs(
             [
                 run("g1", "off", stages=flat(0.70)),
-                run("g1", "on", stages=flat(0.70, EIGHT[:4])),
+                run("g1", "on", stages=flat(0.50, EIGHT[:4])),
                 run("g2", "off", stages=flat(0.70)),
-                run("g2", "on", stages=flat(0.70)),
+                run("g2", "on", stages=flat(0.75)),
             ],
             capability="effort_tiers",
             control_arm="off",
             treatment_arm="on",
         )
-        self.assertEqual((result.n, result.shape_changes), (2, 1))
-        self.assertAlmostEqual(result.mean_difference, 0.0, places=6)
-        self.assertIn("did not reach the same stages", format_trial_report(result))
+        self.assertEqual((result.n, result.shape_changes), (1, 1))
+        self.assertEqual(
+            ([pair.trial_id for pair in result.comparable_pairs],
+             [pair.trial_id for pair in result.shape_changed_pairs]),
+            (["g2"], ["g1"]),
+        )
+        self.assertAlmostEqual(result.mean_difference, 0.05, places=6)
+        self.assertAlmostEqual(result.shape_changed_mean, -0.20, places=6)
+        self.assertEqual((result.wins, result.losses), (1, 0))
+
+        text = format_trial_report(result)
+        self.assertIn("pairs: **1** same-shape (+1 shape-differing)", text)
+        self.assertIn("mean difference: **+0.0500**", text)
+        self.assertIn("set aside: 1 shape-differing pair(s)", text)
+        self.assertIn("**-0.2000**", text)
+        self.assertIn("did not reach the same stages", text)
+
+    def test_the_p_value_and_its_floor_are_over_the_same_pairs_as_the_mean(self) -> None:
+        """The crack this module already records at ``MAX_EXACT_PAIRS``, not reopened.
+
+        `floor` divides by `n` and `p_value` enumerates `differences`. Set the mean
+        aside from some pairs and leave either of those reading `pairs` and the report
+        prints a p from one sample beside a floor from another — which is exactly the
+        shape the header calls out as breaking the underpowered refusal at the point it
+        matters.
+        """
+        records = []
+        for index in range(4):
+            records += [
+                run(f"g{index}", "off", stages=flat(0.70)),
+                run(f"g{index}", "on", stages=flat(0.75)),
+            ]
+        # Two of the four pairs lose their shape; the statistics must fall to n = 2.
+        records += [
+            run("h0", "off", stages=flat(0.70)),
+            run("h0", "on", stages=flat(0.75, EIGHT[:3])),
+            run("h1", "off", stages=flat(0.70)),
+            run("h1", "on", stages=flat(0.75, EIGHT[:3])),
+        ]
+        result = collect_pairs(
+            records, capability="effort_tiers", control_arm="off", treatment_arm="on"
+        )
+        self.assertEqual((result.n, result.shape_changes), (4, 2))
+        self.assertEqual(len(result.differences), result.n)
+        self.assertAlmostEqual(result.floor, min_attainable_p(4), places=12)
+        self.assertAlmostEqual(result.p_value, sign_flip_p(result.differences), places=12)
+
+    def test_a_declared_composition_is_what_makes_a_one_key_measure_see_a_shape_change(
+        self,
+    ) -> None:
+        """The half a benchmark total cannot see, and the half it always could.
+
+        `src.rcb_trial` gives every record one `stage_fitness` key, so the key sets of
+        two arms that got through pairing are equal by construction and `same_shape` was
+        true of every pair it ever saw. The producer knows better and now says so. Same
+        two records both ways, so the only thing that moved is the declaration.
+        """
+        records = [
+            run("g1", "off", stages={"Energy_001|abc": 40.0}),
+            run("g1", "on", stages={"Energy_001|abc": 60.0}),
+        ]
+        kwargs = dict(capability="effort_tiers", control_arm="off", treatment_arm="on")
+
+        undeclared = collect_pairs(records, **kwargs)
+        self.assertEqual((undeclared.n, undeclared.shape_changes), (1, 0))
+
+        declared = collect_pairs(
+            records,
+            **kwargs,
+            composition={
+                ("g1", "off"): ("01_s", "02_s", "03_s", "04_s"),
+                ("g1", "on"): tuple(EIGHT[:7]),
+            },
+        )
+        self.assertEqual((declared.n, declared.shape_changes), (0, 1))
+        self.assertAlmostEqual(declared.shape_changed_mean, 20.0, places=6)
+
+        agreeing = collect_pairs(
+            records,
+            **kwargs,
+            composition={("g1", "off"): tuple(EIGHT), ("g1", "on"): tuple(EIGHT)},
+        )
+        self.assertEqual((agreeing.n, agreeing.shape_changes), (1, 0))
+
+    def test_a_sample_that_is_all_shape_differing_does_not_read_as_a_null(self) -> None:
+        """The state the live trial is actually in, and the sentence it needs.
+
+        With every pair set aside the mean is over nothing and prints `+0.0000`, which
+        reads off the page as "measured, no effect". The report has to say the mean is
+        over nothing, next to the mean.
+        """
+        result = collect_pairs(
+            [
+                run("g1", "off", stages=flat(0.70)),
+                run("g1", "on", stages=flat(0.50, EIGHT[:4])),
+            ],
+            capability="effort_tiers",
+            control_arm="off",
+            treatment_arm="on",
+        )
+        self.assertEqual((result.n, result.shape_changes), (0, 1))
+        text = format_trial_report(result)
+        self.assertIn("there is no same-shape pair yet", text)
+        self.assertIn("mean difference: **+0.0000**", text)
+        self.assertIn("set aside: 1 shape-differing pair(s)", text)
+
+    def test_the_criterion_table_is_over_the_pairs_the_scalar_is_over(self) -> None:
+        """One population, or `concentration` is a percentage of a different number.
+
+        The table is the total's decomposition — on the benchmark path the column sums
+        to the scalar above it — and the report prints a concentration read off it
+        against a floor read off its width. Leave the table on every pair while the
+        mean moves to the same-shape ones and both the share and the support count are
+        computed over a sample the number beside them was not.
+
+        The shape-differing pair moves the criterion by -0.20 and the same-shape pair by
+        +0.05, so support of 2 or a mean of -0.075 is the mutation showing.
+        """
+        result = collect_pairs(
+            [
+                run("g1", "off", stages=flat(0.70), criteria={"c": 0.70}),
+                run("g1", "on", stages=flat(0.50, EIGHT[:4]), criteria={"c": 0.50}),
+                run("g2", "off", stages=flat(0.70), criteria={"c": 0.70}),
+                run("g2", "on", stages=flat(0.75), criteria={"c": 0.75}),
+            ],
+            capability="effort_tiers",
+            control_arm="off",
+            treatment_arm="on",
+        )
+        self.assertEqual((result.n, result.shape_changes), (1, 1))
+        self.assertEqual(result.criterion_support(), {"c": 1})
+        self.assertAlmostEqual(result.criterion_differences()["c"], 0.05, places=6)
+        self.assertAlmostEqual(result.mean_difference, 0.05, places=6)
 
 
 class CollectionTests(unittest.TestCase):

--- a/tools/rcb_trial.py
+++ b/tools/rcb_trial.py
@@ -736,22 +736,14 @@ def fake_score(plan: TrialPlan, workspace: Path, out: Path, *, draws: int = 1) -
     columns that would let a broken seam pass.
 
     ``draws`` is folded by :func:`tools.score_rcb_run.aggregate_draws`, the function the
-    real scorer folds with, and the fabricated score moves with the draw index — that is
-    what ``|{draw_no}`` in the seed below is for. Both halves are the point. A fake judge
-    that ignored ``draws`` would write ``"draws": 1`` into every dry run, so the seam this
-    branch exists to exercise — a declared replicate count arriving at the process that
-    talks to the judge — would be exercised on the one path no test can afford to take.
-    And a fake judge that repeated an identical draw would report a spread of exactly 0.0
-    over three of them, which is the reading ``resolution_is_measured`` exists to keep off
-    the page: a stochastic judge that resolved every item perfectly.
-
-    That second half is a claim about this function, so it is held by a test of this
-    function: ``tests.test_rcb_trial_driver.FakeJudgeDrawsAreDistinctTests`` pins the
-    workspace and output names — the two seed inputs the driver randomises — and asserts
-    the three totals, the spread and every item's per-draw vector against the fold this
-    seed actually produces. Delete ``|{draw_no}`` and three of its five tests fail; the
-    two that survive are the ones about a *single* draw and about reproducibility, which
-    an identical-draws judge really does still satisfy.
+    real scorer folds with, and the fabricated score moves with the draw index. Both
+    halves are the point. A fake judge that ignored ``draws`` would write ``"draws": 1``
+    into every dry run, so the seam this branch exists to exercise — a declared replicate
+    count arriving at the process that talks to the judge — would be exercised on the one
+    path no test can afford to take. And a fake judge that repeated an identical draw
+    would report a spread of exactly 0.0 over three of them, which is the reading
+    ``resolution_is_measured`` exists to keep off the page: a stochastic judge that
+    resolved every item perfectly.
     """
     from tools.score_rcb_run import aggregate_draws
 

--- a/tools/rcb_trial.py
+++ b/tools/rcb_trial.py
@@ -736,14 +736,22 @@ def fake_score(plan: TrialPlan, workspace: Path, out: Path, *, draws: int = 1) -
     columns that would let a broken seam pass.
 
     ``draws`` is folded by :func:`tools.score_rcb_run.aggregate_draws`, the function the
-    real scorer folds with, and the fabricated score moves with the draw index. Both
-    halves are the point. A fake judge that ignored ``draws`` would write ``"draws": 1``
-    into every dry run, so the seam this branch exists to exercise — a declared replicate
-    count arriving at the process that talks to the judge — would be exercised on the one
-    path no test can afford to take. And a fake judge that repeated an identical draw
-    would report a spread of exactly 0.0 over three of them, which is the reading
-    ``resolution_is_measured`` exists to keep off the page: a stochastic judge that
-    resolved every item perfectly.
+    real scorer folds with, and the fabricated score moves with the draw index — that is
+    what ``|{draw_no}`` in the seed below is for. Both halves are the point. A fake judge
+    that ignored ``draws`` would write ``"draws": 1`` into every dry run, so the seam this
+    branch exists to exercise — a declared replicate count arriving at the process that
+    talks to the judge — would be exercised on the one path no test can afford to take.
+    And a fake judge that repeated an identical draw would report a spread of exactly 0.0
+    over three of them, which is the reading ``resolution_is_measured`` exists to keep off
+    the page: a stochastic judge that resolved every item perfectly.
+
+    That second half is a claim about this function, so it is held by a test of this
+    function: ``tests.test_rcb_trial_driver.FakeJudgeDrawsAreDistinctTests`` pins the
+    workspace and output names — the two seed inputs the driver randomises — and asserts
+    the three totals, the spread and every item's per-draw vector against the fold this
+    seed actually produces. Delete ``|{draw_no}`` and three of its five tests fail; the
+    two that survive are the ones about a *single* draw and about reproducibility, which
+    an identical-draws judge really does still satisfy.
     """
     from tools.score_rcb_run import aggregate_draws
 

--- a/tools/rcb_trial.py
+++ b/tools/rcb_trial.py
@@ -72,6 +72,7 @@ from src.rcb_trial import (  # noqa: E402
     driver_clause,
     format_rcb_trial_report,
     items_from_score_payloads,
+    judge_draws_in,
     next_action,
 )
 
@@ -684,14 +685,33 @@ def score_path(plan: TrialPlan, task: str, arm: str, attempt: int, label: str, r
     )
 
 
-def score_once(plan: TrialPlan, state: Mapping[str, Any], out: Path) -> bool:
+def score_once(plan: TrialPlan, state: Mapping[str, Any], out: Path, *, draws: int) -> bool:
+    """One score file, holding ``draws`` judge passes over the same workspace.
+
+    ``draws`` is keyword-only and has no default, which is the whole of the fix for the
+    knob that did not arrive. The plan declared ``replicates: 3`` and this function built
+    a command line with no ``--draws`` on it, so ``score_rcb_run.py`` took its own default
+    of 1 and every score file the driver has ever written says ``"draws": 1`` and
+    ``"total_spread": null`` — including the one the first live pair's 8.5-point gap was
+    read off. The plan's count reached ``final_pass``'s file loop and stopped there, one
+    layer above the process that talks to the judge, on a path a trial in flight has not
+    taken yet. A default here would have let the same call site keep saying nothing;
+    naming the count at each of the two call sites is what makes the spend legible.
+
+    The two realisations are equivalent and :func:`judge_draws_in` is what makes them so:
+    ``final_pass`` spends the budget as ``replicates`` separately checkpointed files of
+    one draw each, so a judge flake costs one draw rather than all of them, and the
+    in-loop score has only one file and spends it as one file of ``replicates`` draws.
+    Either way the arm's recorded draw count is the plan's.
+    """
     workspace = Path(str(state["workspace"]))
     if plan.judge_kind == "fake":
-        return fake_score(plan, workspace, out)
+        return fake_score(plan, workspace, out, draws=draws)
     argv = [
         sys.executable, str(REPO_ROOT / "tools" / "score_rcb_run.py"),
         "--workspace", str(workspace), "--bench", plan.bench,
         "--judge", plan.judge_kind, "--model", plan.judge_model, "--out", str(out),
+        "--draws", str(draws),
     ]
     env = dict(os.environ)
     # Only pins the iteration order of the bench's `IMAGE_EXTENSIONS` set, which decides
@@ -706,7 +726,7 @@ def score_once(plan: TrialPlan, state: Mapping[str, Any], out: Path) -> bool:
     return done.returncode == 0 and out.exists()
 
 
-def fake_score(plan: TrialPlan, workspace: Path, out: Path) -> bool:
+def fake_score(plan: TrialPlan, workspace: Path, out: Path, *, draws: int = 1) -> bool:
     """A deterministic stand-in judge, for exercising the harness without spending it.
 
     It reads the real checklist, so weights, item count, types and ordering are the
@@ -714,7 +734,19 @@ def fake_score(plan: TrialPlan, workspace: Path, out: Path) -> bool:
     ``FAKE_QUALITY`` line, which is the one thing the fake judge reads out of it, so a
     dry run produces a real, signed, non-zero difference instead of two identical
     columns that would let a broken seam pass.
+
+    ``draws`` is folded by :func:`tools.score_rcb_run.aggregate_draws`, the function the
+    real scorer folds with, and the fabricated score moves with the draw index. Both
+    halves are the point. A fake judge that ignored ``draws`` would write ``"draws": 1``
+    into every dry run, so the seam this branch exists to exercise — a declared replicate
+    count arriving at the process that talks to the judge — would be exercised on the one
+    path no test can afford to take. And a fake judge that repeated an identical draw
+    would report a spread of exactly 0.0 over three of them, which is the reading
+    ``resolution_is_measured`` exists to keep off the page: a stochastic judge that
+    resolved every item perfectly.
     """
+    from tools.score_rcb_run import aggregate_draws
+
     meta = read_json(workspace / "_meta.json")
     task = str(meta.get("task_id") or "")
     checklist = json.loads(
@@ -728,46 +760,50 @@ def fake_score(plan: TrialPlan, workspace: Path, out: Path) -> bool:
     for line in text.splitlines():
         if line.startswith("FAKE_QUALITY:"):
             quality = float(line.split(":", 1)[1])
-    items = []
-    total_weighted = 0.0
-    total_weight = 0.0
-    for index, entry in enumerate(checklist):
-        weight = float(entry.get("weight", 0.0))
-        seed = hashlib.sha256(
-            f"{task}|{index}|{workspace.name}|{out.name}".encode("utf-8")
-        ).digest()
-        jitter = seed[0] % 5
-        score = max(0, min(100, int(20 + quality + jitter)))
-        items.append(
+    drawn: list[dict] = []
+    for draw_no in range(max(1, draws)):
+        items = []
+        total_weighted = 0.0
+        total_weight = 0.0
+        for index, entry in enumerate(checklist):
+            weight = float(entry.get("weight", 0.0))
+            seed = hashlib.sha256(
+                f"{task}|{index}|{workspace.name}|{out.name}|{draw_no}".encode("utf-8")
+            ).digest()
+            jitter = seed[0] % 5
+            score = max(0, min(100, int(20 + quality + jitter)))
+            items.append(
+                {
+                    "index": index,
+                    "type": entry.get("type", "text"),
+                    "content": str(entry.get("content", ""))[:200],
+                    "weight": weight,
+                    "score": score,
+                    "reasoning": "fake judge",
+                }
+            )
+            total_weighted += weight * score
+            total_weight += weight
+        drawn.append(
             {
-                "index": index,
-                "type": entry.get("type", "text"),
-                "content": str(entry.get("content", ""))[:200],
-                "weight": weight,
-                "score": score,
-                "reasoning": "fake judge",
+                "run_id": meta.get("run_id"),
+                "task_id": task,
+                "items": items,
+                "total_weight": total_weight,
+                "total_score": round(total_weighted / total_weight, 2) if total_weight else 0,
+                "judge_model": plan.judge_model,
+                "judge_calls": len(items),
+                "judge_failures": [],
+                "checklist_items_expected": len(checklist),
+                # The real sweep, not an empty list: which images the judge is shown is
+                # 60.6% of the benchmark's weight, and a dry run that reports none of them
+                # exercises none of the reporting that exists to say so.
+                "images_shown": [str(path) for path in bench_image_sweep(workspace)[:5]],
+                "images_available": len(bench_image_sweep(workspace)),
+                "bench_revision": "fake-bench",
             }
         )
-        total_weighted += weight * score
-        total_weight += weight
-    payload = {
-        "run_id": meta.get("run_id"),
-        "task_id": task,
-        "items": items,
-        "total_weight": total_weight,
-        "total_score": round(total_weighted / total_weight, 2) if total_weight else 0,
-        "judge_model": plan.judge_model,
-        "judge_calls": len(items),
-        "judge_failures": [],
-        "checklist_items_expected": len(checklist),
-        # The real sweep, not an empty list: which images the judge is shown is 60.6% of
-        # the benchmark's weight, and a dry run that reports none of them exercises none
-        # of the reporting that exists to say so.
-        "images_shown": [str(path) for path in bench_image_sweep(workspace)[:5]],
-        "images_available": len(bench_image_sweep(workspace)),
-        "bench_revision": "fake-bench",
-    }
-    write_json(out, payload)
+    write_json(out, aggregate_draws(drawn))
     return True
 
 
@@ -779,6 +815,11 @@ def final_pass(plan: TrialPlan) -> None:
     across the trial would ride into the published difference unmeasured. The published
     scores all come from one continuous pass with the same judge, and the replicates
     inside it are what turn the noise band from folklore into a measurement.
+
+    ``draws=1`` per file, and the loop is the replication. That split is the reason a
+    lost draw costs one draw: the scorer writes nothing at all when any judge call in an
+    invocation fails, so asking one invocation for all three would make the judge's worst
+    minute cost the whole arm's replication rather than a third of it.
     """
     lost: list[str] = []
     for state in all_states(plan):
@@ -794,7 +835,7 @@ def final_pass(plan: TrialPlan) -> None:
                 # A judge failure inside one replicate is a reason to redraw that
                 # replicate, not to kill the pair. Escalating on the first flake would
                 # hand a four-day trial to the judge's worst minute.
-                if score_once(plan, state, out):
+                if score_once(plan, state, out, draws=1):
                     break
             else:
                 # Giving up quietly is how an arm scored once was published as an arm
@@ -839,7 +880,9 @@ def evidence_for(plan: TrialPlan, state: Mapping[str, Any]) -> ArmEvidence | Non
         # Whatever landed on disk, never what the plan asked for. Two arms averaged over
         # different numbers of judge draws are not comparable, and putting the count in
         # the digest is what makes the composition refusal that already exists say so.
-        judge_replicates=len(payloads),
+        # `judge_draws_in` and not `len(payloads)`: a file is a checkpoint, not a draw,
+        # and one file the scorer wrote with `--draws 3` used to be counted as one.
+        judge_replicates=judge_draws_in(payloads),
     )
     facts = {
         "meta_status": state.get("meta_status"),
@@ -850,6 +893,14 @@ def evidence_for(plan: TrialPlan, state: Mapping[str, Any]) -> ArmEvidence | Non
         "report_md_count": state.get("report_md_count"),
         "report_md_present": state.get("report_md_present"),
         "last_event": state.get("last_event"),
+        # Reported, never gated. `run_status: cancelled` is how the manifest records a
+        # run whose auto-skip budget ran out and which was routed to the deliverable
+        # stage to write what it had; two of the three finished runs of the live
+        # stage-graph trial ended that way. It comes off `run_manifest.json`, which is
+        # inside the run root and therefore writable by the party a gate would
+        # constrain, so no admission clause reads it and none may: it is a label on a
+        # number, not a verdict.
+        "run_status": state.get("run_status"),
         "resource_exhausted_hits": state.get("resource_exhausted_hits", 0),
         "revision_at_launch": state.get("revision_at_launch"),
         "revision_at_finish": state.get("revision_at_finish"),
@@ -1144,7 +1195,15 @@ def cmd_run(plan: TrialPlan) -> int:
                 out = score_path(
                     plan, action.task_id, action.arm, action.attempt, "early", 0
                 )
-                score_once(plan, state, out)
+                # `draws=plan.replicates`, because this is the one score that exists while
+                # a trial is in flight and it is what anybody reads for days. Left at one
+                # draw it published `total_spread: null` beside a gap of 8.5 points, on a
+                # judge whose measured spread over eight draws of one unchanged artifact
+                # set was 8.5 — so the number on screen could not say whether it had
+                # measured anything. One file rather than `replicates` of them: the early
+                # score is not checkpointed and is thrown away by `final_pass`, so there is
+                # nothing here for a per-file retry to salvage.
+                score_once(plan, state, out, draws=plan.replicates)
                 # The in-loop score exists so a systematically-refusing gate is visible
                 # after run one instead of after day five. It never enters a number.
                 evidence_state = dict(state)
@@ -1186,9 +1245,14 @@ def _announce_admission(plan: TrialPlan, state: Mapping[str, Any], out: Path) ->
         arm=str(state.get("arm") or ""),
         run_id=str(state.get("run_id") or ""),
         workspace=str(state.get("workspace") or ""),
-        env=RunEnvironment(),
+        # Only the draw count is filled: the rest of the environment is a gate the final
+        # pass applies and this is a one-arm probe, but a probe that said "0 draws" over
+        # a file the scorer had drawn three times would misreport the one thing this
+        # branch just changed.
+        env=RunEnvironment(judge_replicates=judge_draws_in([payload])),
         items=items_from_score_payloads([payload]),
         published_total=float(payload.get("total_score") or 0.0),
+        replicates_requested=int(plan.replicates),
         judge_failures=tuple(str(x) for x in (payload.get("judge_failures") or [])),
         checklist_items_expected=int(
             payload.get("checklist_items_expected") or len(payload.get("items") or [])
@@ -1210,6 +1274,18 @@ def _announce_admission(plan: TrialPlan, state: Mapping[str, Any], out: Path) ->
     )
     ok, failed = admit_arm(evidence)
     print(f"  admission: {'ADMITTED' if ok else 'REFUSED — ' + ', '.join(failed)}")
+    # On the operator's stdout while it happens, for the same reason the report prints it:
+    # a total whose sampling is unstated cannot be compared with another one, and this is
+    # the number they will be reading for the four days before the final pass exists.
+    print(
+        f"  judge draws: {evidence.replicates} of {plan.replicates} planned"
+        + ("" if evidence.replicates > 1 else "  (spread unmeasured)")
+    )
+    if state.get("run_status") and state.get("run_status") != "completed":
+        print(
+            f"  run_status: {state.get('run_status')} — the deliverable this score is of "
+            "was truncated"
+        )
 
 
 def main(argv: Sequence[str] | None = None) -> int:


### PR DESCRIPTION
The fix agent finished the work and died on an API error while reporting it, so the
branch was pushed and unverified. Both items check out when driven by hand:

- **The identical-draws mutation now kills something.** Removing the per-draw term from
  `fake_score`'s seed in tools/rcb_trial.py — so every draw returns the same number —
  fails six tests. The old `assertIsNotNone(payload["total_spread"])` passed on 0.0 and
  could not tell "three draws that agreed" from "one draw repeated three times", which
  was the whole thing it was added to check.
- The rebase hit one conflict, in the census sentence of
  `tests/test_declared_symbols_are_wired.py`, where main and this branch had each moved
  the same number. Took main's and re-measured against the tree, because this branch
  moves the population itself.

Measured with `python3 -m tests.test_declared_symbols_are_wired --census`: 1326 public
definitions over 1190 distinct names, 30 referenced by nothing outside tests/ and tools/,
20 of the 30 allowlisted have a test. Five figures in that docstring were carrying the
previous tree's values.

One of them was not merely stale but had become false. "It was 32 before this landed ...
reverting that one line is how the 32 comes back" — with the population at 30, reverting
one line gives 31. Restated as a delta, which does not expire: reverting the line puts
the population up by one. The absolute had already outlived two trees.

Testing: 2804 pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



🤖 Generated with [Claude Code](https://claude.com/claude-code)
