### PR TITLE
Give --web-search a real off switch, deny the browsing tools, and let a fresh run start above Stage 01

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -156,7 +156,7 @@ overnight job.
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--web-search {auto,gemini,native}` | `auto`, or the recorded mode when resuming | Which search path the operators use. `gemini` routes searches through the Gemini API's Google Search grounding via `tools/web_search.py`; `native` leaves the backend's own tool in charge; `auto` picks Gemini when it can actually run and falls back to native otherwise. |
+| `--web-search {auto,gemini,native,off}` | `auto`, or the recorded mode when resuming | Which search path the operators use. `gemini` routes searches through the Gemini API's Google Search grounding via `tools/web_search.py`; `native` leaves the backend's own tool in charge; `auto` picks Gemini when it can actually run and falls back to native otherwise; `off` offers no search tool at all and denies `WebSearch` and `WebFetch` to the Claude CLI. |
 
 Set `gemini` on deployments where the built-in `WebSearch` tool is disabled —
 notably **Claude Code on Vertex AI** — otherwise Stage 01 has no way to search
@@ -516,7 +516,7 @@ python rcb_agent.py [--workspace PATH] [--prompt TEXT] [--prompt-file PATH]
                     [--rigor {fast,standard,thorough,max}]
                     [--output-format {markdown,md,latex,tex}] [--final-stage STAGE]
                     [--stage-timeout SECONDS] [--max-attempts N] [--max-auto-skips N]
-                    [--intake] [--web-search {auto,gemini,native}]
+                    [--intake] [--web-search {auto,gemini,native,off}]
                     [--no-synthesis] [--export-only] [--fake-operator]
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ The precedence rules differ slightly per field:
 | `evolve_rounds` | recorded value | `2` for new runs. `0` measures without polishing. `--no-evolve` also forces it to `0`, because rounds steered by a score you are not computing mean nothing. |
 | `evolve_measure` | recorded value | `true` for new runs. `--evolve-rounds N` with `N > 0` turns it back on. |
 | `archive_steer` | recorded value | `false` for new runs. |
-| `web_search` | recorded value | The *mode* (`auto`/`gemini`/`native`) is stored, never the resolved backend: `auto` is a question about the current environment, and freezing today's answer would make a resumed run assert something about the deployment that may no longer be true. |
+| `web_search` | recorded value | The *mode* (`auto`/`gemini`/`native`/`off`) is stored, never the resolved backend: `auto` is a question about the current environment, and freezing today's answer would make a resumed run assert something about the deployment that may no longer be true. |
 | `min_report_figures` | recorded value | The Stage 07 figure floor, clamped into `[1, MAX_REPORT_FIGURES]` by `resolve_min_report_figures`. `1` for new runs; `rcb_agent.py` sets it to `BENCHMARK_MIN_REPORT_FIGURES` (3). No `main.py` flag sets it. |
 | `created_at` | preserved | Never rewritten. |
 
@@ -239,6 +239,23 @@ backend's native search otherwise, so it never advertises a tool that would
 fail on first use. Details in
 [ResearchClawBench → Web search](researchclawbench.md#web-search-on-deployments-where-websearch-is-disabled).
 
+### `--web-search off`
+
+The other three modes are a choice of *which* search the agent uses, and all
+three end with it holding one. `off` is the negation: no Gemini prompt section
+is injected, no credentials are looked for, and `WebSearch` and `WebFetch` are
+named to the Claude CLI as denied via `--disallowed-tools`. It exists for a
+benchmark whose published protocol is "without browsing", where `native` — the
+closest thing available before — says the opposite, and on a deployment where
+the built-in tool works it *is* browsing with no prompt block to show for it.
+
+**It narrows the path to the network; it does not close it.** `Bash` stays
+available, because the stages write files and run scripts through it, and
+`curl` lives inside `Bash`. So whether a run browsed is a question for its tool
+calls, answered after the fact from the transcript, and not something this flag
+can promise. Do not read `off` as a guarantee about what the agent could do —
+read it as the removal of the two tools it would otherwise reach for first.
+
 ---
 
 ## Diagram generation (optional)
@@ -372,6 +389,7 @@ authoritative list.
 | `DEFAULT_STAGE_GRAPH` | `utils.py` | `adaptive` | `--stage-graph` |
 | `DEFAULT_ROUTING_MODE` | `utils.py` | `auto` | `--routing` (the flag is not named after the field) |
 | `DEFAULT_WEB_SEARCH_MODE` | `utils.py` | `auto` | `--web-search` |
+| `NO_BROWSING_DISALLOWED_TOOLS` | `web_search.py` | `WebSearch`, `WebFetch` | `--web-search off` — the tool names handed to the Claude CLI's `--disallowed-tools`. `Bash` is deliberately not among them: denying it would not produce a no-browsing run, it would produce no run. |
 | `DEFAULT_EVOLVE_ROUNDS` | `utils.py` | 2 | `--evolve-rounds` (`DEFAULT_ROUNDS` in `evolution.py` is the same number) |
 | `DEFAULT_MAX_STEPS` | `stage_graph.py` | 20 | `--graph-max-steps` — stage executions in one walk, whatever the per-node budgets allow |
 | `DEFAULT_MAX_VISITS` | `stage_graph.py` | 3 | `--graph-max-visits` — entries into one stage; the fourth is a loop |

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,7 +98,7 @@ its own docstring, not everything it touches.
 
 | Area | Test modules |
 | --- | --- |
-| Workflow end to end | `test_manager_smoke.py`, `test_manager_workflow.py`, `test_cli_smoke.py`, `test_fake_pipeline_end_to_end.py`, `test_graph_walk.py`, `test_auto_skip_preserves_a_valid_draft.py`, `test_unattended.py` |
+| Workflow end to end | `test_manager_smoke.py`, `test_manager_workflow.py`, `test_cli_smoke.py`, `test_fake_pipeline_end_to_end.py`, `test_graph_walk.py`, `test_auto_skip_preserves_a_valid_draft.py`, `test_unattended.py`, `test_manager_start_stage.py` |
 | Graph, routing, rounds | `test_stage_graph.py`, `test_router.py`, `test_graph_cost.py`, `test_research_rounds.py` |
 | Policy dials | `test_rigor.py`, `test_effort.py` |
 | Stage contract and stage summaries | `test_utils_contracts.py`, `test_stage_handoff.py`, `test_decision_ledger.py`, `test_revision_delta.py`, `test_listed_file_patterns.py`, `test_path_reference_heuristic.py`, `test_prompt_gate_correspondence.py` |
@@ -109,7 +109,7 @@ its own docstring, not everything it touches.
 | Review and approval | `test_review_panel.py`, `test_panel_unreachable.py`, `test_panel_inherits_the_ledger.py`, `test_cross_reviewer.py`, `test_review_policy.py`, `test_obligations.py`, `test_stage_comments.py`, `test_deliberation.py`, `test_crux_repeat.py`, `test_verdict_extraction.py`, `test_reviewer_unreadable_verdict.py` |
 | Archive and self-measurement | `test_archive.py`, `test_archive_evidence.py`, `test_archive_exploration.py`, `test_archive_exploration_wiring.py`, `test_decisions.py`, `test_trials.py`, `test_scorecard.py` |
 | Operators, recovery, backend health | `test_operator_recovery.py`, `test_operator_codex.py`, `test_bounded_recovery.py`, `test_backend_health.py` |
-| Web search | `test_web_search.py`, `test_mcp_web_search.py` |
+| Web search | `test_web_search.py`, `test_web_search_off.py`, `test_mcp_web_search.py` |
 | Report output and the benchmark adapter | `test_markdown_report.py`, `test_report_figure_floor.py`, `test_rcb_adapter.py`, `test_rcb_report_source.py`, `test_rcb_scoring.py`, `test_score_rcb_run.py` (which also holds the repository-wide secret scan), `test_score_rcb_run_wiring.py` |
 | Intake and bootstrap | `test_intake.py`, `test_bootstrap.py`, `test_project_bootstrap.py` |
 | Packaging and diagrams | `test_foundry_paper_package.py`, `test_release_package.py`, `test_diagram_gen.py` |

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -489,8 +489,10 @@ or unattended switch of its own.
                         and stays silent when none is.
 --cross-review-model NAME         Default: gemini-3.1-pro-preview
                                   (`DEFAULT_CROSS_REVIEW_MODEL`).
---web-search {auto,gemini,native}
-                        Default: auto. See the section above.
+--web-search {auto,gemini,native,off}
+                        Default: auto. See the section above. `off` offers no search tool and
+                        denies WebSearch and WebFetch to the Claude CLI, for a protocol that
+                        says the run must not browse.
 --no-synthesis          Skip the operator-backed report synthesis pass and use only the
                         deterministic fallback.
 --fake-operator         Smoke-test the adapter. rcb_agent.py threads fake_mode into the
@@ -879,13 +881,22 @@ working untouched:
   total. One key because `Pair._mean_over` is unweighted while the benchmark total is
   weighted, and a mean over one element is that element. The environment digest is in
   the key so that a pair whose arms differed in judge, `model`, `review_model`,
-  checklist bytes, resolved web-search level, `INSTRUCTIONS.md`, benchmark revision or
+  checklist bytes, resolved web-search level, *requested web-search mode*,
+  `INSTRUCTIONS.md`, benchmark revision or
   *the number of judge draws its total averages* is excluded by the composition refusal
   that already exists, with no new gate to get wrong. `rcb_trial.py report` additionally
   names *which* field differed; that is diagnostics, and a test holds it in step with
   the digest field by field — and a second test holds that the fields are actually read
-  off the run, because seven blank strings are a constant digest and a gate that
+  off the run, because eight blank strings are a constant digest and a gate that
   excludes nothing.
+
+  The requested mode sits beside the resolved level because the level stopped
+  separating what it was added to separate. `--web-search off` announces itself at
+  `level: info`, which is the right level for a deliberate choice and is also what an
+  `auto` that found a working backend emits; since `rcb_agent.py` began accepting `off`,
+  an arm told not to browse and an arm that browsed freely could carry the same level.
+  The mode is read off `run_config.json`, which stores the request and never the
+  resolved backend.
 
   The draw count is in there because `final_pass` gives each replicate two tries and
   then moves on writing nothing: an arm silently scored once against an arm scored three

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -138,7 +138,7 @@ The settings the run was started with, so a resume reproduces them.
 | `evolve_measure` | Whether every valid draft is scored and the champion ratchet runs. `true` by default; costs no backend call. |
 | `evolve_rounds` | Improvement rounds per stage; `2` by default, `0` measures without polishing. |
 | `archive_steer` | Whether the cross-run archive may choose this run's topology, as opposed to only recording what it did. `false` by default. |
-| `web_search` | `auto`, `gemini`, or `native`. The mode, not the resolved backend. Absent in runs created before it existed, and read as `auto`. |
+| `web_search` | `auto`, `gemini`, `native`, or `off`. The mode, not the resolved backend. Absent in runs created before it existed, and read as `auto`. |
 | `min_report_figures` | Distinct rendered figures `workspace/report/images/` must hold before Stage 07 can be approved in `markdown` mode. `MIN_REPORT_FIGURES` = 1 for an ordinary run; `rcb_agent.py` sets `BENCHMARK_MIN_REPORT_FIGURES` = 3. `resolve_min_report_figures` clamps whatever it reads into `[1, MAX_REPORT_FIGURES]`, so a value of `0`, `99` or `"three"` becomes 1, 5 and 1 respectively rather than failing the run. Read as a hard gate by `validate_markdown_report`. |
 | `created_at` | ISO-8601 to the second. Preserved across rewrites. |
 

--- a/docs/tutorial_en.md
+++ b/docs/tutorial_en.md
@@ -500,7 +500,7 @@ You do not need the full flag list to start, but these come up almost immediatel
 | `--final-stage STAGE` | run everything | Stop after this stage instead of running the whole workflow, e.g. `--final-stage 07_writing` when you want the report but not the dissemination package. |
 | `--max-attempts N` | `5` | Attempts per stage before AutoR escalates (or, unattended, auto-skips). Each retry re-runs the stage with the previous attempt's validation errors attached. Raise it for a stubborn stage. |
 | `--stage-timeout SECONDS` | `14400` (4 hours) | Wall-clock ceiling for one stage attempt. Raise it before a heavy Stage 05, not after it times out. |
-| `--web-search {auto,gemini,native}` | `auto` | How the agent searches. `gemini` routes searches through the Gemini API, which is what you need where the backend's own web search is disabled (Claude Code on Vertex AI, for example). `native` leaves the backend's own tool in charge. `auto` uses Gemini when a key is available and falls back to native. |
+| `--web-search {auto,gemini,native,off}` | `auto` | How the agent searches. `gemini` routes searches through the Gemini API, which is what you need where the backend's own web search is disabled (Claude Code on Vertex AI, for example). `native` leaves the backend's own tool in charge. `auto` uses Gemini when a key is available and falls back to native. `off` gives the agent no search tool and denies `WebSearch` and `WebFetch` to the CLI. |
 | `--fake-operator` | off | A dry run with no backend and no tokens. See [6.3](#63-optional-run-a-smoke-test-first). |
 | `--resume-run ID`, `--redo-stage STAGE`, `--rollback-stage STAGE` | — | Continue, re-run, or invalidate. See [12.1](#121---redo-stage-vs---rollback-stage). |
 

--- a/docs/tutorial_zh.md
+++ b/docs/tutorial_zh.md
@@ -89,7 +89,7 @@ AutoR 负责的是更上层的 research loop，而不是重新发明一个新的
 | `--evolve` / `--no-evolve` | 每份合格草稿都打分并保留最好的一版，默认已开 |
 | `--archive PATH` / `--archive-report` | 跨 run 记录走过哪些边、收益如何；默认只记录不干预 |
 | `--trial ID --capability X --arm on` / `--trial-report` | 成对 A/B 试验及其统计报告；三个参数必须一起给 |
-| `--web-search {auto,gemini,native}` | 执行器怎么搜网页；`gemini` 用于内置搜索被禁用的部署 |
+| `--web-search {auto,gemini,native,off}` | 执行器怎么搜网页；`gemini` 用于内置搜索被禁用的部署；`off` 不提供任何搜索工具，并向 CLI 声明拒绝 `WebSearch` 和 `WebFetch` |
 | `--cross-review {auto,gemini,off}` | 换一个模型家族复核批准。**注意：`--fake-operator` 下会被拒绝装载，且这个选择不会随 `--resume-run` 保留** |
 
 这张表是提醒，不是参考手册。每个参数的准确语义、默认值、恢复 run 时是否保留，都在 [cli-reference.md](cli-reference.md) 里。

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from typing import Sequence
 
 from src.approval_agent import AutomatedReviewer
 from src.deliberation import DEFAULT_MAX_DELIBERATIONS
@@ -26,6 +27,7 @@ from src.terminal_ui import TerminalUI
 from src.cross_reviewer import resolve_cross_reviewer
 from src.web_search import (
     assess_search_readiness,
+    disallowed_tools_for,
     resolve_web_search_context,
     web_search_notice,
 )
@@ -306,7 +308,10 @@ def parse_args() -> argparse.Namespace:
             "API's Google Search grounding via tools/web_search.py, which is required on "
             "deployments where the built-in WebSearch tool is disabled (for example Claude Code "
             "on Vertex AI). 'native' leaves the backend's own search tool in charge. 'auto' "
-            "(default) uses Gemini when a Gemini API key is available and falls back to native."
+            "(default) uses Gemini when a Gemini API key is available and falls back to native. "
+            "'off' offers no search tool at all and denies WebSearch and WebFetch to the CLI, "
+            "for a protocol that says the run must not browse; Bash remains available, so "
+            "whether a run browsed is a question for its tool calls rather than for this flag."
         ),
     )
     parser.add_argument(
@@ -589,10 +594,14 @@ def create_operator(
     ui: TerminalUI,
     stage_timeout: int,
     web_search_mcp: bool = False,
+    disallowed_tools: Sequence[str] = (),
 ) -> OperatorProtocol:
     if operator_name == "codex":
         # Codex reaches search through the CLI script instead: it takes no --mcp-config
         # here, and its sandbox is the separate question documented in the CLI reference.
+        # `disallowed_tools` is a Claude CLI spelling and is not passed on: Codex's own
+        # search is a boolean this function's caller already resolves, and inventing a
+        # translation would be a second, untested claim about a second CLI.
         return CodexOperator(
             model=model,
             codex_sandbox=codex_sandbox,
@@ -606,6 +615,7 @@ def create_operator(
         ui=ui,
         stage_timeout=stage_timeout,
         web_search_mcp=web_search_mcp,
+        disallowed_tools=disallowed_tools,
     )
 
 
@@ -847,8 +857,17 @@ def resolve_search_context(ui: TerminalUI, *, mode: str, operator: str, codex_sa
     Called once per branch rather than once up front, because the answer depends on the
     operator and sandbox -- and on resume those come from run_config, which is not read
     until inside the branch.
+
+    `off` skips the readiness assessment rather than computing one and discarding it. The
+    assessment reads the environment and probes for an SDK to decide what to say about
+    credentials, and a run that has been told not to search has no question for it; the
+    only thing looking anyway could produce is a sentence about a key that was never
+    going to be used.
     """
-    readiness = assess_search_readiness(operator=operator, codex_sandbox=codex_sandbox)
+    readiness = (
+        None if mode == "off"
+        else assess_search_readiness(operator=operator, codex_sandbox=codex_sandbox)
+    )
     notice, level = web_search_notice(mode, readiness=readiness)
     ui.show_status(notice, level=level)
     if mode == "gemini" and readiness.hard_blocker:
@@ -863,8 +882,15 @@ def resolve_search_context(ui: TerminalUI, *, mode: str, operator: str, codex_sa
 
 
 def configure_effort(manager, args, *, backend_name: str, model: str, ui: TerminalUI, fake_mode: bool,
-                     stage_timeout: int, unattended: bool = False) -> None:
-    """Turn on effort tiering, and give routine stages a cheap gate to use."""
+                     stage_timeout: int, web_search_mode: str, unattended: bool = False) -> None:
+    """Turn on effort tiering, and give routine stages a cheap gate to use.
+
+    `web_search_mode` is required rather than defaulted because of what it decides: the
+    routine operator runs stages, so a mode it is not told about is a tier of the run
+    conducted under a different search protocol than the one the flag asked for. A
+    default here would let a third caller be added that silently hands the cheap tier
+    the browsing tools back.
+    """
     manager.rigor_level = getattr(args, "rigor", "")
     if not getattr(args, "effort_tiers", False):
         return
@@ -878,6 +904,14 @@ def configure_effort(manager, args, *, backend_name: str, model: str, ui: Termin
             ui=ui,
             codex_sandbox=getattr(args, "codex_sandbox", None) or DEFAULT_CODEX_SANDBOX,
             stage_timeout=stage_timeout,
+            # The same denial the primary operator gets. Without it `--web-search off`
+            # was a claim about whichever stages happened to route to the strong tier:
+            # every routine stage kept WebSearch and WebFetch, and nothing said so.
+            # `web_search_mcp` is deliberately still not passed -- the routine operator
+            # has never had the Gemini MCP tool, and giving it one would change what an
+            # existing `--web-search gemini --effort-tiers` run does, which is a
+            # separate question from whether `off` means off.
+            disallowed_tools=disallowed_tools_for(web_search_mode),
         )
         manager.concentration.routine_model = args.routine_model
     if isinstance(manager.reviewer, AutomatedReviewer):
@@ -1044,6 +1078,7 @@ def main() -> int:
             ui=ui,
             stage_timeout=args.stage_timeout,
             web_search_mcp=web_search_context is not None,
+            disallowed_tools=disallowed_tools_for(web_search_mode),
         )
         reviewer = None
         if approval_mode == "agent":
@@ -1093,7 +1128,7 @@ def main() -> int:
         configure_effort(
             manager, args, backend_name=review_operator, model=review_model, ui=ui,
             fake_mode=args.fake_operator, stage_timeout=args.stage_timeout,
-            unattended=unattended,
+            web_search_mode=web_search_mode, unattended=unattended,
         )
         completed = manager.resume_run(
             run_root,
@@ -1133,6 +1168,7 @@ def main() -> int:
         ui=ui,
         stage_timeout=args.stage_timeout,
         web_search_mcp=web_search_context is not None,
+        disallowed_tools=disallowed_tools_for(web_search_mode),
     )
     reviewer = None
     if approval_mode == "agent":
@@ -1183,7 +1219,7 @@ def main() -> int:
     configure_effort(
         manager, args, backend_name=review_operator, model=review_model, ui=ui,
         fake_mode=args.fake_operator, stage_timeout=args.stage_timeout,
-        unattended=unattended,
+        web_search_mode=web_search_mode, unattended=unattended,
     )
 
     goal = resolve_goal(args, unattended=unattended)

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -27,6 +27,7 @@ import sys
 import time
 import traceback
 from pathlib import Path
+from typing import Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent
 if str(REPO_ROOT) not in sys.path:
@@ -67,6 +68,7 @@ from src.utils import (  # noqa: E402
     DEFAULT_OUTPUT_FORMAT,
     DEFAULT_VENUE,
     OUTPUT_FORMAT_CLI_CHOICES,
+    WEB_SEARCH_MODE_CHOICES,
     resolve_output_format,
     resolve_stage,
     resolve_venue_key,
@@ -74,6 +76,7 @@ from src.utils import (  # noqa: E402
 from src.cross_reviewer import resolve_cross_reviewer
 from src.web_search import (  # noqa: E402
     assess_search_readiness,
+    disallowed_tools_for,
     resolve_web_search_context,
     web_search_notice,
 )
@@ -320,10 +323,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--web-search",
-        choices=["auto", "gemini", "native"],
+        # Derived rather than restated. This list was written out by hand and had already
+        # stopped agreeing with the one `main.py` offers and `normalize_web_search_mode`
+        # stores, so a mode added to the constant reached one front end and not the other.
+        choices=list(WEB_SEARCH_MODE_CHOICES),
         default="auto",
         help="Search provider for the operators. 'gemini' is required where the built-in "
-             "WebSearch tool is disabled, such as Claude Code on Vertex AI.",
+             "WebSearch tool is disabled, such as Claude Code on Vertex AI. 'off' offers no "
+             "search tool and denies WebSearch and WebFetch to the CLI. Defaults to auto.",
     )
     parser.add_argument(
         "--no-synthesis",
@@ -360,6 +367,7 @@ def create_operator(
     web_search_mcp: bool = False,
     codex_command: str = "codex",
     codex_web_search: bool = False,
+    disallowed_tools: Sequence[str] = (),
 ):
     if backend == "codex":
         return CodexOperator(
@@ -380,6 +388,7 @@ def create_operator(
         ui=ui,
         stage_timeout=stage_timeout,
         web_search_mcp=web_search_mcp,
+        disallowed_tools=disallowed_tools,
     )
 
 
@@ -460,9 +469,15 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         }
     )
 
-    readiness = assess_search_readiness(
-        operator=operator_backend,
-        codex_sandbox=args.codex_sandbox,
+    # Not assessed under `off`: the assessment exists to say what a run that is going to
+    # search can search with, and this one is not. Looking anyway would only produce a
+    # sentence about a credential nothing was going to use.
+    readiness = (
+        None if args.web_search == "off"
+        else assess_search_readiness(
+            operator=operator_backend,
+            codex_sandbox=args.codex_sandbox,
+        )
     )
     notice, level = web_search_notice(args.web_search, readiness=readiness)
     emit_event({"type": "progress", "stage": "web_search", "level": level, "message": notice})
@@ -486,6 +501,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         web_search_mcp=web_search_context is not None,
         codex_command=args.codex_command,
         codex_web_search=args.web_search == "native",
+        disallowed_tools=disallowed_tools_for(args.web_search),
     )
     synthesizer = None if args.no_synthesis else ReportSynthesizer(operator)
 
@@ -635,6 +651,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
                 web_search_mcp=web_search_context is not None,
                 codex_command=args.codex_command,
                 codex_web_search=args.web_search == "native",
+                disallowed_tools=disallowed_tools_for(args.web_search),
             )
             manager.concentration.routine_model = args.routine_model
         # `unattended=True` like every other reviewer this file builds. Without it the

--- a/src/manager.py
+++ b/src/manager.py
@@ -417,7 +417,43 @@ class ResearchManager:
         paper_corpus: Path | None = None,
         output_format: str | None = None,
         final_stage: StageSpec | None = None,
+        start_stage: StageSpec | None = None,
     ) -> bool:
+        """Create a run and walk it.
+
+        ``start_stage`` skips the stages before it on a *fresh* run, the way
+        ``resume_run`` already skips them on an existing one. Both go through the same
+        ``_select_stages_for_run``, so a caller that enters above Stage 01 gets exactly
+        the population a resume would.
+
+        What that population costs is worth stating rather than discovering: the skipped
+        stages stay ``pending`` in the manifest and the run still ends ``completed``,
+        because it did everything it was asked to do -- the same arrangement
+        ``--final-stage`` already has at the other end of the walk. They are *not* added
+        to ``auto_skipped_stages``; that list is the run's record of gates it gave up on,
+        and a stage the caller chose not to run is not one of those. So the manifest is
+        where the absence is legible, and a reader who wants "did this run survey the
+        literature" has to ask the manifest rather than the run status.
+
+        The caller that wants it is a benchmark whose published protocol forbids
+        browsing: Stage 01 is a literature survey, its evidence ledger can only be
+        satisfied by citations, and the only citations available to a run that cannot
+        search are invented ones. Not running the stage is honest; running it without a
+        search tool is not.
+
+        ``start_stage`` and ``project_root`` are refused together. ``--project-root``
+        runs a bootstrap scan whose whole output is a recommended entry stage, so passing
+        both states two answers to one question, and the silent resolution -- whichever
+        assignment happens to come last in this method -- would be a coin flip decided by
+        source order. The refusal is raised before anything is created, so a rejected
+        call leaves no half-built run directory behind.
+        """
+        if start_stage is not None and project_root is not None:
+            raise ValueError(
+                "start_stage and project_root both decide where the walk begins: "
+                f"start_stage says {start_stage.slug}, and --project-root runs a bootstrap "
+                "scan whose recommended entry stage would say something else. Pass one."
+            )
         self._research_diagram = research_diagram
         self._final_stage = final_stage
         paths = self._create_run(
@@ -440,15 +476,19 @@ class ResearchManager:
                 self.ui.show_status("Run aborted.", level="warn")
                 return False
 
+        # Where the walk begins. Two sources, never both: the caller's `start_stage`, or
+        # the entry stage a `--project-root` bootstrap scan recommends. The guard at the
+        # top of this method is what makes the second assignment safe to write here.
+        entry_stage: StageSpec | None = start_stage
+
         # Run project repo bootstrap if provided
-        bootstrap_start_stage: StageSpec | None = None
         if project_root is not None:
             bootstrap_result = self._run_project_bootstrap(paths, project_root)
             if bootstrap_result is None:
                 append_log_entry(paths.logs, "run_aborted", "Run aborted during project bootstrap.")
                 self.ui.show_status("Run aborted.", level="warn")
                 return False
-            bootstrap_start_stage = bootstrap_result
+            entry_stage = bootstrap_result
 
         # Run bootstrap from paper corpus if provided
         if paper_corpus is not None:
@@ -458,7 +498,17 @@ class ResearchManager:
                 self.ui.show_status("Run aborted.", level="warn")
                 return False
 
-        return self._run_from_paths(paths, start_stage=bootstrap_start_stage)
+        if start_stage is not None:
+            # Said out loud, and as a warning. `resume_run` announces its restart point
+            # for the same reason: a run that produced no literature survey because it
+            # was told not to and a run that produced none because the stage failed look
+            # identical on disk, and only one of them is what the operator asked for.
+            self.ui.show_status(
+                f"Starting at {start_stage.stage_title}; the stages before it will not run "
+                "and stay unsettled in the manifest.",
+                level="warn",
+            )
+        return self._run_from_paths(paths, start_stage=entry_stage)
 
     def resume_run(
         self,

--- a/src/operator.py
+++ b/src/operator.py
@@ -10,7 +10,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import TextIO
+from typing import Sequence, TextIO
 
 from .terminal_ui import TerminalUI
 from .utils import (
@@ -41,6 +41,7 @@ class ClaudeOperator:
         ui: TerminalUI | None = None,
         stage_timeout: int = 14400,
         web_search_mcp: bool = False,
+        disallowed_tools: Sequence[str] | None = None,
     ) -> None:
         self.command = command
         self.model = model
@@ -53,6 +54,12 @@ class ClaudeOperator:
         # more reliably reached for than a prompt paragraph and legible in the trace as a
         # named call rather than an opaque shell command.
         self.web_search_mcp = web_search_mcp
+        # Built-in tools this operator's stages may not call. Empty on every existing
+        # path, and the default has to stay empty: withholding a tool the stage contract
+        # assumes is available fails the stage, not the tool. `src.web_search`'s
+        # `disallowed_tools_for` is the only thing that fills it today, for a run whose
+        # protocol says it must not browse.
+        self.disallowed_tools = tuple(disallowed_tools or ())
 
     def run_stage(
         self,
@@ -1519,6 +1526,7 @@ Original stderr:
                 resume=resume,
                 tools=tools,
                 mcp_config=self._mcp_config_path(paths),
+                disallowed_tools=self.disallowed_tools,
             ),
             paths.run_root,
             None,
@@ -1557,6 +1565,7 @@ Original stderr:
         resume: bool,
         tools: str | None = None,
         mcp_config: Path | None = None,
+        disallowed_tools: Sequence[str] | None = None,
     ) -> list[str]:
         command = [
             self.command,
@@ -1572,6 +1581,14 @@ Original stderr:
             command.extend(["--mcp-config", str(mcp_config)])
         if tools:
             command.extend(["--tools", tools])
+        if disallowed_tools:
+            # One comma-joined argument rather than one argument per tool: `claude --help`
+            # (2.1.229) declares the option variadic, so a second bare word after it is
+            # read as a second tool name. Joining is also what makes the omission legible
+            # -- the flag is absent entirely when nothing is denied, instead of present
+            # with an empty value, which the CLI would read as a denial of nothing and a
+            # reader would have to decide about.
+            command.extend(["--disallowed-tools", ",".join(disallowed_tools)])
         if resume:
             command.extend(["--resume", session_id])
         else:

--- a/src/rcb_trial.py
+++ b/src/rcb_trial.py
@@ -175,6 +175,16 @@ class RunEnvironment:
     review_model: str = ""
     #: Resolved, not requested. ``run_config.json`` records ``"auto"``.
     web_search_level: str = ""
+    #: Requested, not resolved -- the companion to the field above, and here because the
+    #: level alone stopped being a discriminator. ``--web-search off`` announces itself at
+    #: ``level: info``, which is the right level for a deliberate choice and is also what
+    #: an ``auto`` that found a working backend emits, so an arm told not to browse and an
+    #: arm that browsed freely hash the same on the resolved level. That is precisely the
+    #: confound :attr:`web_search_level` was added to catch, arriving from the other
+    #: direction. Read off ``run_config.json``, which stores the mode and never the
+    #: backend, so a resumed arm reports what it was asked for rather than what today's
+    #: environment would answer.
+    web_search_mode: str = ""
     #: The judge reads ``INSTRUCTIONS.md`` as background. Both arms byte-identical.
     instructions_digest: str = ""
     #: ``git rev-parse HEAD`` in the benchmark checkout.

--- a/src/utils.py
+++ b/src/utils.py
@@ -638,7 +638,16 @@ def normalize_walk_settings(source: "Mapping[str, Any]") -> dict[str, Any]:
         "evolve_measure": DEFAULT_EVOLVE_MEASURE if measure is None else bool(measure),
         "archive_steer": DEFAULT_ARCHIVE_STEER if steer is None else bool(steer),
     }
-WEB_SEARCH_MODE_CHOICES = ("auto", "gemini", "native")
+#: The search paths a run can be put on. `off` is the one that is not a choice of
+#: provider: the other three all end with the agent holding a search tool, and a
+#: benchmark whose published protocol is "without browsing" has nowhere to stand on a
+#: flag whose quietest value still hands one over. `native` was the closest thing and it
+#: is the opposite claim -- it says "the backend's own tool is in charge", which on a
+#: deployment where that tool works is browsing with no prompt block to show for it.
+#:
+#: Ordered rather than a set because argparse prints it: the three provider choices come
+#: first and the negation last, which is how the help text reads.
+WEB_SEARCH_MODE_CHOICES = ("auto", "gemini", "native", "off")
 DEFAULT_WEB_SEARCH_MODE = "auto"
 
 

--- a/src/web_search.py
+++ b/src/web_search.py
@@ -690,6 +690,29 @@ def assess_search_readiness(
     )
 
 
+#: The notice for each mode that is decided before any credential is looked at, keyed by
+#: mode, and the source of truth for which modes those are.
+#:
+#: A mapping rather than a chain of early returns because there are two readers of the
+#: mode string and they had already drifted: each returned early for `native` alone and
+#: let every other value fall through to a readiness probe and the Gemini prompt block.
+#: A mode added to one reader only is a mode that gets the Gemini treatment from the
+#: other -- which for `off` would mean the search prompt section is injected under the
+#: flag whose whole purpose is to withhold it. :func:`resolve_web_search_context`
+#: takes its early exit from the keys of this mapping and :func:`web_search_notice`
+#: takes its message from the values, so one entry moves both.
+NOTICES_DECIDED_WITHOUT_A_PROBE: dict[str, tuple[str, str]] = {
+    "native": ("Web search: the backend's native tool.", "info"),
+    "off": (
+        "Web search: off. No search tool is offered to the operators and the browsing "
+        "tools are named to the CLI as denied. Bash is still available, so this narrows "
+        "the path to the network rather than closing it; whether a run browsed is a "
+        "question for its tool calls.",
+        "info",
+    ),
+}
+
+
 def resolve_web_search_context(
     mode: str,
     *,
@@ -703,8 +726,12 @@ def resolve_web_search_context(
     default path never advertises a tool that would fail on first use. An explicit
     `gemini` still injects — the caller is expected to have refused the run already if
     :attr:`SearchReadiness.hard_blocker` is set.
+
+    `off` returns None for a different reason than `native` does, and the difference is
+    the point: `native` keeps a search tool and declines to describe it, `off` is a run
+    that must not search at all. See :data:`NOTICES_DECIDED_WITHOUT_A_PROBE`.
     """
-    if mode == "native":
+    if mode in NOTICES_DECIDED_WITHOUT_A_PROBE:
         return None
     if readiness is None:
         readiness = assess_search_readiness(operator=operator, codex_sandbox=codex_sandbox)
@@ -727,9 +754,16 @@ def web_search_notice(
     work, and Stage 01 goes looking for literature with nothing to search with. Saying so at
     startup is the difference between a diagnosable run and one that quietly invents
     citations.
+
+    The modes in :data:`NOTICES_DECIDED_WITHOUT_A_PROBE` are answered before the probe
+    runs, because the probe is what makes the sentence worth printing: a run that is not
+    going to search has no stake in whether a Gemini key happens to be exported here, and
+    going to look for one anyway is how `off` would end up warning about credentials it
+    was never going to use.
     """
-    if mode == "native":
-        return ("Web search: the backend's native tool.", "info")
+    decided = NOTICES_DECIDED_WITHOUT_A_PROBE.get(mode)
+    if decided is not None:
+        return decided
 
     if readiness is None:
         readiness = assess_search_readiness(operator=operator, codex_sandbox=codex_sandbox)
@@ -753,6 +787,38 @@ def web_search_notice(
         "Stage 01 has no way to search at all. Pass --web-search native to silence this.",
         "warn",
     )
+
+
+#: The two built-in tools that reach the network on their own and need no shell.
+#: `Bash` is deliberately absent: the stages write files, run scripts and inspect the
+#: workspace through it, so denying it would not produce a no-browsing run, it would
+#: produce no run. See :func:`disallowed_tools_for` for what that leaves open.
+NO_BROWSING_DISALLOWED_TOOLS = ("WebSearch", "WebFetch")
+
+
+def disallowed_tools_for(mode: str) -> tuple[str, ...]:
+    """Tool names to deny the coding agent, for a resolved ``--web-search`` mode.
+
+    Empty for every mode but `off`. The three provider modes are a choice of *which*
+    search the agent uses, and denying the tools under them would contradict the flag.
+
+    The spelling was read off the installed binary rather than remembered: `claude
+    --version` reports 2.1.229 (Claude Code), and `claude --help` lists
+    ``--disallowedTools, --disallowed-tools <tools...>`` -- "Comma or space-separated
+    list of tool names to deny". Both spellings are the same option; the hyphenated one
+    is used because the rest of AutoR's command line is hyphenated. The value is passed
+    as one comma-joined argument because the option is variadic, and a second bare word
+    after it would be read as a second tool name rather than as the next thing AutoR
+    meant to say.
+
+    **This narrows the hole; it does not close it.** `Bash` stays, and `curl` lives
+    inside `Bash`, as does any script the agent writes and runs. Denying every path to
+    the network is not on offer here. So a claim that a run was conducted without
+    browsing is a post-hoc measurement of the tool calls it actually made -- the
+    transcript is the witness -- and this flag only removes the two tools the agent would
+    otherwise reach for first, which is worth doing and is not the same statement.
+    """
+    return NO_BROWSING_DISALLOWED_TOOLS if mode == "off" else ()
 
 
 def build_mcp_config(*, repo_root: Path | None = None) -> dict[str, object]:

--- a/tests/test_manager_start_stage.py
+++ b/tests/test_manager_start_stage.py
@@ -1,0 +1,287 @@
+"""A fresh run can be told where to start, and only one thing may tell it.
+
+``resume_run`` has always taken a ``start_stage`` and ``run`` has not, so the only way to
+begin a *new* run above Stage 01 was ``--project-root``: a bootstrap scan whose output is
+a recommended entry stage. That is the wrong instrument for a caller who already knows
+where it wants to start, and it costs an operator invocation to be told something the
+caller could have said.
+
+The caller that needs it is a written-examination benchmark run under a no-browsing
+protocol. Stage 01 is the literature survey; its evidence ledger is satisfied by
+citations and never checks that one exists, so a run that cannot search can only pass it
+by inventing them -- and the grading rubric awards points for specific values from the
+literature, where an invented one displaces a real one. Not running the stage is honest.
+
+The refusal is the other half. ``start_stage`` and ``project_root`` are two answers to
+one question, and before the guard the resolution was whichever assignment came last in
+the method body: the bootstrap's recommendation would have silently overwritten the
+caller's stage with no line anywhere saying so.
+
+The tests below also walk a real fake-operator run from Stage 02, because the interesting
+question is not whether the walk starts in the right place but whether everything hanging
+off it survives stages that never ran: the manifest keeps them pending rather than
+inventing a status, the graph census is written from a path that begins mid-graph, and
+the figure-plan stamp -- which fires on Stage 03's approval and again from Stage 06
+onward -- does nothing rather than stamping a plan that does not exist.
+"""
+
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.approval_agent import AutomatedReviewer
+from src.manager import ResearchManager
+from src.manifest import load_run_manifest
+from src.operator import ClaudeOperator
+from src.terminal_ui import TerminalUI
+from src.utils import STAGES, build_run_paths, read_text, resolve_stage
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+STAGE_02 = resolve_stage("02_hypothesis_generation")
+STAGE_06 = resolve_stage("06_analysis")
+
+
+def _manager(runs_dir: Path, *, stream: io.StringIO):
+    ui = TerminalUI(output_stream=stream, interactive=False)
+    operator = ClaudeOperator(
+        model="sonnet", fake_mode=True, ui=ui, output_stream=stream, stage_timeout=60
+    )
+    reviewer = AutomatedReviewer(
+        "claude", model="sonnet", fake_mode=True, ui=ui, stage_timeout=60, unattended=True
+    )
+    return ResearchManager(
+        project_root=REPO_ROOT,
+        runs_dir=runs_dir,
+        operator=operator,
+        ui=ui,
+        output_stream=stream,
+        reviewer=reviewer,
+        approval_mode="agent",
+        unattended=True,
+        max_auto_skips=0,
+    )
+
+
+class TheStagePopulationStartsWhereItIsToldTest(unittest.TestCase):
+    """``_select_stages_for_run`` is the one place both entry points converge."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.stream = io.StringIO()
+        self.manager = _manager(Path(self._tmp.name) / "runs", stream=self.stream)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+
+    def test_a_start_stage_drops_everything_before_it(self) -> None:
+        selected = self.manager._select_stages_for_run(self.paths, STAGE_02)
+        self.assertEqual(selected[0].slug, "02_hypothesis_generation")
+        self.assertNotIn("01_literature_survey", [stage.slug for stage in selected])
+
+    def test_it_still_stops_where_the_final_stage_says(self) -> None:
+        self.manager._final_stage = STAGE_06
+        selected = self.manager._select_stages_for_run(self.paths, STAGE_02)
+        self.assertEqual(
+            [stage.slug for stage in selected],
+            [stage.slug for stage in STAGES if 2 <= stage.number <= 6],
+        )
+
+    def test_a_start_stage_equal_to_the_final_stage_selects_exactly_one(self) -> None:
+        self.manager._final_stage = STAGE_02
+        selected = self.manager._select_stages_for_run(self.paths, STAGE_02)
+        self.assertEqual([stage.slug for stage in selected], ["02_hypothesis_generation"])
+
+    def test_without_one_the_population_is_every_unsettled_stage(self) -> None:
+        """Control. The three above are only meaningful if the default is different."""
+        from src.utils import ensure_run_layout
+
+        ensure_run_layout(self.paths)
+        selected = self.manager._select_stages_for_run(self.paths, None)
+        self.assertEqual(selected[0].slug, "01_literature_survey")
+        self.assertEqual(len(selected), len(STAGES))
+
+
+class TwoAnswersToOneQuestionAreRefusedTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.runs_dir = Path(self._tmp.name) / "runs"
+        self.stream = io.StringIO()
+        self.manager = _manager(self.runs_dir, stream=self.stream)
+
+    def test_passing_both_start_mechanisms_raises(self) -> None:
+        with self.assertRaises(ValueError) as caught:
+            self.manager.run(
+                "goal",
+                skip_intake=True,
+                start_stage=STAGE_02,
+                project_root=Path(self._tmp.name),
+            )
+        message = str(caught.exception)
+        self.assertIn("start_stage", message)
+        self.assertIn("project_root", message)
+        self.assertIn("02_hypothesis_generation", message)
+
+    def test_the_refusal_happens_before_anything_is_created(self) -> None:
+        """A half-built run directory is worse than the refusal: the next reader finds a
+        run with a manifest, no stages and no record of why."""
+        with self.assertRaises(ValueError):
+            self.manager.run(
+                "goal",
+                skip_intake=True,
+                start_stage=STAGE_02,
+                project_root=Path(self._tmp.name),
+            )
+        self.assertFalse(self.runs_dir.exists() and any(self.runs_dir.iterdir()))
+
+    def test_either_one_alone_is_accepted(self) -> None:
+        """Control: the refusal is about the pair, not about either argument.
+
+        The walk is stubbed out because what is under test is the guard, and running two
+        more fake pipelines to learn nothing about it is a minute of CI.
+        """
+        for kwargs in ({"start_stage": STAGE_02}, {"project_root": Path(self._tmp.name)}):
+            with self.subTest(passed=sorted(kwargs)):
+                manager = _manager(self.runs_dir, stream=self.stream)
+                with patch.object(ResearchManager, "_run_from_paths", return_value=True), \
+                     patch.object(
+                         ResearchManager, "_run_project_bootstrap", return_value=STAGE_06
+                     ):
+                    self.assertTrue(manager.run("goal", skip_intake=True, **kwargs))
+
+    def test_the_caller_and_the_bootstrap_reach_the_walk_the_same_way(self) -> None:
+        """Both sources feed one argument, so neither can grow its own walk semantics."""
+        seen: list[object] = []
+
+        def _capture(self, paths, start_stage=None):  # noqa: ANN001
+            seen.append(start_stage)
+            return True
+
+        with patch.object(ResearchManager, "_run_from_paths", _capture), \
+             patch.object(ResearchManager, "_run_project_bootstrap", return_value=STAGE_06):
+            _manager(self.runs_dir, stream=self.stream).run(
+                "goal", skip_intake=True, start_stage=STAGE_02
+            )
+            _manager(self.runs_dir, stream=self.stream).run(
+                "goal", skip_intake=True, project_root=Path(self._tmp.name)
+            )
+            _manager(self.runs_dir, stream=self.stream).run("goal", skip_intake=True)
+        self.assertEqual(seen, [STAGE_02, STAGE_06, None])
+
+
+class AWalkThatBeginsAtStageTwoTest(unittest.TestCase):
+    """A real fake-operator run, because the question is what the run *records*."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = tempfile.TemporaryDirectory()
+        runs_dir = Path(cls._tmp.name) / "runs"
+        cls.stream = io.StringIO()
+        manager = _manager(runs_dir, stream=cls.stream)
+        cls.completed = manager.run(
+            "A written examination question with no dataset and nothing to search.",
+            skip_intake=True,
+            output_format="markdown",
+            start_stage=STAGE_02,
+            final_stage=STAGE_02,
+        )
+        cls.auto_skipped = list(manager.auto_skipped_stages)
+        roots = sorted(path for path in runs_dir.iterdir() if path.is_dir())
+        assert len(roots) == 1, roots
+        cls.paths = build_run_paths(roots[0])
+        manifest = load_run_manifest(cls.paths.run_manifest)
+        assert manifest is not None
+        cls.manifest = manifest
+        cls.log_text = read_text(cls.paths.logs)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def test_the_run_completes(self) -> None:
+        self.assertTrue(self.completed, msg=self.stream.getvalue()[-3000:])
+
+    def test_stage_two_ran_and_was_approved(self) -> None:
+        entry = next(e for e in self.manifest.stages if e.slug == "02_hypothesis_generation")
+        self.assertTrue(entry.settled)
+        self.assertEqual(entry.status, "approved")
+
+    def test_stage_one_never_ran(self) -> None:
+        entry = next(e for e in self.manifest.stages if e.slug == "01_literature_survey")
+        self.assertFalse(entry.settled)
+        self.assertEqual(entry.status, "pending")
+
+    def test_the_skipped_stage_is_pending_rather_than_auto_skipped(self) -> None:
+        """`auto_skipped_stages` is the run's record of gates it gave up on. A stage the
+        caller chose not to run is not one of those, and putting it there would make a
+        deliberate entry point indistinguishable from an exhausted retry budget."""
+        self.assertEqual(self.auto_skipped, [])
+
+    def test_the_graph_census_was_written_from_a_path_that_starts_mid_graph(self) -> None:
+        """`_record_block_census` returns early on an empty path, which is how a walk
+        that never entered a node looks. This one entered one."""
+        self.assertIn("route_census", self.log_text)
+
+    def test_the_figure_plan_was_not_stamped(self) -> None:
+        """Stage 03 declares the plan and Stage 03 never ran. The stamp hook fires on
+        Stage 03's approval and again while preparing every stage from 06 onward, and on
+        a run with no plan on disk it has to do nothing rather than declare an empty
+        one -- a `report_plan declared` line here would be a claim about a document that
+        does not exist."""
+        self.assertNotIn("report_plan declared", self.log_text)
+        self.assertNotIn("report_plan amended", self.log_text)
+
+    def test_the_operator_was_told_the_run_starts_here(self) -> None:
+        """A run with no literature survey because it was told not to and one with none
+        because the stage failed look identical on disk."""
+        self.assertIn("Starting at", self.stream.getvalue())
+
+    def test_only_the_selected_stage_produced_a_stage_file(self) -> None:
+        settled = [entry.slug for entry in self.manifest.stages if entry.settled]
+        self.assertEqual(settled, ["02_hypothesis_generation"])
+
+
+class TheDefaultPathIsUnchangedTest(unittest.TestCase):
+    """Control for the class above: the same harness, with no start stage, runs Stage 01."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._tmp = tempfile.TemporaryDirectory()
+        runs_dir = Path(cls._tmp.name) / "runs"
+        cls.stream = io.StringIO()
+        manager = _manager(runs_dir, stream=cls.stream)
+        cls.completed = manager.run(
+            "A written examination question with no dataset and nothing to search.",
+            skip_intake=True,
+            output_format="markdown",
+            final_stage=STAGE_02,
+        )
+        roots = sorted(path for path in runs_dir.iterdir() if path.is_dir())
+        assert len(roots) == 1, roots
+        manifest = load_run_manifest(build_run_paths(roots[0]).run_manifest)
+        assert manifest is not None
+        cls.manifest = manifest
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._tmp.cleanup()
+
+    def test_the_run_completes(self) -> None:
+        self.assertTrue(self.completed, msg=self.stream.getvalue()[-3000:])
+
+    def test_stage_one_ran(self) -> None:
+        entry = next(e for e in self.manifest.stages if e.slug == "01_literature_survey")
+        self.assertTrue(entry.settled)
+        self.assertEqual(entry.status, "approved")
+
+    def test_nothing_announced_a_restart_point(self) -> None:
+        self.assertNotIn("Starting at", self.stream.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rcb_trial.py
+++ b/tests/test_rcb_trial.py
@@ -325,6 +325,40 @@ class EnvironmentTests(unittest.TestCase):
         self.assertEqual(len(result.excluded), 1)
         self.assertIn("web_search_level", result.excluded[0][1])
 
+    def test_a_deliberate_off_and_a_working_search_are_not_the_same_environment(self) -> None:
+        """The resolved level stopped separating the two things it was added to separate.
+
+        ``--web-search off`` announces itself at ``level: info`` -- the right level for a
+        deliberate choice -- and so does an ``auto`` that found a working backend. Since
+        `rcb_agent.py` began accepting ``off``, an arm told not to browse and an arm that
+        browsed freely could carry the identical ``web_search_level`` and hash the same,
+        which is the confound the field exists to catch arriving from the other side. The
+        requested mode is recorded next to it.
+        """
+        browsing = env(web_search_mode="auto", web_search_level="info")
+        not_browsing = env(web_search_mode="off", web_search_level="info")
+
+        self.assertNotEqual(browsing.digest, not_browsing.digest)
+        self.assertTrue(
+            any("web_search_mode" in reason
+                for reason in browsing.describe_difference(not_browsing)),
+            browsing.describe_difference(not_browsing),
+        )
+        self.assertEqual(trial(arm(), arm(label="47f3fbf", environment=not_browsing)).result.n, 0)
+
+    def test_two_arms_that_asked_for_the_same_search_still_pair(self) -> None:
+        """Control: the digest above differs because the mode differs, not because two
+        environments built the same way now differ."""
+        both = dict(web_search_mode="auto", web_search_level="info")
+        self.assertEqual(env(**both).digest, env(**both).digest)
+        self.assertEqual(
+            trial(
+                arm(environment=env(**both)),
+                arm(label="47f3fbf", environment=env(**both)),
+            ).result.n,
+            1,
+        )
+
     def test_a_different_judge_in_the_two_arms_is_not_a_comparison(self) -> None:
         """Judge choice is worth about sixteen points on identical artifacts."""
         control = arm()

--- a/tests/test_rcb_trial_driver.py
+++ b/tests/test_rcb_trial_driver.py
@@ -210,6 +210,41 @@ class StateTests(unittest.TestCase):
         )
         self.assertEqual(self.tool.search_level(log), "warn")
 
+    def test_the_requested_web_search_mode_is_harvested_beside_the_resolved_level(self) -> None:
+        """``off`` and a working ``auto`` both announce themselves at ``level: info``.
+
+        The level is the resolved answer and the only thing the progress event carries,
+        so once `rcb_agent.py` began accepting ``--web-search off`` an arm told not to
+        browse and an arm that browsed freely produced the same one. The request is in
+        ``run_config.json``, and reading it is what keeps the two apart in the digest.
+        """
+        workspace = self.root / "asked_for_off"
+        root = workspace / ".autor" / "r1"
+        root.mkdir(parents=True)
+        (root / "run_config.json").write_text(
+            json.dumps({"model": "opus", "web_search": "off"}), encoding="utf-8"
+        )
+        log = self.root / "off.log"
+        log.write_text(
+            '{"type":"progress","stage":"web_search","level":"info"}\n', encoding="utf-8"
+        )
+
+        facts = self.tool.harvest(workspace, log)
+        self.assertEqual(facts["web_search_mode"], "off")
+        self.assertEqual(facts["web_search_level"], "info")
+
+    def test_a_run_whose_config_never_named_a_mode_reports_no_mode(self) -> None:
+        """Control, and the shape of the field on every run recorded before this.
+
+        A missing key must read as unknown rather than as the default: an arm harvested
+        from a workspace with no ``run_config.json`` has not been observed to have asked
+        for ``auto``, and writing ``auto`` in would let it pair with an arm that did.
+        """
+        workspace = self.root / "no_config"
+        (workspace / ".autor" / "r1").mkdir(parents=True)
+
+        self.assertEqual(self.tool.harvest(workspace)["web_search_mode"], "")
+
     def test_a_log_with_no_progress_event_yields_no_level_rather_than_a_guess(self) -> None:
         log = self.root / "out.log"
         log.write_text("nothing here\n", encoding="utf-8")
@@ -643,7 +678,8 @@ class EvidenceTests(unittest.TestCase):
             "task_id": "Energy_001", "arm": arm, "attempt": 1, "phase": "finished",
             "workspace": f"/ws/{arm}", "run_id": f"run-{arm}",
             "agent_model": "claude-opus-4-5", "review_model": "claude-sonnet-4-5",
-            "web_search_level": "warn", "instructions_digest": "ins-digest",
+            "web_search_level": "warn", "web_search_mode": "auto",
+            "instructions_digest": "ins-digest",
             "meta_status": "completed", "meta_pipeline_completed": True,
             "meta_report_source": "agent", "autor_run_count": 1,
             "images_under_outputs": 0, "report_md_count": 1,
@@ -711,6 +747,7 @@ class EvidenceTests(unittest.TestCase):
         self.assertEqual(evidence.env.agent_model, "claude-opus-4-5")
         self.assertEqual(evidence.env.review_model, "claude-sonnet-4-5")
         self.assertEqual(evidence.env.web_search_level, "warn")
+        self.assertEqual(evidence.env.web_search_mode, "auto")
         self.assertEqual(evidence.env.instructions_digest, "ins-digest")
         self.assertEqual(evidence.env.judge_model, "gpt-5.1")
         self.assertEqual(evidence.env.bench_revision, "bench-sha")

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 import main as autor_main
 from src import web_search as web_search_module
-from src.utils import STAGES, build_prompt
+from src.utils import STAGES, WEB_SEARCH_MODE_CHOICES, build_prompt
 from src.web_search import (
     DEFAULT_SEARCH_MODEL,
     DEFAULT_VERTEX_LOCATION,
@@ -368,7 +368,13 @@ class WebSearchNoticeTest(unittest.TestCase):
         self.assertEqual(level, "info")
 
     def test_every_mode_yields_a_notice(self) -> None:
-        for mode in ("auto", "gemini", "native"):
+        """Derived from the constant, not restated.
+
+        The literal `("auto", "gemini", "native")` stood here while `off` was added to
+        `WEB_SEARCH_MODE_CHOICES`, and a mode the CLI accepts and this loop does not see
+        is a mode with no coverage at all.
+        """
+        for mode in WEB_SEARCH_MODE_CHOICES:
             for env in ({}, {"GEMINI_API_KEY": "k"}):
                 with patch.dict(os.environ, env, clear=True), self._no_key():
                     message, level = web_search_notice(mode)
@@ -377,17 +383,36 @@ class WebSearchNoticeTest(unittest.TestCase):
 
     def test_the_notice_agrees_with_what_is_injected(self) -> None:
         """A warn/error notice must mean no Gemini block reached the prompt, and vice versa."""
-        for mode in ("auto", "gemini", "native"):
+        for mode in WEB_SEARCH_MODE_CHOICES:
             for env in ({}, {"GEMINI_API_KEY": "k"}):
                 with patch.dict(os.environ, env, clear=True), self._no_key():
                     _message, level = web_search_notice(mode)
                     injected = resolve_web_search_context(mode) is not None
                 if mode == "gemini":
                     self.assertTrue(injected, mode)   # gemini always injects, even keyless
-                elif mode == "native":
+                elif mode in ("native", "off"):
                     self.assertFalse(injected, mode)
+                    # Neither is a failure to find a search tool, so neither may be
+                    # announced as one: the warn level is what an operator scans for.
+                    self.assertEqual(level, "info", mode)
                 else:
                     self.assertEqual(injected, level == "info", (mode, env))
+
+    def test_this_loop_would_notice_a_mode_that_injected_under_a_calm_notice(self) -> None:
+        """Control for the two tests above: they scan a real population and can fail.
+
+        Without it, `WEB_SEARCH_MODE_CHOICES` shrinking to nothing, or `off` quietly
+        gaining a Gemini block while still reporting `info`, would both read as green.
+        """
+        self.assertGreaterEqual(len(WEB_SEARCH_MODE_CHOICES), 4)
+        with patch.dict(os.environ, {}, clear=True), self._no_key():
+            with patch(
+                "src.web_search.NOTICES_DECIDED_WITHOUT_A_PROBE",
+                {"native": ("Web search: the backend's native tool.", "info")},
+            ):
+                # `off` is no longer answered before the probe, so it falls through to
+                # the Gemini path -- which is exactly the defect the mapping prevents.
+                self.assertIsNotNone(resolve_web_search_context("off"))
 
 
 class WebSearchModeTest(unittest.TestCase):
@@ -438,9 +463,12 @@ class WebSearchModeTest(unittest.TestCase):
                 self.assertIs(getattr(autor_main, name), canonical)
 
     def test_the_two_entry_points_agree_on_every_mode(self) -> None:
+        """Every mode the constant declares, not the three that were current when this
+        was written: a fourth added to the constant is exactly the case where the two
+        front ends can disagree, and a literal here would have skipped it."""
         import rcb_agent
 
-        for mode in ("auto", "gemini", "native"):
+        for mode in WEB_SEARCH_MODE_CHOICES:
             for env in ({"GEMINI_API_KEY": "k"}, {}):
                 with self.subTest(mode=mode, keyed=bool(env)):
                     with patch.dict(os.environ, env, clear=True), \
@@ -1418,7 +1446,7 @@ class WebSearchModePersistenceTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             paths = self._paths(tmp)
-            for mode in ("auto", "gemini", "native"):
+            for mode in WEB_SEARCH_MODE_CHOICES:
                 with self.subTest(mode=mode):
                     save_run_config(paths, {"web_search": mode})
                     self.assertEqual(load_run_config(paths)["web_search"], mode)
@@ -1481,7 +1509,7 @@ class NormalizeWebSearchModeTest(unittest.TestCase):
     def test_known_modes_survive(self) -> None:
         from src.utils import normalize_web_search_mode
 
-        for mode in ("auto", "gemini", "native"):
+        for mode in WEB_SEARCH_MODE_CHOICES:
             self.assertEqual(normalize_web_search_mode(mode), mode)
 
     def test_case_and_padding_are_tolerated(self) -> None:

--- a/tests/test_web_search_off.py
+++ b/tests/test_web_search_off.py
@@ -1,0 +1,564 @@
+"""`--web-search off` has to mean off, in both readers and at the command line.
+
+Five defects, one flag.
+
+The first: ``src.web_search`` has two readers of the mode string and they had the same
+shape and the same hole. ``resolve_web_search_context`` returned early for ``"native"``
+and let everything else fall through to ``build_web_search_prompt_section()``;
+``web_search_notice`` returned early for ``"native"`` and let everything else fall
+through to a credential probe. Adding ``"off"`` to ``WEB_SEARCH_MODE_CHOICES`` and to one
+of them would have produced a flag named `off` that injected the Gemini search prompt
+section and warned about a missing API key -- the opposite of both halves of its name.
+The fix is a single mapping both readers consult, so a fifth mode cannot be added to one
+of them alone.
+
+The second: ``ClaudeOperator._build_cli_command`` built a fixed command line and passed
+tool restrictions only on the repair path, so a run conducted "without browsing" still
+had ``WebSearch`` and ``WebFetch`` in the agent's tool list. Being told not to search is
+not the same as not being able to, and the difference matters for a benchmark whose
+published protocol is the former.
+
+The third: ``main.configure_effort`` built the routine-tier operator -- the one that runs
+whole stages under ``--effort-tiers --routine-model`` -- with no denied tools, so the
+flag held for the stages the effort plan sent to the strong tier and not for the others.
+``rcb_agent.py`` passed the list at the same construction, so the two front ends
+disagreed about what one flag meant.
+
+The fourth is a defect in the guard rather than in the code it guards, and is why the
+call sites are read with ``ast`` here rather than grepped. The first version of this
+module asserted ``"disallowed_tools=disallowed_tools_for(" in source``, and both files
+contain that string more than once: deleting the fresh-run wiring in `main.py` -- the
+line every ordinary ``python main.py --web-search off`` executes -- kept the suite green
+on the strength of the ``--resume-run`` branch's copy, and no substring could have seen
+the routine tier above at all.
+
+The fifth is what these tests are careful *not* to claim. ``Bash`` is still available --
+the stages cannot run without it -- and ``curl`` lives inside ``Bash``. So the flag
+narrows the path to the network and does not close it, and every assertion below is about
+what reaches the command line, never about what a run could not possibly do.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import main as autor_main
+import rcb_agent
+from src.utils import WEB_SEARCH_MODE_CHOICES, build_run_paths, ensure_run_layout
+from src.web_search import (
+    NO_BROWSING_DISALLOWED_TOOLS,
+    NOTICES_DECIDED_WITHOUT_A_PROBE,
+    disallowed_tools_for,
+    resolve_web_search_context,
+    web_search_notice,
+)
+
+
+#: The two front-end files, found through the imported module rather than through the
+#: working directory: `unittest discover` is run from the repository root today, and a
+#: source-reading test that silently reads nothing when it is not is a test that reports
+#: green for the wrong reason.
+REPO_ROOT = Path(autor_main.__file__).resolve().parent
+
+
+def _no_key():
+    """The key file this box may actually have is not part of any of these questions."""
+    return patch("src.web_search.DIAGRAM_CONFIG_PATH", Path("/nonexistent/diagram.yaml"))
+
+
+class TheOffModeIsAKnownModeTest(unittest.TestCase):
+    def test_the_constant_offers_it(self) -> None:
+        self.assertIn("off", WEB_SEARCH_MODE_CHOICES)
+
+    def test_both_front_ends_accept_it(self) -> None:
+        """The two CLIs used to declare their choices separately, and had drifted.
+
+        `main.py` derived its list from ``WEB_SEARCH_MODE_CHOICES`` and `rcb_agent.py`
+        wrote the three values out by hand, so a mode added to the constant reached one
+        front end and not the other. Both are asked here.
+        """
+        with patch.object(sys, "argv", ["main.py", "--web-search", "off", "--goal", "g"]):
+            self.assertEqual(autor_main.parse_args().web_search, "off")
+        self.assertEqual(rcb_agent.parse_args(["--web-search", "off"]).web_search, "off")
+
+    def test_a_run_can_record_it_and_read_it_back(self) -> None:
+        """A mode the config cannot store is silently downgraded on resume."""
+        from src.utils import load_run_config, normalize_web_search_mode, save_run_config
+
+        self.assertEqual(normalize_web_search_mode("off"), "off")
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = build_run_paths(Path(tmp) / "run")
+            ensure_run_layout(paths)
+            save_run_config(paths, {"web_search": "off"})
+            self.assertEqual(load_run_config(paths)["web_search"], "off")
+
+
+class TheOffModeInjectsNoSearchPromptTest(unittest.TestCase):
+    def test_off_resolves_to_no_prompt_section(self) -> None:
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "k"}, clear=True):
+            self.assertIsNone(resolve_web_search_context("off"))
+
+    def test_off_resolves_to_no_prompt_section_even_with_a_working_backend(self) -> None:
+        """The credential state is not an input to this question, and must not become one."""
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "k"}, clear=True), \
+             patch("src.web_search.genai_sdk_available", return_value=True):
+            self.assertIsNone(resolve_web_search_context("off"))
+
+    def test_auto_with_a_usable_backend_still_injects(self) -> None:
+        """Control. Without it, a `resolve_web_search_context` that returned None for
+        everything would pass the test above."""
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "k"}, clear=True), \
+             patch("src.web_search.genai_sdk_available", return_value=True):
+            self.assertIsNotNone(resolve_web_search_context("auto"))
+
+    def test_the_stage_prompt_carries_no_search_heading_under_off(self) -> None:
+        """One level down from the resolver: the block's absence at the seam that uses it."""
+        from src.utils import STAGES, build_prompt
+
+        with patch.dict(os.environ, {"GEMINI_API_KEY": "k"}, clear=True), \
+             patch("src.web_search.genai_sdk_available", return_value=True):
+            off_context = resolve_web_search_context("off")
+            auto_context = resolve_web_search_context("auto")
+        off_prompt = build_prompt(
+            STAGES[0], "template", "goal", "memory", web_search_context=off_context
+        )
+        auto_prompt = build_prompt(
+            STAGES[0], "template", "goal", "memory", web_search_context=auto_context
+        )
+        self.assertNotIn("# Web Search Capability", off_prompt)
+        self.assertIn("# Web Search Capability", auto_prompt)
+
+
+class TheOffModeDoesNotGoLookingForCredentialsTest(unittest.TestCase):
+    """A run told not to search has no question for the readiness probe.
+
+    The probe reads the environment, imports a spec for `google-genai` and may open a
+    config file, all to decide what to say about credentials. Under `off` the only thing
+    it could produce is a sentence about a key nothing was going to use -- and, before
+    the fix, a `warn` about it.
+    """
+
+    def test_the_notice_for_off_performs_no_readiness_probe(self) -> None:
+        with patch("src.web_search.assess_search_readiness") as probe:
+            message, level = web_search_notice("off")
+        probe.assert_not_called()
+        self.assertEqual(level, "info")
+        self.assertTrue(message.strip())
+
+    def test_the_notice_for_auto_does_perform_one(self) -> None:
+        """Control: the assertion above is about `off`, not about a probe nobody calls."""
+        with patch("src.web_search.assess_search_readiness") as probe:
+            probe.return_value.blocker = None
+            probe.return_value.backend.describe.return_value = "a backend"
+            web_search_notice("auto")
+        probe.assert_called_once()
+
+    def test_the_notice_for_off_says_off_rather_than_warning_about_a_key(self) -> None:
+        with patch.dict(os.environ, {}, clear=True), _no_key():
+            message, level = web_search_notice("off")
+        self.assertEqual(level, "info")
+        self.assertNotIn("GEMINI_API_KEY", message)
+        self.assertIn("off", message.lower())
+
+    def test_auto_without_a_key_still_warns(self) -> None:
+        """Control for the one above: `off` is quiet because it is off, not because the
+        warning was removed."""
+        with patch.dict(os.environ, {}, clear=True), _no_key():
+            _message, level = web_search_notice("auto")
+        self.assertEqual(level, "warn")
+
+    def test_mains_search_context_resolver_skips_the_probe_under_off(self) -> None:
+        from src.terminal_ui import TerminalUI
+
+        ui = TerminalUI(output_stream=io.StringIO(), interactive=False)
+        with patch("main.assess_search_readiness") as probe:
+            context = autor_main.resolve_search_context(
+                ui, mode="off", operator="claude", codex_sandbox="workspace-write"
+            )
+        probe.assert_not_called()
+        self.assertIsNone(context)
+
+    def test_mains_search_context_resolver_still_probes_under_auto(self) -> None:
+        """Control. `--web-search gemini` is refused on a blocker, and that refusal reads
+        the probe; a resolver that stopped probing at all would take the refusal with it."""
+        from src.terminal_ui import TerminalUI
+
+        ui = TerminalUI(output_stream=io.StringIO(), interactive=False)
+        with patch("main.assess_search_readiness") as probe:
+            probe.return_value.blocker = None
+            probe.return_value.hard_blocker = None
+            probe.return_value.backend.describe.return_value = "a backend"
+            probe.return_value.usable = True
+            autor_main.resolve_search_context(
+                ui, mode="auto", operator="claude", codex_sandbox="workspace-write"
+            )
+        probe.assert_called_once()
+
+
+class TheTwoReadersCannotDriftAgainTest(unittest.TestCase):
+    """Both early exits come from one mapping, so a fifth mode moves both or neither."""
+
+    def test_every_mode_answered_without_a_probe_also_injects_nothing(self) -> None:
+        self.assertTrue(NOTICES_DECIDED_WITHOUT_A_PROBE)
+        for mode in NOTICES_DECIDED_WITHOUT_A_PROBE:
+            with self.subTest(mode=mode):
+                with patch("src.web_search.assess_search_readiness") as probe:
+                    self.assertIsNone(resolve_web_search_context(mode))
+                    web_search_notice(mode)
+                probe.assert_not_called()
+
+    def test_every_mode_in_the_mapping_is_a_mode_the_cli_accepts(self) -> None:
+        """A notice for a mode nobody can select is a branch no run reaches."""
+        for mode in NOTICES_DECIDED_WITHOUT_A_PROBE:
+            self.assertIn(mode, WEB_SEARCH_MODE_CHOICES)
+
+    def test_the_modes_outside_the_mapping_are_the_ones_that_need_the_probe(self) -> None:
+        """Control: the population the test above scans is not everything."""
+        self.assertEqual(
+            set(WEB_SEARCH_MODE_CHOICES) - set(NOTICES_DECIDED_WITHOUT_A_PROBE),
+            {"auto", "gemini"},
+        )
+
+
+class DisallowedToolsForTest(unittest.TestCase):
+    def test_off_denies_the_two_browsing_tools(self) -> None:
+        self.assertEqual(disallowed_tools_for("off"), ("WebSearch", "WebFetch"))
+        self.assertTrue(disallowed_tools_for("off"))
+
+    def test_every_other_mode_denies_nothing(self) -> None:
+        for mode in WEB_SEARCH_MODE_CHOICES:
+            if mode == "off":
+                continue
+            with self.subTest(mode=mode):
+                self.assertEqual(disallowed_tools_for(mode), ())
+
+    def test_an_unknown_mode_denies_nothing_rather_than_guessing(self) -> None:
+        self.assertEqual(disallowed_tools_for("sideways"), ())
+
+    def test_bash_is_not_denied_and_the_docstring_says_why(self) -> None:
+        """The honest limit of this flag, pinned so it cannot be quietly overstated.
+
+        Denying `Bash` would not produce a no-browsing run, it would produce no run: the
+        stages write files and execute scripts through it. `curl` is inside it, so this
+        narrows the path to the network rather than closing it, and that sentence is part
+        of the contract rather than a caveat someone may drop.
+        """
+        self.assertNotIn("Bash", NO_BROWSING_DISALLOWED_TOOLS)
+        doc = " ".join((disallowed_tools_for.__doc__ or "").split())
+        self.assertIn("narrows the hole; it does not close it", doc)
+        self.assertNotIn("impossible", doc)
+
+
+class TheDisallowFlagReachesTheClaudeCommandTest(unittest.TestCase):
+    """Rendered when tools are denied, absent when they are not. Both directions.
+
+    The flag spelling was read off the installed binary: `claude --version` reports
+    2.1.229 (Claude Code) and `claude --help` lists
+    ``--disallowedTools, --disallowed-tools <tools...>``. A flag invented from memory is
+    a silent no-op, and a silent no-op here reads as a protocol that was enforced.
+    """
+
+    def _operator(self, **kwargs):
+        from src.operator import ClaudeOperator
+
+        return ClaudeOperator(**kwargs)
+
+    def _paths(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(paths)
+        return paths
+
+    def test_the_flag_is_rendered_when_tools_are_passed(self) -> None:
+        paths = self._paths()
+        command = self._operator()._build_cli_command(
+            paths.prompt_cache_dir / "p.md",
+            "sid",
+            resume=False,
+            disallowed_tools=("WebSearch", "WebFetch"),
+        )
+        self.assertIn("--disallowed-tools", command)
+        self.assertEqual(
+            command[command.index("--disallowed-tools") + 1], "WebSearch,WebFetch"
+        )
+
+    def test_the_flag_is_absent_when_nothing_is_denied(self) -> None:
+        paths = self._paths()
+        for denied in (None, ()):
+            with self.subTest(denied=denied):
+                command = self._operator()._build_cli_command(
+                    paths.prompt_cache_dir / "p.md",
+                    "sid",
+                    resume=False,
+                    disallowed_tools=denied,
+                )
+                self.assertNotIn("--disallowed-tools", command)
+
+    def test_the_default_command_is_unchanged(self) -> None:
+        """Every existing caller passes nothing, and must produce what it produced before."""
+        paths = self._paths()
+        command = self._operator()._build_cli_command(
+            paths.prompt_cache_dir / "p.md", "sid", resume=False
+        )
+        self.assertNotIn("--disallowed-tools", command)
+        self.assertEqual(command[:2], ["claude", "--model"])
+
+    def test_the_denied_list_is_one_argument_not_several(self) -> None:
+        """The CLI declares the option variadic, so a second bare word after it would be
+        read as a third tool name and the option would swallow whatever came next."""
+        paths = self._paths()
+        command = self._operator()._build_cli_command(
+            paths.prompt_cache_dir / "p.md",
+            "sid",
+            resume=False,
+            disallowed_tools=("WebSearch", "WebFetch"),
+        )
+        after = command[command.index("--disallowed-tools") + 2]
+        self.assertTrue(after.startswith("-"), after)
+
+    def test_the_operators_own_setting_reaches_the_command(self) -> None:
+        """A parameter no constructor can fill is a parameter no run can use."""
+        paths = self._paths()
+        operator = self._operator(disallowed_tools=("WebSearch", "WebFetch"))
+        command, _, _ = operator._prepare_invocation(
+            paths.prompt_cache_dir / "p.md", "sid", paths=paths, resume=False
+        )
+        self.assertIn("--disallowed-tools", command)
+
+    def test_an_operator_built_the_old_way_denies_nothing(self) -> None:
+        """Control for the one above, and the RCB regression: every existing construction
+        omits the argument and must keep the command line it had."""
+        paths = self._paths()
+        command, _, _ = self._operator()._prepare_invocation(
+            paths.prompt_cache_dir / "p.md", "sid", paths=paths, resume=False
+        )
+        self.assertNotIn("--disallowed-tools", command)
+
+
+class TheFrontEndsWireTheModeToTheToolListTest(unittest.TestCase):
+    """`--web-search off` and a browsing tool in the tool list is the flag lying."""
+
+    def _claude_operator(self, factory, mode: str, **extra):
+        from src.terminal_ui import TerminalUI
+        from src.web_search import disallowed_tools_for as helper
+
+        return factory(
+            "claude",
+            model="sonnet",
+            codex_sandbox="workspace-write",
+            fake_mode=True,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+            stage_timeout=60,
+            disallowed_tools=helper(mode),
+            **extra,
+        )
+
+    def test_main_denies_the_browsing_tools_under_off(self) -> None:
+        operator = self._claude_operator(autor_main.create_operator, "off")
+        self.assertEqual(operator.disallowed_tools, ("WebSearch", "WebFetch"))
+
+    def test_main_denies_nothing_under_the_default_mode(self) -> None:
+        operator = self._claude_operator(autor_main.create_operator, "auto")
+        self.assertEqual(operator.disallowed_tools, ())
+
+    def test_the_rcb_agent_denies_the_browsing_tools_under_off(self) -> None:
+        operator = self._claude_operator(rcb_agent.create_operator, "off")
+        self.assertEqual(operator.disallowed_tools, ("WebSearch", "WebFetch"))
+
+    def test_the_rcb_agent_denies_nothing_under_the_default_mode(self) -> None:
+        operator = self._claude_operator(rcb_agent.create_operator, "auto")
+        self.assertEqual(operator.disallowed_tools, ())
+
+
+class EveryOperatorTheFrontEndsBuildIsToldWhatToDenyTest(unittest.TestCase):
+    """The call sites, not the string. A substring check here missed two live defects.
+
+    The tests above build the operator the way the front end does, so they pass on a
+    `main()` that passes nothing. The guard that replaced them was
+    ``assertIn("disallowed_tools=disallowed_tools_for(", source)`` over each file's text,
+    and a file with two occurrences answers it with one: deleting the fresh-run wiring --
+    the line every ordinary ``python main.py --web-search off`` executes -- left the whole
+    suite green on the strength of the `--resume-run` branch's surviving copy. It also
+    could not see `configure_effort`, which built the routine-tier operator with no
+    denied tools at all, so a run with `--effort-tiers --routine-model` kept `WebSearch`
+    and `WebFetch` on every stage routed to the cheap tier.
+
+    Reading the calls instead of the file text answers both, and answers them for a call
+    site that does not exist yet.
+    """
+
+    #: The `create_operator` calls each front end makes today. Pinned, because the
+    #: assertion below is a loop over whatever the walk returns and an empty walk passes
+    #: it silently -- a renamed function, a call moved behind a factory, a mistake in the
+    #: matcher. main.py builds three (the `--resume-run` branch's operator, the fresh
+    #: branch's, and the routine-tier one in `configure_effort`); rcb_agent.py builds two
+    #: (its own and its routine-tier one). A number that moves here is a call site added
+    #: or removed, which is exactly the event that should make someone look.
+    CALL_SITES = {"main.py": 3, "rcb_agent.py": 2}
+
+    @staticmethod
+    def _create_operator_calls(path: Path) -> list:
+        """Every `create_operator(...)` in one file, as AST call nodes."""
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        calls = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.id if isinstance(func, ast.Name)
+                else func.attr if isinstance(func, ast.Attribute)
+                else ""
+            )
+            if name == "create_operator":
+                calls.append(node)
+        return calls
+
+    def test_every_call_site_passes_a_denied_tool_list(self) -> None:
+        for name in self.CALL_SITES:
+            for call in self._create_operator_calls(REPO_ROOT / name):
+                with self.subTest(entry_point=name, line=call.lineno):
+                    passed = {keyword.arg for keyword in call.keywords}
+                    self.assertIn(
+                        "disallowed_tools",
+                        passed,
+                        f"{name}:{call.lineno} builds an operator without saying what to "
+                        f"deny, so `--web-search off` does not reach it",
+                    )
+
+    def test_the_walk_finds_the_whole_population_of_call_sites(self) -> None:
+        """Control. Without it the assertion above passes on a walk that finds nothing."""
+        found = {
+            name: len(self._create_operator_calls(REPO_ROOT / name))
+            for name in self.CALL_SITES
+        }
+        self.assertEqual(found, self.CALL_SITES)
+
+    def test_the_walk_can_tell_a_call_that_denies_nothing(self) -> None:
+        """Control for the control: the matcher answers `no` on source that omits it.
+
+        The population count and the keyword check are both read off the same walk, so
+        a matcher that returned `disallowed_tools` for every call would satisfy the test
+        above and hold nothing. This drives it over a file that has one of each.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            sample = Path(tmp) / "sample.py"
+            sample.write_text(
+                "create_operator('claude', disallowed_tools=())\n"
+                "create_operator('claude')\n",
+                encoding="utf-8",
+            )
+            calls = self._create_operator_calls(sample)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(
+            [{keyword.arg for keyword in call.keywords} for call in calls],
+            [{"disallowed_tools"}, set()],
+        )
+
+
+class TheRoutineTierIsUnderTheSameProtocolTest(unittest.TestCase):
+    """`--effort-tiers --routine-model X` runs whole stages on a second operator.
+
+    It was built with no denied tools, so under `--web-search off` every stage the
+    effort plan routed to the cheap tier kept `WebSearch` and `WebFetch` -- a protocol
+    that held for some of the run, decided by which stages the tiering happened to send
+    where, and recorded nowhere. `rcb_agent.py`'s equivalent construction already passed
+    the list, so the two front ends disagreed about what the same flag meant.
+    """
+
+    def _manager_with_a_routine_tier(self, mode: str):
+        from types import SimpleNamespace
+
+        from src.terminal_ui import TerminalUI
+
+        manager = SimpleNamespace(
+            operator=SimpleNamespace(backend_name="claude"),
+            concentration=SimpleNamespace(routine_model=None),
+            reviewer=None,
+            routine_operator=None,
+        )
+        args = SimpleNamespace(
+            rigor="", effort_tiers=True, routine_model="haiku", codex_sandbox=None
+        )
+        autor_main.configure_effort(
+            manager,
+            args,
+            backend_name="claude",
+            model="opus",
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+            fake_mode=True,
+            stage_timeout=60,
+            web_search_mode=mode,
+        )
+        return manager
+
+    def test_the_routine_operator_is_denied_the_browsing_tools_under_off(self) -> None:
+        manager = self._manager_with_a_routine_tier("off")
+        self.assertEqual(manager.routine_operator.disallowed_tools, ("WebSearch", "WebFetch"))
+
+    def test_the_routine_operator_is_denied_nothing_under_the_default_mode(self) -> None:
+        """Control: the tier is not simply always denied."""
+        manager = self._manager_with_a_routine_tier("auto")
+        self.assertEqual(manager.routine_operator.disallowed_tools, ())
+
+
+class TheBenchmarkFrontEndSkipsTheProbeUnderOffTest(unittest.TestCase):
+    """`main.py` has this test already; `rcb_agent.py` had the same code and none.
+
+    The two copies of the conditional are two lines apiece and read the same literal, and
+    the copy on the benchmark path was asserted only in the pull request's prose --
+    reverting it to the eager call left the whole suite green. This drives `rcb_agent.run`
+    as far as the notice and stops it there.
+
+    The conditional is deliberately still written out in both front ends rather than
+    factored into `src.web_search`: the probe is reached through each front end's own
+    module global, which is the seam `main.assess_search_readiness` patches in four
+    existing tests and which `test_the_rcb_adapter_resolves_the_same_way` pins by
+    identity. Moving the call would relocate that seam to buy the removal of one
+    two-line ternary, and both copies are now covered from the outside anyway.
+    """
+
+    class _Stop(BaseException):
+        """Abort `run()` just past the notice; the pipeline is not the question."""
+
+    def _run_to_the_notice(self, mode: str):
+        with tempfile.TemporaryDirectory() as tmp:
+            args = rcb_agent.parse_args(
+                ["--workspace", tmp, "--web-search", mode, "--fake-operator"]
+            )
+            with patch("rcb_agent.assess_search_readiness") as probe, \
+                 patch("rcb_agent.resolve_web_search_context", side_effect=self._Stop), \
+                 patch("rcb_agent.emit_event"):
+                probe.return_value.hard_blocker = None
+                probe.return_value.blocker = None
+                probe.return_value.backend.describe.return_value = "a backend"
+                # `run` builds its own non-interactive UI on stdout; the notice it prints
+                # is the thing under test, not something the suite's log needs.
+                try:
+                    with redirect_stdout(io.StringIO()):
+                        rcb_agent.run(args)
+                except self._Stop:
+                    pass
+        return probe
+
+    def test_the_benchmark_front_end_does_not_probe_under_off(self) -> None:
+        self._run_to_the_notice("off").assert_not_called()
+
+    def test_the_benchmark_front_end_still_probes_under_auto(self) -> None:
+        """Control. `--web-search gemini` is refused on a hard blocker and that refusal
+        reads the probe, so a front end that stopped probing at all would take the
+        benchmark's own refusal with it."""
+        self._run_to_the_notice("auto").assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/rcb_trial.py
+++ b/tools/rcb_trial.py
@@ -450,6 +450,12 @@ def harvest(
         "agent_model": config.get("model", ""),
         "review_model": config.get("review_model", ""),
         "web_search_level": search_level(stdout_path) if stdout_path else "",
+        # The request, next to the resolved level, because the level stopped separating
+        # the two things it was added to separate: `--web-search off` announces itself at
+        # `level: info` and so does an `auto` that found a working backend. Taken from
+        # `run_config.json` rather than from the command line the driver remembers, so a
+        # run relaunched by hand is described by what it recorded.
+        "web_search_mode": str(config.get("web_search") or ""),
         "instructions_digest": instructions_digest(workspace),
         "autor_stages_scored": stages,
         "settled_reasoning_dose": dose,
@@ -834,6 +840,7 @@ def evidence_for(plan: TrialPlan, state: Mapping[str, Any]) -> ArmEvidence | Non
         agent_model=str(state.get("agent_model") or ""),
         review_model=str(state.get("review_model") or ""),
         web_search_level=str(state.get("web_search_level") or ""),
+        web_search_mode=str(state.get("web_search_mode") or ""),
         instructions_digest=str(state.get("instructions_digest") or ""),
         bench_revision=str(first.get("bench_revision") or ""),
         # Whatever landed on disk, never what the plan asked for. Two arms averaged over


### PR DESCRIPTION
Three enablers a no-browsing benchmark needs, each independently justified.

### 1. `--web-search off`

`WEB_SEARCH_MODE_CHOICES` had no `off`, and the reason that matters is the shape of the code
underneath: `resolve_web_search_context` returned early **only** for `native`, so every other
mode fell through and built the search prompt section. Adding `off` to the tuple and patching
that one reader would have made `--web-search off` inject the search prompt — the opposite of
the flag's name. `web_search_notice` has the same shape and additionally runs a readiness probe,
and both front ends computed that probe eagerly and passed it in, so `off` would still have read
the environment looking for a search backend. All four readers are patched in one change.

`rcb_agent.py`'s `--web-search` had a hand-written `choices=["auto", "gemini", "native"]` that
had already drifted from `main.py`'s, which derives from the constant. It now derives too.

### 2. `--disallowed-tools` reaching the CLI

A "no browsing" run still handed the operator WebSearch, WebFetch and Bash, because tool
restrictions were passed only on the repair path. `disallowed_tools_for(mode)` returns the set
for a mode and `_build_cli_command` renders it. The spelling was checked against the installed
binary, not remembered: `claude --help` on 2.1.229 documents `--disallowed-tools` as a comma or
space separated list of tool names to deny.

This narrows the path to the network; it does not close it. Bash can still reach out with curl,
so whether a run browsed is a question for its tool calls, not a claim the configuration makes.
The docstrings say so, and nothing in this PR says "impossible".

The wiring is guarded by an AST walk over `main.py` and `rcb_agent.py` that finds every
`create_operator` call and asserts each one passes `disallowed_tools`, with a control proving the
walk finds a non-empty set. That test is what caught `configure_effort` building the routine-tier
operator without it — under `--web-search off` the routine operator still had the browsing tools.

`RunEnvironment` now records the requested mode alongside the resolved level. `off` and an `auto`
that resolved to nothing both emitted an `info`-level progress event, so a trial digest could not
tell a deliberate refusal from a failed lookup — two configurations a digest cannot distinguish
is the failure mode the digest exists to prevent.

### 3. `ResearchManager.run(start_stage=...)`

A benchmark whose protocol forbids browsing cannot pass Stage 01's evidence ledger honestly: the
gate never checks that a URL resolves, so the cheapest way through it is an invented citation.
`start_stage` lets a fresh run begin above it. It is mutually exclusive with the bootstrap entry
stage and raises when both are given, and the run prints a warning naming the stages that will
stay unsettled in the manifest, mirroring what `resume_run` already does.

Suite: `Ran 2768 tests in 213.888s / OK (skipped=1)` before the review fixes, `OK` after
(2717 on `main`). RCB is unmoved: `test_rcb*.py` is 275 passing at both this commit and the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)