### PR TITLE
Give the run a supervisor that intervenes inside a stage, not after it

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -2556,10 +2556,10 @@ class ResearchManager:
             self._note_supervisor_ruling(paths, stage, ruling)
             # `attempt_ceiling` is a `min` against `--max-attempts`, so this can differ
             # from the ceiling the run was started with only downwards, and only on a
-            # stage a backward edge has already re-entered.
-            ceiling = self.supervisor.attempt_ceiling(
-                paths, stage.slug, self.max_stage_attempts
-            )
+            # stage `reallocate` has already moved budget away from. It is a *per-visit*
+            # ceiling, which is what `loop_attempts` counts against: every entry to a
+            # stage is funded, so a backward edge still buys a real visit.
+            ceiling = self.supervisor.attempt_ceiling(stage.slug, self.max_stage_attempts)
             if stuck or ruling.ends_the_visit or attempts_exhausted(
                 loop_attempts - (polish_rounds - entry_polish_rounds) + 1,
                 ceiling,

--- a/src/manager.py
+++ b/src/manager.py
@@ -126,6 +126,12 @@ from .manifest import (
 from .operator_protocol import OperatorProtocol
 from .evolution import EvolutionConfig, EvolutionController
 from .router import StageRouter, format_decision
+from .supervisor import (
+    INTERVENTION_EFFECTS,
+    REDIRECT,
+    Intervention,
+    RunSupervisor,
+)
 from .stage_comments import (
     assess_revision,
     build_comment_feedback,
@@ -347,6 +353,14 @@ class ResearchManager:
         self._stage_cost: "StageCostMeter | None" = None
         self.unattended = unattended
         self.max_auto_skips = max_auto_skips
+        #: The run-level supervisor. Built here rather than passed in because there is no
+        #: configuration to make: every threshold it applies was measured, and a knob on a
+        #: measured value is an invitation to unmeasure it. It reads the stage cost ledger
+        #: and can only ever slow the run down; see :mod:`src.supervisor`.
+        self.supervisor = RunSupervisor(
+            stage_slugs=[item.slug for item in STAGES],
+            max_auto_skips=max_auto_skips,
+        )
         #: How many times Stages 03-06 may run. 1 keeps the historical
         #: single-pass behaviour; the round decision is recorded either way,
         #: so a one-round run still says whether it converged or just stopped.
@@ -972,6 +986,22 @@ class ResearchManager:
             state.path[-1].closed_round = self._closed_round
 
         intent = self._round_intent
+        # The other boundary. A stage that has now ended two visits without an approval is
+        # not one a third visit fixes, and the supervisor says so by naming a forward move
+        # -- but only one the guards already left open, which is why the admissible set is
+        # computed here and handed in rather than looked up there.
+        exit_ruling = self.supervisor.review_stage_exit(
+            paths=paths,
+            stage_slug=stage.slug,
+            admissible_forward=[
+                move.target
+                for move in self.stage_graph.moves(
+                    paths, stage.slug, state, final_stage=self._final_stage
+                )
+                if move.admissible and move.edge.kind in {"advance", "finish"}
+            ],
+        )
+        self._note_supervisor_ruling(paths, stage, exit_ruling)
         decision = self.router.choose(
             paths=paths,
             stage=stage,
@@ -998,6 +1028,11 @@ class ResearchManager:
             skips_left=(
                 self.max_auto_skips - len(self.auto_skipped_stages)
                 if self.unattended
+                else None
+            ),
+            required=(
+                (exit_ruling.target, exit_ruling.because)
+                if exit_ruling.kind == REDIRECT
                 else None
             ),
         )
@@ -2333,6 +2368,44 @@ class ResearchManager:
         except Exception:
             pass
 
+    def _deliverable_stage_number(self) -> int:
+        """The stage a run out of budget would be routed to, as a number.
+
+        The same value ``_route_to_deliverable`` computes, read from the same two places
+        so the supervisor's last-resort rule and the routing it describes cannot disagree:
+        the writing node, unless ``--final-stage`` names an earlier one, in which case the
+        run was told to stop there and there is nothing beyond it either.
+        """
+        target = WRITING_STAGE
+        if self._final_stage is not None and self._final_stage.number < target.number:
+            target = self._final_stage
+        return target.number
+
+    def _note_supervisor_ruling(
+        self, paths: RunPaths, stage: StageSpec, ruling: "Intervention"
+    ) -> None:
+        """Put an acting ruling in the run log, beside everything else the run did.
+
+        Only the ones that act. Every ruling including the ones that changed nothing is
+        already in the supervisor's own ledger, which is what an audit reads; copying a
+        hundred and fifty ``continue``s into ``logs.txt`` would bury the two or three that
+        mattered under the ones that did not.
+        """
+        if not ruling.acts:
+            return
+        try:
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} supervisor_{ruling.kind}",
+                (
+                    f"rule: {ruling.rule}\n"
+                    f"permitted: {INTERVENTION_EFFECTS[ruling.kind]}\n"
+                    f"because: {ruling.because}"
+                ),
+            )
+        except Exception:
+            pass
+
     def _note_stage_failure(self, stage: StageSpec, attempt_no: int, kind: str, reason: str = "") -> None:
         """Charge one consumed attempt to the open meter, if this stage owns it.
 
@@ -2465,9 +2538,31 @@ class ResearchManager:
             # "no attempts allowed" and every stage fails before it starts, which is the
             # opposite of no limit. Same predicate, offset by one to match the `>=`.
             stuck = is_stuck(recent_failures)
-            if stuck or attempts_exhausted(
+            # The supervisor is asked here, before the attempt is bought, because the
+            # failure it exists to prevent is a visit grinding through attempt after
+            # attempt inside one stage: asked only at the stage boundary it would watch
+            # the money leave and comment afterwards. It rules on the harness-written cost
+            # ledger and the open meter, never on anything under `workspace/`.
+            ruling = self.supervisor.review_attempt(
+                paths=paths,
+                stage_slug=stage.slug,
+                stage_number=stage.number,
+                meter=self._stage_cost,
+                attempt_no=attempt_no,
+                auto_skips_spent=len(self.auto_skipped_stages),
+                deliverable_number=self._deliverable_stage_number(),
+                per_stage_ceiling=self.max_stage_attempts,
+            )
+            self._note_supervisor_ruling(paths, stage, ruling)
+            # `attempt_ceiling` is a `min` against `--max-attempts`, so this can differ
+            # from the ceiling the run was started with only downwards, and only on a
+            # stage a backward edge has already re-entered.
+            ceiling = self.supervisor.attempt_ceiling(
+                paths, stage.slug, self.max_stage_attempts
+            )
+            if stuck or ruling.ends_the_visit or attempts_exhausted(
                 loop_attempts - (polish_rounds - entry_polish_rounds) + 1,
-                self.max_stage_attempts,
+                ceiling,
             ):
                 # What the attempts were spent on, from the meter rather than from
                 # `last_validation_errors`. That list is assigned at exactly one place --
@@ -2486,7 +2581,16 @@ class ResearchManager:
                 )
                 if self._stage_cost is not None:
                     self._stage_cost.note_exhausted()
-                if stuck:
+                if ruling.ends_the_visit:
+                    # Named as the supervisor's, not folded into the exhaustion message:
+                    # a stage the run chose to stop paying for and a stage that ran out of
+                    # tries are different events, and only one of them has a rule behind
+                    # it that can be looked up.
+                    error = (
+                        f"The run supervisor ruled `{ruling.kind}` under `{ruling.rule}`: "
+                        f"{ruling.because}. Attempts spent on: {spent_on}."
+                    )
+                elif stuck:
                     error = (
                         f"{STUCK_AFTER_IDENTICAL_FAILURES} consecutive attempts failed in "
                         f"exactly the same way, so another one cannot help. Attempts spent "
@@ -2495,22 +2599,31 @@ class ResearchManager:
                     )
                 else:
                     error = (
-                        f"Exceeded {self.max_stage_attempts} attempts in the current stage run. "
+                        f"Exceeded {ceiling} attempts in the current stage run. "
                         f"Attempts spent on: {spent_on}. "
                         f"Last validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
                     )
                 self.ui.show_status(
                     f"{stage.stage_title} "
                     + (
-                        f"made no progress across {STUCK_AFTER_IDENTICAL_FAILURES} identical failures."
+                        f"was stopped by the run supervisor: {ruling.because}."
+                        if ruling.ends_the_visit
+                        else f"made no progress across {STUCK_AFTER_IDENTICAL_FAILURES} identical failures."
                         if stuck
-                        else f"failed after {self.max_stage_attempts} attempts in this run."
+                        else f"failed after {ceiling} attempts in this run."
                     ),
                     level="error",
                 )
                 append_log_entry(
                     paths.logs,
-                    f"{stage.slug} " + ("stage_stuck" if stuck else "max_attempts_exceeded"),
+                    f"{stage.slug} "
+                    + (
+                        f"supervisor_{ruling.kind}"
+                        if ruling.ends_the_visit
+                        else "stage_stuck"
+                        if stuck
+                        else "max_attempts_exceeded"
+                    ),
                     error,
                 )
                 mark_stage_failed_manifest(paths, stage, error)

--- a/src/manager.py
+++ b/src/manager.py
@@ -2581,7 +2581,25 @@ class ResearchManager:
                 )
                 if self._stage_cost is not None:
                     self._stage_cost.note_exhausted()
-                if ruling.ends_the_visit:
+                if stuck:
+                    # `is_stuck` first, and the supervisor second, where both would fire.
+                    # They agree on the count -- `STUCK_AFTER_IDENTICAL_FAILURES` and
+                    # `STOP_AFTER_IDENTICAL_FAILURES` are both three -- so on a repeated
+                    # *validator* refusal they land on the same attempt, and whichever is
+                    # asked first writes the message. `is_stuck` is the more specific of
+                    # the two: it names the validation errors that repeated. The
+                    # supervisor's own reason for existing beside it is that it covers what
+                    # `is_stuck` cannot see -- a reviewer refusing three times, a backend
+                    # not answering three times -- neither of which reaches
+                    # `last_validation_errors`. Letting the general rule pre-empt the
+                    # specific one trades a message naming the errors for one naming a rule.
+                    error = (
+                        f"{STUCK_AFTER_IDENTICAL_FAILURES} consecutive attempts failed in "
+                        f"exactly the same way, so another one cannot help. Attempts spent "
+                        f"on: {spent_on}. Repeated "
+                        f"validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
+                    )
+                elif ruling.ends_the_visit:
                     # Named as the supervisor's, not folded into the exhaustion message:
                     # a stage the run chose to stop paying for and a stage that ran out of
                     # tries are different events, and only one of them has a rule behind
@@ -2589,13 +2607,6 @@ class ResearchManager:
                     error = (
                         f"The run supervisor ruled `{ruling.kind}` under `{ruling.rule}`: "
                         f"{ruling.because}. Attempts spent on: {spent_on}."
-                    )
-                elif stuck:
-                    error = (
-                        f"{STUCK_AFTER_IDENTICAL_FAILURES} consecutive attempts failed in "
-                        f"exactly the same way, so another one cannot help. Attempts spent "
-                        f"on: {spent_on}. Repeated "
-                        f"validation errors: {'; '.join(last_validation_errors) or 'None recorded.'}"
                     )
                 else:
                     error = (
@@ -2606,10 +2617,10 @@ class ResearchManager:
                 self.ui.show_status(
                     f"{stage.stage_title} "
                     + (
-                        f"was stopped by the run supervisor: {ruling.because}."
-                        if ruling.ends_the_visit
-                        else f"made no progress across {STUCK_AFTER_IDENTICAL_FAILURES} identical failures."
+                        f"made no progress across {STUCK_AFTER_IDENTICAL_FAILURES} identical failures."
                         if stuck
+                        else f"was stopped by the run supervisor: {ruling.because}."
+                        if ruling.ends_the_visit
                         else f"failed after {ceiling} attempts in this run."
                     ),
                     level="error",
@@ -2618,10 +2629,12 @@ class ResearchManager:
                     paths.logs,
                     f"{stage.slug} "
                     + (
-                        f"supervisor_{ruling.kind}"
-                        if ruling.ends_the_visit
-                        else "stage_stuck"
+                        # Same precedence as the message above, for the same reason: the
+                        # specific rule names its cause, the general one names itself.
+                        "stage_stuck"
                         if stuck
+                        else f"supervisor_{ruling.kind}"
+                        if ruling.ends_the_visit
                         else "max_attempts_exceeded"
                     ),
                     error,

--- a/src/router.py
+++ b/src/router.py
@@ -170,6 +170,7 @@ class StageRouter:
         final_stage: StageSpec | None = None,
         declared: tuple[str, str] | None = None,
         skips_left: int | None = None,
+        required: tuple[str, str] | None = None,
     ) -> RoutingDecision:
         # `skips_left` reaches the graph and stops there. It is deliberately not shown
         # to the agent here and not weighed by anything in this module: the decision
@@ -248,6 +249,44 @@ class StageRouter:
             )
             return RoutingDecision(
                 target, chosen.edge.kind, reason, default_target, agent_directed=True,
+                offered=offered, blocked=blocked_kinds,
+            )
+
+        # The run supervisor's redirect: a target it requires, with the reason it gave.
+        #
+        # Ranked below a closed round's decision and above the backend. A round has
+        # reasoned about the *results* and written its conclusion to disk; the supervisor
+        # has reasoned about the *spend*, which is the weaker claim about where the run
+        # should go next, so a round that has spoken is not overruled by it.
+        #
+        # Checked against `live` exactly as `declared` is, and refused the same way. That
+        # is the whole of "only an edge the guards already leave open": there is no branch
+        # here that consults a blocked move, so a redirect cannot open one.
+        #
+        # `agent_directed=False`, deliberately. The archive learns which moves the *agent*
+        # chose pay off, and recording a move the agent did not make as one it did is the
+        # one thing the offered/blocked bookkeeping exists to keep out.
+        if required is not None and declared is None:
+            target, reason = required
+            chosen = next((move for move in live if move.edge.target == target), None)
+            if chosen is None:
+                unavailable = next((move for move in moves if move.edge.target == target), None)
+                detail = (
+                    f"the supervisor required `{target}`: {unavailable.blocked_because}"
+                    if unavailable is not None
+                    else f"the supervisor required `{target}`, which is not a move out of {stage.slug}"
+                )
+                return self._refuse(
+                    paths, stage, default, default_target, detail,
+                    offered=offered, blocked=blocked_kinds,
+                )
+            append_log_entry(
+                paths.logs,
+                f"{stage.slug} route_required_by_supervisor",
+                f"target: {target}\nreason: {reason}",
+            )
+            return RoutingDecision(
+                target, chosen.edge.kind, reason, default_target, agent_directed=False,
                 offered=offered, blocked=blocked_kinds,
             )
 

--- a/src/supervisor.py
+++ b/src/supervisor.py
@@ -43,7 +43,7 @@ validator, or raise any budget's total. It may stop, it may reallocate inside a 
 never increases, and it may choose among moves the guards have already left open. Three
 things in the code, not in this paragraph, are what hold that:
 
-* :meth:`AttemptAllowance.ceiling` is a :func:`min` against the run's own
+* :meth:`AttemptAllowance.visit_ceiling` is a :func:`min` against the run's own
   ``--max-attempts``. No state of the allowance ledger can return a larger number than the
   run already allows, so no intervention can buy an attempt the run had not already
   bought. A run that declared no ceiling gets ``None`` back and no pool: the supervisor
@@ -65,33 +65,54 @@ supervisor that cannot add cannot make that mistake, and this one cannot add.
 
 Every threshold here was measured, and what against
 ----------------------------------------------------
-The replay is ``tools/supervisor_threshold_replay.py``. The population is the first live
-paired trial under ``/rmeng_data/robtang/rcb-trial-graph``: its three finished runs, which
-are 22 stage visits and 141 attempt-loop iterations, reconstructed from each run's
-``logs.txt``. A fourth run was still walking when this was measured; it fires no rule and
-pointing the replay at all four reports a larger population and the same firings. The
-replay calls the predicates below rather than reimplementing them, so a threshold that
-moves here moves there, and the numbers in this docstring describe what this code does
-rather than what a second copy of it did.
+The replay is ``tools/supervisor_threshold_replay.py`` and the population is
+``tools.supervisor_threshold_replay.MEASURED_RUNS``: the three *finished* runs of the
+first live paired trial under ``/rmeng_data/robtang/rcb-trial-graph``, named rather than
+globbed, which reconstruct to 22 stage visits and 141 attempt-loop iterations from each
+run's ``logs.txt``. Every population figure below is one of those two numbers, they are
+``MEASURED_VISITS`` and ``MEASURED_ITERATIONS``, and running the replay on that invocation
+prints ``population: as recorded`` or says which way it drifted. Do not quote the glob
+``workspaces/*/.autor/*/``: a fourth run under the same directory is still being written,
+it gave 26 visits and 166 iterations the day this branch was opened and 27 and 167 the
+next, and an earlier version of this docstring claimed a denominator of 162 that no
+invocation ever printed. The replay calls the predicates below rather than reimplementing
+them, so a threshold that moves here moves there.
 
-:data:`STOP_AFTER_IDENTICAL_FAILURES` **= 2.** Two identical failure digests in a row
-happened three times over the 22 visits, three in a row once, and four in a row never.
-The three at ``N=2`` are Astronomy_000 linear ``03_study_design`` and Chemistry_000
-adaptive ``03_study_design`` -- both repeating the same ``report_plan.json task output N
-states nothing`` refusal, both cut after attempt 2 where the visit ran to attempt 10 and
-was auto-skipped anyway -- and Astronomy_000 linear ``07_writing``, the one visit the
-existing :func:`~src.utils.is_stuck` also ends. **None of the three went on to be
-approved**, so no measured visit that reached an approval loses an attempt, and 17 of the
-141 iterations are not bought for the same three outcomes. ``N=3`` fires only on the visit
-``is_stuck`` already ends, and buys nothing.
+:data:`STOP_AFTER_IDENTICAL_FAILURES` **= 3.** On this population that is near-inert, which
+is the honest answer and a finding about the population rather than about the rule.
 
-Two honest limits on that. Every repeat in the three runs was a *validator* error -- a
-reviewer's and a cross-reviewer's reasons are model prose and never repeat byte for byte
--- so reading the whole census rather than only the validation errors moved no firing on
-this data, and what changed the count was 2 rather than 3. And the looser rule of
-repeating the failure *kind* is refused by the same replay, which prints it as a control:
-13 of 22 visits at two, and at three only 2 visits for a single iteration, because a kind
-repeats three times only at the end of a visit where there is nothing left to save.
+Two identical failure digests in a row happened three times over the 22 visits, three in a
+row once, and four in a row never. The replay's original report stopped there and read
+``N=2`` as saving 17 iterations, which is what the rule *stops* rather than what it
+*saves*. With :func:`~tools.supervisor_threshold_replay.bought` beside it, the same three
+firings read: 17 iterations cut, **12 inert and 5 productive**. The five are a repair that
+put the draft back inside the gate on attempt 3, and a promoted draft with obligations
+discharged on attempt 5, in each of the two ``03_study_design`` visits that carry 16 of
+the 17. And the decisive column is neither: in all three firings the draft on disk is
+*outside* the gate at the moment of the cut, because a repeated **validator** refusal is
+by construction a moment at which validation is failing. Both ``03_study_design`` visits
+went on to end auto-skipped with a draft that did validate, so
+``_validated_draft_for_skip`` kept it -- 49,347 and 23,513 bytes of stage summary. Cut at
+attempt 2 and that call returns ``None`` and the 1,911-byte ``.skip_stub.md`` beside each
+of them becomes Stage 03's output for every downstream stage. ``N=2`` does not buy 17
+iterations; it buys 12 inert ones and pays two stage summaries for them.
+
+So ``N=2`` is refused, and no larger value does useful work on this data either: ``N=3``
+fires on 1 of the 22 visits and cuts **0** iterations, ``N=4`` and ``N=5`` fire on nothing
+at all. Three is shipped as the safe value -- the smallest at which the measured cost is
+zero on both columns -- and the finding recorded beside it is about the population:
+**every repeat in these three runs is a validator error** (four repeat events, all
+``validators_refused``, no other kind ever repeating), and a repeated validator error is
+what :func:`~src.utils.is_stuck` already ends at the same count of three. What this rule
+adds over ``is_stuck`` is real and unmeasurable here: ``is_stuck`` reads only
+``last_validation_errors``, which the attempt loop assigns at one place, so it is blind to
+a reviewer refusing identically, a cross-model veto repeating, or a backend failing the
+same way; this reads the whole census. Three runs containing no such repeat cannot say
+what that is worth, and the number to raise it against is a population that contains one.
+
+The looser rule of repeating the failure *kind* is refused by the same replay, which
+prints it as a control: 13 of 22 visits at two, cutting 43 iterations of which 9 were
+productive; at three only 2 visits and a single iteration, and that one was productive.
 
 :data:`DISPROPORTIONATE_MULTIPLE` **= 2** and
 :data:`MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION` **= 3.** The comparison is against the run's
@@ -100,29 +121,40 @@ its visits, against the median of the stages that have closed. At ``2x`` with th
 stages the rule fires on 2 of the 22 visits, both the *second* visit to a stage in
 Astronomy_000 adaptive -- the one run in the trial that took a real backward edge --
 ``06_analysis`` at 5 charged against a median of 2, and ``07_writing`` at 5 against 2.
-``2.5x`` and ``3x`` fire on nothing. ``1.5x`` fires on three, one of them the *first*
-visit to ``07_writing``, which went on to be approved. Requiring only two closed stages
-rather than three changes nothing at ``2x`` on this data and adds two more firings at
-``1.5x``; three is the minimum anyway, because a median over a run's first two stages is a
-median over its two cheapest. Both firings survive the replay's ``after_stop_spending``
-column, which re-runs the sweep with the visits :data:`STOP_SPENDING` has already cut
-removed -- a proportionality rule that counts those is taking credit for another rule's
-work, and at ``1.5x`` with two closed stages it does.
+``2.5x`` and ``3x`` fire on nothing. ``1.5x`` with two closed stages fires on five, and
+the replay's ``binds`` column says what the extra ones cost: Astronomy_000 linear
+``03_study_design`` would have been rationed to 6 in a visit that charged 7, so that
+firing shortens a visit and the two at ``2x`` shorten nothing. At ``2x`` itself, two
+closed stages and three fire identically, so the population does not distinguish them and
+the case for three is the structural one -- a median over a run's first two stages is a
+median over its two cheapest. Both ``2x`` firings survive the replay's
+``after_stop_spending`` column, which re-runs the sweep with the visits
+:data:`STOP_SPENDING` has already cut removed -- a proportionality rule that counts those
+is taking credit for another rule's work. At the shipped ``N`` that column removes nothing
+anywhere, which is another way of saying the stop rule is inert on this population.
 
-In both firings the ration :func:`ration` leaves -- 5 charged plus the run's median of 2,
-so 7 -- is above the 5 either stage charged in total, so no attempt would have been taken
-from a visit that was later approved, and one unit of allowance would have moved to
-``08_dissemination``, the only stage that run had not entered. A stage that has already
+Neither firing costs the run anything, and that is measured rather than argued: the ration
+:func:`ration` leaves is 5 for ``06_analysis`` and 3 for ``07_writing``, those visits
+charged 3 and 1, and no later visit to either stage charged more, so the replay prints
+``the narrowed per-visit allowance binds nothing`` for both. What moves is 3 and 5 units
+to ``08_dissemination``, the only stage that run had not entered. A stage that has already
 charged more than its allowance less the median has no unspent units at all and gets a
 ``continue``: budget that is spent cannot be reallocated, which is arithmetic rather than
 policy, and it is why the rule is checked for a surplus before it is recorded.
 
-:data:`UNSETTLED_VISITS_BEFORE_A_REDIRECT` **= 2**, and it fires on none of the 22. Two is
-the first count at which "this stage failed the same way twice" can be said at all, and
-the replay finds no stage in the trial reaching it: the only stage pair visited twice --
-``06_analysis`` and ``07_writing`` in Astronomy_000 adaptive -- had an approved first
-visit each. That is the number worth reporting about this rule, because it is the one that
-says the trial's single backward edge would have been left alone.
+:data:`UNSETTLED_VISITS_BEFORE_A_REDIRECT` **= 2**, and it is reached at none of the 22
+stage exits. This is the replay's ``redirect`` column, which did not exist until the
+threshold was questioned -- two sentences here credited the instrument with a finding it
+had no column for, which is the same defect as a number nobody ran. It now imports
+:func:`unsettled_visits` and evaluates it where the manager does, over the ledger rows
+closed including the visit just ended: at one unsettled visit 10 of the 22 exits reach the
+threshold, at two none do, at three none do. The only stage pair visited twice --
+``06_analysis`` and ``07_writing`` in Astronomy_000 adaptive -- had an approved first visit
+each. The count is an upper bound, because the replay cannot reconstruct which forward
+edges the guards left open at each exit and requiring one can only remove firings; zero is
+therefore zero for the whole rule. Two is the first count at which "this stage failed the
+same way twice" can be said at all, and the number worth reporting is that the trial's
+single backward edge would have been left alone.
 
 :data:`NO_RECOVERY_LEFT` fires on 1 of the 22 and takes one iteration away, at
 Astronomy_000 linear ``07_writing`` with all three auto-skips already spent -- the visit
@@ -140,15 +172,16 @@ reason recorded names which precondition was short. :data:`UNCHANGING_FAILURE` n
 distribution -- it is a repeat count inside one visit -- so it is live from the first
 visit of the run. A guess standing in for the distribution is the thing not on offer.
 
-The pool cost the measured runs nothing, which is also measured. Reconstructed charged
-attempts came to 22, 21 and 31 per run against a total of 64 for a benchmark run's eight
-stages at ``--max-attempts 8``, so the run-level half was never near binding. The
-per-stage half can only bind on a revisit, and the trial contains exactly one revisit pair
--- ``06_analysis`` and ``07_writing`` in Astronomy_000 adaptive -- whose first visits
-charged 2 and 4, leaving 6 and 4 for the second visits, which charged 3 and 1. Neither
-would have been shortened. An envelope nothing pressed against is an envelope that cost
-nothing; it is here because :data:`REALLOCATE` has to have a total to conserve, and a
-total invented at the moment of the first transfer would be one the run never agreed to.
+The pool cost the measured runs nothing, which is also measured, and it is a *per-visit*
+pool: see :class:`AttemptAllowance` for why an earlier lifetime-per-stage version of it
+was a budget cut nobody asked for. Reconstructed charged attempts came to 22, 21 and 31
+per run against 64 for one round of a benchmark run's eight stages at ``--max-attempts
+8``. The per-visit half binds only where a transfer has already narrowed a stage, and the
+two transfers the trial would have seen narrow ``06_analysis`` to 5 and ``07_writing`` to
+3 in a run whose later visits to them charged 3 and 1. An envelope nothing pressed against
+is an envelope that cost nothing; it is here because :data:`REALLOCATE` has to have a
+total to conserve, and a total invented at the moment of the first transfer would be one
+the run never agreed to.
 """
 
 from __future__ import annotations
@@ -255,9 +288,10 @@ SUPERVISOR_RULES: tuple[str, ...] = (
 #: standing to overrule. :data:`~src.utils.MAX_AUTOMATED_SENDBACKS` draws that line in
 #: those words for the reviewer's budget; this is the same line drawn on the attempt
 #: budget, and without it a supervisor built to bound an automated loop would be bounding
-#: a person instead. Measured cost: none. All four trial runs ran ``approval_mode: agent``,
-#: so no human refusal appears anywhere in the population the thresholds were measured
-#: over, and excluding the kind moves no firing in the replay.
+#: a person instead. Measured cost: none. All three runs of ``MEASURED_RUNS`` ran
+#: ``approval_mode: agent`` -- as does the fourth, still-walking one -- so no human refusal
+#: appears anywhere in the population the thresholds were measured over, and excluding the
+#: kind moves no firing in the replay.
 NOT_COUNTED_AS_A_REPEAT: tuple[str, ...] = (HUMAN_REFUSED,)
 
 #: Attempts that must still be at stake for :data:`STOP_SPENDING` to be worth taking.
@@ -266,45 +300,62 @@ NOT_COUNTED_AS_A_REPEAT: tuple[str, ...] = (HUMAN_REFUSED,)
 #: from ending the visit, stopping it now renames an event the exhaustion path is about to
 #: record at the next boundary anyway, and the run already has a name for that event.
 #:
-#: Measured cost on the trial: none, and the replay prints both columns to show it. The
-#: four runs walked under ``--max-attempts 8`` and all three firings land at attempt 2
-#: with six still at stake, so the rule fires identically with the condition and without
-#: it. What the condition changes is a run whose ceiling is tight: at ``--max-attempts 3``
-#: the second identical failure arrives with one attempt left, and there the supervisor
-#: would be relabelling the exhaustion rather than preventing it.
+#: Measured cost on the trial: none, and the replay prints the sweep with and without the
+#: condition to show it. ``MEASURED_RUNS`` walked under ``--max-attempts 8``, and at every
+#: candidate ``N`` from 2 to 5 the two columns are identical -- at the shipped 3 the single
+#: firing lands at attempt 3 with five still at stake. What the condition changes is a run
+#: whose ceiling is tight: at ``--max-attempts 3`` the third identical failure arrives with
+#: nothing left, and there the supervisor would be relabelling the exhaustion rather than
+#: preventing it.
 MIN_ATTEMPTS_AT_STAKE = 2
 
 #: Identical failure digests in a row before :data:`STOP_SPENDING`.
 #:
-#: Measured, not chosen. Over the 26 stage visits of the first live paired trial two in a
-#: row happened three times, three once and four never; at two the rule fires on three
-#: visits, none of which went on to be approved, and saves 17 of the run set's 162
-#: attempt-loop iterations. At three it fires only on the visit
-#: :func:`~src.utils.is_stuck` already ends. ``tools/supervisor_threshold_replay.py`` is
-#: the replay and prints both columns.
-STOP_AFTER_IDENTICAL_FAILURES = 2
+#: Measured, and the measurement says the safe value. Over the 22 stage visits of
+#: ``MEASURED_RUNS`` (141 attempt-loop iterations; see the module docstring for the
+#: invocation) two in a row happened three times, three once and four never. At **2** the
+#: rule cuts 17 iterations of which only 12 produced nothing, and all three cuts land at a
+#: moment when the draft is outside the gate, so the two visits that ended auto-skipped
+#: with a rescued 49,347-byte and 23,513-byte stage summary would instead have published
+#: the 1,911-byte skip stub. At **3** it fires on one visit and cuts 0 iterations; at 4 and
+#: 5 it fires on nothing. Three is shipped: the smallest value whose measured cost on both
+#: columns is zero. That it is also near-inert here is a fact about the population -- all
+#: four repeat events in these runs are ``validators_refused``, which
+#: :func:`~src.utils.is_stuck` already ends at the same count -- and this rule reads the
+#: whole failure census rather than only ``last_validation_errors``, so what it adds is a
+#: reviewer or a cross-model reviewer or a backend repeating, which these three runs never
+#: do. ``tools/supervisor_threshold_replay.py`` prints both columns.
+STOP_AFTER_IDENTICAL_FAILURES = 3
 
 #: How many times the run's own median a stage may consume before :data:`REALLOCATE`.
 #:
-#: Measured against the same 26 visits: at ``2x`` the rule fires twice, both on a second
-#: visit in the one run that took a backward edge; ``2.5x`` and ``3x`` fire on nothing and
-#: ``1.5x`` reaches a visit that was approved.
+#: Measured against the same 22 visits: at ``2x`` the rule fires twice, both on a second
+#: visit in the one run that took a backward edge, and the replay's ``binds`` column says
+#: neither narrowed allowance would have shortened any visit. ``2.5x`` and ``3x`` fire on
+#: nothing. ``1.5x`` adds a firing that rations a visit to 6 which went on to charge 7.
 DISPROPORTIONATE_MULTIPLE = 2
 
 #: Closed stages needed before there is a distribution to be disproportionate against.
 #:
-#: Three, measured: at two, the rule picks up two further visits that
-#: :data:`STOP_SPENDING` has already cut, and the median is being taken over a run's first
-#: two stages, which are its cheapest. Below this the supervisor does nothing rather than
-#: guessing what a typical stage of this run costs.
+#: Three. At the shipped ``2x`` the measured population does not distinguish two from
+#: three -- both fire on the same 2 of 22 visits -- and the docstring says so rather than
+#: claiming a difference. Where the population does speak is at ``1.5x``: two closed stages
+#: gives 5 firings against three's 3, and one of the two extra is Astronomy_000 linear
+#: ``03_study_design``, rationed to 6 in a visit that went on to charge 7, which the
+#: replay's ``binds`` column marks. The structural half is the reason three is the minimum
+#: anyway: a median over a run's first two stages is a median over its two cheapest. Below
+#: this the supervisor does nothing rather than guessing what a typical stage costs.
 MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION = 3
 
 #: Visits that ended without an approval before a stage stops being funded for another
 #: one. Two rather than a measured larger number because two is the first count at which
-#: "this stage failed the same way twice" can be said at all, and the replay finds no
-#: stage in the trial reaching even that: the only stage pair visited twice
+#: "this stage failed the same way twice" can be said at all, and the replay's ``redirect``
+#: column -- which imports :func:`unsettled_visits` and evaluates it at each stage exit
+#: over the rows closed so far -- reaches it at none of the 22: 10 exits reach one
+#: unsettled visit, none reach two, none reach three. The only stage pair visited twice
 #: (``06_analysis`` and ``07_writing`` in Astronomy_000 adaptive) had an approved first
-#: visit, so :data:`UNFUNDED_REVISIT` fires on none of the 26.
+#: visit. That is an upper bound, since the replay cannot see which forward edges the
+#: guards left open and requiring one only removes firings.
 UNSETTLED_VISITS_BEFORE_A_REDIRECT = 2
 
 #: Where the rulings go. Run root, beside the stage cost ledger and for the same reason:
@@ -453,16 +504,33 @@ class AllowanceError(RuntimeError):
 
 
 class AttemptAllowance:
-    """A run-wide attempt pool, denominated in the run's own ``--max-attempts``.
+    """A pool of **per-visit** attempt allowances, denominated in ``--max-attempts``.
 
-    The status quo has no run total at all: the ceiling is *per stage visit*, so a graph
-    walk of ``--graph-max-steps`` steps may buy ``steps x --max-attempts`` attempts. This
-    pool is ``stages x --max-attempts``, which for a benchmark run is 64 against the 160
-    the walk could otherwise spend, and :meth:`ceiling` hands out
-    ``min(--max-attempts, what is left)`` -- a :func:`min` against the status quo, so no
-    state of this ledger can produce a visit ceiling larger than the run already allows.
-    Both halves matter: the pool is what :data:`REALLOCATE` moves inside, and the ``min``
-    is why moving inside it cannot buy an attempt.
+    One unit is one attempt of one *visit*, not one attempt of a stage's whole lifetime.
+    That is what the run itself buys: ``_run_stage_attempts`` counts from zero on every
+    entry to a stage, so without a supervisor a stage entered three times gets
+    ``--max-attempts`` three times. :meth:`visit_ceiling` hands back
+    ``min(--max-attempts, what this stage holds)`` -- a :func:`min` against the status
+    quo, so no state of this ledger can hand a visit a larger ceiling than the run
+    already allows, and a stage nothing has moved budget away from gets exactly what it
+    would have got with no supervisor at all.
+
+    **This is not a run total, and it must not be turned into one.** An earlier shape of
+    this class charged a stage's closed visits against a single lifetime allowance, which
+    read as a tighter run budget and was in fact a rule that funded the first visit and
+    starved every one after it: a stage whose first visit charged the ceiling got
+    ``remaining = 0``, ``attempt_ceiling`` returned 0, and the revisit died before buying
+    an attempt with the ledger recording ``continue / nothing_to_decide``. The capability
+    that narrows to zero is the backward edge, which is the one thing this project has
+    that a plain agent loop does not. The invariant is "never above what the run would
+    have had", and what the run would have had is ``--max-attempts`` *per visit*.
+
+    What :attr:`total` conserves is therefore the run's per-visit envelope --
+    ``stages x --max-attempts``, the budget for one round of visits -- and
+    :meth:`transfer` is the only method that moves anything inside it. Narrowing one
+    stage's per-visit allowance is a real narrowing that persists across its later visits;
+    widening another's is capped by the ``min`` and can only ever restore a stage that had
+    been narrowed. Both directions lower or leave the run where it was; neither raises it.
     """
 
     def __init__(self, stage_slugs: Sequence[str], per_stage: int) -> None:
@@ -475,18 +543,19 @@ class AttemptAllowance:
     def conserved(self) -> bool:
         return sum(self.allowance.values()) == self.total
 
-    def remaining(self, stage_slug: str, spent: int) -> int:
-        """Units left for *stage_slug* after *spent* charged attempts, never negative."""
-        return max(self.allowance.get(stage_slug, self.per_stage) - spent, 0)
-
-    def ceiling(self, stage_slug: str, spent: int) -> int:
-        """This visit's attempt ceiling: the run's own, or what is left, whichever is less.
+    def visit_ceiling(self, stage_slug: str) -> int:
+        """What one visit to *stage_slug* may charge: the run's own ceiling, or less.
 
         The ``min`` is the invariant. Whatever the allowance ledger has been moved to, the
         number handed back is bounded above by the ceiling the run was started with, so
         the supervisor can only ever lower it.
+
+        Note what is *not* subtracted here: anything a previous visit charged. The attempt
+        loop counts from zero on every entry, so this is the number that loop compares
+        against, and subtracting a closed visit's spend from it would charge the same
+        attempts twice -- once to the visit that spent them and once to every visit after.
         """
-        return min(self.per_stage, self.remaining(stage_slug, spent))
+        return min(self.per_stage, self.allowance.get(stage_slug, self.per_stage))
 
     def transfer(self, donor: str, recipients: Sequence[str], units: int) -> int:
         """Move *units* from *donor*, split as evenly as the units allow.
@@ -495,13 +564,24 @@ class AttemptAllowance:
         or nobody to move it to. The total is asserted on the way out rather than trusted:
         this is the one method in the module that can change a budget, and a conservation
         law nobody checks is a comment.
+
+        A donor may not give away everything it holds, and that bound is here rather than
+        in the rule that calls it. A stage at zero per-visit allowance is a stage that
+        fails on entry with "Exceeded 0 attempts" before it has run once -- which is the
+        regression this class was reshaped to remove, arrived at from the other side.
+        Making a stage impossible to enter is the mirror of opening a guarded edge, and
+        neither is on offer. The *policy* floor is higher and lives in
+        :meth:`RunSupervisor._rule_on_attempt`, which leaves the donor
+        :func:`ration`'s "this visit's spend plus the run's own median"; this is the
+        structural floor under it, checkable without knowing the median.
         """
         if units <= 0 or not recipients:
             return 0
         held = self.allowance.get(donor)
-        if held is None or units > held:
+        if held is None or units >= held:
             raise AllowanceError(
-                f"{donor} holds {held} allowance unit(s) and cannot give away {units}"
+                f"{donor} holds {held} allowance unit(s) and cannot give away {units}: a "
+                "donor must keep enough to fund one more visit"
             )
         self.allowance[donor] = held - units
         for index in range(units):
@@ -672,18 +752,25 @@ class RunSupervisor:
             self.allowance = AttemptAllowance(self.stage_slugs, per_stage)
         return self.allowance
 
-    def attempt_ceiling(self, paths: RunPaths, stage_slug: str, per_stage: int | None) -> int | None:
-        """This visit's ceiling: *per_stage*, or what the stage has left, whichever is less.
+    def attempt_ceiling(self, stage_slug: str, per_stage: int | None) -> int | None:
+        """This visit's ceiling: *per_stage*, or what this stage holds, whichever is less.
 
         The value handed to ``attempts_exhausted`` in place of ``--max-attempts``. It is a
         :func:`min` against the ceiling the caller passed in, so it can differ from it only
-        downwards, and only on a stage the run has already visited: on a first visit
-        nothing has been charged and the two are equal.
+        downwards, and only on a stage :data:`REALLOCATE` has already moved budget away
+        from. Every visit is funded, including the second and third: a backward edge is
+        the capability this component exists beside, not one for it to price out.
+
+        It takes no ``RunPaths``, and that absence is the fix rather than a tidy-up. The
+        version that read the closed cost ledger here subtracted a stage's finished visits
+        from its per-visit ceiling, so a stage whose first visit charged ``--max-attempts``
+        was handed 0 on its second and died before buying an attempt. A ceiling that
+        cannot see what previous visits spent cannot make that mistake again.
         """
         pool = self._pool(per_stage)
         if pool is None:
             return per_stage
-        return min(per_stage, pool.remaining(stage_slug, self.closed_spend(paths).get(stage_slug, 0)))
+        return pool.visit_ceiling(stage_slug)
 
     # -- the attempt boundary ------------------------------------------------
 
@@ -750,7 +837,7 @@ class RunSupervisor:
     ) -> Intervention:
         digests = countable_digests(meter.attempt_digests()) if meter is not None else []
         live_charged = max(meter.attempts - meter.polish_rounds, 0) if meter is not None else 0
-        ceiling = self.attempt_ceiling(paths, stage_slug, per_stage_ceiling)
+        ceiling = self.attempt_ceiling(stage_slug, per_stage_ceiling)
         at_stake = None if ceiling is None else max(ceiling - live_charged, 0)
         closed = self.closed_spend(paths)
         stage_spend = closed.get(stage_slug, 0) + live_charged
@@ -827,7 +914,21 @@ class RunSupervisor:
         unentered = [
             slug for slug in self.stage_slugs if slug not in closed and slug != stage_slug
         ]
-        keep = ration(stage_spend, others) if others else 0
+        # Two different spends, on purpose, because the rule asks two different questions.
+        #
+        # The *trigger* below is `stage_spend`: what this stage has charged over all its
+        # visits, against the median of the stages that have closed. Lifetime against
+        # lifetime is what "disproportionate on the run's own terms" means, and it is the
+        # comparison the replay swept.
+        #
+        # The *amount* is `keep`, and it is computed from `live_charged` -- this visit --
+        # because the pool is denominated in per-visit allowances and a per-visit
+        # allowance can only be compared with a per-visit spend. Using the lifetime figure
+        # here would make `surplus` zero on every second visit, which is to say the rule
+        # would stand down on exactly the revisits it was written to notice. On a first
+        # visit the two numbers are equal, which is why nothing in the replay's sweep of
+        # the trial's first visits moves.
+        keep = ration(live_charged, others) if others else 0
         surplus = (
             max(pool.allowance.get(stage_slug, 0) - keep, 0) if pool is not None else 0
         )
@@ -853,11 +954,16 @@ class RunSupervisor:
                 because=(
                     f"{stage_slug} has charged {stage_spend} attempt(s) against a median of "
                     f"{statistics.median(others)} for the {len(others)} stage(s) this run has "
-                    f"closed, which is more than {DISPROPORTIONATE_MULTIPLE}x; it keeps the run's "
-                    f"own ration and the surplus goes to the stages that have not run"
+                    f"closed, which is more than {DISPROPORTIONATE_MULTIPLE}x; this visit keeps "
+                    f"the {live_charged} it has charged plus the run's own median, so {keep} "
+                    f"per visit, and the surplus goes to the stages that have not run"
                 ),
                 evidence={
                     "stage_charged_attempts": stage_spend,
+                    # Both spends, because the trigger reads one and the amount reads the
+                    # other, and a reader recomputing the decision from this row needs
+                    # whichever of the two the number in front of them came from.
+                    "visit_charged_attempts": live_charged,
                     "closed_stage_charges": sorted(others),
                     "median": statistics.median(others),
                     "multiple": DISPROPORTIONATE_MULTIPLE,
@@ -868,6 +974,10 @@ class RunSupervisor:
                     "to": list(unentered),
                     "run_total": pool.total,
                     "total_conserved": pool.conserved(),
+                    #: What this stage's later visits are now funded at. The narrowing is
+                    #: the point of the intervention, so it is recorded rather than left
+                    #: to be inferred from `units_moved`.
+                    "visit_ceiling_after": pool.visit_ceiling(stage_slug),
                 },
             )
 

--- a/src/supervisor.py
+++ b/src/supervisor.py
@@ -101,8 +101,10 @@ So ``N=2`` is refused, and no larger value does useful work on this data either:
 fires on 1 of the 22 visits and cuts **0** iterations, ``N=4`` and ``N=5`` fire on nothing
 at all. Three is shipped as the safe value -- the smallest at which the measured cost is
 zero on both columns -- and the finding recorded beside it is about the population:
-**every repeat in these three runs is a validator error** (four repeat events, all
-``validators_refused``, no other kind ever repeating), and a repeated validator error is
+**every repeat in these three runs is a validator error** (three maximal runs of an
+unchanged digest, of lengths 2, 3 and 2, which is four adjacent duplicate pairs -- both
+counts are given because "a repeat event" reads as either and the bare number was
+ambiguous; all ``validators_refused``, no other kind ever repeating), and a repeated validator error is
 what :func:`~src.utils.is_stuck` already ends at the same count of three. What this rule
 adds over ``is_stuck`` is real and unmeasurable here: ``is_stuck`` reads only
 ``last_validation_errors``, which the attempt loop assigns at one place, so it is blind to
@@ -156,10 +158,14 @@ therefore zero for the whole rule. Two is the first count at which "this stage f
 same way twice" can be said at all, and the number worth reporting is that the trial's
 single backward edge would have been left alone.
 
-:data:`NO_RECOVERY_LEFT` fires on 1 of the 22 and takes one iteration away, at
-Astronomy_000 linear ``07_writing`` with all three auto-skips already spent -- the visit
-that ended that run as ``run_status: cancelled``. That it takes only one is the whole
-design of its third precondition, and the number the replay prints beside it. Without that
+:data:`NO_RECOVERY_LEFT` fires on 1 of the 22 and takes **nothing** away, at
+Astronomy_000 linear ``07_writing`` at attempt 3 with all three auto-skips already spent --
+the visit that ended that run as ``run_status: cancelled``. The replay prints
+``0 iteration(s) taken away`` beside it. It said *one* until this module moved
+:data:`STOP_AFTER_IDENTICAL_FAILURES` from two to three, which moved the escalate window
+with it: at attempt 3 the visit had nothing left to lose. Recorded because it is the shape
+of staleness this file is most exposed to -- a number measured correctly, invalidated by
+the same commit that measured it. Without that
 precondition the rule fires at the *first* attempt boundary of the writing stage on every
 run that reached it by routing to the deliverable, which is every run whose skip budget is
 spent, and ends the deliverable stage before it has run once -- the opposite of the trade
@@ -320,7 +326,8 @@ MIN_ATTEMPTS_AT_STAKE = 2
 #: the 1,911-byte skip stub. At **3** it fires on one visit and cuts 0 iterations; at 4 and
 #: 5 it fires on nothing. Three is shipped: the smallest value whose measured cost on both
 #: columns is zero. That it is also near-inert here is a fact about the population -- all
-#: four repeat events in these runs are ``validators_refused``, which
+#: repeats in these runs -- three maximal runs of lengths 2, 3 and 2, so four adjacent
+#: duplicate pairs -- are ``validators_refused``, which
 #: :func:`~src.utils.is_stuck` already ends at the same count -- and this rule reads the
 #: whole failure census rather than only ``last_validation_errors``, so what it adds is a
 #: reviewer or a cross-model reviewer or a backend repeating, which these three runs never
@@ -756,9 +763,13 @@ class RunSupervisor:
         """This visit's ceiling: *per_stage*, or what this stage holds, whichever is less.
 
         The value handed to ``attempts_exhausted`` in place of ``--max-attempts``. It is a
-        :func:`min` against the ceiling the caller passed in, so it can differ from it only
-        downwards, and only on a stage :data:`REALLOCATE` has already moved budget away
-        from. Every visit is funded, including the second and third: a backward edge is
+        :func:`min` against the ceiling **the pool was built with**, not against the
+        argument of this call, so it can differ from that ceiling only downwards and only
+        on a stage :data:`REALLOCATE` has already moved budget away from. The distinction is
+        invisible in production -- ``max_stage_attempts`` is set once in
+        :class:`~src.manager.ResearchManager` and never reassigned -- and it is written down
+        because the docstring used to claim the other one: calling this with 8 and then with
+        3 returns 8 both times. Every visit is funded, including the second and third: a backward edge is
         the capability this component exists beside, not one for it to price out.
 
         It takes no ``RunPaths``, and that absence is the fix rather than a tidy-up. The

--- a/src/supervisor.py
+++ b/src/supervisor.py
@@ -1,0 +1,988 @@
+"""Something that watches the whole walk while the walk is still happening, and acts.
+
+Every other decider in the tree is local. :mod:`src.evolution` ranks the drafts of one
+stage. :mod:`src.router` picks the next edge at one node, from state at that node.
+:mod:`src.archive` compares runs that already finished. :mod:`src.review_panel` and
+:mod:`src.validity_review` judge content rather than spend. :mod:`src.effort` is the
+closest relative and is still a different thing: it assigns a tier *ahead of time*, from
+the stage's identity, and never looks at what the stage went on to cost. Nothing looked at
+the run as a whole while there was still money to save, and nothing acted on what it saw.
+
+The deliverable here is interventions, not a report
+---------------------------------------------------
+There is no view in this module, no progress artifact, no terminal summary, and nothing
+formatted for a person. The README's Limits section already records the defect of building
+the other thing -- "the self-measurement files feed a report, not a decision" -- and a
+second one would be a regression dressed as a feature. What is written is
+:data:`SUPERVISOR_LEDGER_FILENAME`, one line per ruling, so an intervention can be audited
+afterwards; that is the whole output.
+
+It wakes inside a stage
+-----------------------
+:meth:`RunSupervisor.review_attempt` is called at the top of the attempt loop, next to the
+existing stuck check, and :meth:`RunSupervisor.review_stage_exit` at the stage boundary.
+The failure this exists to prevent happens *within* a stage -- a visit burning attempt
+after attempt against one unchanging objection -- so a supervisor that only woke between
+stages would watch the money leave and comment afterwards.
+
+What it reads, and what it may not
+----------------------------------
+Only the harness-written per-stage cost ledger (:mod:`src.stage_cost`): the closed rows
+via :func:`~src.stage_cost.read_stage_cost_ledger`, and the open
+:class:`~src.stage_cost.StageCostMeter` for the visit in progress. Never a field the agent
+wrote. The operator runs ``bypassPermissions`` at ``cwd=run_root`` and every stage prompt
+directs it at ``workspace/``, so a supervisor that believed anything under ``workspace/``
+would be a supervisor the supervised party writes.
+``SupervisorReadsOnlyHarnessFieldsTests`` resolves every ``paths.<field>`` this module
+touches against ``build_run_paths`` and fails if one lands under ``workspace/``.
+
+The invariant: it may never make a gate pass
+--------------------------------------------
+It cannot approve a stage, open a guarded edge, discharge an obligation, satisfy a
+validator, or raise any budget's total. It may stop, it may reallocate inside a total it
+never increases, and it may choose among moves the guards have already left open. Three
+things in the code, not in this paragraph, are what hold that:
+
+* :meth:`AttemptAllowance.ceiling` is a :func:`min` against the run's own
+  ``--max-attempts``. No state of the allowance ledger can return a larger number than the
+  run already allows, so no intervention can buy an attempt the run had not already
+  bought. A run that declared no ceiling gets ``None`` back and no pool: the supervisor
+  does not invent a bound the operator declined, and does not invent a budget to move.
+* :meth:`AttemptAllowance.transfer` moves units between stages and asserts
+  :meth:`AttemptAllowance.conserved` on the way out. The total is fixed at construction and
+  there is no method that raises it.
+* :data:`INTERVENTION_EFFECTS` is the complete list of what a caller may do with a ruling,
+  and the only one that changes control flow inside a stage is "end the visit", which hands
+  to ``_handle_stage_exhaustion`` -- the recovery path that already exists, whose two
+  outcomes are an explicit skip stub and an abort. Neither writes an approval.
+
+This is the shape two rules in the tree already have, and it is stated in those terms on
+purpose: the archive may reorder which move is preferred and may never open a guarded
+edge, and the cross-model reviewer is a veto and never an override. Three independent
+reviews refused wiring a learned statistic into ``default_move`` because it would put an
+unrandomised, guard-selected number in charge at the moment a guard has just failed. A
+supervisor that cannot add cannot make that mistake, and this one cannot add.
+
+Every threshold here was measured, and what against
+----------------------------------------------------
+The replay is ``tools/supervisor_threshold_replay.py``. The population is the first live
+paired trial under ``/rmeng_data/robtang/rcb-trial-graph``: its three finished runs, which
+are 22 stage visits and 141 attempt-loop iterations, reconstructed from each run's
+``logs.txt``. A fourth run was still walking when this was measured; it fires no rule and
+pointing the replay at all four reports a larger population and the same firings. The
+replay calls the predicates below rather than reimplementing them, so a threshold that
+moves here moves there, and the numbers in this docstring describe what this code does
+rather than what a second copy of it did.
+
+:data:`STOP_AFTER_IDENTICAL_FAILURES` **= 2.** Two identical failure digests in a row
+happened three times over the 22 visits, three in a row once, and four in a row never.
+The three at ``N=2`` are Astronomy_000 linear ``03_study_design`` and Chemistry_000
+adaptive ``03_study_design`` -- both repeating the same ``report_plan.json task output N
+states nothing`` refusal, both cut after attempt 2 where the visit ran to attempt 10 and
+was auto-skipped anyway -- and Astronomy_000 linear ``07_writing``, the one visit the
+existing :func:`~src.utils.is_stuck` also ends. **None of the three went on to be
+approved**, so no measured visit that reached an approval loses an attempt, and 17 of the
+141 iterations are not bought for the same three outcomes. ``N=3`` fires only on the visit
+``is_stuck`` already ends, and buys nothing.
+
+Two honest limits on that. Every repeat in the three runs was a *validator* error -- a
+reviewer's and a cross-reviewer's reasons are model prose and never repeat byte for byte
+-- so reading the whole census rather than only the validation errors moved no firing on
+this data, and what changed the count was 2 rather than 3. And the looser rule of
+repeating the failure *kind* is refused by the same replay, which prints it as a control:
+13 of 22 visits at two, and at three only 2 visits for a single iteration, because a kind
+repeats three times only at the end of a visit where there is nothing left to save.
+
+:data:`DISPROPORTIONATE_MULTIPLE` **= 2** and
+:data:`MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION` **= 3.** The comparison is against the run's
+own distribution rather than a declared ceiling: a stage's charged attempts summed over
+its visits, against the median of the stages that have closed. At ``2x`` with three closed
+stages the rule fires on 2 of the 22 visits, both the *second* visit to a stage in
+Astronomy_000 adaptive -- the one run in the trial that took a real backward edge --
+``06_analysis`` at 5 charged against a median of 2, and ``07_writing`` at 5 against 2.
+``2.5x`` and ``3x`` fire on nothing. ``1.5x`` fires on three, one of them the *first*
+visit to ``07_writing``, which went on to be approved. Requiring only two closed stages
+rather than three changes nothing at ``2x`` on this data and adds two more firings at
+``1.5x``; three is the minimum anyway, because a median over a run's first two stages is a
+median over its two cheapest. Both firings survive the replay's ``after_stop_spending``
+column, which re-runs the sweep with the visits :data:`STOP_SPENDING` has already cut
+removed -- a proportionality rule that counts those is taking credit for another rule's
+work, and at ``1.5x`` with two closed stages it does.
+
+In both firings the ration :func:`ration` leaves -- 5 charged plus the run's median of 2,
+so 7 -- is above the 5 either stage charged in total, so no attempt would have been taken
+from a visit that was later approved, and one unit of allowance would have moved to
+``08_dissemination``, the only stage that run had not entered. A stage that has already
+charged more than its allowance less the median has no unspent units at all and gets a
+``continue``: budget that is spent cannot be reallocated, which is arithmetic rather than
+policy, and it is why the rule is checked for a surplus before it is recorded.
+
+:data:`UNSETTLED_VISITS_BEFORE_A_REDIRECT` **= 2**, and it fires on none of the 22. Two is
+the first count at which "this stage failed the same way twice" can be said at all, and
+the replay finds no stage in the trial reaching it: the only stage pair visited twice --
+``06_analysis`` and ``07_writing`` in Astronomy_000 adaptive -- had an approved first
+visit each. That is the number worth reporting about this rule, because it is the one that
+says the trial's single backward edge would have been left alone.
+
+:data:`NO_RECOVERY_LEFT` fires on 1 of the 22 and takes one iteration away, at
+Astronomy_000 linear ``07_writing`` with all three auto-skips already spent -- the visit
+that ended that run as ``run_status: cancelled``. That it takes only one is the whole
+design of its third precondition, and the number the replay prints beside it. Without that
+precondition the rule fires at the *first* attempt boundary of the writing stage on every
+run that reached it by routing to the deliverable, which is every run whose skip budget is
+spent, and ends the deliverable stage before it has run once -- the opposite of the trade
+``_route_to_deliverable`` exists to make.
+
+**Early in a run, before there is a distribution, it does nothing.** Fewer than
+:data:`MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION` closed stages and
+:data:`DISPROPORTIONATE_SPEND` cannot fire at all; the ruling is ``continue`` and the
+reason recorded names which precondition was short. :data:`UNCHANGING_FAILURE` needs no
+distribution -- it is a repeat count inside one visit -- so it is live from the first
+visit of the run. A guess standing in for the distribution is the thing not on offer.
+
+The pool cost the measured runs nothing, which is also measured. Reconstructed charged
+attempts came to 22, 21 and 31 per run against a total of 64 for a benchmark run's eight
+stages at ``--max-attempts 8``, so the run-level half was never near binding. The
+per-stage half can only bind on a revisit, and the trial contains exactly one revisit pair
+-- ``06_analysis`` and ``07_writing`` in Astronomy_000 adaptive -- whose first visits
+charged 2 and 4, leaving 6 and 4 for the second visits, which charged 3 and 1. Neither
+would have been shortened. An envelope nothing pressed against is an envelope that cost
+nothing; it is here because :data:`REALLOCATE` has to have a total to conserve, and a
+total invented at the moment of the first transfer would be one the run never agreed to.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from .stage_cost import HUMAN_REFUSED, StageCostMeter, read_stage_cost_ledger
+from .utils import RunPaths, append_jsonl
+
+
+# ---------------------------------------------------------------------------
+# The vocabulary
+# ---------------------------------------------------------------------------
+
+#: Nothing. Recorded anyway, because a supervisor that speaks only when it acts cannot be
+#: audited: a reader of the ledger has to be able to tell "it looked and let this pass"
+#: from "it never looked".
+CONTINUE = "continue"
+
+#: Cut the stage's remaining attempts now and hand to the recovery path that already
+#: exists. Not a verdict on the work: the recovery path writes an explicit skip stub or
+#: aborts, and neither of those is an approval.
+STOP_SPENDING = "stop_spending"
+
+#: Move unspent attempt allowance between stages. Conserves the run total exactly and
+#: never raises it; see :meth:`AttemptAllowance.transfer`.
+REALLOCATE = "reallocate"
+
+#: Require the next move out of this stage to be a named edge. Only ever an edge the
+#: guards already leave open -- the supervisor picks from the admissible set it is handed
+#: and cannot add to it.
+REDIRECT = "redirect"
+
+#: Mark the run for a human and stop spending on this stage. Last resort.
+ESCALATE = "escalate"
+
+#: The whole vocabulary, declared and bounded, in the shape ``BLOCK_KINDS``, the
+#: scorecard's verdicts and the gate trust levels already have.
+INTERVENTIONS: tuple[str, ...] = (
+    CONTINUE,
+    STOP_SPENDING,
+    REALLOCATE,
+    REDIRECT,
+    ESCALATE,
+)
+
+#: What a caller is permitted to do with each ruling, exhaustively. Nothing in this table
+#: approves a stage, opens an edge, discharges an obligation or satisfies a validator, and
+#: the one entry that changes control flow inside a stage names the recovery path that
+#: already exists rather than a new one.
+INTERVENTION_EFFECTS: dict[str, str] = {
+    CONTINUE: "nothing",
+    STOP_SPENDING: "end the visit through the existing stage-exhaustion recovery path",
+    REALLOCATE: "move attempt allowance between stages inside a conserved total",
+    REDIRECT: "name one of the moves the guards already left open",
+    ESCALATE: "end the visit through the existing recovery path and mark the run for a human",
+}
+
+
+# ---------------------------------------------------------------------------
+# The rules, one per intervention that is not the default
+# ---------------------------------------------------------------------------
+
+#: The default's rule. Named rather than left blank so every row in the ledger carries the
+#: same two columns and a reader never has to interpret an absence.
+NOTHING_TO_DECIDE = "nothing_to_decide"
+
+#: The same failure, unchanged, enough times that another attempt at it cannot help.
+UNCHANGING_FAILURE = "unchanging_failure"
+
+#: This stage has consumed several times what a stage of this run consumes.
+DISPROPORTIONATE_SPEND = "disproportionate_spend"
+
+#: This stage has now failed to settle twice, so a third visit is not the move.
+UNFUNDED_REVISIT = "unfunded_revisit"
+
+#: The auto-skip budget is spent and the run is at the stage that writes the deliverable,
+#: which is the exact state in which ``_route_to_deliverable`` has nowhere left to route.
+NO_RECOVERY_LEFT = "no_recovery_left"
+
+#: Every rule this module can decide on. A registry rather than a set of ``if`` branches
+#: for the same reason ``GUARDS`` and ``FEATURES`` are registries: a new rule joins the
+#: gate table in ``tests/test_writable_decisive_fields.py`` or fails it.
+SUPERVISOR_RULES: tuple[str, ...] = (
+    NOTHING_TO_DECIDE,
+    UNCHANGING_FAILURE,
+    DISPROPORTIONATE_SPEND,
+    UNFUNDED_REVISIT,
+    NO_RECOVERY_LEFT,
+)
+
+
+# ---------------------------------------------------------------------------
+# The measured thresholds
+# ---------------------------------------------------------------------------
+
+#: Failure kinds the repeat rule does not count.
+#:
+#: A person who asks for the same change twice is exercising judgement AutoR has no
+#: standing to overrule. :data:`~src.utils.MAX_AUTOMATED_SENDBACKS` draws that line in
+#: those words for the reviewer's budget; this is the same line drawn on the attempt
+#: budget, and without it a supervisor built to bound an automated loop would be bounding
+#: a person instead. Measured cost: none. All four trial runs ran ``approval_mode: agent``,
+#: so no human refusal appears anywhere in the population the thresholds were measured
+#: over, and excluding the kind moves no firing in the replay.
+NOT_COUNTED_AS_A_REPEAT: tuple[str, ...] = (HUMAN_REFUSED,)
+
+#: Attempts that must still be at stake for :data:`STOP_SPENDING` to be worth taking.
+#:
+#: The intervention exists to stop money leaving. When the run's own ceiling is one attempt
+#: from ending the visit, stopping it now renames an event the exhaustion path is about to
+#: record at the next boundary anyway, and the run already has a name for that event.
+#:
+#: Measured cost on the trial: none, and the replay prints both columns to show it. The
+#: four runs walked under ``--max-attempts 8`` and all three firings land at attempt 2
+#: with six still at stake, so the rule fires identically with the condition and without
+#: it. What the condition changes is a run whose ceiling is tight: at ``--max-attempts 3``
+#: the second identical failure arrives with one attempt left, and there the supervisor
+#: would be relabelling the exhaustion rather than preventing it.
+MIN_ATTEMPTS_AT_STAKE = 2
+
+#: Identical failure digests in a row before :data:`STOP_SPENDING`.
+#:
+#: Measured, not chosen. Over the 26 stage visits of the first live paired trial two in a
+#: row happened three times, three once and four never; at two the rule fires on three
+#: visits, none of which went on to be approved, and saves 17 of the run set's 162
+#: attempt-loop iterations. At three it fires only on the visit
+#: :func:`~src.utils.is_stuck` already ends. ``tools/supervisor_threshold_replay.py`` is
+#: the replay and prints both columns.
+STOP_AFTER_IDENTICAL_FAILURES = 2
+
+#: How many times the run's own median a stage may consume before :data:`REALLOCATE`.
+#:
+#: Measured against the same 26 visits: at ``2x`` the rule fires twice, both on a second
+#: visit in the one run that took a backward edge; ``2.5x`` and ``3x`` fire on nothing and
+#: ``1.5x`` reaches a visit that was approved.
+DISPROPORTIONATE_MULTIPLE = 2
+
+#: Closed stages needed before there is a distribution to be disproportionate against.
+#:
+#: Three, measured: at two, the rule picks up two further visits that
+#: :data:`STOP_SPENDING` has already cut, and the median is being taken over a run's first
+#: two stages, which are its cheapest. Below this the supervisor does nothing rather than
+#: guessing what a typical stage of this run costs.
+MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION = 3
+
+#: Visits that ended without an approval before a stage stops being funded for another
+#: one. Two rather than a measured larger number because two is the first count at which
+#: "this stage failed the same way twice" can be said at all, and the replay finds no
+#: stage in the trial reaching even that: the only stage pair visited twice
+#: (``06_analysis`` and ``07_writing`` in Astronomy_000 adaptive) had an approved first
+#: visit, so :data:`UNFUNDED_REVISIT` fires on none of the 26.
+UNSETTLED_VISITS_BEFORE_A_REDIRECT = 2
+
+#: Where the rulings go. Run root, beside the stage cost ledger and for the same reason:
+#: the operator is sent at ``workspace/``, and a record of the decisions taken about a
+#: party's spending must not sit where that party is told to write. JSON Lines rather than
+#: a rewritten document because every ruling is recorded, including the ones that did
+#: nothing, and a file rewritten once per attempt is a file that grows quadratically.
+SUPERVISOR_LEDGER_FILENAME = "supervisor_ledger.jsonl"
+
+#: Bumped when a row grows or loses a field, so a reader that predates a change can say so
+#: rather than reading a missing key as a zero.
+SUPERVISOR_LEDGER_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# The predicates, separately callable so the replay runs the rule and not a copy
+# ---------------------------------------------------------------------------
+
+
+def longest_unchanged_run(digests: Sequence[str]) -> int:
+    """The longest unbroken run of one digest in *digests*.
+
+    ``0`` for a visit that recorded nothing and ``1`` for one whose failures were all
+    different. :class:`~src.stage_cost.StageCostMeter` computes the same thing for the
+    open visit; this is here for the closed rows, whose ``attempt_digests`` come back off
+    disk as dictionaries, and for the replay.
+    """
+    longest = 0
+    run = 0
+    previous: str | None = None
+    for digest in digests:
+        run = run + 1 if digest == previous else 1
+        previous = digest
+        longest = max(longest, run)
+    return longest
+
+
+def countable_digests(entries: Sequence[Mapping[str, Any]]) -> list[str]:
+    """The digests a repeat rule may count, in order.
+
+    Everything :data:`NOT_COUNTED_AS_A_REPEAT` names is dropped rather than treated as a
+    break in the run, because a human asking twice for the same change is not evidence
+    about whether the *automated* loop is going anywhere -- and treating it as a break
+    would let one human comment between two identical validator refusals hide them from
+    the rule.
+    """
+    return [
+        str(entry.get("digest") or "")
+        for entry in entries
+        if entry.get("kind") not in NOT_COUNTED_AS_A_REPEAT and entry.get("digest")
+    ]
+
+
+def unchanging_failure(digests: Sequence[str], *, repeats: int = STOP_AFTER_IDENTICAL_FAILURES) -> bool:
+    """Whether the same failure has now happened *repeats* times with nothing changing.
+
+    Consecutive rather than merely frequent. "The same objection again" and "the same
+    objection again and again" are different claims, and only the second one says another
+    attempt cannot help: a stage alternating between two objections is being told
+    different things each time and is still making progress of a kind.
+    """
+    return repeats > 0 and longest_unchanged_run(digests) >= repeats
+
+
+def disproportionate(
+    spent: int,
+    closed: Sequence[int],
+    *,
+    multiple: int = DISPROPORTIONATE_MULTIPLE,
+    minimum_population: int = MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION,
+) -> bool:
+    """Whether *spent* is out of proportion to what a stage of this run costs.
+
+    *closed* is one number per stage that has finished -- its charged attempts summed over
+    its visits. The comparison is against the run's own median rather than against a
+    declared ceiling, because a ceiling is a claim about every run and a median is a claim
+    about this one, and the ceiling was measured not to be the binding budget anyway.
+
+    ``False`` while the population is smaller than *minimum_population*. That is the
+    answer to "what does it do before there is a distribution", and it is deliberately
+    "nothing": a median over one or two stages is a median over a run's opening stages,
+    which are its cheapest.
+    """
+    if multiple <= 0 or len(closed) < minimum_population:
+        return False
+    median = statistics.median(closed)
+    return median > 0 and spent > multiple * median
+
+
+def ration(spent: int, closed: Sequence[int]) -> int:
+    """What a stage put back on the run's own average ration is left with.
+
+    *spent* plus the median closed stage, floored at one more attempt. The floor is
+    structural rather than a taste: a ration of zero is :data:`STOP_SPENDING`, which has
+    its own precondition and its own record, and collapsing the two would leave the ledger
+    unable to say which rule ended a visit.
+    """
+    if not closed:
+        return spent + 1
+    return spent + max(1, int(round(statistics.median(closed))))
+
+
+def charged_attempts(row: Mapping[str, Any]) -> int:
+    """Attempts a closed ledger row charged against ``--max-attempts``.
+
+    A polish round improves work that already passed validation and the attempt loop does
+    not charge it, so neither does this. Reading the two fields and subtracting rather
+    than trusting one of them is what keeps this in step with the loop's own comparison.
+    """
+    try:
+        attempts = int(row.get("attempts") or 0)
+        polish = int(row.get("polish_rounds") or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(attempts - polish, 0)
+
+
+#: Row outcomes that mean the visit ended without the stage being approved. Spelled as a
+#: set of what *is* an approval rather than a list of what is not, so a new outcome in
+#: :mod:`src.stage_cost` counts as unsettled -- the conservative direction, because the
+#: only thing :data:`UNFUNDED_REVISIT` does with it is decline to fund another visit.
+SETTLED_OUTCOMES: tuple[str, ...] = ("approved",)
+
+
+def unsettled_visits(rows: Iterable[Mapping[str, Any]], stage_slug: str) -> int:
+    """How many closed visits to *stage_slug* ended without an approval."""
+    return sum(
+        1
+        for row in rows
+        if row.get("stage") == stage_slug and str(row.get("outcome") or "") not in SETTLED_OUTCOMES
+    )
+
+
+# ---------------------------------------------------------------------------
+# The conserved total
+# ---------------------------------------------------------------------------
+
+
+class AllowanceError(RuntimeError):
+    """A transfer that would not conserve the total, or would come from nowhere.
+
+    Raised rather than clamped. A budget that silently rounds itself back into shape is a
+    budget nobody can audit, and :meth:`RunSupervisor.review_attempt` catches this on the
+    way out so a bookkeeping bug cannot fail a run that produced good work.
+    """
+
+
+class AttemptAllowance:
+    """A run-wide attempt pool, denominated in the run's own ``--max-attempts``.
+
+    The status quo has no run total at all: the ceiling is *per stage visit*, so a graph
+    walk of ``--graph-max-steps`` steps may buy ``steps x --max-attempts`` attempts. This
+    pool is ``stages x --max-attempts``, which for a benchmark run is 64 against the 160
+    the walk could otherwise spend, and :meth:`ceiling` hands out
+    ``min(--max-attempts, what is left)`` -- a :func:`min` against the status quo, so no
+    state of this ledger can produce a visit ceiling larger than the run already allows.
+    Both halves matter: the pool is what :data:`REALLOCATE` moves inside, and the ``min``
+    is why moving inside it cannot buy an attempt.
+    """
+
+    def __init__(self, stage_slugs: Sequence[str], per_stage: int) -> None:
+        self.per_stage = per_stage
+        self.allowance: dict[str, int] = {slug: per_stage for slug in stage_slugs}
+        #: Fixed at construction and read-only afterwards. There is no method that raises
+        #: it, which is the point.
+        self.total = sum(self.allowance.values())
+
+    def conserved(self) -> bool:
+        return sum(self.allowance.values()) == self.total
+
+    def remaining(self, stage_slug: str, spent: int) -> int:
+        """Units left for *stage_slug* after *spent* charged attempts, never negative."""
+        return max(self.allowance.get(stage_slug, self.per_stage) - spent, 0)
+
+    def ceiling(self, stage_slug: str, spent: int) -> int:
+        """This visit's attempt ceiling: the run's own, or what is left, whichever is less.
+
+        The ``min`` is the invariant. Whatever the allowance ledger has been moved to, the
+        number handed back is bounded above by the ceiling the run was started with, so
+        the supervisor can only ever lower it.
+        """
+        return min(self.per_stage, self.remaining(stage_slug, spent))
+
+    def transfer(self, donor: str, recipients: Sequence[str], units: int) -> int:
+        """Move *units* from *donor*, split as evenly as the units allow.
+
+        Returns how many units actually moved, which is zero when there is nothing to move
+        or nobody to move it to. The total is asserted on the way out rather than trusted:
+        this is the one method in the module that can change a budget, and a conservation
+        law nobody checks is a comment.
+        """
+        if units <= 0 or not recipients:
+            return 0
+        held = self.allowance.get(donor)
+        if held is None or units > held:
+            raise AllowanceError(
+                f"{donor} holds {held} allowance unit(s) and cannot give away {units}"
+            )
+        self.allowance[donor] = held - units
+        for index in range(units):
+            target = recipients[index % len(recipients)]
+            self.allowance[target] = self.allowance.get(target, 0) + 1
+        if not self.conserved():
+            raise AllowanceError(
+                f"transfer of {units} from {donor} left the total at "
+                f"{sum(self.allowance.values())}, not {self.total}"
+            )
+        return units
+
+
+# ---------------------------------------------------------------------------
+# A ruling
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Intervention:
+    """One ruling, and everything needed to audit it.
+
+    :attr:`evidence` carries the numbers the rule actually read, so a reader can recompute
+    the decision instead of taking the sentence in :attr:`because` on trust. That is the
+    difference between an audit trail and a report: nothing here is formatted, ordered or
+    summarised for a person.
+    """
+
+    kind: str
+    rule: str
+    stage: str
+    because: str
+    boundary: str = "attempt"
+    attempt: int = 0
+    #: For :data:`REDIRECT`, the edge the supervisor names. Always one of the moves it was
+    #: handed as admissible; never one it constructed.
+    target: str = ""
+    #: For :data:`ESCALATE`. The run has nothing left to try and a person has to look.
+    needs_a_human: bool = False
+    evidence: dict[str, Any] = field(default_factory=dict)
+    effect: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """A ruling outside the declared vocabulary is refused at construction.
+
+        The same shape ``Move.__post_init__`` uses for ``BLOCK_KINDS``, and for the same
+        reason: a vocabulary that is only enforced by the constant being spelled right at
+        every call site is a vocabulary. Both callers of this class wrap construction in
+        a handler that falls back to a ``continue`` built from literals, so the check
+        cannot be the thing that ends a run.
+        """
+        if self.kind not in INTERVENTIONS:
+            raise ValueError(
+                f"{self.kind!r} is not an intervention; the vocabulary is "
+                f"{', '.join(INTERVENTIONS)}."
+            )
+        if self.rule not in SUPERVISOR_RULES:
+            raise ValueError(
+                f"{self.rule!r} is not a supervisor rule; the rules are "
+                f"{', '.join(SUPERVISOR_RULES)}."
+            )
+
+    @property
+    def acts(self) -> bool:
+        """Whether this ruling asks the caller to do anything at all."""
+        return self.kind != CONTINUE
+
+    @property
+    def ends_the_visit(self) -> bool:
+        """Whether the caller must hand to the stage-exhaustion recovery path."""
+        return self.kind in {STOP_SPENDING, ESCALATE}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": SUPERVISOR_LEDGER_VERSION,
+            "at": datetime.now().isoformat(timespec="seconds"),
+            "boundary": self.boundary,
+            "intervention": self.kind,
+            #: The bound on what the caller was allowed to do with this ruling, written
+            #: beside the ruling rather than left to a reader to look up, so the ledger
+            #: answers "could this have approved anything" without leaving the file.
+            "permitted_effect": INTERVENTION_EFFECTS[self.kind],
+            "rule": self.rule,
+            "stage": self.stage,
+            "attempt": self.attempt,
+            "because": self.because,
+            "target": self.target,
+            "needs_a_human": self.needs_a_human,
+            "evidence": dict(self.evidence),
+            "effect": dict(self.effect),
+        }
+
+
+def supervisor_ledger_path(paths: RunPaths) -> Path:
+    """Where the rulings go. Run root; see :data:`SUPERVISOR_LEDGER_FILENAME`."""
+    return paths.run_root / SUPERVISOR_LEDGER_FILENAME
+
+
+def record_intervention(paths: RunPaths, intervention: Intervention) -> bool:
+    """Append one ruling. Returns whether it landed, and never raises.
+
+    Bookkeeping may not fail a run. A run that produced good work must not be lost because
+    the account of a decision about it could not be written, and this is called from
+    inside the attempt loop where an exception would replace whatever the stage was doing.
+    """
+    try:
+        path = supervisor_ledger_path(paths)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        append_jsonl(path, intervention.to_dict())
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# The supervisor
+# ---------------------------------------------------------------------------
+
+
+class RunSupervisor:
+    """Reads the cost ledger, rules on the walk, and can only ever slow it down.
+
+    Constructed once per run and asked twice per stage: at every attempt boundary and once
+    on the way out of a stage. It holds no opinion about the research and reads nothing
+    the agent wrote.
+    """
+
+    def __init__(self, *, stage_slugs: Sequence[str], max_auto_skips: int) -> None:
+        self.stage_slugs = tuple(stage_slugs)
+        self.max_auto_skips = max_auto_skips
+        #: The pool, once there is a ceiling to denominate it in. ``None`` until then, and
+        #: forever on a run that declared none: the supervisor does not invent a bound the
+        #: operator declined, and without one there is no total for :data:`REALLOCATE` to
+        #: conserve, so that rule stands down and says so.
+        self.allowance: AttemptAllowance | None = None
+        #: Stages already put back on the run's ration, so the surplus is moved once
+        #: rather than at every subsequent attempt boundary.
+        self.rationed: set[str] = set()
+
+    # -- what the ledger says ------------------------------------------------
+
+    def closed_spend(self, paths: RunPaths) -> dict[str, int]:
+        """Charged attempts per stage, summed over the visits that have closed."""
+        spend: dict[str, int] = {}
+        for row in read_stage_cost_ledger(paths):
+            slug = str(row.get("stage") or "")
+            if not slug:
+                continue
+            spend[slug] = spend.get(slug, 0) + charged_attempts(row)
+        return spend
+
+    def _pool(self, per_stage: int | None) -> AttemptAllowance | None:
+        """The allowance pool, created the first time a ceiling is offered.
+
+        Lazily rather than in ``__init__`` because the ceiling is not the supervisor's to
+        hold: ``ResearchManager.max_stage_attempts`` is a plain attribute a caller may set
+        after construction, and a supervisor holding a copy of it would enforce a ceiling
+        the run no longer has -- which, when the copy is ``None``, is no ceiling at all and
+        an attempt loop that cannot end. The number is asked for at every boundary instead.
+
+        Zero is left without a pool on purpose. It already means "allow no attempts, fail
+        at once" and is how a test reaches the skip path; a pool would answer the same
+        thing more slowly and with more to go wrong.
+        """
+        if per_stage is None or per_stage <= 0:
+            return None
+        if self.allowance is None:
+            self.allowance = AttemptAllowance(self.stage_slugs, per_stage)
+        return self.allowance
+
+    def attempt_ceiling(self, paths: RunPaths, stage_slug: str, per_stage: int | None) -> int | None:
+        """This visit's ceiling: *per_stage*, or what the stage has left, whichever is less.
+
+        The value handed to ``attempts_exhausted`` in place of ``--max-attempts``. It is a
+        :func:`min` against the ceiling the caller passed in, so it can differ from it only
+        downwards, and only on a stage the run has already visited: on a first visit
+        nothing has been charged and the two are equal.
+        """
+        pool = self._pool(per_stage)
+        if pool is None:
+            return per_stage
+        return min(per_stage, pool.remaining(stage_slug, self.closed_spend(paths).get(stage_slug, 0)))
+
+    # -- the attempt boundary ------------------------------------------------
+
+    def review_attempt(
+        self,
+        *,
+        paths: RunPaths,
+        stage_slug: str,
+        stage_number: int,
+        meter: StageCostMeter | None,
+        attempt_no: int,
+        auto_skips_spent: int,
+        deliverable_number: int,
+        per_stage_ceiling: int | None,
+    ) -> Intervention:
+        """Rule on one attempt boundary, before the attempt is bought.
+
+        Order is severity, not convenience: nothing can be salvaged once there is no
+        recovery path, so :data:`ESCALATE` is asked first; a stage that cannot succeed
+        should not be given a ration, so :data:`STOP_SPENDING` is asked before
+        :data:`REALLOCATE`.
+
+        *deliverable_number* is the stage the run would be routed to if this one ran out
+        of budget -- ``WRITING_STAGE`` unless ``--final-stage`` names an earlier one --
+        and is passed per call rather than held, because the caller can be told which
+        stage that is after this object is built.
+        """
+        try:
+            intervention = self._rule_on_attempt(
+                paths=paths,
+                stage_slug=stage_slug,
+                stage_number=stage_number,
+                meter=meter,
+                attempt_no=attempt_no,
+                auto_skips_spent=auto_skips_spent,
+                deliverable_number=deliverable_number,
+                per_stage_ceiling=per_stage_ceiling,
+            )
+        except Exception as error:  # pragma: no cover - defended, not expected
+            # A supervisor that raises has failed the run over bookkeeping, which is the
+            # one thing it is told not to do. Fall back to the ruling that changes
+            # nothing, and record that it did.
+            intervention = Intervention(
+                kind=CONTINUE,
+                rule=NOTHING_TO_DECIDE,
+                stage=stage_slug,
+                attempt=attempt_no,
+                because=f"the supervisor could not rule on this attempt: {error}",
+            )
+        record_intervention(paths, intervention)
+        return intervention
+
+    def _rule_on_attempt(
+        self,
+        *,
+        paths: RunPaths,
+        stage_slug: str,
+        stage_number: int,
+        meter: StageCostMeter | None,
+        attempt_no: int,
+        auto_skips_spent: int,
+        deliverable_number: int,
+        per_stage_ceiling: int | None,
+    ) -> Intervention:
+        digests = countable_digests(meter.attempt_digests()) if meter is not None else []
+        live_charged = max(meter.attempts - meter.polish_rounds, 0) if meter is not None else 0
+        ceiling = self.attempt_ceiling(paths, stage_slug, per_stage_ceiling)
+        at_stake = None if ceiling is None else max(ceiling - live_charged, 0)
+        closed = self.closed_spend(paths)
+        stage_spend = closed.get(stage_slug, 0) + live_charged
+        others = [value for slug, value in closed.items() if slug != stage_slug]
+
+        # The two conditions ``_route_to_deliverable`` returns False on, and a third that
+        # keeps this from causing the failure it reports.
+        #
+        # The first two: the skip budget is spent, and the run is already at or past the
+        # node that writes the deliverable, so there is no stage left to route a failure
+        # to. Read off the stage *number* rather than the slug because ``--final-stage``
+        # can move which node that is, and the routing code compares numbers for the same
+        # reason.
+        #
+        # The third is `nothing_left_to_buy`, and it is not decoration. Without it this
+        # fires at the *first* attempt boundary of the writing stage on every run that got
+        # there by routing to the deliverable -- which is every run whose skip budget is
+        # spent, since routing there is what spends the last of it -- and ends the visit
+        # before the stage has run once. That is the opposite of the trade
+        # ``_route_to_deliverable`` exists to make: spend what is left writing up rather
+        # than exiting with nothing. So the last resort may only be reached at a boundary
+        # the visit was going to end at anyway, and what it adds there is the mark for a
+        # human, not the ending.
+        nothing_left_to_buy = (at_stake is not None and at_stake <= 0) or unchanging_failure(digests)
+        if (
+            auto_skips_spent >= self.max_auto_skips
+            and stage_number >= deliverable_number
+            and nothing_left_to_buy
+        ):
+            return Intervention(
+                kind=ESCALATE,
+                rule=NO_RECOVERY_LEFT,
+                stage=stage_slug,
+                attempt=attempt_no,
+                needs_a_human=True,
+                because=(
+                    f"the auto-skip budget ({self.max_auto_skips}) is spent, the run is at "
+                    f"stage {stage_number}, at or past the stage that writes the deliverable "
+                    f"({deliverable_number}), and this visit has nothing left to buy, so "
+                    "there is nowhere left to route a failure and nobody left to ask but a "
+                    "person"
+                ),
+                evidence={
+                    "auto_skips_spent": auto_skips_spent,
+                    "max_auto_skips": self.max_auto_skips,
+                    "stage_number": stage_number,
+                    "deliverable_stage_number": deliverable_number,
+                    "attempts_at_stake": at_stake,
+                    "longest_unchanged_run": longest_unchanged_run(digests),
+                },
+                effect={"stops_the_visit": True, "marks_the_run_for_a_human": True},
+            )
+
+        if unchanging_failure(digests) and (at_stake is None or at_stake >= MIN_ATTEMPTS_AT_STAKE):
+            return Intervention(
+                kind=STOP_SPENDING,
+                rule=UNCHANGING_FAILURE,
+                stage=stage_slug,
+                attempt=attempt_no,
+                because=(
+                    f"the same failure has now been recorded {STOP_AFTER_IDENTICAL_FAILURES} "
+                    "times running with nothing changing, so another attempt at it cannot help"
+                ),
+                evidence={
+                    "repeats_required": STOP_AFTER_IDENTICAL_FAILURES,
+                    "longest_unchanged_run": longest_unchanged_run(digests),
+                    "attempts_at_stake": at_stake,
+                    "digests": list(digests),
+                },
+                effect={"stops_the_visit": True},
+            )
+
+        pool = self._pool(per_stage_ceiling)
+        unentered = [
+            slug for slug in self.stage_slugs if slug not in closed and slug != stage_slug
+        ]
+        keep = ration(stage_spend, others) if others else 0
+        surplus = (
+            max(pool.allowance.get(stage_slug, 0) - keep, 0) if pool is not None else 0
+        )
+        # A `reallocate` that moves nothing is a mislabelled `continue`: the ledger would
+        # record an intervention against a run where no budget changed hands, and the one
+        # thing an audit trail may not do is overstate what was done. Both ways that
+        # happens are checked here rather than left to the transfer to shrug off -- the
+        # stage is already at or below its ration, and there is no stage left to give to.
+        if (
+            pool is not None
+            and stage_slug not in self.rationed
+            and surplus > 0
+            and unentered
+            and disproportionate(stage_spend, others)
+        ):
+            moved = pool.transfer(stage_slug, unentered, surplus)
+            self.rationed.add(stage_slug)
+            return Intervention(
+                kind=REALLOCATE,
+                rule=DISPROPORTIONATE_SPEND,
+                stage=stage_slug,
+                attempt=attempt_no,
+                because=(
+                    f"{stage_slug} has charged {stage_spend} attempt(s) against a median of "
+                    f"{statistics.median(others)} for the {len(others)} stage(s) this run has "
+                    f"closed, which is more than {DISPROPORTIONATE_MULTIPLE}x; it keeps the run's "
+                    f"own ration and the surplus goes to the stages that have not run"
+                ),
+                evidence={
+                    "stage_charged_attempts": stage_spend,
+                    "closed_stage_charges": sorted(others),
+                    "median": statistics.median(others),
+                    "multiple": DISPROPORTIONATE_MULTIPLE,
+                    "ration": keep,
+                },
+                effect={
+                    "units_moved": moved,
+                    "to": list(unentered),
+                    "run_total": pool.total,
+                    "total_conserved": pool.conserved(),
+                },
+            )
+
+        return Intervention(
+            kind=CONTINUE,
+            rule=NOTHING_TO_DECIDE,
+            stage=stage_slug,
+            attempt=attempt_no,
+            because=self._why_nothing(digests, others, at_stake),
+            evidence={
+                "stage_charged_attempts": stage_spend,
+                "closed_stages": len(others),
+                "longest_unchanged_run": longest_unchanged_run(digests),
+            },
+        )
+
+    def _why_nothing(
+        self, digests: Sequence[str], others: Sequence[int], at_stake: int | None = None
+    ) -> str:
+        """Which precondition was short, so a `continue` row says more than "nothing".
+
+        The three cases are named separately because they are short for different reasons
+        and only one of them is temporary: a distribution arrives as the run walks, a
+        ceiling about to fire does not un-fire, and a failure that has not repeated may
+        yet.
+        """
+        if unchanging_failure(digests):
+            return (
+                f"the same failure has repeated, but only {at_stake} attempt(s) are at "
+                f"stake and stopping is worth taking at {MIN_ATTEMPTS_AT_STAKE}; the "
+                "run's own ceiling ends this visit either way"
+            )
+        if len(others) < MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION:
+            return (
+                f"{len(others)} stage(s) have closed and a distribution needs "
+                f"{MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION}, so there is nothing to be "
+                "disproportionate against yet; no failure has repeated unchanged either"
+            )
+        return (
+            "no failure has repeated unchanged and this stage is within the run's own "
+            "spread"
+        )
+
+    # -- the stage boundary --------------------------------------------------
+
+    def review_stage_exit(
+        self,
+        *,
+        paths: RunPaths,
+        stage_slug: str,
+        admissible_forward: Sequence[str],
+    ) -> Intervention:
+        """Rule on the way out of a stage.
+
+        *admissible_forward* is the set of forward targets the guards have already left
+        open, computed by the graph and handed in. The supervisor picks from it and cannot
+        add to it, which is why :data:`REDIRECT` can never open a guarded edge: there is
+        no code path from here to :meth:`~src.stage_graph.StageGraph.moves`.
+        """
+        try:
+            intervention = self._rule_on_stage_exit(
+                paths=paths, stage_slug=stage_slug, admissible_forward=admissible_forward
+            )
+        except Exception as error:  # pragma: no cover - defended, not expected
+            intervention = Intervention(
+                kind=CONTINUE,
+                rule=NOTHING_TO_DECIDE,
+                stage=stage_slug,
+                boundary="stage_exit",
+                because=f"the supervisor could not rule on this stage exit: {error}",
+            )
+        record_intervention(paths, intervention)
+        return intervention
+
+    def _rule_on_stage_exit(
+        self,
+        *,
+        paths: RunPaths,
+        stage_slug: str,
+        admissible_forward: Sequence[str],
+    ) -> Intervention:
+        rows = read_stage_cost_ledger(paths)
+        unsettled = unsettled_visits(rows, stage_slug)
+        if unsettled >= UNSETTLED_VISITS_BEFORE_A_REDIRECT and admissible_forward:
+            target = admissible_forward[0]
+            return Intervention(
+                kind=REDIRECT,
+                rule=UNFUNDED_REVISIT,
+                stage=stage_slug,
+                boundary="stage_exit",
+                target=target,
+                because=(
+                    f"{stage_slug} has now ended {unsettled} visit(s) without an approval, so "
+                    f"another visit to it is not the move; `{target}` is taken from the moves "
+                    "the guards already left open"
+                ),
+                evidence={
+                    "unsettled_visits": unsettled,
+                    "threshold": UNSETTLED_VISITS_BEFORE_A_REDIRECT,
+                    "chosen_from": list(admissible_forward),
+                },
+                effect={"names_an_open_edge": target},
+            )
+        return Intervention(
+            kind=CONTINUE,
+            rule=NOTHING_TO_DECIDE,
+            stage=stage_slug,
+            boundary="stage_exit",
+            because=(
+                f"{stage_slug} has {unsettled} visit(s) that ended without an approval, below "
+                f"the {UNSETTLED_VISITS_BEFORE_A_REDIRECT} at which the run stops funding "
+                "another one"
+            ),
+            evidence={
+                "unsettled_visits": unsettled,
+                "admissible_forward": list(admissible_forward),
+            },
+        )

--- a/tests/test_run_supervisor.py
+++ b/tests/test_run_supervisor.py
@@ -1,0 +1,1028 @@
+"""The supervisor decides things, so what it can decide has to be bounded by a test.
+
+Three questions this file answers, in the order a reviewer asks them.
+
+**Can it ever make a gate pass?** No, and not because the docstring says so. The three
+things that hold it are checkable and each has a test that dies when the rule is reverted:
+:meth:`~src.supervisor.AttemptAllowance.ceiling` is a ``min`` against the run's own
+``--max-attempts``, so ``NoInterventionRaisesABudgetTests`` sweeps every allowance state
+reachable by transfer and finds none that hands back a larger number;
+:meth:`~src.supervisor.AttemptAllowance.transfer` asserts conservation on the way out, so
+a transfer that would not conserve raises rather than clamps; and the manager's only
+response to a ruling that ends a visit is the stage-exhaustion recovery path that already
+existed, which ``TheManagerIsWiredToTheSupervisorTests`` reads out of the source rather
+than trusting.
+
+**Does it read anything the party it constrains can write?**
+``SupervisorReadsOnlyHarnessFieldsTests`` parses every ``paths.<field>`` in
+``src/supervisor.py``, resolves each against ``build_run_paths``, and fails if one lands
+under ``workspace/`` -- the directory every stage prompt sends an operator running with
+``bypassPermissions``. The control below fabricates a module that reads one and shows the
+scan catching it, because a scan that finds nothing and a scan that looks for nothing are
+the same green.
+
+**Are the thresholds measured?** The values are pinned to the module docstring's account
+of what they were measured against, and the replay that produced them,
+``tools/supervisor_threshold_replay.py``, is pinned to importing the shipped predicates
+rather than reimplementing them. An instrument that reimplements the rule it measures
+reports on a program that does not exist.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.stage_cost import (
+    OUTCOME_APPROVED,
+    OUTCOME_AUTO_SKIPPED,
+    StageCostMeter,
+    append_stage_cost_row,
+    failure_digest,
+)
+from src.supervisor import (
+    CONTINUE,
+    DISPROPORTIONATE_MULTIPLE,
+    DISPROPORTIONATE_SPEND,
+    ESCALATE,
+    INTERVENTION_EFFECTS,
+    INTERVENTIONS,
+    MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION,
+    NO_RECOVERY_LEFT,
+    NOTHING_TO_DECIDE,
+    REALLOCATE,
+    REDIRECT,
+    STOP_AFTER_IDENTICAL_FAILURES,
+    STOP_SPENDING,
+    SUPERVISOR_LEDGER_FILENAME,
+    SUPERVISOR_RULES,
+    UNCHANGING_FAILURE,
+    UNFUNDED_REVISIT,
+    UNSETTLED_VISITS_BEFORE_A_REDIRECT,
+    AllowanceError,
+    AttemptAllowance,
+    Intervention,
+    RunSupervisor,
+    disproportionate,
+    longest_unchanged_run,
+    ration,
+    supervisor_ledger_path,
+    unchanging_failure,
+    unsettled_visits,
+)
+from src.router import StageRouter
+from src.stage_graph import GraphState, StageGraph
+from src.utils import STAGES, RunPaths, build_run_paths, ensure_run_layout, write_text
+
+REPO = Path(__file__).resolve().parent.parent
+SUPERVISOR_SOURCE = (REPO / "src" / "supervisor.py").read_text(encoding="utf-8")
+REPLAY_SOURCE = (REPO / "tools" / "supervisor_threshold_replay.py").read_text(encoding="utf-8")
+MANAGER_SOURCE = (REPO / "src" / "manager.py").read_text(encoding="utf-8")
+
+SLUGS = [stage.slug for stage in STAGES]
+WRITING = "07_writing"
+WRITING_NUMBER = next(stage.number for stage in STAGES if stage.slug == WRITING)
+
+
+def fresh_paths(root: str) -> RunPaths:
+    paths = build_run_paths(Path(root) / "run")
+    ensure_run_layout(paths)
+    paths.run_root.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+def a_meter(slug: str, *, failures: list[str] | None = None, polish: int = 0) -> StageCostMeter:
+    """An open meter carrying *failures* as one attempt each, plus *polish* rounds."""
+    stage = next(item for item in STAGES if item.slug == slug)
+    meter = StageCostMeter(stage)
+    number = 0
+    for reason in failures or []:
+        number += 1
+        meter.note_attempt()
+        meter.note_failure(number, "validators_refused", reason)
+    for _ in range(polish):
+        number += 1
+        meter.note_attempt()
+        meter.note_polish_round(number)
+    return meter
+
+
+def close_a_visit(paths: RunPaths, slug: str, *, charged: int, outcome: str = OUTCOME_APPROVED) -> None:
+    """Put one finished visit in the cost ledger, charging *charged* attempts."""
+    meter = a_meter(slug)
+    for _ in range(charged):
+        meter.note_attempt()
+    meter.note_outcome(outcome)
+    append_stage_cost_row(paths, meter.close())
+
+
+CEILING = 8
+
+
+def a_supervisor(*, skips: int = 3) -> RunSupervisor:
+    return RunSupervisor(stage_slugs=SLUGS, max_auto_skips=skips)
+
+
+def rule_on(
+    supervisor: RunSupervisor,
+    paths: RunPaths,
+    slug: str,
+    *,
+    meter: StageCostMeter | None = None,
+    attempt: int = 1,
+    skips_spent: int = 0,
+    ceiling: int | None = CEILING,
+) -> Intervention:
+    number = next(item.number for item in STAGES if item.slug == slug)
+    return supervisor.review_attempt(
+        paths=paths,
+        stage_slug=slug,
+        stage_number=number,
+        meter=meter,
+        attempt_no=attempt,
+        auto_skips_spent=skips_spent,
+        deliverable_number=WRITING_NUMBER,
+        per_stage_ceiling=ceiling,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The vocabulary
+# ---------------------------------------------------------------------------
+
+
+class TheVocabularyIsDeclaredAndBoundedTests(unittest.TestCase):
+    def test_the_five_interventions_are_exactly_the_declared_ones(self) -> None:
+        self.assertEqual(
+            INTERVENTIONS,
+            (CONTINUE, STOP_SPENDING, REALLOCATE, REDIRECT, ESCALATE),
+        )
+
+    def test_every_intervention_has_a_permitted_effect_and_no_other_does(self) -> None:
+        """A ruling nobody wrote a bound for is a ruling with no bound."""
+        self.assertEqual(sorted(INTERVENTION_EFFECTS), sorted(INTERVENTIONS))
+
+    def test_no_permitted_effect_approves_anything(self) -> None:
+        """The invariant, read off the table a caller is allowed to act on."""
+        for kind, effect in INTERVENTION_EFFECTS.items():
+            with self.subTest(kind=kind):
+                for forbidden in ("approve", "pass", "discharge", "satisfy", "raise the"):
+                    self.assertNotIn(forbidden, effect.lower())
+
+    def test_a_ruling_outside_the_vocabulary_is_refused_at_construction(self) -> None:
+        with self.assertRaises(ValueError):
+            Intervention(kind="approve", rule=NOTHING_TO_DECIDE, stage=WRITING, because="")
+
+    def test_a_rule_outside_the_registry_is_refused_at_construction(self) -> None:
+        with self.assertRaises(ValueError):
+            Intervention(kind=CONTINUE, rule="because_i_said_so", stage=WRITING, because="")
+
+    def test_every_rule_in_the_registry_is_reachable(self) -> None:
+        """A rule nothing can decide is a row in a table and not a rule.
+
+        Each name has to appear in a ``rule=`` argument somewhere in the module, which is
+        the only place a ruling can be built.
+        """
+        built = set(re.findall(r"rule=([A-Z_]+),", SUPERVISOR_SOURCE))
+        expected = {
+            "NOTHING_TO_DECIDE",
+            "UNCHANGING_FAILURE",
+            "DISPROPORTIONATE_SPEND",
+            "UNFUNDED_REVISIT",
+            "NO_RECOVERY_LEFT",
+        }
+        self.assertEqual(built, expected)
+        self.assertEqual(len(SUPERVISOR_RULES), len(expected))
+
+
+# ---------------------------------------------------------------------------
+# The invariant
+# ---------------------------------------------------------------------------
+
+
+class NoInterventionRaisesABudgetTests(unittest.TestCase):
+    """The supervisor may stop and may move; it may never add."""
+
+    def test_the_ceiling_is_never_above_the_runs_own(self) -> None:
+        """Swept over every allowance state a sequence of transfers can reach.
+
+        Not a spot check: the whole point of the ``min`` is that no state of the ledger
+        can defeat it, and a single example would leave that as a hope.
+        """
+        allowance = AttemptAllowance(["a", "b", "c"], 8)
+        for donor, recipient, units in (("a", ["b"], 8), ("b", ["c"], 5), ("c", ["a", "b"], 4)):
+            allowance.transfer(donor, recipient, units)
+            for slug in ("a", "b", "c"):
+                for spent in range(0, 20):
+                    with self.subTest(slug=slug, spent=spent):
+                        self.assertLessEqual(allowance.ceiling(slug, spent), 8)
+
+    def test_a_recipient_that_holds_more_than_the_ceiling_still_gets_the_ceiling(self) -> None:
+        """The case the ``min`` exists for: allowance above ``--max-attempts``."""
+        allowance = AttemptAllowance(["a", "b"], 8)
+        allowance.transfer("a", ["b"], 8)
+        self.assertEqual(allowance.allowance["b"], 16)
+        self.assertEqual(allowance.ceiling("b", 0), 8)
+
+    def test_a_transfer_conserves_the_total(self) -> None:
+        allowance = AttemptAllowance(SLUGS, 8)
+        before = allowance.total
+        allowance.transfer(SLUGS[0], SLUGS[1:4], 6)
+        self.assertTrue(allowance.conserved())
+        self.assertEqual(allowance.total, before)
+        self.assertEqual(sum(allowance.allowance.values()), before)
+
+    def test_a_transfer_that_would_not_conserve_is_refused_rather_than_clamped(self) -> None:
+        """The net under a future edit, and what it catches.
+
+        The arithmetic in :meth:`AttemptAllowance.transfer` conserves by construction
+        today, so the only way to reach the check is to hand it a ledger that has already
+        drifted from its declared total -- which is exactly the state a later edit
+        recomputing an allowance somewhere else would produce, and exactly what the check
+        is a net under. A budget that silently rounds itself back into shape is a budget
+        nobody can audit, so it raises.
+        """
+        allowance = AttemptAllowance(["a", "b"], 8)
+        allowance.total = 99
+        with self.assertRaises(AllowanceError):
+            allowance.transfer("a", ["b"], 1)
+
+    def test_a_transfer_larger_than_the_donor_holds_is_refused(self) -> None:
+        allowance = AttemptAllowance(["a", "b"], 8)
+        with self.assertRaises(AllowanceError):
+            allowance.transfer("a", ["b"], 9)
+        self.assertTrue(allowance.conserved())
+
+    def test_a_transfer_to_nobody_moves_nothing(self) -> None:
+        allowance = AttemptAllowance(["a"], 8)
+        self.assertEqual(allowance.transfer("a", [], 4), 0)
+        self.assertEqual(allowance.allowance["a"], 8)
+
+    def test_the_run_declaring_no_ceiling_gets_no_pool(self) -> None:
+        """The supervisor does not invent a bound the operator declined."""
+        supervisor = a_supervisor()
+        self.assertIsNone(supervisor.allowance)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            self.assertIsNone(supervisor.attempt_ceiling(paths, WRITING, None))
+            self.assertIsNone(supervisor.allowance)
+
+    def test_a_first_visit_gets_exactly_what_the_run_allows(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            self.assertEqual(supervisor.attempt_ceiling(paths, "03_study_design", CEILING), 8)
+
+    def test_a_second_visit_gets_what_the_stage_has_left_and_not_a_fresh_ceiling(self) -> None:
+        """The status quo hands every visit a fresh ``--max-attempts``; the pool does not."""
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            close_a_visit(paths, "06_analysis", charged=6)
+            self.assertEqual(supervisor.attempt_ceiling(paths, "06_analysis", CEILING), 2)
+
+    def test_reallocating_never_lifts_a_ceiling_above_the_runs_own(self) -> None:
+        """End to end: the one intervention that moves budget, then the ceiling."""
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for slug in ("01_literature_survey", "02_hypothesis_generation", "04_implementation"):
+                close_a_visit(paths, slug, charged=1)
+            # Three charged against a median of one is disproportionate, and the ration it
+            # leaves (3 + 1) is still under the stage's allowance, so there is a surplus to
+            # move. A stage that has already charged more than its allowance minus the
+            # median has nothing unspent left and gets a `continue` instead -- budget that
+            # is spent cannot be reallocated, which is arithmetic rather than policy.
+            meter = a_meter("03_study_design", failures=["a", "b", "c"])
+            ruling = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=4)
+            self.assertEqual(ruling.kind, REALLOCATE)
+            self.assertTrue(supervisor.allowance.conserved())
+            for slug in SLUGS:
+                with self.subTest(slug=slug):
+                    self.assertLessEqual(supervisor.attempt_ceiling(paths, slug, CEILING), 8)
+
+
+# ---------------------------------------------------------------------------
+# What it is allowed to read
+# ---------------------------------------------------------------------------
+
+
+def paths_fields_read(source: str) -> set[str]:
+    """Every ``<name>.<field>`` where ``<name>`` is a ``RunPaths`` parameter.
+
+    An AST walk rather than a text search, because a text search is what a comment
+    mentioning ``paths.workspace`` would fool, and this check is the one that has to be
+    hard to fool.
+    """
+    tree = ast.parse(source)
+    holders = {"paths"}
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            if node.value.id in holders:
+                found.add(node.attr)
+    return found
+
+
+class SupervisorReadsOnlyHarnessFieldsTests(unittest.TestCase):
+    def test_no_path_the_supervisor_reads_is_under_the_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            workspace = paths.workspace_root.resolve()
+            for attr in sorted(paths_fields_read(SUPERVISOR_SOURCE)):
+                value = getattr(paths, attr, None)
+                if not isinstance(value, Path):
+                    continue
+                with self.subTest(field=attr):
+                    self.assertFalse(
+                        value.resolve().is_relative_to(workspace),
+                        f"src/supervisor.py reads paths.{attr}, which is under workspace/ -- "
+                        "the directory the supervised operator is sent to write in",
+                    )
+
+    def test_the_ledger_it_writes_is_outside_the_workspace_too(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            self.assertFalse(
+                supervisor_ledger_path(paths).resolve().is_relative_to(paths.workspace_root.resolve())
+            )
+            self.assertEqual(supervisor_ledger_path(paths).name, SUPERVISOR_LEDGER_FILENAME)
+
+    def test_the_scan_would_catch_a_supervisor_that_read_the_workspace(self) -> None:
+        """Control. The assertion above passes whether or not the scan sees anything."""
+        fabricated = "def rule(paths):\n    return paths.workspace_root.exists()\n"
+        self.assertIn("workspace_root", paths_fields_read(fabricated))
+
+
+# ---------------------------------------------------------------------------
+# stop_spending
+# ---------------------------------------------------------------------------
+
+
+class UnchangingFailureTests(unittest.TestCase):
+    def test_the_threshold_is_the_shipped_one(self) -> None:
+        self.assertEqual(STOP_AFTER_IDENTICAL_FAILURES, 2)
+
+    def test_it_fires_at_the_threshold_and_not_one_short(self) -> None:
+        digest = failure_digest("validators_refused", "report_plan.json task output 1 states nothing")
+        self.assertFalse(unchanging_failure([digest] * (STOP_AFTER_IDENTICAL_FAILURES - 1)))
+        self.assertTrue(unchanging_failure([digest] * STOP_AFTER_IDENTICAL_FAILURES))
+
+    def test_two_objections_alternating_are_not_one_objection_repeating(self) -> None:
+        """A stage being told different things is still being told something."""
+        self.assertFalse(unchanging_failure(["a", "b", "a", "b", "a", "b"]))
+        self.assertEqual(longest_unchanged_run(["a", "b", "a", "b"]), 1)
+
+    def test_progress_then_a_repeat_only_counts_the_tail(self) -> None:
+        self.assertEqual(longest_unchanged_run(["a", "b", "b", "c"]), 2)
+        self.assertEqual(longest_unchanged_run([]), 0)
+
+    def test_the_supervisor_stops_a_visit_repeating_one_refusal(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            meter = a_meter("03_study_design", failures=["report_plan.json task output 1 states nothing"] * 2)
+            ruling = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=3)
+            self.assertEqual(ruling.kind, STOP_SPENDING)
+            self.assertEqual(ruling.rule, UNCHANGING_FAILURE)
+            self.assertTrue(ruling.ends_the_visit)
+            self.assertEqual(ruling.evidence["longest_unchanged_run"], 2)
+
+    def test_a_visit_failing_differently_is_left_alone(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            meter = a_meter("03_study_design", failures=["one", "two", "three", "four"])
+            ruling = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=5)
+            self.assertEqual(ruling.kind, CONTINUE)
+            self.assertFalse(ruling.ends_the_visit)
+
+    def test_a_polish_round_does_not_break_a_run_of_one_refusal(self) -> None:
+        """Polish rounds are not failures, and the meter leaves them out of the digests."""
+        stage = next(item for item in STAGES if item.slug == "03_study_design")
+        meter = StageCostMeter(stage)
+        meter.note_attempt()
+        meter.note_failure(1, "validators_refused", "same")
+        meter.note_attempt()
+        meter.note_polish_round(2)
+        meter.note_attempt()
+        meter.note_failure(3, "validators_refused", "same")
+        digests = [entry["digest"] for entry in meter.attempt_digests()]
+        self.assertTrue(unchanging_failure(digests))
+
+
+# ---------------------------------------------------------------------------
+# reallocate
+# ---------------------------------------------------------------------------
+
+
+class DisproportionateSpendTests(unittest.TestCase):
+    def test_the_thresholds_are_the_shipped_ones(self) -> None:
+        self.assertEqual(DISPROPORTIONATE_MULTIPLE, 2)
+        self.assertEqual(MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION, 3)
+
+    def test_it_fires_above_the_multiple_and_not_at_it(self) -> None:
+        closed = [2, 2, 4]
+        self.assertFalse(disproportionate(4, closed))
+        self.assertTrue(disproportionate(5, closed))
+
+    def test_there_is_nothing_to_be_disproportionate_against_early_in_a_run(self) -> None:
+        """The answer to "what does it do before there is a distribution" is nothing."""
+        for population in ([], [2], [2, 2]):
+            with self.subTest(population=population):
+                self.assertFalse(disproportionate(99, population))
+        self.assertTrue(disproportionate(99, [2, 2, 2]))
+
+    def test_a_run_of_free_stages_does_not_make_every_stage_disproportionate(self) -> None:
+        """A median of zero would make ``spent > 0`` the whole rule."""
+        self.assertFalse(disproportionate(5, [0, 0, 0]))
+
+    def test_the_ration_is_the_runs_own_median_and_never_zero(self) -> None:
+        self.assertEqual(ration(5, [2, 2, 4]), 7)
+        self.assertEqual(ration(5, [0, 0, 0]), 6)
+
+    def test_the_early_ruling_says_which_precondition_was_short(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            ruling = rule_on(supervisor, paths, "03_study_design", meter=a_meter("03_study_design"))
+            self.assertEqual(ruling.kind, CONTINUE)
+            self.assertEqual(ruling.rule, NOTHING_TO_DECIDE)
+            self.assertIn(str(MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION), ruling.because)
+            self.assertEqual(ruling.evidence["closed_stages"], 0)
+
+    def test_it_moves_the_surplus_to_the_stages_that_have_not_run(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for slug in ("01_literature_survey", "02_hypothesis_generation", "04_implementation"):
+                close_a_visit(paths, slug, charged=2)
+            meter = a_meter("03_study_design", failures=[f"e{i}" for i in range(5)])
+            ruling = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=6)
+            self.assertEqual(ruling.kind, REALLOCATE)
+            self.assertEqual(ruling.rule, DISPROPORTIONATE_SPEND)
+            self.assertEqual(ruling.evidence["median"], 2)
+            self.assertEqual(ruling.evidence["ration"], 7)
+            self.assertEqual(ruling.effect["units_moved"], 1)
+            self.assertTrue(ruling.effect["total_conserved"])
+            self.assertNotIn("03_study_design", ruling.effect["to"])
+            for entered in ("01_literature_survey", "02_hypothesis_generation", "04_implementation"):
+                self.assertNotIn(entered, ruling.effect["to"])
+
+    def test_it_rations_a_stage_once_and_not_at_every_boundary_after(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for slug in ("01_literature_survey", "02_hypothesis_generation", "04_implementation"):
+                close_a_visit(paths, slug, charged=2)
+            meter = a_meter("03_study_design", failures=[f"e{i}" for i in range(5)])
+            first = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=6)
+            second = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=7)
+            self.assertEqual(first.kind, REALLOCATE)
+            self.assertEqual(second.kind, CONTINUE)
+
+    def test_a_stage_with_nothing_unspent_left_is_a_continue_too(self) -> None:
+        """Budget that is already spent cannot be moved, however disproportionate it is."""
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for slug in ("01_literature_survey", "02_hypothesis_generation", "04_implementation"):
+                close_a_visit(paths, slug, charged=2)
+            # 7 charged of an allowance of 8, so the ration (7 + the median 2) is above
+            # what the stage holds and the surplus is nothing.
+            meter = a_meter("03_study_design", failures=[f"e{i}" for i in range(7)])
+            ruling = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=8)
+            self.assertEqual(ruling.kind, CONTINUE)
+
+    def test_a_reallocate_that_would_move_nothing_is_a_continue(self) -> None:
+        """An audit trail may not overstate what was done.
+
+        With every other stage already entered there is nobody to give the surplus to, so
+        recording a `reallocate` would put an intervention in the ledger against a run
+        where no budget changed hands.
+        """
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for slug in SLUGS:
+                if slug != "03_study_design":
+                    close_a_visit(paths, slug, charged=2)
+            meter = a_meter("03_study_design", failures=[f"e{i}" for i in range(5)])
+            ruling = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=6)
+            self.assertEqual(ruling.kind, CONTINUE)
+
+    def test_a_run_with_no_pool_reallocates_nothing(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for slug in ("01_literature_survey", "02_hypothesis_generation", "04_implementation"):
+                close_a_visit(paths, slug, charged=2)
+            meter = a_meter("03_study_design", failures=[f"e{i}" for i in range(9)])
+            ruling = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=10, ceiling=None)
+            self.assertEqual(ruling.kind, CONTINUE)
+
+
+# ---------------------------------------------------------------------------
+# redirect
+# ---------------------------------------------------------------------------
+
+
+class UnfundedRevisitTests(unittest.TestCase):
+    def test_it_counts_only_the_visits_that_ended_without_an_approval(self) -> None:
+        rows = [
+            {"stage": "06_analysis", "outcome": OUTCOME_APPROVED},
+            {"stage": "06_analysis", "outcome": OUTCOME_AUTO_SKIPPED},
+            {"stage": "07_writing", "outcome": OUTCOME_AUTO_SKIPPED},
+        ]
+        self.assertEqual(unsettled_visits(rows, "06_analysis"), 1)
+        self.assertEqual(unsettled_visits(rows, "07_writing"), 1)
+
+    def test_it_names_an_edge_only_from_the_ones_it_was_handed(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for _ in range(UNSETTLED_VISITS_BEFORE_A_REDIRECT):
+                close_a_visit(paths, "06_analysis", charged=3, outcome=OUTCOME_AUTO_SKIPPED)
+            ruling = supervisor.review_stage_exit(
+                paths=paths, stage_slug="06_analysis", admissible_forward=["07_writing"]
+            )
+            self.assertEqual(ruling.kind, REDIRECT)
+            self.assertEqual(ruling.rule, UNFUNDED_REVISIT)
+            self.assertEqual(ruling.target, "07_writing")
+            self.assertIn(ruling.target, ruling.evidence["chosen_from"])
+
+    def test_with_no_open_forward_edge_it_names_nothing(self) -> None:
+        """It picks from the admissible set; it cannot construct a move."""
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for _ in range(UNSETTLED_VISITS_BEFORE_A_REDIRECT):
+                close_a_visit(paths, "06_analysis", charged=3, outcome=OUTCOME_AUTO_SKIPPED)
+            ruling = supervisor.review_stage_exit(
+                paths=paths, stage_slug="06_analysis", admissible_forward=[]
+            )
+            self.assertEqual(ruling.kind, CONTINUE)
+            self.assertEqual(ruling.target, "")
+
+    def test_one_unsettled_visit_is_not_enough(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            close_a_visit(paths, "06_analysis", charged=3, outcome=OUTCOME_AUTO_SKIPPED)
+            ruling = supervisor.review_stage_exit(
+                paths=paths, stage_slug="06_analysis", admissible_forward=["07_writing"]
+            )
+            self.assertEqual(ruling.kind, CONTINUE)
+
+    def test_a_stage_that_kept_being_approved_is_never_redirected_away_from(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for _ in range(4):
+                close_a_visit(paths, "06_analysis", charged=3, outcome=OUTCOME_APPROVED)
+            ruling = supervisor.review_stage_exit(
+                paths=paths, stage_slug="06_analysis", admissible_forward=["07_writing"]
+            )
+            self.assertEqual(ruling.kind, CONTINUE)
+
+
+# ---------------------------------------------------------------------------
+# escalate
+# ---------------------------------------------------------------------------
+
+
+class NoRecoveryLeftTests(unittest.TestCase):
+    def test_it_fires_on_exactly_the_state_that_aborts_a_run(self) -> None:
+        """Skip budget spent, at the node that writes the deliverable, nothing left to buy."""
+        supervisor = a_supervisor(skips=3)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            meter = a_meter(WRITING, failures=["requires at least one closed research round"] * 2)
+            ruling = rule_on(supervisor, paths, WRITING, meter=meter, skips_spent=3, attempt=3)
+            self.assertEqual(ruling.kind, ESCALATE)
+            self.assertEqual(ruling.rule, NO_RECOVERY_LEFT)
+            self.assertTrue(ruling.needs_a_human)
+            self.assertTrue(ruling.ends_the_visit)
+
+    def test_it_does_not_take_the_deliverable_stage_s_first_attempt_away(self) -> None:
+        """The defect this precondition's third clause exists for, pinned.
+
+        A run whose skip budget is spent got to the writing stage by ``_route_to_deliverable``
+        -- spending the last of the budget is *how* it got there -- so without the "nothing
+        left to buy" clause the last resort fires at the writing stage's first attempt
+        boundary, on every such run, and ends the visit before the stage has run once. That
+        turns the trade the route exists to make ("spend what is left writing up rather than
+        exiting with nothing") into exiting with nothing.
+        """
+        supervisor = a_supervisor(skips=3)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            ruling = rule_on(supervisor, paths, WRITING, meter=a_meter(WRITING), skips_spent=6)
+            self.assertEqual(ruling.kind, CONTINUE)
+            self.assertFalse(ruling.ends_the_visit)
+
+    def test_it_fires_when_the_ceiling_leaves_nothing_to_buy(self) -> None:
+        supervisor = a_supervisor(skips=3)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            meter = a_meter(WRITING, failures=[f"e{i}" for i in range(CEILING)])
+            ruling = rule_on(
+                supervisor, paths, WRITING, meter=meter, skips_spent=3, attempt=CEILING + 1
+            )
+            self.assertEqual(ruling.kind, ESCALATE)
+            self.assertEqual(ruling.evidence["attempts_at_stake"], 0)
+
+    def test_a_skip_still_in_hand_is_not_a_last_resort(self) -> None:
+        supervisor = a_supervisor(skips=3)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            meter = a_meter(WRITING, failures=["same"] * 2)
+            ruling = rule_on(supervisor, paths, WRITING, meter=meter, skips_spent=2, attempt=3)
+            self.assertEqual(ruling.kind, STOP_SPENDING)
+
+    def test_an_earlier_stage_still_has_somewhere_to_be_routed(self) -> None:
+        """Below the deliverable node a failure can still be skipped past, so this is not
+        the last resort even with the budget spent."""
+        supervisor = a_supervisor(skips=3)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            meter = a_meter("03_study_design", failures=["same"] * 2)
+            ruling = rule_on(
+                supervisor, paths, "03_study_design", meter=meter, skips_spent=3, attempt=3
+            )
+            self.assertEqual(ruling.kind, STOP_SPENDING)
+
+    def test_it_outranks_a_stage_that_is_also_stuck(self) -> None:
+        """Nothing can be salvaged once there is no recovery path, so it is asked first."""
+        supervisor = a_supervisor(skips=1)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            meter = a_meter(WRITING, failures=["requires at least one closed research round"] * 3)
+            ruling = rule_on(supervisor, paths, WRITING, meter=meter, skips_spent=1, attempt=4)
+            self.assertEqual(ruling.kind, ESCALATE)
+
+
+# ---------------------------------------------------------------------------
+# The record
+# ---------------------------------------------------------------------------
+
+
+class EveryRulingIsRecordedTests(unittest.TestCase):
+    def read(self, paths: RunPaths) -> list[dict]:
+        text = supervisor_ledger_path(paths).read_text(encoding="utf-8")
+        return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+    def test_a_continue_is_written_too(self) -> None:
+        """A supervisor that speaks only when it acts cannot be audited."""
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            rule_on(supervisor, paths, "01_literature_survey", meter=a_meter("01_literature_survey"))
+            rows = self.read(paths)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["intervention"], CONTINUE)
+            self.assertTrue(rows[0]["because"])
+
+    def test_the_row_carries_what_the_rule_read(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            meter = a_meter("03_study_design", failures=["same"] * 2)
+            rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=3)
+            row = self.read(paths)[-1]
+            self.assertEqual(row["intervention"], STOP_SPENDING)
+            self.assertEqual(row["rule"], UNCHANGING_FAILURE)
+            self.assertEqual(row["attempt"], 3)
+            self.assertEqual(row["evidence"]["longest_unchanged_run"], 2)
+            self.assertEqual(row["permitted_effect"], INTERVENTION_EFFECTS[STOP_SPENDING])
+
+    def test_a_stage_exit_ruling_says_which_boundary_it_came_from(self) -> None:
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            supervisor.review_stage_exit(paths=paths, stage_slug=WRITING, admissible_forward=[])
+            self.assertEqual(self.read(paths)[-1]["boundary"], "stage_exit")
+
+    def test_an_unwritable_ledger_does_not_fail_the_run(self) -> None:
+        """A run that produced good work is not lost because the account could not be written."""
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            supervisor_ledger_path(paths).mkdir(parents=True)  # a directory where the file goes
+            ruling = rule_on(supervisor, paths, WRITING, meter=a_meter(WRITING))
+            self.assertEqual(ruling.kind, CONTINUE)
+
+    def test_a_rule_that_raises_becomes_a_continue_and_not_an_exception(self) -> None:
+        """Bookkeeping may not fail a run, and neither may the supervisor's own arithmetic."""
+
+        class Exploding:
+            def attempt_digests(self):
+                raise RuntimeError("boom")
+
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            ruling = supervisor.review_attempt(
+                paths=paths,
+                stage_slug=WRITING,
+                stage_number=WRITING_NUMBER,
+                meter=Exploding(),  # type: ignore[arg-type]
+                attempt_no=1,
+                auto_skips_spent=0,
+                deliverable_number=WRITING_NUMBER,
+                per_stage_ceiling=CEILING,
+            )
+            self.assertEqual(ruling.kind, CONTINUE)
+            self.assertIn("boom", ruling.because)
+
+
+# ---------------------------------------------------------------------------
+# The thresholds, and the instrument that produced them
+# ---------------------------------------------------------------------------
+
+
+class TheThresholdsAreMeasuredTests(unittest.TestCase):
+    """Each value is pinned to the docstring's account of what it was measured against.
+
+    Not to the measurement's result -- the four trial runs are not in this repository and
+    a test that read them would be a test that only passes on one machine. What is pinned
+    is that the number in the code and the number in the sentence explaining it are the
+    same number, which is the half that rots.
+    """
+
+    def test_the_docstring_states_the_population_the_thresholds_were_measured_over(self) -> None:
+        from src import supervisor
+
+        doc = supervisor.__doc__ or ""
+        self.assertIn("22 stage visits", doc)
+        self.assertIn("141 attempt-loop iterations", doc)
+        self.assertIn("tools/supervisor_threshold_replay.py", doc)
+
+    def test_the_stop_threshold_in_the_prose_is_the_shipped_one(self) -> None:
+        from src import supervisor
+
+        doc = supervisor.__doc__ or ""
+        self.assertIn(f"**= {STOP_AFTER_IDENTICAL_FAILURES}.**", doc)
+
+    def test_the_proportionality_thresholds_in_the_prose_are_the_shipped_ones(self) -> None:
+        from src import supervisor
+
+        doc = supervisor.__doc__ or ""
+        self.assertIn(f"**= {DISPROPORTIONATE_MULTIPLE}**", doc)
+        self.assertIn(f"**= {MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION}.**", doc)
+        self.assertIn(f"{DISPROPORTIONATE_MULTIPLE}x", doc)
+
+    def test_the_replay_runs_the_shipped_rule_rather_than_a_copy(self) -> None:
+        """An instrument that reimplements the rule measures a program that does not exist."""
+        tree = ast.parse(REPLAY_SOURCE)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "src.supervisor":
+                imported |= {alias.name for alias in node.names}
+        for name in ("unchanging_failure", "disproportionate", "ration", "longest_unchanged_run"):
+            with self.subTest(name=name):
+                self.assertIn(name, imported)
+        defined = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        self.assertEqual(defined & imported, set(), "the replay redefines a rule it imports")
+
+    def test_the_replay_also_takes_its_digest_from_the_ledger_module(self) -> None:
+        tree = ast.parse(REPLAY_SOURCE)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "src.stage_cost":
+                imported |= {alias.name for alias in node.names}
+        self.assertIn("failure_digest", imported)
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+class TheManagerIsWiredToTheSupervisorTests(unittest.TestCase):
+    """A supervisor nothing asks is a module, not a role.
+
+    Read out of ``src/manager.py`` rather than exercised through a full stage, because
+    what these assert is *where* the calls are -- inside the attempt loop and at the stage
+    boundary -- and a behavioural test passes just as well when the only call is at the
+    end.
+    """
+
+    def _function(self, name: str) -> ast.FunctionDef:
+        tree = ast.parse(MANAGER_SOURCE)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == name:
+                return node
+        raise AssertionError(f"{name} is not in src/manager.py")
+
+    def _calls_in(self, node: ast.AST) -> set[str]:
+        found: set[str] = set()
+        for item in ast.walk(node):
+            if isinstance(item, ast.Call) and isinstance(item.func, ast.Attribute):
+                found.add(item.func.attr)
+        return found
+
+    def test_the_attempt_loop_asks_before_it_buys_an_attempt(self) -> None:
+        """Inside the stage, not only between stages.
+
+        The whole point of the component: the grinding happens within one visit, so a
+        supervisor woken only at stage boundaries watches the money leave.
+        """
+        loop = self._function("_run_stage_attempts")
+        whiles = [node for node in ast.walk(loop) if isinstance(node, ast.While)]
+        self.assertTrue(whiles, "_run_stage_attempts has no attempt loop")
+        self.assertTrue(
+            any("review_attempt" in self._calls_in(node) for node in whiles),
+            "the attempt loop does not consult the supervisor",
+        )
+
+    def test_the_stage_boundary_asks_too(self) -> None:
+        self.assertIn("review_stage_exit", self._calls_in(self._function("_advance_from")))
+
+    def test_the_ceiling_the_loop_enforces_is_the_supervisors(self) -> None:
+        """Computed *and* used. Calling it and then comparing against `--max-attempts`
+        anyway is the shape a source check for the call alone cannot see."""
+        loop = self._function("_run_stage_attempts")
+        self.assertIn("attempt_ceiling", self._calls_in(loop))
+        exhausted = [
+            node
+            for node in ast.walk(loop)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "attempts_exhausted"
+        ]
+        self.assertTrue(exhausted, "the attempt loop no longer bounds itself at all")
+        ceilings = {
+            arg.id
+            for call in exhausted
+            for arg in call.args
+            if isinstance(arg, ast.Name)
+        }
+        self.assertIn(
+            "ceiling",
+            ceilings,
+            "the loop bounds itself on something other than the supervisor's ceiling",
+        )
+
+    def test_the_only_thing_a_ruling_can_do_inside_a_stage_is_end_the_visit(self) -> None:
+        """The invariant, read off the branch that acts on a ruling.
+
+        ``ends_the_visit`` is the sole gate on the supervisor changing control flow in the
+        attempt loop, and the branch it guards is the one that already existed for an
+        exhausted stage -- whose outcomes are a skip stub and an abort, neither of which
+        is an approval.
+        """
+        loop = self._function("_run_stage_attempts")
+        guarded = [
+            node
+            for node in ast.walk(loop)
+            if isinstance(node, ast.If)
+            and "ends_the_visit" in (ast.get_source_segment(MANAGER_SOURCE, node.test) or "")
+        ]
+        self.assertTrue(guarded, "no branch in the attempt loop is guarded by the ruling")
+        # The outermost such branch is the one that decides whether the visit ends; the
+        # inner mention is the message saying which of the three reasons it was.
+        outermost = min(guarded, key=lambda node: node.lineno)
+        body = "\n".join(
+            ast.get_source_segment(MANAGER_SOURCE, statement) or "" for statement in outermost.body
+        )
+        self.assertIn("_handle_stage_exhaustion", body)
+        for approving in ("mark_stage_approved", "promote", "approve"):
+            with self.subTest(call=approving):
+                self.assertNotIn(approving, body)
+
+    def test_the_supervisor_is_built_once_per_run(self) -> None:
+        self.assertIn("RunSupervisor(", MANAGER_SOURCE)
+
+    def test_a_redirect_goes_through_the_router_and_not_around_it(self) -> None:
+        """Going around the router is how the archive learns a move the run did not make."""
+        advance = self._function("_advance_from")
+        chooses = [
+            node
+            for node in ast.walk(advance)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "choose"
+        ]
+        self.assertEqual(len(chooses), 1, "_advance_from no longer routes through the router")
+        required = [kw for kw in chooses[0].keywords if kw.arg == "required"]
+        self.assertEqual(len(required), 1, "the router is called with no required target")
+        # And the value has to come from the ruling, not from a literal `None` left behind
+        # when the wiring was removed.
+        names = {
+            node.id
+            for node in ast.walk(required[0].value)
+            if isinstance(node, ast.Name)
+        }
+        self.assertIn(
+            "exit_ruling",
+            names,
+            "the required target is not the supervisor's ruling",
+        )
+
+
+class TheRouterRefusesARedirectTheGuardsShutTests(unittest.TestCase):
+    """``redirect`` may only name an edge the guards already leave open.
+
+    Driven through the real :meth:`~src.router.StageRouter.choose` rather than read out of
+    its source, because what has to hold is the behaviour: a required target is checked
+    against the *live* moves, and one the guards have shut degrades to the forward edge
+    with a refusal recorded rather than being taken.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        self.stage = next(item for item in STAGES if item.number == 6)
+        write_text(self.paths.stage_file(self.stage), "# Stage 06: Analysis\n\nBody.\n")
+        self.graph = StageGraph.adaptive()
+        self.state = GraphState()
+        self.router = StageRouter(None, mode="off")
+
+    def _moves(self) -> list:
+        return self.graph.moves(self.paths, self.stage.slug, self.state)
+
+    def test_a_required_target_the_guards_left_open_is_taken(self) -> None:
+        live = [move for move in self._moves() if move.admissible]
+        self.assertTrue(live, "the fixture leaves no move open, so this proves nothing")
+        target = live[0].edge.target
+        decision = self.router.choose(
+            paths=self.paths,
+            stage=self.stage,
+            graph=self.graph,
+            state=self.state,
+            required=(target, "the supervisor stopped funding another visit"),
+        )
+        self.assertEqual(decision.target, target)
+        self.assertEqual(decision.refusal, "")
+
+    def test_a_required_target_the_guards_shut_is_refused_and_not_opened(self) -> None:
+        """The refusal, not the target, is what has to hold.
+
+        The default out of this node is itself a guard-blocked advance that
+        ``default_move`` takes as a last resort, so a refusal can land on the same slug
+        the redirect asked for. What distinguishes "the guards let it through" from "the
+        guards refused and the run fell back" is the recorded refusal and the edge kind,
+        so the case picked here is a blocked *revisit* -- a different kind from the
+        default -- and both are asserted.
+        """
+        default = self.graph.default_move(self.paths, self.stage.slug, self.state)
+        blocked = [
+            move
+            for move in self._moves()
+            if not move.admissible and move.edge.target != default.target
+        ]
+        self.assertTrue(blocked, "the fixture blocks nothing else, so this proves nothing")
+        target = blocked[0].edge.target
+        decision = self.router.choose(
+            paths=self.paths,
+            stage=self.stage,
+            graph=self.graph,
+            state=self.state,
+            required=(target, "the supervisor stopped funding another visit"),
+        )
+        self.assertNotEqual(decision.target, target)
+        self.assertEqual(decision.target, default.target)
+        self.assertIn("the supervisor required", decision.refusal)
+
+    def test_a_supervisor_redirect_is_not_recorded_as_the_agents_choice(self) -> None:
+        """The archive learns from ``agent_directed``; a redirect is not an agent's move,
+        and recording one as the agent's is how the archive learns a move nobody made."""
+        live = [move for move in self._moves() if move.admissible]
+        decision = self.router.choose(
+            paths=self.paths,
+            stage=self.stage,
+            graph=self.graph,
+            state=self.state,
+            required=(live[0].edge.target, "because"),
+        )
+        self.assertFalse(decision.agent_directed)
+
+    def test_a_closed_round_outranks_the_supervisor(self) -> None:
+        """A round has reasoned about the results; this has reasoned about the spend."""
+        live = [move.edge.target for move in self._moves() if move.admissible]
+        self.assertGreaterEqual(len(live), 2, "the fixture cannot distinguish the two")
+        decision = self.router.choose(
+            paths=self.paths,
+            stage=self.stage,
+            graph=self.graph,
+            state=self.state,
+            declared=(live[0], "the round asked"),
+            required=(live[1], "the supervisor required"),
+        )
+        self.assertEqual(decision.target, live[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_supervisor.py
+++ b/tests/test_run_supervisor.py
@@ -4,9 +4,10 @@ Three questions this file answers, in the order a reviewer asks them.
 
 **Can it ever make a gate pass?** No, and not because the docstring says so. The three
 things that hold it are checkable and each has a test that dies when the rule is reverted:
-:meth:`~src.supervisor.AttemptAllowance.ceiling` is a ``min`` against the run's own
+:meth:`~src.supervisor.AttemptAllowance.visit_ceiling` is a ``min`` against the run's own
 ``--max-attempts``, so ``NoInterventionRaisesABudgetTests`` sweeps every allowance state
-reachable by transfer and finds none that hands back a larger number;
+reachable by transfer and finds none that hands back a larger number -- and, since the
+first version of this class starved every revisit instead, none that hands back zero;
 :meth:`~src.supervisor.AttemptAllowance.transfer` asserts conservation on the way out, so
 a transfer that would not conserve raises rather than clamps; and the manager's only
 response to a ruling that ends a visit is the stage-exhaustion recovery path that already
@@ -21,11 +22,31 @@ under ``workspace/`` -- the directory every stage prompt sends an operator runni
 scan catching it, because a scan that finds nothing and a scan that looks for nothing are
 the same green.
 
+**Does every visit get funded?** ``EveryVisitIsFundedTests`` drives
+``ResearchManager._run_stage`` twice into one stage, because the defect it exists for was
+arithmetic that read correctly and starved every revisit: a stage whose first visit
+charged ``--max-attempts`` was handed a ceiling of 0 on its second and died before buying
+an attempt. The backward edge is the one thing this project has that a plain agent loop
+does not, so a supervisor that prices it out is worse than no supervisor, and no
+assertion on the pool's arithmetic could have caught it -- the arithmetic was self
+consistent and about the wrong quantity.
+
 **Are the thresholds measured?** The values are pinned to the module docstring's account
-of what they were measured against, and the replay that produced them,
-``tools/supervisor_threshold_replay.py``, is pinned to importing the shipped predicates
-rather than reimplementing them. An instrument that reimplements the rule it measures
-reports on a program that does not exist.
+of what they were measured against; every ``:data:`NAME` **= V**`` phrase has to name the
+shipped constant, no stale population figure may survive anywhere in the module, and the
+replay's own ``population_matches`` self-check is exercised on all three of its answers.
+``tools/supervisor_threshold_replay.py`` is pinned to importing the shipped predicates
+rather than reimplementing them, and to actually computing the two columns the docstring
+credits it with -- the outcome of a cut iteration, and the redirect count -- because
+naming an instrument as the source of a claim it has no column for is the same defect as
+a number nobody ran.
+
+**And is any of that held?** :data:`SUPERVISOR_MUTATIONS` is the answer as an instrument
+rather than as a sentence. Fifteen one-anchor edits, the first of which puts the revisit
+regression back exactly as it was::
+
+    git worktree add --detach /tmp/sweep HEAD
+    cd /tmp/sweep && python3 -m tests.test_run_supervisor --mutations
 """
 
 from __future__ import annotations
@@ -33,16 +54,21 @@ from __future__ import annotations
 import ast
 import json
 import re
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from src.stage_cost import (
     OUTCOME_APPROVED,
     OUTCOME_AUTO_SKIPPED,
+    REVIEWER_REFUSED,
     StageCostMeter,
     append_stage_cost_row,
     failure_digest,
+    read_stage_cost_ledger,
 )
 from src.supervisor import (
     CONTINUE,
@@ -74,9 +100,20 @@ from src.supervisor import (
     unchanging_failure,
     unsettled_visits,
 )
+from src.approval_agent import ReviewDecision
+from src.manifest import load_run_manifest
 from src.router import StageRouter
 from src.stage_graph import GraphState, StageGraph
-from src.utils import STAGES, RunPaths, build_run_paths, ensure_run_layout, write_text
+from src.utils import (
+    STAGES,
+    STUCK_AFTER_IDENTICAL_FAILURES,
+    RunPaths,
+    build_run_paths,
+    ensure_run_layout,
+    is_stuck,
+    write_text,
+)
+from tests.test_stage_cost_ledger import ManagerLoopFixture, _StubReviewer
 
 REPO = Path(__file__).resolve().parent.parent
 SUPERVISOR_SOURCE = (REPO / "src" / "supervisor.py").read_text(encoding="utf-8")
@@ -214,19 +251,46 @@ class NoInterventionRaisesABudgetTests(unittest.TestCase):
         can defeat it, and a single example would leave that as a hope.
         """
         allowance = AttemptAllowance(["a", "b", "c"], 8)
-        for donor, recipient, units in (("a", ["b"], 8), ("b", ["c"], 5), ("c", ["a", "b"], 4)):
+        for donor, recipient, units in (("a", ["b"], 7), ("b", ["c"], 5), ("c", ["a", "b"], 4)):
             allowance.transfer(donor, recipient, units)
             for slug in ("a", "b", "c"):
-                for spent in range(0, 20):
-                    with self.subTest(slug=slug, spent=spent):
-                        self.assertLessEqual(allowance.ceiling(slug, spent), 8)
+                with self.subTest(slug=slug):
+                    self.assertLessEqual(allowance.visit_ceiling(slug), 8)
+
+    def test_no_state_of_the_pool_can_starve_a_visit_of_every_attempt(self) -> None:
+        """The other direction of the same invariant, and the one that regressed.
+
+        A per-visit ceiling of zero is a stage that fails on entry with "Exceeded 0
+        attempts" before it has run once. Swept over the same reachable states, because
+        the first version of this class produced exactly that on any second visit and the
+        pool is the only thing that can produce it now.
+        """
+        allowance = AttemptAllowance(["a", "b", "c"], 8)
+        for donor, recipient, units in (("a", ["b"], 7), ("b", ["c"], 5), ("c", ["a", "b"], 4)):
+            allowance.transfer(donor, recipient, units)
+            for slug in ("a", "b", "c"):
+                with self.subTest(slug=slug):
+                    self.assertGreaterEqual(allowance.visit_ceiling(slug), 1)
+
+    def test_a_donor_may_not_give_away_everything_it_holds(self) -> None:
+        """A stage the run can never enter again is the mirror of a guarded edge opened.
+
+        The structural floor under the policy floor: :meth:`AttemptAllowance.transfer` is
+        the only method that can lower an allowance, so refusing the emptying transfer
+        there is what makes a zero per-visit ceiling unreachable by any caller.
+        """
+        allowance = AttemptAllowance(["a", "b"], 8)
+        with self.assertRaises(AllowanceError):
+            allowance.transfer("a", ["b"], 8)
+        self.assertEqual(allowance.allowance["a"], 8)
+        self.assertTrue(allowance.conserved())
 
     def test_a_recipient_that_holds_more_than_the_ceiling_still_gets_the_ceiling(self) -> None:
         """The case the ``min`` exists for: allowance above ``--max-attempts``."""
         allowance = AttemptAllowance(["a", "b"], 8)
-        allowance.transfer("a", ["b"], 8)
-        self.assertEqual(allowance.allowance["b"], 16)
-        self.assertEqual(allowance.ceiling("b", 0), 8)
+        allowance.transfer("a", ["b"], 7)
+        self.assertEqual(allowance.allowance["b"], 15)
+        self.assertEqual(allowance.visit_ceiling("b"), 8)
 
     def test_a_transfer_conserves_the_total(self) -> None:
         allowance = AttemptAllowance(SLUGS, 8)
@@ -266,24 +330,12 @@ class NoInterventionRaisesABudgetTests(unittest.TestCase):
         """The supervisor does not invent a bound the operator declined."""
         supervisor = a_supervisor()
         self.assertIsNone(supervisor.allowance)
-        with tempfile.TemporaryDirectory() as tmp:
-            paths = fresh_paths(tmp)
-            self.assertIsNone(supervisor.attempt_ceiling(paths, WRITING, None))
-            self.assertIsNone(supervisor.allowance)
+        self.assertIsNone(supervisor.attempt_ceiling(WRITING, None))
+        self.assertIsNone(supervisor.allowance)
 
     def test_a_first_visit_gets_exactly_what_the_run_allows(self) -> None:
         supervisor = a_supervisor()
-        with tempfile.TemporaryDirectory() as tmp:
-            paths = fresh_paths(tmp)
-            self.assertEqual(supervisor.attempt_ceiling(paths, "03_study_design", CEILING), 8)
-
-    def test_a_second_visit_gets_what_the_stage_has_left_and_not_a_fresh_ceiling(self) -> None:
-        """The status quo hands every visit a fresh ``--max-attempts``; the pool does not."""
-        supervisor = a_supervisor()
-        with tempfile.TemporaryDirectory() as tmp:
-            paths = fresh_paths(tmp)
-            close_a_visit(paths, "06_analysis", charged=6)
-            self.assertEqual(supervisor.attempt_ceiling(paths, "06_analysis", CEILING), 2)
+        self.assertEqual(supervisor.attempt_ceiling("03_study_design", CEILING), 8)
 
     def test_reallocating_never_lifts_a_ceiling_above_the_runs_own(self) -> None:
         """End to end: the one intervention that moves budget, then the ceiling."""
@@ -303,7 +355,7 @@ class NoInterventionRaisesABudgetTests(unittest.TestCase):
             self.assertTrue(supervisor.allowance.conserved())
             for slug in SLUGS:
                 with self.subTest(slug=slug):
-                    self.assertLessEqual(supervisor.attempt_ceiling(paths, slug, CEILING), 8)
+                    self.assertLessEqual(supervisor.attempt_ceiling(slug, CEILING), 8)
 
 
 # ---------------------------------------------------------------------------
@@ -365,7 +417,41 @@ class SupervisorReadsOnlyHarnessFieldsTests(unittest.TestCase):
 
 class UnchangingFailureTests(unittest.TestCase):
     def test_the_threshold_is_the_shipped_one(self) -> None:
-        self.assertEqual(STOP_AFTER_IDENTICAL_FAILURES, 2)
+        self.assertEqual(STOP_AFTER_IDENTICAL_FAILURES, 3)
+
+    def test_the_rule_is_not_a_second_copy_of_the_stuck_check(self) -> None:
+        """Same count, wider population, and the docstring says so -- so pin the width.
+
+        The two numbers agreeing is not a coincidence to hide: ``is_stuck`` reads
+        ``recent_failures``, which ``_run_stage_attempts`` appends to at exactly one place
+        -- the branch where validation, repair and local normalisation all failed -- so it
+        cannot see a reviewer refusing identically three times, a cross-model veto
+        repeating, or a backend failing the same way. This rule reads the whole census. On
+        ``MEASURED_RUNS`` every repeat is a validator error, so the difference is invisible
+        there and has to be pinned here instead.
+        """
+        refusals = [["the reviewer says no"]] * STUCK_AFTER_IDENTICAL_FAILURES
+        self.assertTrue(is_stuck(refusals), "the fixture is not a run of identical failures")
+        # The same three attempts, charged to the reviewer rather than the validators, are
+        # invisible to `is_stuck` because nothing appends them to `recent_failures`.
+        supervisor = a_supervisor()
+        stage = next(item for item in STAGES if item.slug == "03_study_design")
+        meter = StageCostMeter(stage)
+        for number in range(1, STOP_AFTER_IDENTICAL_FAILURES + 1):
+            meter.note_attempt()
+            meter.note_failure(number, REVIEWER_REFUSED, "the reviewer says no")
+        self.assertFalse(is_stuck([]), "the loop's own list stays empty for a reviewer refusal")
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            ruling = rule_on(
+                supervisor,
+                paths,
+                "03_study_design",
+                meter=meter,
+                attempt=STOP_AFTER_IDENTICAL_FAILURES + 1,
+            )
+        self.assertEqual(ruling.kind, STOP_SPENDING)
+        self.assertEqual(ruling.rule, UNCHANGING_FAILURE)
 
     def test_it_fires_at_the_threshold_and_not_one_short(self) -> None:
         digest = failure_digest("validators_refused", "report_plan.json task output 1 states nothing")
@@ -385,12 +471,24 @@ class UnchangingFailureTests(unittest.TestCase):
         supervisor = a_supervisor()
         with tempfile.TemporaryDirectory() as tmp:
             paths = fresh_paths(tmp)
-            meter = a_meter("03_study_design", failures=["report_plan.json task output 1 states nothing"] * 2)
-            ruling = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=3)
+            meter = a_meter(
+                "03_study_design",
+                failures=["report_plan.json task output 1 states nothing"]
+                * STOP_AFTER_IDENTICAL_FAILURES,
+            )
+            ruling = rule_on(
+                supervisor,
+                paths,
+                "03_study_design",
+                meter=meter,
+                attempt=STOP_AFTER_IDENTICAL_FAILURES + 1,
+            )
             self.assertEqual(ruling.kind, STOP_SPENDING)
             self.assertEqual(ruling.rule, UNCHANGING_FAILURE)
             self.assertTrue(ruling.ends_the_visit)
-            self.assertEqual(ruling.evidence["longest_unchanged_run"], 2)
+            self.assertEqual(
+                ruling.evidence["longest_unchanged_run"], STOP_AFTER_IDENTICAL_FAILURES
+            )
 
     def test_a_visit_failing_differently_is_left_alone(self) -> None:
         supervisor = a_supervisor()
@@ -405,12 +503,14 @@ class UnchangingFailureTests(unittest.TestCase):
         """Polish rounds are not failures, and the meter leaves them out of the digests."""
         stage = next(item for item in STAGES if item.slug == "03_study_design")
         meter = StageCostMeter(stage)
-        meter.note_attempt()
-        meter.note_failure(1, "validators_refused", "same")
-        meter.note_attempt()
-        meter.note_polish_round(2)
-        meter.note_attempt()
-        meter.note_failure(3, "validators_refused", "same")
+        number = 0
+        for index in range(STOP_AFTER_IDENTICAL_FAILURES):
+            number += 1
+            meter.note_attempt()
+            meter.note_failure(number, "validators_refused", "same")
+            number += 1
+            meter.note_attempt()
+            meter.note_polish_round(number)
         digests = [entry["digest"] for entry in meter.attempt_digests()]
         self.assertTrue(unchanging_failure(digests))
 
@@ -472,6 +572,34 @@ class DisproportionateSpendTests(unittest.TestCase):
             self.assertNotIn("03_study_design", ruling.effect["to"])
             for entered in ("01_literature_survey", "02_hypothesis_generation", "04_implementation"):
                 self.assertNotIn(entered, ruling.effect["to"])
+
+    def test_a_revisit_can_still_be_rationed_and_keeps_a_visits_worth(self) -> None:
+        """The half of the pool's per-visit turn that a first-visit test cannot see.
+
+        On a first visit the stage's lifetime spend and the open visit's spend are the
+        same number, so every assertion above passes whichever of the two the ration is
+        computed from. Here they differ: 6 charged in a closed visit, 1 in the open one.
+        Against a per-visit allowance of 8 the lifetime figure leaves ``8 - (6 + 2) = 0``
+        surplus and the rule stands down on exactly the revisits it exists to notice; the
+        visit figure leaves ``8 - (1 + 2) = 5`` and the stage keeps the run's own ration
+        for the visit it is in.
+        """
+        supervisor = a_supervisor()
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            for slug in ("01_literature_survey", "02_hypothesis_generation", "04_implementation"):
+                close_a_visit(paths, slug, charged=2)
+            close_a_visit(paths, "03_study_design", charged=6, outcome=OUTCOME_AUTO_SKIPPED)
+            meter = a_meter("03_study_design", failures=["one"])
+            ruling = rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=2)
+            self.assertEqual(ruling.kind, REALLOCATE)
+            self.assertEqual(ruling.evidence["stage_charged_attempts"], 7)
+            self.assertEqual(ruling.evidence["visit_charged_attempts"], 1)
+            self.assertEqual(ruling.evidence["ration"], 3)
+            self.assertEqual(ruling.effect["units_moved"], 5)
+            self.assertEqual(ruling.effect["visit_ceiling_after"], 3)
+            # And the narrowing it leaves is still a fundable visit, not a starved one.
+            self.assertGreaterEqual(supervisor.attempt_ceiling("03_study_design", CEILING), 1)
 
     def test_it_rations_a_stage_once_and_not_at_every_boundary_after(self) -> None:
         supervisor = a_supervisor()
@@ -601,8 +729,19 @@ class NoRecoveryLeftTests(unittest.TestCase):
         supervisor = a_supervisor(skips=3)
         with tempfile.TemporaryDirectory() as tmp:
             paths = fresh_paths(tmp)
-            meter = a_meter(WRITING, failures=["requires at least one closed research round"] * 2)
-            ruling = rule_on(supervisor, paths, WRITING, meter=meter, skips_spent=3, attempt=3)
+            meter = a_meter(
+                WRITING,
+                failures=["requires at least one closed research round"]
+                * STOP_AFTER_IDENTICAL_FAILURES,
+            )
+            ruling = rule_on(
+                supervisor,
+                paths,
+                WRITING,
+                meter=meter,
+                skips_spent=3,
+                attempt=STOP_AFTER_IDENTICAL_FAILURES + 1,
+            )
             self.assertEqual(ruling.kind, ESCALATE)
             self.assertEqual(ruling.rule, NO_RECOVERY_LEFT)
             self.assertTrue(ruling.needs_a_human)
@@ -640,8 +779,15 @@ class NoRecoveryLeftTests(unittest.TestCase):
         supervisor = a_supervisor(skips=3)
         with tempfile.TemporaryDirectory() as tmp:
             paths = fresh_paths(tmp)
-            meter = a_meter(WRITING, failures=["same"] * 2)
-            ruling = rule_on(supervisor, paths, WRITING, meter=meter, skips_spent=2, attempt=3)
+            meter = a_meter(WRITING, failures=["same"] * STOP_AFTER_IDENTICAL_FAILURES)
+            ruling = rule_on(
+                supervisor,
+                paths,
+                WRITING,
+                meter=meter,
+                skips_spent=2,
+                attempt=STOP_AFTER_IDENTICAL_FAILURES + 1,
+            )
             self.assertEqual(ruling.kind, STOP_SPENDING)
 
     def test_an_earlier_stage_still_has_somewhere_to_be_routed(self) -> None:
@@ -650,9 +796,14 @@ class NoRecoveryLeftTests(unittest.TestCase):
         supervisor = a_supervisor(skips=3)
         with tempfile.TemporaryDirectory() as tmp:
             paths = fresh_paths(tmp)
-            meter = a_meter("03_study_design", failures=["same"] * 2)
+            meter = a_meter("03_study_design", failures=["same"] * STOP_AFTER_IDENTICAL_FAILURES)
             ruling = rule_on(
-                supervisor, paths, "03_study_design", meter=meter, skips_spent=3, attempt=3
+                supervisor,
+                paths,
+                "03_study_design",
+                meter=meter,
+                skips_spent=3,
+                attempt=STOP_AFTER_IDENTICAL_FAILURES + 1,
             )
             self.assertEqual(ruling.kind, STOP_SPENDING)
 
@@ -661,8 +812,19 @@ class NoRecoveryLeftTests(unittest.TestCase):
         supervisor = a_supervisor(skips=1)
         with tempfile.TemporaryDirectory() as tmp:
             paths = fresh_paths(tmp)
-            meter = a_meter(WRITING, failures=["requires at least one closed research round"] * 3)
-            ruling = rule_on(supervisor, paths, WRITING, meter=meter, skips_spent=1, attempt=4)
+            meter = a_meter(
+                WRITING,
+                failures=["requires at least one closed research round"]
+                * (STOP_AFTER_IDENTICAL_FAILURES + 1),
+            )
+            ruling = rule_on(
+                supervisor,
+                paths,
+                WRITING,
+                meter=meter,
+                skips_spent=1,
+                attempt=STOP_AFTER_IDENTICAL_FAILURES + 2,
+            )
             self.assertEqual(ruling.kind, ESCALATE)
 
 
@@ -691,13 +853,21 @@ class EveryRulingIsRecordedTests(unittest.TestCase):
         supervisor = a_supervisor()
         with tempfile.TemporaryDirectory() as tmp:
             paths = fresh_paths(tmp)
-            meter = a_meter("03_study_design", failures=["same"] * 2)
-            rule_on(supervisor, paths, "03_study_design", meter=meter, attempt=3)
+            meter = a_meter("03_study_design", failures=["same"] * STOP_AFTER_IDENTICAL_FAILURES)
+            rule_on(
+                supervisor,
+                paths,
+                "03_study_design",
+                meter=meter,
+                attempt=STOP_AFTER_IDENTICAL_FAILURES + 1,
+            )
             row = self.read(paths)[-1]
             self.assertEqual(row["intervention"], STOP_SPENDING)
             self.assertEqual(row["rule"], UNCHANGING_FAILURE)
-            self.assertEqual(row["attempt"], 3)
-            self.assertEqual(row["evidence"]["longest_unchanged_run"], 2)
+            self.assertEqual(row["attempt"], STOP_AFTER_IDENTICAL_FAILURES + 1)
+            self.assertEqual(
+                row["evidence"]["longest_unchanged_run"], STOP_AFTER_IDENTICAL_FAILURES
+            )
             self.assertEqual(row["permitted_effect"], INTERVENTION_EFFECTS[STOP_SPENDING])
 
     def test_a_stage_exit_ruling_says_which_boundary_it_came_from(self) -> None:
@@ -748,32 +918,116 @@ class EveryRulingIsRecordedTests(unittest.TestCase):
 class TheThresholdsAreMeasuredTests(unittest.TestCase):
     """Each value is pinned to the docstring's account of what it was measured against.
 
-    Not to the measurement's result -- the four trial runs are not in this repository and
-    a test that read them would be a test that only passes on one machine. What is pinned
-    is that the number in the code and the number in the sentence explaining it are the
-    same number, which is the half that rots.
+    Not to the measurement's result -- the trial runs are not in this repository and a
+    test that read them would be a test that only passes on one machine. What is pinned
+    here is the half that rots: that the number in the code and the number in the sentence
+    explaining it are the same number, that the population figure in the prose is the one
+    the instrument records, and that the instrument refuses to print a different one under
+    the invocation the prose names.
     """
 
     def test_the_docstring_states_the_population_the_thresholds_were_measured_over(self) -> None:
+        """And states the one the instrument records, not one nobody ran.
+
+        The number this replaces was ``162``, which neither invocation of the replay ever
+        printed -- the three-run command gives 141 and the four-run glob gave 166 and then
+        167 as the fourth run kept being written. The docstring is now pinned against
+        ``MEASURED_VISITS`` and ``MEASURED_ITERATIONS``, which the tool checks itself
+        against every time it runs.
+        """
         from src import supervisor
+        from tools.supervisor_threshold_replay import MEASURED_ITERATIONS, MEASURED_VISITS
 
         doc = supervisor.__doc__ or ""
-        self.assertIn("22 stage visits", doc)
-        self.assertIn("141 attempt-loop iterations", doc)
+        self.assertIn(f"{MEASURED_VISITS} stage visits", doc)
+        self.assertIn(f"{MEASURED_ITERATIONS} attempt-loop iterations", doc)
         self.assertIn("tools/supervisor_threshold_replay.py", doc)
+        self.assertIn("MEASURED_RUNS", doc)
 
-    def test_the_stop_threshold_in_the_prose_is_the_shipped_one(self) -> None:
+    def test_the_docstring_names_no_population_figure_that_is_not_the_recorded_one(self) -> None:
+        """The control the previous test cannot be: a stale figure left beside a fresh one.
+
+        ``assertIn`` passes whether or not the sentence it matched is the only one, and
+        the branch this fixes shipped ``22 stage visits`` in the module docstring and
+        ``26 stage visits`` in two constant docstrings at the same time. This reads every
+        ``<number> stage visit`` and ``<number> ... iteration`` in the whole module -- prose
+        and comments -- and refuses any that is not the recorded population.
+        """
+        from tools.supervisor_threshold_replay import MEASURED_ITERATIONS, MEASURED_VISITS
+
+        # The 26/166/167 sentence in the module docstring is the one place a different
+        # population is named on purpose, so it is named in words that this can exclude.
+        prose = "\n".join(
+            line
+            for line in SUPERVISOR_SOURCE.splitlines()
+            if "still being written" not in line and "and 27 and 167" not in line
+        )
+        visits = {int(value) for value in re.findall(r"(\d+) stage visits?\b", prose)}
+        iterations = {
+            int(value) for value in re.findall(r"(\d+) attempt-loop iterations?\b", prose)
+        }
+        self.assertLessEqual(visits, {MEASURED_VISITS}, f"a stale visit count survives: {visits}")
+        self.assertLessEqual(
+            iterations,
+            {MEASURED_ITERATIONS},
+            f"a stale iteration count survives: {iterations}",
+        )
+
+    def test_the_instrument_refuses_a_population_that_is_not_the_recorded_one(self) -> None:
+        """The self-check, exercised rather than described.
+
+        This is what makes the docstring's denominator re-derivable on a machine that has
+        the trial data: run the named invocation and the report either says ``as
+        recorded`` or says which way it drifted. Both wrong answers are checked here,
+        because a self-check that only ever returns the happy string is the same green as
+        no self-check.
+        """
+        from tools.supervisor_threshold_replay import (
+            MEASURED_ITERATIONS,
+            MEASURED_RUNS,
+            MEASURED_VISITS,
+            population_matches,
+        )
+
+        self.assertIn(
+            "as recorded",
+            population_matches(list(MEASURED_RUNS), MEASURED_VISITS, MEASURED_ITERATIONS),
+        )
+        self.assertIn(
+            "DRIFTED",
+            population_matches(list(MEASURED_RUNS), MEASURED_VISITS + 1, MEASURED_ITERATIONS),
+        )
+        self.assertIn(
+            "DRIFTED",
+            population_matches(list(MEASURED_RUNS), MEASURED_VISITS, MEASURED_ITERATIONS + 25),
+        )
+        self.assertIn(
+            "not the recorded one",
+            population_matches(
+                [*MEASURED_RUNS, "Chemistry_000_20260816_173127"],
+                MEASURED_VISITS + 5,
+                MEASURED_ITERATIONS + 26,
+            ),
+        )
+
+    def test_every_threshold_in_the_prose_is_the_shipped_one(self) -> None:
+        """One sweep over the table rather than one assertion per constant.
+
+        ``assertIn("**= 3.**")`` was satisfied by *any* threshold documented as three, so
+        the sentence checked and the constant checked did not have to be about the same
+        rule. The whole ``:data:`NAME` **= V**`` phrase cannot be.
+        """
         from src import supervisor
 
         doc = supervisor.__doc__ or ""
-        self.assertIn(f"**= {STOP_AFTER_IDENTICAL_FAILURES}.**", doc)
-
-    def test_the_proportionality_thresholds_in_the_prose_are_the_shipped_ones(self) -> None:
-        from src import supervisor
-
-        doc = supervisor.__doc__ or ""
-        self.assertIn(f"**= {DISPROPORTIONATE_MULTIPLE}**", doc)
-        self.assertIn(f"**= {MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION}.**", doc)
+        for name, value in (
+            ("STOP_AFTER_IDENTICAL_FAILURES", STOP_AFTER_IDENTICAL_FAILURES),
+            ("DISPROPORTIONATE_MULTIPLE", DISPROPORTIONATE_MULTIPLE),
+            ("MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION", MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION),
+            ("UNSETTLED_VISITS_BEFORE_A_REDIRECT", UNSETTLED_VISITS_BEFORE_A_REDIRECT),
+        ):
+            with self.subTest(name=name):
+                self.assertRegex(doc, rf":data:`{name}` \*\*= {value}[.*]")
         self.assertIn(f"{DISPROPORTIONATE_MULTIPLE}x", doc)
 
     def test_the_replay_runs_the_shipped_rule_rather_than_a_copy(self) -> None:
@@ -783,7 +1037,16 @@ class TheThresholdsAreMeasuredTests(unittest.TestCase):
         for node in ast.walk(tree):
             if isinstance(node, ast.ImportFrom) and node.module == "src.supervisor":
                 imported |= {alias.name for alias in node.names}
-        for name in ("unchanging_failure", "disproportionate", "ration", "longest_unchanged_run"):
+        for name in (
+            "unchanging_failure",
+            "disproportionate",
+            "ration",
+            "longest_unchanged_run",
+            # The redirect column's predicate. Two sentences in `src/supervisor.py` used
+            # to credit this tool with a finding about `UNSETTLED_VISITS_BEFORE_A_REDIRECT`
+            # while it had no redirect column and did not import this at all.
+            "unsettled_visits",
+        ):
             with self.subTest(name=name):
                 self.assertIn(name, imported)
         defined = {
@@ -792,6 +1055,69 @@ class TheThresholdsAreMeasuredTests(unittest.TestCase):
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         }
         self.assertEqual(defined & imported, set(), "the replay redefines a rule it imports")
+
+    def test_the_replay_computes_the_redirect_claim_the_docstring_credits_it_with(self) -> None:
+        """Naming the instrument as the source of a claim it cannot compute is the defect.
+
+        Driven rather than read: a hand-built walk in which one stage ends two visits
+        without an approval, so the column has to reach the threshold, and a second in
+        which the first visit was approved, so it must not.
+        """
+        from tools.supervisor_threshold_replay import redirect_fires
+
+        def walk(*outcomes: str) -> list[dict]:
+            return [
+                {"stage": "06_analysis", "outcome": outcome, "attempts": [], "stage_number": 6}
+                for outcome in outcomes
+            ]
+
+        twice_unsettled = redirect_fires([("run", walk("skipped", "skipped"))])
+        self.assertEqual(len(twice_unsettled), 1)
+        self.assertEqual(twice_unsettled[0]["unsettled"], UNSETTLED_VISITS_BEFORE_A_REDIRECT)
+        self.assertEqual(
+            redirect_fires([("run", walk("approved", "skipped"))]),
+            [],
+            "a stage with an approved visit was redirected away from",
+        )
+
+    def test_the_replay_reports_what_a_cut_iteration_produced(self) -> None:
+        """The column whose absence made ``N = 2`` look measured.
+
+        ``bought`` is the classifier and this is its contract: the entries the manager
+        writes when an attempt produced something, and an empty tuple when it did not. The
+        veto case is here because it is the one that flatters the rule -- an approval the
+        cross-model reviewer overrode is not an approval, and counting it as one would
+        have inflated the "productive" column by six attempts.
+        """
+        from tools.supervisor_threshold_replay import (
+            PRODUCED_APPROVAL,
+            PRODUCED_DRAFT,
+            PRODUCED_OBLIGATIONS,
+            PRODUCED_REPAIR,
+            bought,
+            draft_was_valid,
+        )
+
+        self.assertEqual(bought({"result": "", "prompt": ""}), ())
+        self.assertEqual(bought({"reviewer_choice": "choice: 5"}), (PRODUCED_APPROVAL,))
+        self.assertEqual(
+            bought({"reviewer_choice": "choice: 5", "cross_review": "agrees: False"}),
+            (),
+            "an approval the cross-model reviewer vetoed was counted as productive",
+        )
+        self.assertEqual(bought({"evolution_promoted": ""}), (PRODUCED_DRAFT,))
+        self.assertEqual(bought({"validation_failed": "bad"}), (PRODUCED_REPAIR,))
+        self.assertEqual(
+            bought({"validation_failed": "bad", "local_normalization_failed": "still bad"}),
+            (),
+            "a validation failure that was never repaired was counted as a repair",
+        )
+        self.assertEqual(bought({"obligation_recorded": ""}), ())
+        self.assertEqual(bought({"obligation_discharged": ""}), (PRODUCED_OBLIGATIONS,))
+        # And the column the harm turns on: after a repeated validator refusal there is
+        # nothing for `_validated_draft_for_skip` to rescue.
+        self.assertFalse(draft_was_valid({"local_normalization_failed": "still bad"}))
+        self.assertTrue(draft_was_valid({"reviewer_choice": "choice: 4"}))
 
     def test_the_replay_also_takes_its_digest_from_the_ledger_module(self) -> None:
         tree = ast.parse(REPLAY_SOURCE)
@@ -929,6 +1255,142 @@ class TheManagerIsWiredToTheSupervisorTests(unittest.TestCase):
         )
 
 
+class EveryVisitIsFundedTests(ManagerLoopFixture, unittest.TestCase):
+    """The backward edge has to be affordable, and only the real loop can say it is.
+
+    This is the regression that made the reviewer refuse the branch. The pool used to
+    charge a stage's *closed* visits against a single lifetime allowance, so a stage whose
+    first visit spent ``--max-attempts`` was handed ``remaining = 0`` on its second,
+    ``attempt_ceiling`` returned 0, and ``attempts_exhausted(1, 0)`` ended the visit before
+    it bought anything -- with the manifest reading ``Exceeded 0 attempts`` and the
+    supervisor's own ledger recording ``continue / nothing_to_decide``, which
+    :func:`~src.supervisor.ration`'s docstring forbids in as many words.
+
+    Driven through ``ResearchManager._run_stage`` twice rather than asserted on the
+    arithmetic, because the arithmetic is what was wrong: reading
+    ``min(per_stage, allowance - spent)`` and concluding it funds a revisit is exactly the
+    mistake, and only the loop knows that ``loop_attempts`` restarts at zero on every
+    entry and so already accounts for what the visit itself has spent.
+    """
+
+    STAGE = STAGES[0]
+
+    def _visit(self, decision: ReviewDecision) -> bool:
+        self._stub_operator(self._valid_draft(self.STAGE))
+        self.manager.reviewer = _StubReviewer([decision])
+        return self.manager._run_stage(self.paths, self.STAGE)
+
+    def _exhausting_visit(self) -> bool:
+        """One visit that spends the whole ceiling on validation failures.
+
+        Reviewer refusals cannot be used for this: ``MAX_AUTOMATED_SENDBACKS`` is counted
+        per *stage* and read from disk, so the second visit's first refusal is converted
+        into an approval and the visit ends after one attempt for a reason that has
+        nothing to do with funding. A draft the validators refuse is refused every time.
+        """
+        draft = self.paths.stage_tmp_file(self.STAGE)
+        draft.parent.mkdir(parents=True, exist_ok=True)
+        draft.write_text("# nothing useful here\n", encoding="utf-8")
+        self._stub_operator(draft)
+        self.operator.repair_stage_summary = MagicMock(
+            return_value=MagicMock(
+                success=True,
+                exit_code=0,
+                session_id="session-1",
+                stage_file_path=draft,
+                stdout="",
+                stderr="",
+            )
+        )
+        self.manager.reviewer = _StubReviewer(
+            [ReviewDecision(choice="5", decision_token="approve")]
+        )
+        return self.manager._run_stage(self.paths, self.STAGE)
+
+    def _rows(self) -> list[dict]:
+        return read_stage_cost_ledger(self.paths)
+
+    def _ledger(self) -> list[dict]:
+        text = supervisor_ledger_path(self.paths).read_text(encoding="utf-8")
+        return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+    def _last_error(self) -> str:
+        manifest = load_run_manifest(self.paths.run_manifest)
+        entry = next(item for item in manifest.stages if item.slug == self.STAGE.slug)
+        return entry.last_error or ""
+
+    def test_a_second_visit_to_an_exhausted_stage_still_buys_attempts(self) -> None:
+        """The whole item, end to end: exhaust the ceiling, come back, get approved."""
+        self.manager.max_stage_attempts = 3
+        self.assertFalse(
+            self._visit(
+                ReviewDecision(
+                    choice="4", decision_token="revise", reason="no", feedback="again"
+                )
+            )
+        )
+        self.assertTrue(self._visit(ReviewDecision(choice="5", decision_token="approve")))
+        rows = self._rows()
+        self.assertEqual([row["visit"] for row in rows], [1, 2])
+        self.assertEqual(rows[0]["attempts"], 3, "the first visit charged the whole ceiling")
+        self.assertGreaterEqual(rows[1]["attempts"], 1, "the revisit bought no attempt at all")
+        self.assertFalse(rows[1]["exhausted"])
+        self.assertEqual(rows[1]["outcome"], OUTCOME_APPROVED)
+        self.assertNotIn("Exceeded 0 attempts", self._last_error())
+
+    def test_a_revisit_gets_the_whole_ceiling_and_not_one_attempt(self) -> None:
+        """"Floor it at one" is not the fix: one attempt is a revisit that cannot work.
+
+        Both visits fail the same way to exhaustion, so what each *charges* is the ceiling
+        it was funded at. Anything less on the second than on the first would mean the
+        supervisor still narrowed the revisit, and a floor of one would show up here as
+        ``[2, 1]``.
+        """
+        self.manager.max_stage_attempts = 2
+        self.assertFalse(self._exhausting_visit())
+        self.assertFalse(self._exhausting_visit())
+        self.assertEqual([row["attempts"] for row in self._rows()], [2, 2])
+        self.assertEqual(self.manager.supervisor.attempt_ceiling(self.STAGE.slug, 2), 2)
+
+    def test_no_visit_dies_at_a_boundary_the_ledger_calls_nothing_to_decide(self) -> None:
+        """A ration of zero is ``stop_spending``, and the ledger has to be able to say so.
+
+        The failure this pins is not "the ruling was wrong" -- ``continue`` was the right
+        ruling for every one of those boundaries -- it is that the visit died anyway, so
+        the audit trail could not name the rule that ended it. Checked as an invariant over
+        the whole two-visit run rather than at one boundary: no visit may end without
+        buying an attempt, and no ``continue`` may be the last word on one that did.
+        """
+        self.manager.max_stage_attempts = 2
+        self._exhausting_visit()
+        self._exhausting_visit()
+        starved = [row for row in self._rows() if row["attempts"] == 0]
+        self.assertEqual(starved, [], "a visit was funded at zero attempts")
+        acting = [row for row in self._ledger() if row["intervention"] != CONTINUE]
+        self.assertEqual(
+            acting,
+            [],
+            "the supervisor acted on a run where nothing should have moved it",
+        )
+        self.assertNotIn("Exceeded 0 attempts", self._last_error())
+
+    def test_the_manager_asks_for_a_per_visit_ceiling_and_gets_the_runs_own(self) -> None:
+        """The ceiling the loop enforces, read from the supervisor the manager built.
+
+        Two closed visits' worth of spend is on disk when this asks, which is the state
+        that used to return 0.
+        """
+        self.manager.max_stage_attempts = 2
+        self._exhausting_visit()
+        self._exhausting_visit()
+        self.assertEqual(
+            sum(row["attempts"] for row in self._rows()),
+            4,
+            "the fixture did not put two exhausted visits on disk",
+        )
+        self.assertEqual(self.manager.supervisor.attempt_ceiling(self.STAGE.slug, 2), 2)
+
+
 class TheRouterRefusesARedirectTheGuardsShutTests(unittest.TestCase):
     """``redirect`` may only name an edge the guards already leave open.
 
@@ -1024,5 +1486,160 @@ class TheRouterRefusesARedirectTheGuardsShutTests(unittest.TestCase):
         self.assertEqual(decision.target, live[0])
 
 
+# ---------------------------------------------------------------------------
+# The mutation sweep, as an instrument
+# ---------------------------------------------------------------------------
+
+SUPERVISOR = "src/supervisor.py"
+MANAGER_FILE = "src/manager.py"
+REPLAY = "tools/supervisor_threshold_replay.py"
+
+#: ``(what it breaks, file, the text to replace, what to replace it with)``.
+#:
+#: The same shape ``tests/test_stage_cost_ledger.MUTATIONS`` uses, and for the same
+#: reason: "N mutations, all killed" is a number a reader has to believe unless the sweep
+#: is a thing they can run::
+#:
+#:     git worktree add --detach /tmp/sweep HEAD
+#:     cd /tmp/sweep && python3 -m tests.test_run_supervisor --mutations
+#:
+#: What it covers is what this pass changed -- the per-visit funding rule, the floor under
+#: a transfer, the ration's spend, the shipped repeat count, and the three replay columns
+#: whose absence let a docstring claim things the instrument could not compute. The first
+#: entry is the regression itself, put back exactly: an ``attempt_ceiling`` that subtracts
+#: what the stage's closed visits charged.
+SUPERVISOR_MUTATIONS: tuple[tuple[str, str, str, str], ...] = (
+    ("the revisit regression, restored: the ceiling charges closed visits again", MANAGER_FILE,
+     "            ceiling = self.supervisor.attempt_ceiling(stage.slug, self.max_stage_attempts)",
+     "            ceiling = max(\n"
+     "                self.supervisor.attempt_ceiling(stage.slug, self.max_stage_attempts)\n"
+     "                - self.supervisor.closed_spend(paths).get(stage.slug, 0),\n"
+     "                0,\n"
+     "            )"),
+    ("visit_ceiling loses the min against --max-attempts", SUPERVISOR,
+     "        return min(self.per_stage, self.allowance.get(stage_slug, self.per_stage))",
+     "        return self.allowance.get(stage_slug, self.per_stage)"),
+    ("a donor may empty itself again", SUPERVISOR,
+     "        if held is None or units >= held:", "        if held is None or units > held:"),
+    ("the ration is computed from the stage's lifetime rather than the visit", SUPERVISOR,
+     "        keep = ration(live_charged, others) if others else 0",
+     "        keep = ration(stage_spend, others) if others else 0"),
+    ("the transfer stops conserving", SUPERVISOR,
+     "        if not self.conserved():", "        if False:"),
+    ("the repeat count goes back to the value the replay refused", SUPERVISOR,
+     "STOP_AFTER_IDENTICAL_FAILURES = 3", "STOP_AFTER_IDENTICAL_FAILURES = 2"),
+    ("the repeat rule stops requiring the repeats to be consecutive", SUPERVISOR,
+     "        run = run + 1 if digest == previous else 1", "        run = run + 1"),
+    ("the redirect threshold drops to one unsettled visit", SUPERVISOR,
+     "UNSETTLED_VISITS_BEFORE_A_REDIRECT = 2", "UNSETTLED_VISITS_BEFORE_A_REDIRECT = 1"),
+    ("an approval the cross-model reviewer vetoed counts as productive", REPLAY,
+     "    if not vetoed and (\"approved\" in entry or (gate is not None and _field(gate, \"choice\") == \"5\")):",
+     "    if \"approved\" in entry or (gate is not None and _field(gate, \"choice\") == \"5\"):"),
+    ("an obligation merely recorded counts as discharged", REPLAY,
+     '    if "obligation_discharged" in entry:',
+     '    if "obligation_discharged" in entry or "obligation_recorded" in entry:'),
+    ("a validation failure nothing repaired counts as a repair", REPLAY,
+     '    if "validation_failed" in entry and "local_normalization_failed" not in entry:',
+     '    if "validation_failed" in entry:'),
+    ("the draft is always reported as inside the gate", REPLAY,
+     '    return "local_normalization_failed" not in entry', "    return True"),
+    ("the redirect column never fires", REPLAY,
+     "            if unsettled >= unsettled_before:", "            if False:"),
+    ("the population self-check always says the population is the recorded one", REPLAY,
+     "    if tuple(names) != MEASURED_RUNS:", "    if False:"),
+    ("the recorded population goes back to the figure no invocation printed", REPLAY,
+     "MEASURED_ITERATIONS = 141", "MEASURED_ITERATIONS = 162"),
+)
+
+#: Tests that die under every mutation because applying one is what stops their own
+#: anchor from matching. Subtracting them is what keeps a kill an actual kill; see
+#: ``tests/test_stage_cost_ledger.SWEEP_SELF_TESTS``, which this mirrors.
+SUPERVISOR_SWEEP_SELF_TESTS = frozenset({"test_every_anchor_matches_its_file_exactly_once"})
+
+
+def _dead_tests(root: Path) -> set[str]:
+    proc = subprocess.run(
+        [sys.executable, "-m", "unittest", __spec__.name if __spec__ else __name__, "-v"],
+        cwd=root, capture_output=True, text=True,
+    )
+    out = proc.stdout + proc.stderr
+    dead = set(re.findall(r"^(\w+) \(tests\.[\w.]+\) \.\.\. (?:FAIL|ERROR)", out, re.M))
+    dead |= set(re.findall(r"^(?:FAIL|ERROR): (\w+) ", out, re.M))
+    return dead - SUPERVISOR_SWEEP_SELF_TESTS
+
+
+def run_mutations(root: Path | None = None) -> int:
+    """Apply each of :data:`SUPERVISOR_MUTATIONS` in turn; return the survivor count.
+
+    Restores every file in a ``finally``, so an interrupted sweep leaves the tree as it
+    found it -- but it does edit the tree, so run it in a scratch checkout.
+    """
+    root = root or Path(__file__).resolve().parent.parent
+    baseline = _dead_tests(root)
+    if baseline:
+        print(f"REFUSED: the tree is not green before mutating: {sorted(baseline)}")
+        return len(baseline)
+    print(f"baseline green; {len(SUPERVISOR_MUTATIONS)} mutations to try\n")
+    survivors: list[str] = []
+    for name, relative, old, new in SUPERVISOR_MUTATIONS:
+        path = root / relative
+        text = path.read_text(encoding="utf-8")
+        if text.count(old) != 1:
+            print(f"NOT APPLIED ({text.count(old)} anchor matches): {name}")
+            survivors.append(name)
+            continue
+        path.write_text(text.replace(old, new), encoding="utf-8")
+        try:
+            dead = _dead_tests(root)
+        finally:
+            path.write_text(text, encoding="utf-8")
+        if dead:
+            print(f"killed  {name}\n            by: {', '.join(sorted(dead))}")
+        else:
+            print(f"SURVIVED  {name}")
+            survivors.append(name)
+    print(f"\ntried {len(SUPERVISOR_MUTATIONS)}, "
+          f"killed {len(SUPERVISOR_MUTATIONS) - len(survivors)}, survivors {len(survivors)}")
+    for name in survivors:
+        print("   SURVIVOR:", name)
+    return len(survivors)
+
+
+class TheSweepIsRunnableTests(unittest.TestCase):
+    """The instrument, checked without running it: fifteen subprocess suites is not a unit test.
+
+    What goes stale without anyone noticing is an *anchor*, and an anchor that no longer
+    matches is a mutation silently not applied -- which reads in the output exactly like
+    one that was killed.
+    """
+
+    def test_every_anchor_matches_its_file_exactly_once(self) -> None:
+        for name, relative, old, _new in SUPERVISOR_MUTATIONS:
+            with self.subTest(mutation=name):
+                text = (REPO / relative).read_text(encoding="utf-8")
+                self.assertEqual(
+                    text.count(old), 1,
+                    f"{name}: anchor matches {text.count(old)} times in {relative}",
+                )
+
+    def test_no_mutation_leaves_the_file_unchanged(self) -> None:
+        for name, _relative, old, new in SUPERVISOR_MUTATIONS:
+            with self.subTest(mutation=name):
+                self.assertNotEqual(old, new, f"{name} is not a mutation")
+
+    def test_the_self_test_exclusion_names_a_test_that_exists(self) -> None:
+        """An exclusion pointing at nothing would silently stop excluding."""
+        for name in SUPERVISOR_SWEEP_SELF_TESTS:
+            self.assertTrue(hasattr(TheSweepIsRunnableTests, name), name)
+
+    def test_the_sweep_covers_all_three_files_this_pass_touched(self) -> None:
+        self.assertEqual(
+            {relative for _n, relative, _o, _w in SUPERVISOR_MUTATIONS},
+            {SUPERVISOR, MANAGER_FILE, REPLAY},
+        )
+
+
 if __name__ == "__main__":
+    if "--mutations" in sys.argv:
+        raise SystemExit(1 if run_mutations() else 0)
     unittest.main()

--- a/tests/test_stage_cost_ledger.py
+++ b/tests/test_stage_cost_ledger.py
@@ -816,7 +816,16 @@ class _StubCrossReviewer:
         return self._verdict
 
 
-class ManagerWritesTheLedgerTests(unittest.TestCase):
+class ManagerLoopFixture:
+    """A real ``ResearchManager`` over a real run root, with the operator stubbed.
+
+    Split out of the test class below rather than copied, because
+    ``tests/test_run_supervisor.py`` needs the same apparatus to drive the attempt loop
+    twice into one stage and a second copy of a hundred lines of draft fixture is a second
+    thing to keep in step. Not a ``TestCase``: it carries no ``test_`` methods, so nothing
+    here is discovered or run twice.
+    """
+
     def setUp(self) -> None:
         self.tmp = tempfile.mkdtemp()
         self.runs_dir = Path(self.tmp) / "runs"
@@ -934,6 +943,8 @@ class ManagerWritesTheLedgerTests(unittest.TestCase):
             )
         )
 
+
+class ManagerWritesTheLedgerTests(ManagerLoopFixture, unittest.TestCase):
     def _run_until_exhausted(self, decision: ReviewDecision, *, attempts: int = 3):
         stage = STAGE_01
         self._stub_operator(self._valid_draft(stage))

--- a/tests/test_writable_decisive_fields.py
+++ b/tests/test_writable_decisive_fields.py
@@ -34,8 +34,13 @@ one behind the tuple is the same defect one level up from the one this file is a
 
 **What is derived and what is declared.** The population is derived: the ``validate_*``
 functions are parsed out of ``src/*.py`` at module scope and on classes, the guards come
-from ``stage_graph.GUARDS`` and the assessors from ``scorecard.FEATURES``, so a new gate
-fails this file rather than joining the tree unclassified. Each declared path is resolved
+from ``stage_graph.GUARDS``, the assessors from ``scorecard.FEATURES`` and the run
+supervisor's rules from ``supervisor.SUPERVISOR_RULES``, so a new gate fails this file
+rather than joining the tree unclassified. The supervisor is here because it decides
+things -- it can end a stage visit and move an attempt budget -- and the question this
+file asks about a decider is the one its own design turns on: the operator writes under
+``workspace/``, so a supervisor that read anything there would be one the supervised party
+writes. Each declared path is resolved
 against ``build_run_paths``, so a renamed ``RunPaths`` field fails too, and *whether a path
 is under* ``workspace/`` is computed rather than asserted.
 
@@ -59,6 +64,7 @@ from typing import Callable, NamedTuple
 
 from src.scorecard import DROP, FEATURES, KEEP, build_scorecard
 from src.stage_graph import GUARDS, GraphState, Visit
+from src.supervisor import SUPERVISOR_RULES
 from src.utils import STAGES, RunPaths, build_run_paths, ensure_run_layout
 
 REPO = Path(__file__).resolve().parent.parent
@@ -379,6 +385,63 @@ GATES: tuple[Gate, ...] = (
         "As review_panel, with the ledger at reviews/effort.json: `summary.run_as_routine` "
         "is the number the verdict turns on.",
     ),
+    # ------------------------------------------------- the run supervisor's rules
+    #
+    # Not gates in the sense the rest of this table is -- none of them lets anything
+    # through, and by construction none of them can: `AttemptAllowance.ceiling` is a `min`
+    # against the run's own `--max-attempts` and there is no path from a ruling to an
+    # approval. They are here because they *refuse* spending, and the question this file
+    # asks of a refusal is who wrote the field it turns on. Every one of them reads
+    # `stage_cost_ledger.json` or an in-memory meter the harness fills, and nothing else.
+    Gate(
+        "supervisor:nothing_to_decide",
+        (),
+        NO_FIELD,
+        "The default ruling. It reads the same fields as the rules that did not fire and "
+        "acts on none of them, so there is no decisive field. In the table for the reason "
+        "`guard:always` is: a rule that decides nothing and a rule nobody classified look "
+        "the same from outside.",
+    ),
+    Gate(
+        "supervisor:unchanging_failure",
+        ("stage_cost_ledger",),
+        HARNESS,
+        "Ends a stage visit when the same failure digest has repeated. The digests come "
+        "from the open `StageCostMeter`, which the manager fills at its own branch points "
+        "and closes into `stage_cost_ledger.json` at the run root; the agent authors the "
+        "*reason text* a reviewer or validator wrote about its draft, but not the record "
+        "that the refusal happened, and cannot reach either file. Ending a visit hands to "
+        "the stage-exhaustion path, whose outcomes are a skip stub and an abort.",
+    ),
+    Gate(
+        "supervisor:disproportionate_spend",
+        ("stage_cost_ledger",),
+        HARNESS,
+        "Moves a stage's unspent attempt allowance to the stages that have not run, on "
+        "the charged-attempt counts in `stage_cost_ledger.json`. Counts, written by the "
+        "manager as it dispatches: nothing here reads a claim. The total is conserved and "
+        "the per-visit ceiling stays a `min` against `--max-attempts`, so the move cannot "
+        "buy an attempt the run had not already bought.",
+    ),
+    Gate(
+        "supervisor:unfunded_revisit",
+        ("stage_cost_ledger",),
+        HARNESS,
+        "Names a forward move when a stage has ended two visits without an approval. The "
+        "outcome field it counts is written by the manager on the way out of each visit. "
+        "It picks from the admissible set the graph hands it and the router checks the "
+        "name against the live moves again, so it can only ever remove alternatives.",
+    ),
+    Gate(
+        "supervisor:no_recovery_left",
+        (),
+        NO_FIELD,
+        "Marks the run for a human and stops spending when the auto-skip budget is spent "
+        "and the run is at or past the stage that writes the deliverable. Both inputs are "
+        "the manager's own in-memory state -- `auto_skipped_stages` and the stage number "
+        "-- so there is no file and nobody to trust. It reproduces the condition "
+        "`_route_to_deliverable` returns False on rather than adding one.",
+    ),
 )
 
 
@@ -421,6 +484,7 @@ def _gates_in_the_tree() -> set[str]:
         found |= _validators_in(path.read_text(encoding="utf-8"), path.stem)
     found |= {f"guard:{name}" for name in GUARDS}
     found |= {f"scorecard:{feature['key']}" for feature in FEATURES}
+    found |= {f"supervisor:{rule}" for rule in SUPERVISOR_RULES}
     return found
 
 

--- a/tests/test_writable_decisive_fields.py
+++ b/tests/test_writable_decisive_fields.py
@@ -388,8 +388,8 @@ GATES: tuple[Gate, ...] = (
     # ------------------------------------------------- the run supervisor's rules
     #
     # Not gates in the sense the rest of this table is -- none of them lets anything
-    # through, and by construction none of them can: `AttemptAllowance.ceiling` is a `min`
-    # against the run's own `--max-attempts` and there is no path from a ruling to an
+    # through, and by construction none of them can: `AttemptAllowance.visit_ceiling` is a
+    # `min` against the run's own `--max-attempts` and there is no path from a ruling to an
     # approval. They are here because they *refuse* spending, and the question this file
     # asks of a refusal is who wrote the field it turns on. Every one of them reads
     # `stage_cost_ledger.json` or an in-memory meter the harness fills, and nothing else.

--- a/tools/supervisor_threshold_replay.py
+++ b/tools/supervisor_threshold_replay.py
@@ -274,10 +274,12 @@ def bought(entry: dict[str, str]) -> tuple[str, ...]:
     rather than worse, because the point of this column is to stop the rule being credited
     with a saving it did not make:
 
-    * an approval the cross-model reviewer then vetoed is not an approval. Six attempts in
-      this population have ``reviewer_choice: 5`` and ``cross_review`` reading
-      ``agrees: False`` on the same attempt; the veto is what the loop acted on, so the
-      attempt bought nothing.
+    * an approval the cross-model reviewer then vetoed is not an approval: the veto is what
+      the loop acted on, so the attempt bought nothing. No count is given for how often that
+      happens because three readings of "this population" produced three answers -- over the
+      cut iterations, over every attempt in the 22 visits, and over every attempt entry the
+      loader returns -- and a number that depends on an unstated slice is not a measurement.
+      Slice it yourself if you need one; the rule above does not.
     * ``obligation_recorded`` and ``obligations_deferred`` are not discharges. Only
       ``obligation_discharged`` counts.
     """

--- a/tools/supervisor_threshold_replay.py
+++ b/tools/supervisor_threshold_replay.py
@@ -3,18 +3,38 @@
 
 The thresholds in :mod:`src.supervisor` are measured rather than chosen, and this is the
 measurement. Point it at finished run directories and it reconstructs, per stage visit,
-the attempt sequence and what each attempt was spent on, then reports for each candidate
-threshold which visits the rule would have acted on and how many attempt-loop iterations
-that would have cost or saved.
+the attempt sequence, what each attempt was spent on, **what each attempt produced**, and
+how the visit ended; then reports for each candidate threshold which visits the rule would
+have acted on and what cutting there would have cost.
+
+The invocation every number in ``src/supervisor.py``'s docstring comes from is the three
+finished runs, named rather than globbed -- see :data:`MEASURED_RUNS`::
 
     python3 tools/supervisor_threshold_replay.py \
-        /rmeng_data/robtang/rcb-trial-graph/workspaces/*/.autor/*/
+        /rmeng_data/robtang/rcb-trial-graph/workspaces/Astronomy_000_20260814_175426/.autor/*/ \
+        /rmeng_data/robtang/rcb-trial-graph/workspaces/Astronomy_000_20260815_074118/.autor/*/ \
+        /rmeng_data/robtang/rcb-trial-graph/workspaces/Chemistry_000_20260816_011751/.autor/*/
+
+The first two lines of the report say which population was loaded and whether it is that
+one. ``workspaces/*/.autor/*/`` picks up a fourth run that is still being written and is a
+different population every day; the report refuses to compare against it.
+
+**Counting iterations is not measuring a saving.** The first version of this instrument
+reported, per candidate threshold, how many attempt-loop iterations the rule would not
+have bought -- and nothing about what those iterations produced. Chosen against that
+column, ``STOP_AFTER_IDENTICAL_FAILURES = 2`` looked like it saved 17 iterations; 16 of
+them came out of two visits that were, at the time, repairing the validation failure,
+promoting a validated draft and discharging obligations, and both of those visits ended
+auto-skipped with the rescued draft as the stage's output. :func:`bought` and
+:func:`draft_was_valid` are the missing columns, and ``inert`` -- iterations that produced
+nothing -- is the one a threshold may be chosen against.
 
 **It calls the shipped predicates.** ``unchanging_failure``, ``disproportionate``,
-``ration`` and ``failure_digest`` are imported, not reimplemented, so a threshold that
-moves in ``src/supervisor.py`` moves here and a rule that changes shape cannot leave a
-stale number behind in a docstring. Reimplementing the rule in the instrument that
-measures it is how a measurement comes out right about a program that does something else.
+``ration``, ``unsettled_visits`` and ``failure_digest`` are imported, not reimplemented, so
+a threshold that moves in ``src/supervisor.py`` moves here and a rule that changes shape
+cannot leave a stale number behind in a docstring. Reimplementing the rule in the
+instrument that measures it is how a measurement comes out right about a program that does
+something else.
 
 **Why it reads ``logs.txt``.** The per-stage cost ledger this replay is *about* did not
 exist when these runs were walked, so the only record of what each attempt was spent on is
@@ -53,21 +73,92 @@ from src.supervisor import (  # noqa: E402
     MIN_ATTEMPTS_AT_STAKE,
     MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION,
     STOP_AFTER_IDENTICAL_FAILURES,
+    UNSETTLED_VISITS_BEFORE_A_REDIRECT,
     countable_digests,
     disproportionate,
     longest_unchanged_run,
     ration,
     unchanging_failure,
+    unsettled_visits,
 )
 
 ENTRY = re.compile(r"^=== ([0-9T:\-]+) \| (.*?) ===$", re.M)
 ATTEMPT = re.compile(r"^(\d\d_[a-z_]+) attempt (\d+) (.*)$")
 SKIP = re.compile(r"^(\d\d_[a-z_]+) unattended_auto_skip$")
+#: How a visit ended, as the manager writes it. `approved` is the only one
+#: :data:`~src.supervisor.SETTLED_OUTCOMES` counts as settled, which is what the redirect
+#: column below has to know per visit.
+CLOSED = re.compile(r"^(\d\d_[a-z_]+) (approved|max_attempts_exceeded|stage_stuck|skipped)$")
 
 #: Stage number of the node that writes the deliverable, for the last-resort rule. The
 #: replayed runs all ran to `WRITING_STAGE`, whose number is read from the shipped stage
 #: list rather than spelled here.
 DELIVERABLE_NUMBER = next(stage.number for stage in STAGES if stage.slug == "07_writing")
+
+# ---------------------------------------------------------------------------
+# The population the shipped numbers were measured over
+# ---------------------------------------------------------------------------
+
+#: The three finished runs of the first live paired trial, named rather than globbed.
+#:
+#: The glob in the usage line above is a *moving target* and quoting a number from it is
+#: how ``src/supervisor.py`` came to claim a denominator no invocation printed. A fourth
+#: run under the same trial directory was still walking when the thresholds were measured
+#: and is still walking now: ``workspaces/*/.autor/*/`` gave 26 visits / 166 iterations
+#: when the branch was written and 27 / 167 the next day, and neither is the population
+#: any threshold here was chosen against. These three have a terminal ``run_complete``,
+#: ``run_aborted`` or ``unattended_abort`` entry in their logs and cannot move again.
+MEASURED_RUNS: tuple[str, ...] = (
+    "Astronomy_000_20260814_175426",
+    "Astronomy_000_20260815_074118",
+    "Chemistry_000_20260816_011751",
+)
+
+#: What :data:`MEASURED_RUNS` reconstructs to. Every population figure in
+#: ``src/supervisor.py``'s docstring is one of these two, and
+#: :func:`population_matches` is what makes running the tool on the documented
+#: invocation refuse to print a different one in silence.
+MEASURED_VISITS = 22
+MEASURED_ITERATIONS = 141
+
+# ---------------------------------------------------------------------------
+# What an iteration bought
+# ---------------------------------------------------------------------------
+
+#: An attempt's own productive outcome, if it had one, most decisive first.
+#:
+#: This column is the one the first version of this instrument did not have, and its
+#: absence is what made ``STOP_AFTER_IDENTICAL_FAILURES`` look measured when it was not.
+#: The old report counted iterations a candidate ``N`` would not have bought and stopped
+#: there. "Not bought" is a cost only if the iteration produced nothing; the two visits
+#: carrying 16 of the 17 iterations ``N=2`` claimed to save each contain a repair that
+#: cleared the validation failure, a promoted draft, and obligations discharged, and both
+#: ended auto-skipped with the validated draft rescued rather than the 1.9KB stub. An
+#: iteration that produced the stage's output is not a saving.
+#:
+#: Each label is a log entry the manager writes at a moment nothing else writes it:
+#:
+#: * ``repair_cleared_validation`` -- the attempt failed validation and did *not* go on to
+#:   record ``local_normalization_failed``, which is the manager's own record that repair
+#:   or local normalisation put the draft back inside the gate. This is the state the
+#:   attempt loop calls a cleared failure, so a cut before it throws away a fix that worked.
+#: * ``draft_promoted`` -- ``evolution_promoted`` or ``evolution_first``: a validated draft
+#:   entered or won the champion slot, which is exactly what ``_validated_draft_for_skip``
+#:   looks for when a visit is auto-skipped.
+#: * ``reviewer_approved`` -- the approval gate returned an approval on this attempt.
+#: * ``obligations_discharged`` -- ``obligation_discharged``, one per obligation closed.
+PRODUCED_REPAIR = "repair_cleared_validation"
+PRODUCED_DRAFT = "draft_promoted"
+PRODUCED_APPROVAL = "reviewer_approved"
+PRODUCED_OBLIGATIONS = "obligations_discharged"
+PRODUCED_NOTHING = "nothing"
+
+PRODUCTIVE_OUTCOMES: tuple[str, ...] = (
+    PRODUCED_APPROVAL,
+    PRODUCED_DRAFT,
+    PRODUCED_REPAIR,
+    PRODUCED_OBLIGATIONS,
+)
 
 
 def _entries(path: Path) -> list[tuple[str, str, str]]:
@@ -95,21 +186,30 @@ def _reason(body: str) -> str:
 
 
 def visits(path: Path) -> list[dict[str, Any]]:
-    """One entry per stage visit: its slug, and one record per attempt.
+    """One entry per stage visit: its slug, how it ended, and one record per attempt.
 
     A visit is a maximal run of consecutive attempt entries carrying the same slug, which
     is what a stage visit looks like in the log: the manager writes nothing for another
-    stage while one is open.
+    stage while one is open. ``outcome`` is the closing entry that follows those attempts
+    -- ``approved`` or one of the three ways a visit ends without one -- and it is what
+    the redirect column reads through the shipped :func:`~src.supervisor.unsettled_visits`.
     """
     sequence: list[tuple[str, int, str, str]] = []
     #: Auto-skips the run had spent by the time each attempt entry was written. The run
     #: log records one `unattended_auto_skip` per unit, so counting them forward gives the
     #: state the last-resort rule reads at every boundary.
     skips_at: dict[int, int] = {}
+    #: How the visit that owned each attempt ended, keyed the same way: the closing entry
+    #: is written after the attempts, so it is attached backwards to the open group.
+    closed_at: dict[int, str] = {}
     spent = 0
     for _, heading, body in _entries(path):
         if SKIP.match(heading):
             spent += 1
+            continue
+        ending = CLOSED.match(heading)
+        if ending is not None:
+            closed_at[len(sequence)] = ending.group(2)
             continue
         match = ATTEMPT.match(heading)
         if match:
@@ -142,6 +242,8 @@ def visits(path: Path) -> list[dict[str, Any]]:
                     "attempt": number,
                     "kind": kind,
                     "digest": failure_digest(kind, reason) if kind else "",
+                    "bought": bought(entry),
+                    "draft_valid": draft_was_valid(entry),
                 }
             )
         number = next((item.number for item in STAGES if item.slug == slug), 0)
@@ -150,10 +252,66 @@ def visits(path: Path) -> list[dict[str, Any]]:
                 "stage": slug,
                 "stage_number": number,
                 "skips_before": skips_before,
+                # `approved` is the only settled outcome; a visit whose closing entry is
+                # missing from the log (a run killed mid-visit) is not an approval either,
+                # and reading it as one would be the unsafe direction.
+                "outcome": closed_at.get(seen, ""),
                 "attempts": attempts,
             }
         )
     return out
+
+
+def bought(entry: dict[str, str]) -> tuple[str, ...]:
+    """What one attempt produced, from the entries the manager wrote for it.
+
+    Empty for an attempt that produced nothing. An attempt can buy more than one thing --
+    the promoted draft and the obligations discharged beside it are one attempt in both of
+    the visits ``N=2`` would have cut -- so this is a tuple ordered by
+    :data:`PRODUCTIVE_OUTCOMES` rather than a single label.
+
+    Two deliberate conservatisms, both in the direction that makes the *rule* look better
+    rather than worse, because the point of this column is to stop the rule being credited
+    with a saving it did not make:
+
+    * an approval the cross-model reviewer then vetoed is not an approval. Six attempts in
+      this population have ``reviewer_choice: 5`` and ``cross_review`` reading
+      ``agrees: False`` on the same attempt; the veto is what the loop acted on, so the
+      attempt bought nothing.
+    * ``obligation_recorded`` and ``obligations_deferred`` are not discharges. Only
+      ``obligation_discharged`` counts.
+    """
+    produced: list[str] = []
+    gate = entry.get("reviewer_choice")
+    audit = entry.get("cross_review")
+    vetoed = audit is not None and _field(audit, "agrees") == "False"
+    if not vetoed and ("approved" in entry or (gate is not None and _field(gate, "choice") == "5")):
+        produced.append(PRODUCED_APPROVAL)
+    if "evolution_promoted" in entry or "evolution_first" in entry:
+        produced.append(PRODUCED_DRAFT)
+    if "validation_failed" in entry and "local_normalization_failed" not in entry:
+        produced.append(PRODUCED_REPAIR)
+    if "obligation_discharged" in entry:
+        produced.append(PRODUCED_OBLIGATIONS)
+    return tuple(label for label in PRODUCTIVE_OUTCOMES if label in produced)
+
+
+def draft_was_valid(entry: dict[str, str]) -> bool:
+    """Whether the draft on disk was inside the gate when this attempt ended.
+
+    The decisive column, and the one behind the harm ``N=2`` would have done. When a visit
+    is auto-skipped, :meth:`~src.manager.ResearchManager._validated_draft_for_skip` reads
+    the tmp draft and keeps it as the stage's output if it still passes the markdown and
+    artifact gates; otherwise the 1.9KB skip stub becomes the output every downstream
+    stage reads. ``local_normalization_failed`` is the manager's own record that the draft
+    did *not* pass, so an attempt that ends there is an attempt after which there is
+    nothing to rescue.
+
+    That is a structural fact about ``stop_spending`` and not a fact about this data: the
+    rule cuts on a *repeated* failure, and a repeated validator refusal is by construction
+    a moment at which the draft is outside the gate.
+    """
+    return "local_normalization_failed" not in entry
 
 
 def _classify(entry: dict[str, str]) -> tuple[str, str]:
@@ -246,6 +404,12 @@ def stop_fires(
                     if left < at_stake:
                         continue
                 if unchanging_failure(window, repeats=repeats):
+                    cut = [
+                        other
+                        for other in visit["attempts"]
+                        if other["attempt"] > item["attempt"]
+                    ]
+                    produced = [label for other in cut for label in other["bought"]]
                     fires.append(
                         {
                             "run": name,
@@ -253,6 +417,19 @@ def stop_fires(
                             "cut_after": item["attempt"],
                             "visit_ran_to": visit["attempts"][-1]["attempt"],
                             "iterations": len(visit["attempts"]),
+                            # The column the first version of this instrument did not
+                            # have. `cut_iterations` is what the old report called
+                            # "not bought"; the two beside it split that number by
+                            # whether the iteration produced anything.
+                            "cut_iterations": len(cut),
+                            "cut_productive": sum(1 for other in cut if other["bought"]),
+                            "cut_inert": sum(1 for other in cut if not other["bought"]),
+                            "produced": produced,
+                            "outcome": visit["outcome"],
+                            # Whether the visit would still have had something to rescue
+                            # if it had ended here. See `draft_was_valid`.
+                            "draft_valid_at_cut": item["draft_valid"],
+                            "draft_valid_at_end": visit["attempts"][-1]["draft_valid"],
                         }
                     )
                     break
@@ -272,12 +449,30 @@ def reallocate_fires(
     *shadowed_by_stop* replays the rules in the order the supervisor asks them: a visit
     ``stop_spending`` has already cut cannot also be reallocated, and a proportionality
     rule that counts those visits is taking credit for another rule's work.
+
+    The two spends here are deliberately different numbers, because the rule asks two
+    different questions with them, and the supervisor passes the same two:
+
+    * the *trigger* is the stage's charged attempts summed over all its visits against the
+      median of the stages that have closed -- lifetime against lifetime, which is what
+      "disproportionate on the run's own terms" means;
+    * the *amount* is what this **visit** has charged plus that median, because the pool
+      is denominated in per-visit allowances. Comparing a per-visit allowance against a
+      lifetime spend is how a rule stops firing on exactly the revisits it was written
+      for: on a second visit the lifetime spend already exceeds the ceiling and the
+      surplus is always zero.
     """
     fires: list[dict[str, Any]] = []
     for name, walk in runs:
         closed: dict[str, int] = {}
-        for visit in walk:
+        for index, visit in enumerate(walk):
             slug = visit["stage"]
+            # What the stage's *later* visits went on to charge. A transfer lowers the
+            # donor's per-visit allowance for good, so whether the intervention cost the
+            # run anything is a question about the visits after it, not about this one.
+            later = [
+                charged(other) for other in walk[index + 1 :] if other["stage"] == slug
+            ]
             cut = None
             if shadowed_by_stop:
                 stops = stop_fires(
@@ -291,8 +486,9 @@ def reallocate_fires(
             for item in visit["attempts"]:
                 if cut is not None and item["attempt"] > cut:
                     break
-                spent = closed.get(slug, 0) + charged(visit, through=item["attempt"])
-                keep = ration(spent, others) if others else 0
+                in_visit = charged(visit, through=item["attempt"])
+                spent = closed.get(slug, 0) + in_visit
+                keep = ration(in_visit, others) if others else 0
                 surplus = max((ceiling or 0) - keep, 0)
                 unentered = [
                     item.slug
@@ -317,10 +513,59 @@ def reallocate_fires(
                             "moves": surplus,
                             "to": unentered,
                             "visit_spent": charged(visit),
+                            "later_visits": later,
+                            # Whether the narrowed per-visit allowance would have bound:
+                            # this visit's remaining spend, or any later visit's.
+                            "binds": charged(visit) > keep or any(spent > keep for spent in later),
                         }
                     )
                     break
             closed[slug] = closed.get(slug, 0) + charged(visit)
+    return fires
+
+
+def redirect_fires(
+    runs: Sequence[tuple[str, list[dict[str, Any]]]],
+    *,
+    unsettled_before: int = UNSETTLED_VISITS_BEFORE_A_REDIRECT,
+) -> list[dict[str, Any]]:
+    """Where ``redirect`` would have been reached, at each stage exit.
+
+    This column did not exist, and two sentences in :mod:`src.supervisor` credited this
+    file with producing it anyway. The rule is ``unsettled_visits(rows, slug) >=
+    UNSETTLED_VISITS_BEFORE_A_REDIRECT`` evaluated where the manager evaluates it -- on
+    the way out of a stage, over the ledger rows closed *including* the visit that has
+    just ended, because ``_run_stage`` appends the row before ``_advance_from`` asks.
+
+    ``unsettled_visits`` is imported, not reimplemented, so this reports on the shipped
+    predicate; what the replay supplies is the ``outcome`` per visit, reconstructed from
+    the closing entry in the log. The rows are shaped as
+    :func:`~src.stage_cost.read_stage_cost_ledger` returns them for the same reason.
+
+    What is *not* replayed is the second half of the rule -- whether the graph left a
+    forward edge open at that exit -- because the admissible set is computed from live
+    graph state the log does not carry. That only ever removes firings, so a count of
+    zero here is a count of zero for the whole rule, and any non-zero count is an upper
+    bound. The report says so beside the number.
+    """
+    fires: list[dict[str, Any]] = []
+    for name, walk in runs:
+        rows: list[dict[str, Any]] = []
+        for visit in walk:
+            # The log's closing entry is already the ledger's vocabulary for the one
+            # outcome that matters here: `approved` is `OUTCOME_APPROVED`, and every
+            # other closing entry is one of the ways a visit ends without an approval.
+            rows.append({"stage": visit["stage"], "outcome": visit["outcome"]})
+            unsettled = unsettled_visits(rows, visit["stage"])
+            if unsettled >= unsettled_before:
+                fires.append(
+                    {
+                        "run": name,
+                        "stage": visit["stage"],
+                        "unsettled": unsettled,
+                        "visits": sum(1 for row in rows if row["stage"] == visit["stage"]),
+                    }
+                )
     return fires
 
 
@@ -359,6 +604,53 @@ def escalate_fires(
                     )
                     break
     return fires
+
+
+def population_matches(names: Sequence[str], visits_seen: int, iterations: int) -> str:
+    """One line saying whether this invocation is the documented one, and whether it drifted.
+
+    Three answers, and the middle one is the whole point of the function. If *names* is
+    not :data:`MEASURED_RUNS` the report says so and claims nothing: a reader who globbed
+    a directory containing a run still being written is looking at a different population
+    from the one the thresholds were chosen against, and no comparison is offered. If it
+    *is* :data:`MEASURED_RUNS` and the totals differ from :data:`MEASURED_VISITS` and
+    :data:`MEASURED_ITERATIONS`, the line says ``DRIFTED`` and prints both -- which is the
+    only mechanism by which a number written into ``src/supervisor.py``'s docstring can
+    stop being true out loud rather than quietly.
+    """
+    if tuple(names) != MEASURED_RUNS:
+        return (
+            "population: not the recorded one "
+            f"({len(names)} run(s)); the recorded population is "
+            f"{', '.join(MEASURED_RUNS)}, and no docstring figure describes this one"
+        )
+    if (visits_seen, iterations) != (MEASURED_VISITS, MEASURED_ITERATIONS):
+        return (
+            f"population: DRIFTED -- the recorded population is {MEASURED_VISITS} visit(s) "
+            f"and {MEASURED_ITERATIONS} iteration(s), this reconstruction is {visits_seen} "
+            f"and {iterations}; src/supervisor.py's docstring is now wrong"
+        )
+    return (
+        f"population: as recorded -- {MEASURED_VISITS} visit(s), "
+        f"{MEASURED_ITERATIONS} iteration(s) over {len(MEASURED_RUNS)} finished run(s)"
+    )
+
+
+def _stop_totals(fires: Sequence[dict[str, Any]], total_visits: int) -> str:
+    """The two columns, side by side, so neither can be quoted without the other.
+
+    The first version of this report printed only ``cut``. That number is what the rule
+    *stops*, not what it *saves*, and the difference is the whole of item 2 of the fix:
+    16 of the 17 iterations ``N=2`` claimed came out of two visits that were producing
+    the stage's output at the time.
+    """
+    cut = sum(fire["cut_iterations"] for fire in fires)
+    inert = sum(fire["cut_inert"] for fire in fires)
+    productive = sum(fire["cut_productive"] for fire in fires)
+    return (
+        f"{len(fires)} of {total_visits} visits, {cut} iteration(s) cut "
+        f"({inert} inert, {productive} productive)"
+    )
 
 
 def load(paths: Iterable[str]) -> list[tuple[str, list[dict[str, Any]]]]:
@@ -400,6 +692,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     total_visits = sum(len(walk) for _, walk in runs)
     total_iterations = sum(len(visit["attempts"]) for _, walk in runs for visit in walk)
     print(f"{len(runs)} run(s), {total_visits} stage visit(s), {total_iterations} attempt-loop iteration(s)")
+    print(population_matches([name for name, _ in runs], total_visits, total_iterations))
 
     if args.per_visit:
         for name, walk in runs:
@@ -409,26 +702,37 @@ def main(argv: Sequence[str] | None = None) -> int:
                 print(
                     f"  {visit['stage']:26s} iterations={len(visit['attempts']):2d} "
                     f"charged={charged(visit):2d} distinct={len(set(digests)):2d} "
-                    f"longest_unchanged_run={longest_unchanged_run(digests)}"
+                    f"longest_unchanged_run={longest_unchanged_run(digests)} "
+                    f"outcome={visit['outcome'] or 'unclosed'} "
+                    f"productive_iterations="
+                    f"{sum(1 for item in visit['attempts'] if item['bought'])}"
                 )
 
     print(
         f"\n== stop_spending: identical failure digests in a row "
-        f"(shipped value {STOP_AFTER_IDENTICAL_FAILURES}, at stake {MIN_ATTEMPTS_AT_STAKE}) =="
+        f"(shipped value {STOP_AFTER_IDENTICAL_FAILURES}, at stake {MIN_ATTEMPTS_AT_STAKE}) ==\n"
+        "   `cut` is how many attempt-loop iterations the rule would not have bought.\n"
+        "   `inert` is how many of those produced nothing, and it is the column N is\n"
+        "   chosen against: an iteration that repaired the failure, promoted a validated\n"
+        "   draft, won an approval or discharged an obligation is not a saving."
     )
     for stake in (0, MIN_ATTEMPTS_AT_STAKE):
         label = "any saving" if not stake else f"{stake} attempt(s) at stake"
         for repeats in (2, 3, 4, 5):
             fires = stop_fires(runs, repeats, ceiling=args.max_attempts, at_stake=stake)
-            saved = sum(fire["iterations"] - fire["cut_after"] for fire in fires)
-            print(
-                f"  N={repeats}, {label}: {len(fires)} of {total_visits} visits, "
-                f"{saved} iteration(s) not bought"
-            )
+            print(f"  N={repeats}, {label}: {_stop_totals(fires, total_visits)}")
             for fire in fires:
                 print(
                     f"        {fire['run']:30s} {fire['stage']:24s} cut after attempt "
-                    f"{fire['cut_after']:2d}; the visit ran to {fire['iterations']} iteration(s)"
+                    f"{fire['cut_after']:2d}; the visit ran to {fire['iterations']} "
+                    f"iteration(s) and ended {fire['outcome'] or 'unclosed'}; "
+                    f"cut {fire['cut_iterations']} "
+                    f"({fire['cut_inert']} inert, {fire['cut_productive']} productive"
+                    + (f": {', '.join(sorted(set(fire['produced'])))}" if fire["produced"] else "")
+                    + f"); draft inside the gate at the cut: "
+                    + ("yes" if fire["draft_valid_at_cut"] else "NO")
+                    + ", at the visit's real end: "
+                    + ("yes" if fire["draft_valid_at_end"] else "no")
                 )
 
     print("\n== control: the same rule on the failure KIND rather than the digest ==")
@@ -436,11 +740,25 @@ def main(argv: Sequence[str] | None = None) -> int:
         fires = stop_fires(
             runs, repeats, ceiling=args.max_attempts, at_stake=MIN_ATTEMPTS_AT_STAKE, on_kinds=True
         )
-        saved = sum(fire["iterations"] - fire["cut_after"] for fire in fires)
+        print(f"  N={repeats} on kinds: {_stop_totals(fires, total_visits)}")
+
+    print(
+        f"\n== redirect: visits that ended without an approval, per stage "
+        f"(shipped value {UNSETTLED_VISITS_BEFORE_A_REDIRECT}) ==\n"
+        "   An upper bound: the admissible forward set is live graph state the log does\n"
+        "   not carry, and requiring it can only remove firings."
+    )
+    for unsettled_before in (1, 2, 3):
+        fires = redirect_fires(runs, unsettled_before=unsettled_before)
         print(
-            f"  N={repeats} on kinds: {len(fires)} of {total_visits} visits, "
-            f"{saved} iteration(s) not bought"
+            f"  {unsettled_before} unsettled visit(s): {len(fires)} of {total_visits} "
+            f"stage exits reach the threshold"
         )
+        for fire in fires:
+            print(
+                f"        {fire['run']:30s} {fire['stage']:24s} "
+                f"{fire['unsettled']} unsettled of {fire['visits']} visit(s)"
+            )
 
     print("\n== escalate: the last resort, and what taking it would have cost ==")
     fires = escalate_fires(runs, ceiling=args.max_attempts, max_auto_skips=args.max_auto_skips)
@@ -477,7 +795,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                         f"{fire['at_attempt']:2d}: {fire['charged']} charged vs median "
                         f"{fire['median']}, ration {fire['ration']}, moving "
                         f"{fire['moves']} unit(s) to {', '.join(fire['to']) or 'nobody'}; "
-                        f"the visit went on to charge {fire['visit_spent']}"
+                        f"the visit charged {fire['visit_spent']} in total and this "
+                        f"stage's later visits charged "
+                        f"{', '.join(str(item) for item in fire['later_visits']) or 'nothing'}"
+                        f"; the narrowed per-visit allowance "
+                        + ("BINDS" if fire["binds"] else "binds nothing")
                     )
     return 0
 

--- a/tools/supervisor_threshold_replay.py
+++ b/tools/supervisor_threshold_replay.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Replay finished runs against the supervisor's rules, and report what would have fired.
+
+The thresholds in :mod:`src.supervisor` are measured rather than chosen, and this is the
+measurement. Point it at finished run directories and it reconstructs, per stage visit,
+the attempt sequence and what each attempt was spent on, then reports for each candidate
+threshold which visits the rule would have acted on and how many attempt-loop iterations
+that would have cost or saved.
+
+    python3 tools/supervisor_threshold_replay.py \
+        /rmeng_data/robtang/rcb-trial-graph/workspaces/*/.autor/*/
+
+**It calls the shipped predicates.** ``unchanging_failure``, ``disproportionate``,
+``ration`` and ``failure_digest`` are imported, not reimplemented, so a threshold that
+moves in ``src/supervisor.py`` moves here and a rule that changes shape cannot leave a
+stale number behind in a docstring. Reimplementing the rule in the instrument that
+measures it is how a measurement comes out right about a program that does something else.
+
+**Why it reads ``logs.txt``.** The per-stage cost ledger this replay is *about* did not
+exist when these runs were walked, so the only record of what each attempt was spent on is
+the run's own log. The reconstruction below mirrors :func:`src.stage_cost.classify_refusal`
+and the attempt loop's control flow: an attempt is charged to the validators when local
+normalisation failed after repair, to the cross-model reviewer when the audit disagreed,
+to the polish loop when the evolution controller directed another round, and to the
+approval gate when the reviewer's choice was not an approval. It is a reconstruction, and
+the flag ``--per-visit`` prints it in full so a reader can check it against the log rather
+than take it on trust.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import re
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.stage_cost import (  # noqa: E402
+    CROSS_REVIEW_VETOED,
+    POLISH_ROUND,
+    REVIEWER_REFUSED,
+    VALIDATORS_REFUSED,
+    failure_digest,
+)
+from src.utils import STAGES  # noqa: E402
+from src.supervisor import (  # noqa: E402
+    DISPROPORTIONATE_MULTIPLE,
+    MIN_ATTEMPTS_AT_STAKE,
+    MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION,
+    STOP_AFTER_IDENTICAL_FAILURES,
+    countable_digests,
+    disproportionate,
+    longest_unchanged_run,
+    ration,
+    unchanging_failure,
+)
+
+ENTRY = re.compile(r"^=== ([0-9T:\-]+) \| (.*?) ===$", re.M)
+ATTEMPT = re.compile(r"^(\d\d_[a-z_]+) attempt (\d+) (.*)$")
+SKIP = re.compile(r"^(\d\d_[a-z_]+) unattended_auto_skip$")
+
+#: Stage number of the node that writes the deliverable, for the last-resort rule. The
+#: replayed runs all ran to `WRITING_STAGE`, whose number is read from the shipped stage
+#: list rather than spelled here.
+DELIVERABLE_NUMBER = next(stage.number for stage in STAGES if stage.slug == "07_writing")
+
+
+def _entries(path: Path) -> list[tuple[str, str, str]]:
+    """Every ``=== timestamp | heading ===`` block in a run log, with its body."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    out: list[tuple[str, str, str]] = []
+    last: tuple[str, str, int] | None = None
+    for match in ENTRY.finditer(text):
+        if last is not None:
+            out.append((last[0], last[1], text[last[2] : match.start()]))
+        last = (match.group(1), match.group(2), match.end())
+    if last is not None:
+        out.append((last[0], last[1], text[last[2] :]))
+    return out
+
+
+def _field(body: str, name: str) -> str:
+    match = re.search(rf"^{name}:\s*(.*)$", body, re.M)
+    return match.group(1).strip() if match else ""
+
+
+def _reason(body: str) -> str:
+    match = re.search(r"^reason:\s*(.*)", body, re.M | re.S)
+    return match.group(1).strip() if match else ""
+
+
+def visits(path: Path) -> list[dict[str, Any]]:
+    """One entry per stage visit: its slug, and one record per attempt.
+
+    A visit is a maximal run of consecutive attempt entries carrying the same slug, which
+    is what a stage visit looks like in the log: the manager writes nothing for another
+    stage while one is open.
+    """
+    sequence: list[tuple[str, int, str, str]] = []
+    #: Auto-skips the run had spent by the time each attempt entry was written. The run
+    #: log records one `unattended_auto_skip` per unit, so counting them forward gives the
+    #: state the last-resort rule reads at every boundary.
+    skips_at: dict[int, int] = {}
+    spent = 0
+    for _, heading, body in _entries(path):
+        if SKIP.match(heading):
+            spent += 1
+            continue
+        match = ATTEMPT.match(heading)
+        if match:
+            skips_at[len(sequence)] = spent
+            sequence.append((match.group(1), int(match.group(2)), match.group(3), body))
+
+    grouped: list[tuple[str, list[tuple[int, str, str]]]] = []
+    for slug, number, kind, body in sequence:
+        if not grouped or grouped[-1][0] != slug:
+            grouped.append((slug, []))
+        grouped[-1][1].append((number, kind, body))
+
+    seen = 0
+    out: list[dict[str, Any]] = []
+    for slug, items in grouped:
+        skips_before = skips_at.get(seen, 0)
+        seen += len(items)
+        by_attempt: dict[int, dict[str, str]] = defaultdict(dict)
+        order: list[int] = []
+        for number, kind, body in items:
+            if number not in by_attempt:
+                order.append(number)
+            by_attempt[number][kind] = body
+        attempts: list[dict[str, Any]] = []
+        for number in order:
+            entry = by_attempt[number]
+            kind, reason = _classify(entry)
+            attempts.append(
+                {
+                    "attempt": number,
+                    "kind": kind,
+                    "digest": failure_digest(kind, reason) if kind else "",
+                }
+            )
+        number = next((item.number for item in STAGES if item.slug == slug), 0)
+        out.append(
+            {
+                "stage": slug,
+                "stage_number": number,
+                "skips_before": skips_before,
+                "attempts": attempts,
+            }
+        )
+    return out
+
+
+def _classify(entry: dict[str, str]) -> tuple[str, str]:
+    """What one attempt was spent on, in :mod:`src.stage_cost`'s vocabulary.
+
+    Ordered as the attempt loop is: a draft that failed validation, repair and local
+    normalisation is charged to the validators before anything else looks at it; a
+    cross-model veto overrides an approval the primary gave, so it is read before the
+    primary's own choice; a directed polish round is not a failure and is charged to the
+    polish budget.
+    """
+    if "local_normalization_failed" in entry:
+        return VALIDATORS_REFUSED, entry.get("validation_failed", entry["local_normalization_failed"])
+    audit = entry.get("cross_review")
+    if audit is not None and _field(audit, "agrees") == "False":
+        return CROSS_REVIEW_VETOED, _reason(audit)
+    if "evolution_directed" in entry:
+        return POLISH_ROUND, ""
+    gate = entry.get("reviewer_choice")
+    if gate is not None and _field(gate, "choice") not in {"5", "6", ""}:
+        return REVIEWER_REFUSED, _reason(gate)
+    return "", ""
+
+
+def charged(visit: dict[str, Any], through: int | None = None) -> int:
+    """Attempts in *visit* that the loop charges against ``--max-attempts``."""
+    return sum(
+        1
+        for item in visit["attempts"]
+        if item["kind"] != POLISH_ROUND and (through is None or item["attempt"] <= through)
+    )
+
+
+def failure_digests(visit: dict[str, Any], through: int | None = None) -> list[str]:
+    """The visit's countable failure digests in order, filtered by the shipped rule."""
+    return countable_digests(
+        [
+            item
+            for item in visit["attempts"]
+            if item["kind"]
+            and item["kind"] != POLISH_ROUND
+            and (through is None or item["attempt"] <= through)
+        ]
+    )
+
+
+def kind_runs(visit: dict[str, Any], through: int | None = None) -> list[str]:
+    """The visit's failure *kinds* in order: the looser rule, for the control column.
+
+    "The reviewer refused three times running" is a weaker claim than "the reviewer made
+    the same objection three times running", and the report prints what the weaker one
+    would have cost so the choice of digest is a measured one rather than an assumed one.
+    """
+    return [
+        item["kind"]
+        for item in visit["attempts"]
+        if item["kind"]
+        and item["kind"] != POLISH_ROUND
+        and (through is None or item["attempt"] <= through)
+    ]
+
+
+def stop_fires(
+    runs: Sequence[tuple[str, list[dict[str, Any]]]],
+    repeats: int,
+    *,
+    ceiling: int | None = None,
+    at_stake: int = 0,
+    on_kinds: bool = False,
+) -> list[dict[str, Any]]:
+    """Where ``stop_spending`` would have cut, at *repeats* identical failures.
+
+    *at_stake* replays the second half of the rule: the intervention is declined when the
+    run's own ``--max-attempts`` is within that many attempts of ending the visit anyway.
+    Zero replays the rule without it, which is what the two columns in the report compare.
+    """
+    fires: list[dict[str, Any]] = []
+    for name, walk in runs:
+        for visit in walk:
+            for item in visit["attempts"]:
+                if not item["kind"] or item["kind"] == POLISH_ROUND:
+                    continue
+                window = (
+                    kind_runs(visit, through=item["attempt"])
+                    if on_kinds
+                    else failure_digests(visit, through=item["attempt"])
+                )
+                if ceiling is not None and at_stake:
+                    left = max(ceiling - charged(visit, through=item["attempt"]), 0)
+                    if left < at_stake:
+                        continue
+                if unchanging_failure(window, repeats=repeats):
+                    fires.append(
+                        {
+                            "run": name,
+                            "stage": visit["stage"],
+                            "cut_after": item["attempt"],
+                            "visit_ran_to": visit["attempts"][-1]["attempt"],
+                            "iterations": len(visit["attempts"]),
+                        }
+                    )
+                    break
+    return fires
+
+
+def reallocate_fires(
+    runs: Sequence[tuple[str, list[dict[str, Any]]]],
+    *,
+    multiple: float,
+    minimum_population: int,
+    shadowed_by_stop: bool,
+    ceiling: int | None = None,
+) -> list[dict[str, Any]]:
+    """Where ``reallocate`` would have fired, on the run's own distribution.
+
+    *shadowed_by_stop* replays the rules in the order the supervisor asks them: a visit
+    ``stop_spending`` has already cut cannot also be reallocated, and a proportionality
+    rule that counts those visits is taking credit for another rule's work.
+    """
+    fires: list[dict[str, Any]] = []
+    for name, walk in runs:
+        closed: dict[str, int] = {}
+        for visit in walk:
+            slug = visit["stage"]
+            cut = None
+            if shadowed_by_stop:
+                stops = stop_fires(
+                    [(name, [visit])],
+                    STOP_AFTER_IDENTICAL_FAILURES,
+                    ceiling=ceiling,
+                    at_stake=MIN_ATTEMPTS_AT_STAKE,
+                )
+                cut = stops[0]["cut_after"] if stops else None
+            others = [value for other, value in closed.items() if other != slug]
+            for item in visit["attempts"]:
+                if cut is not None and item["attempt"] > cut:
+                    break
+                spent = closed.get(slug, 0) + charged(visit, through=item["attempt"])
+                keep = ration(spent, others) if others else 0
+                surplus = max((ceiling or 0) - keep, 0)
+                unentered = [
+                    item.slug
+                    for item in STAGES
+                    if item.slug not in closed and item.slug != slug
+                ]
+                if (
+                    surplus > 0
+                    and unentered
+                    and disproportionate(
+                        spent, others, multiple=multiple, minimum_population=minimum_population
+                    )
+                ):
+                    fires.append(
+                        {
+                            "run": name,
+                            "stage": slug,
+                            "at_attempt": item["attempt"],
+                            "charged": spent,
+                            "median": statistics.median(others),
+                            "ration": keep,
+                            "moves": surplus,
+                            "to": unentered,
+                            "visit_spent": charged(visit),
+                        }
+                    )
+                    break
+            closed[slug] = closed.get(slug, 0) + charged(visit)
+    return fires
+
+
+def escalate_fires(
+    runs: Sequence[tuple[str, list[dict[str, Any]]]],
+    *,
+    ceiling: int,
+    max_auto_skips: int,
+) -> list[dict[str, Any]]:
+    """Where the last resort would have been reached, and what it would have cost.
+
+    The three conditions in :mod:`src.supervisor`'s ``no_recovery_left``, replayed: the
+    skip budget spent, the run at or past the node that writes the deliverable, and the
+    visit with nothing left to buy. ``cost`` is how many attempt-loop iterations the
+    ruling would have taken away, and zero is the answer the third condition exists to
+    produce.
+    """
+    fires: list[dict[str, Any]] = []
+    for name, walk in runs:
+        for visit in walk:
+            if visit["skips_before"] < max_auto_skips or visit["stage_number"] < DELIVERABLE_NUMBER:
+                continue
+            for item in visit["attempts"]:
+                spent = charged(visit, through=item["attempt"])
+                at_stake = max(ceiling - spent, 0)
+                window = failure_digests(visit, through=item["attempt"])
+                if at_stake <= 0 or unchanging_failure(window):
+                    fires.append(
+                        {
+                            "run": name,
+                            "stage": visit["stage"],
+                            "at_attempt": item["attempt"],
+                            "skips_before": visit["skips_before"],
+                            "cost": len(visit["attempts"]) - item["attempt"],
+                        }
+                    )
+                    break
+    return fires
+
+
+def load(paths: Iterable[str]) -> list[tuple[str, list[dict[str, Any]]]]:
+    runs: list[tuple[str, list[dict[str, Any]]]] = []
+    for pattern in paths:
+        for match in sorted(glob.glob(pattern)):
+            log = Path(match) / "logs.txt" if Path(match).is_dir() else Path(match)
+            if log.exists():
+                runs.append((log.parent.parent.parent.name, visits(log)))
+    return runs
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("runs", nargs="+", help="run directories, or logs.txt paths")
+    parser.add_argument("--per-visit", action="store_true", help="print the reconstruction itself")
+    parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=8,
+        help="the per-visit ceiling the replayed runs walked under. The trial's four runs "
+             "were driven by rcb_agent.py, whose DEFAULT_MAX_ATTEMPTS is 8, and their logs "
+             "say 'Exceeded 8 attempts'. Defaults to 8.",
+    )
+    parser.add_argument(
+        "--max-auto-skips",
+        type=int,
+        default=3,
+        help="the auto-skip budget the replayed runs walked under. Defaults to 3, which is "
+             "ResearchManager's own default and what the trial's four runs report in their "
+             "skip stubs.",
+    )
+    args = parser.parse_args(argv)
+
+    runs = load(args.runs)
+    if not runs:
+        print("no runs found")
+        return 1
+    total_visits = sum(len(walk) for _, walk in runs)
+    total_iterations = sum(len(visit["attempts"]) for _, walk in runs for visit in walk)
+    print(f"{len(runs)} run(s), {total_visits} stage visit(s), {total_iterations} attempt-loop iteration(s)")
+
+    if args.per_visit:
+        for name, walk in runs:
+            print(f"\n### {name}")
+            for visit in walk:
+                digests = failure_digests(visit)
+                print(
+                    f"  {visit['stage']:26s} iterations={len(visit['attempts']):2d} "
+                    f"charged={charged(visit):2d} distinct={len(set(digests)):2d} "
+                    f"longest_unchanged_run={longest_unchanged_run(digests)}"
+                )
+
+    print(
+        f"\n== stop_spending: identical failure digests in a row "
+        f"(shipped value {STOP_AFTER_IDENTICAL_FAILURES}, at stake {MIN_ATTEMPTS_AT_STAKE}) =="
+    )
+    for stake in (0, MIN_ATTEMPTS_AT_STAKE):
+        label = "any saving" if not stake else f"{stake} attempt(s) at stake"
+        for repeats in (2, 3, 4, 5):
+            fires = stop_fires(runs, repeats, ceiling=args.max_attempts, at_stake=stake)
+            saved = sum(fire["iterations"] - fire["cut_after"] for fire in fires)
+            print(
+                f"  N={repeats}, {label}: {len(fires)} of {total_visits} visits, "
+                f"{saved} iteration(s) not bought"
+            )
+            for fire in fires:
+                print(
+                    f"        {fire['run']:30s} {fire['stage']:24s} cut after attempt "
+                    f"{fire['cut_after']:2d}; the visit ran to {fire['iterations']} iteration(s)"
+                )
+
+    print("\n== control: the same rule on the failure KIND rather than the digest ==")
+    for repeats in (2, 3, 4):
+        fires = stop_fires(
+            runs, repeats, ceiling=args.max_attempts, at_stake=MIN_ATTEMPTS_AT_STAKE, on_kinds=True
+        )
+        saved = sum(fire["iterations"] - fire["cut_after"] for fire in fires)
+        print(
+            f"  N={repeats} on kinds: {len(fires)} of {total_visits} visits, "
+            f"{saved} iteration(s) not bought"
+        )
+
+    print("\n== escalate: the last resort, and what taking it would have cost ==")
+    fires = escalate_fires(runs, ceiling=args.max_attempts, max_auto_skips=args.max_auto_skips)
+    print(f"  {len(fires)} of {total_visits} visits")
+    for fire in fires:
+        print(
+            f"        {fire['run']:30s} {fire['stage']:24s} at attempt {fire['at_attempt']:2d} "
+            f"with {fire['skips_before']} skip(s) already spent; "
+            f"{fire['cost']} iteration(s) taken away"
+        )
+
+    print(
+        f"\n== reallocate: a stage's charged attempts vs the run's own median "
+        f"(shipped values {DISPROPORTIONATE_MULTIPLE}x, {MIN_CLOSED_STAGES_FOR_A_DISTRIBUTION} closed stages) =="
+    )
+    for multiple in (1.5, 2, 2.5, 3):
+        for population in (2, 3):
+            for shadowed in (False, True):
+                fires = reallocate_fires(
+                    runs,
+                    multiple=multiple,
+                    minimum_population=population,
+                    shadowed_by_stop=shadowed,
+                    ceiling=args.max_attempts,
+                )
+                print(
+                    f"  {multiple}x  min_closed_stages={population}  "
+                    f"after_stop_spending={'yes' if shadowed else 'no ':3s}: "
+                    f"{len(fires)} of {total_visits} visits"
+                )
+                for fire in fires:
+                    print(
+                        f"        {fire['run']:30s} {fire['stage']:24s} at attempt "
+                        f"{fire['at_attempt']:2d}: {fire['charged']} charged vs median "
+                        f"{fire['median']}, ration {fire['ration']}, moving "
+                        f"{fire['moves']} unit(s) to {', '.join(fire['to']) or 'nobody'}; "
+                        f"the visit went on to charge {fire['visit_spent']}"
+                    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Rebasing the supervisor onto a main that had gained #243, #244 and #245 surfaced a
collision the branch could not have seen: `STUCK_AFTER_IDENTICAL_FAILURES` and
`STOP_AFTER_IDENTICAL_FAILURES` are both three, so on a repeated *validator* refusal
`is_stuck` and the supervisor's `unchanging_failure` land on the same attempt, and
whichever is asked first writes the message, the banner and the log entry.

The supervisor was asked first, so a stage that failed validation three identical times
recorded:

    The run supervisor ruled `stop_spending` under `unchanging_failure`: the same
    failure has now been recorded 3 times running with nothing changing...

instead of the errors that repeated. `is_stuck` is the more specific of the two — it
names them — and the supervisor's own reason for existing beside it is that it covers what
`is_stuck` cannot see: a reviewer refusing three times, a backend not answering three
times, neither of which reaches `last_validation_errors`. A general rule pre-empting the
specific one trades a message naming the cause for one naming a rule. Flipped at all three
precedence points: the manifest error, the terminal banner, and the log entry heading.

Two additive conflicts resolved on the way, both parameters that must coexist: `choose`
takes #245's `skips_left` (which it passes to the graph, where the refusal is made) and
the supervisor's `required` (a redirect the supervisor has already ruled).

The branch was also rebased with `--onto`, dropping its copy of the cost-ledger commit:
that work is on main in its reviewed form as #244, and replaying the pre-review version
over it conflicted on every file it touched.

Testing: 3055 pass. `python3 -m tests.test_run_supervisor --mutations` -> tried 15,
killed 15, survivors 0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>



🤖 Generated with [Claude Code](https://claude.com/claude-code)
