### PR TITLE
An input a tool cannot read is not an input that lacks the term

### DIFF
--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -868,47 +868,47 @@ will do — which is the cheapest way to see what the adapter writes where.
 
 ---
 
-## About a tenth of the weight asks about a paper the workspace does not contain
+## About a tenth of the weight is scored by nobody, and half of it is on disk
 
 A task-by-task study of the 2026-08-16 arm found 16 criteria, **4.00 of 40.0 total weight
 (10.0%)**, where AutoR's new code, AutoR's pre-fix code and a bare agent all score at or
-below 10. The study called that the remaining headroom. It is not headroom, and the
-correction is worth more than the original claim.
+below 10. The study called that the remaining headroom. A first correction said it was not
+headroom at all — that those criteria name things which live only in the target paper,
+which ResearchClawBench does not ship — and reported that 2 of 30 distinctive identifiers
+appeared in the supplied inputs.
 
-Every one of those criteria names something specific — an analysis (`SHAP`), a dataset
-(`TextVQA`), a model (`Qwen2.5-3B`), a tool (`HADDOCK3`), an event (CAPRI round 57,
-target 268), a pipeline (`FlyWire`, `FAFB`). Those names come from the **target paper**,
-and the benchmark does not ship it. `related_work/` holds *other* papers. Searching only
-what the agent is given — `related_work/` and `data/`, nothing the run wrote —
-**2 of 30 distinctive identifiers from these criteria appear anywhere**:
+**That correction was wrong, and its error is the most useful thing in this section.** It
+shelled out to `pdftotext`, which is not installed on the machine it ran on, and caught
+the `FileNotFoundError` under `except (OSError, ...)`. Every PDF contributed the empty
+string. Every term in every paper came back "absent", and the number agreed with the
+conclusion the author had already reached.
 
-| task | supplied text | absent from it |
-|:---|---:|:---|
-| Neuroscience_000 #1–#3 | 3,463,517 chars | `SHAP`, `Lab1`, `Lab2`, `CSDS` |
-| Chemistry_002 #3–#4 | 1,602,208 chars | `CAPRI`, `HADDOCK3`, `VoroIF` |
-| Life_001 #0, #3 | 2,462,557 chars | `NeoAgDT`, `NetMHCpan` |
-| Information_001 #2 | **0 chars** | `Qwen2.5-3B`, `TextVQA` |
-| Neuroscience_002 #0, #4 | **0 chars** | `FlyWire`, `FAFB`, `FFN`, `EmbedNet` |
-| Information_003 #4 | **0 chars** | `DIDS`, `MFL` |
+Read with an extractor that works, the answer is **14 of 30**:
 
-Four of those tasks supply no readable text at all: their `related_work/` and `data/` are
-tensors and images. Three and a half million characters of Neuroscience_000's supplied
-papers contain the string "SHAP" zero times.
+| in the supplied papers, and unmined | not on disk |
+|:---|:---|
+| `SHAP` (17 occurrences, Neuroscience_000) | `FlyWire`, `FAFB`, `FlyTracing` |
+| `CAPRI` (37) and `HADDOCK3` (25), Chemistry_002 | `NeoAgDT`, `EmbedNet`, `DIDS`, `MFL` |
+| `NetMHCpan` (5, Life_001) | `Lab1` / `Lab2`, `CSDS`, `Qwen2.5-3B` |
 
-So this is not a gap a skill or a gate can close. It is the benchmark's floor for an agent
-that is not given the document it is graded against, and any claim about how much of
-ResearchClawBench is reachable should be quoted against **90%**, not 100%.
+So the tenth splits roughly in half. **The half that is present is headroom nobody mined**
+— three agents, including one with no harness, all failed to read the supplied papers for
+the analyses they name. The half that is absent is the floor for an agent not given the
+document it is graded against, and any claim about how much of this benchmark is reachable
+should be quoted against something under 100%.
 
-The one route that would reach it is fetching the target paper from the web and reading
-its methods section. That is a research-integrity question rather than an engineering one
-— on a reproduction benchmark, reading the target's results and restating them is close to
-copying the answer — and it is recorded here rather than taken.
+Fetching the target paper from the web would reach the second half. That is a
+research-integrity question rather than an engineering one — on a reproduction benchmark,
+reading the target's results and restating them is close to copying the answer — and it is
+recorded here rather than taken.
 
 `python tools/unreachable_criteria.py --arms <score dirs> --runs <workspace root>`
-re-derives all of it. Two earlier attempts at this measurement were wrong in the same
-direction: one searched the criterion's words in a corpus that included `_score.json`, the
-judge's own output, which contains the criteria verbatim, and got 30 of 30 "present". A
-search for a criterion's words that includes the criterion answers yes by construction.
+re-derives it, and now **refuses to judge a task whose supplied files it could not read**
+rather than counting them as empty. An input a tool cannot open is not an input that lacks
+the term; silence counted as absence is how a measurement tells you what you already
+believed. Two earlier versions were wrong in that same direction — one also searched a
+corpus that included `_score.json`, the judge's own output, which contains the criteria
+verbatim, and duly found 30 of 30 "present".
 
 ## Measuring a change against the benchmark score
 

--- a/tools/unreachable_criteria.py
+++ b/tools/unreachable_criteria.py
@@ -1,25 +1,38 @@
 """How much of the benchmark asks about a paper the workspace does not contain.
 
-The claim this exists to keep honest. A task-by-task study of the 2026-08-16 arm
-reported that "10.0% of total weight sits on 16 criteria where all three arms score at
-or below 10" and called it the remaining headroom. It is not headroom. Every one of
-those criteria names something specific -- an analysis (SHAP), a dataset (TextVQA), a
-model (Qwen2.5-3B), a tool (HADDOCK3), an event (CAPRI round 57) -- and those names are
-in the *target paper*, which ResearchClawBench does not ship. `related_work/` holds
-other papers: 3.4 million characters of them for Neuroscience_000, containing the string
-"SHAP" zero times.
+The claim this exists to keep honest, and the reason it is on its third correction.
 
-Measured here rather than asserted, because the first two attempts at this measurement
-were both wrong in ways that flattered the conclusion. The first read only the top level
-of two directories and undercounted. The second recursed and got 30 of 30 identifiers
-"present" -- because it was reading `_score.json`, the judge's own output, which contains
-the criteria verbatim, and `outputs/`, which the agent wrote. **A search for a criterion's
-words that includes the criterion, or anything downstream of it, answers yes by
-construction.** Only `related_work/` and `data/` are read here.
+A task-by-task study reported that "10.0% of total weight sits on 16 criteria where all
+three arms score at or below 10" and called it the remaining headroom. A first correction
+said it was not headroom at all -- that those criteria name things (`SHAP`, `CAPRI`,
+`Qwen2.5-3B`) which live only in the target paper, and that ResearchClawBench does not
+ship it. **That correction was wrong, and wrong for a reason worth more than either
+claim.** It shelled out to `pdftotext`, which is not installed on the machine it ran on,
+and caught the resulting `FileNotFoundError` under `except (OSError, ...)`. Every PDF
+silently contributed the empty string, so every term in every paper was "absent", and the
+measurement reported 2 of 30 identifiers present.
+
+Read with an extractor that works: **14 of 30**. `SHAP` occurs 17 times in
+Neuroscience_000's supplied papers, `CAPRI` 37 times and `HADDOCK3` 25 in
+Chemistry_002's. About half of what those criteria name is on disk and was not mined --
+that half is headroom. The other half (`FlyWire`, `FAFB`, `NeoAgDT`, `EmbedNet`, `DIDS`)
+is not on disk and is the floor.
+
+So the rule this file now enforces, which is the actual finding: **an input this tool
+cannot read is not an input that lacks the term.** A missing extractor, an encrypted PDF,
+a scanned page -- each of them produces silence, and silence counted as absence is how a
+tool tells you what you were already inclined to believe. It refuses to print a verdict
+for any task whose PDFs it could not open.
+
+Two other ways this measurement has been wrong, both preserved as guards below: reading
+only the top level of two directories undercounted, and recursing the whole workspace
+reported 30 of 30 "present" because it was reading `_score.json`, the judge's own output,
+which contains the criteria verbatim. A search for a criterion's words in a corpus that
+includes the criterion answers yes by construction.
 
 Usage::
 
-    python tools/unreachable_criteria.py --arm /path/to/scores --runs /path/to/runs
+    python tools/unreachable_criteria.py --arms <score dirs> --runs <workspace root>
 """
 
 from __future__ import annotations
@@ -55,25 +68,60 @@ _MAX_TEXT_BYTES = 20_000_000
 _FLOOR = 10
 
 
-def supplied_text(workspace: Path) -> str:
+def _pdf_text(path: Path) -> str | None:
+    """The text of one PDF, or None if this machine cannot read it.
+
+    None and "" are different answers and the difference is the whole point: an empty
+    string means the paper contains nothing, and None means we do not know what the paper
+    contains. The version of this tool that conflated them reported that a 631,001-word
+    corpus containing "SHAP" seventeen times contained it zero times.
+    """
+    try:
+        import pymupdf  # noqa: PLC0415 - optional, and its absence is a reportable state
+    except ImportError:
+        pymupdf = None
+    if pymupdf is not None:
+        try:
+            with pymupdf.open(path) as document:
+                return "\n".join(page.get_text() for page in document)
+        except Exception:  # noqa: BLE001 - an unreadable PDF is a state, not a crash
+            return None
+    try:
+        completed = subprocess.run(  # noqa: S603
+            ["pdftotext", str(path), "-"],
+            capture_output=True, text=True, timeout=120, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return completed.stdout if completed.returncode == 0 else None
+
+
+def supplied_text(workspace: Path) -> tuple[str, list[str]]:
+    """What the benchmark hands the agent, and the files that could not be read.
+
+    Returns the unreadable list rather than swallowing it, so a caller cannot mistake
+    "we could not open the papers" for "the papers do not mention it".
+    """
     parts: list[str] = []
+    unreadable: list[str] = []
     for sub in _SUPPLIED_DIRS:
         for path in sorted((workspace / sub).rglob("*")):
             if not path.is_file():
                 continue
-            try:
-                if path.suffix.lower() == ".pdf":
-                    parts.append(
-                        subprocess.run(  # noqa: S603
-                            ["pdftotext", str(path), "-"],
-                            capture_output=True, text=True, timeout=120, check=False,
-                        ).stdout
-                    )
-                elif path.suffix.lower() in _TEXT_SUFFIXES and path.stat().st_size < _MAX_TEXT_BYTES:
-                    parts.append(path.read_text(encoding="utf-8", errors="replace"))
-            except (OSError, subprocess.SubprocessError):
+            if path.suffix.lower() == ".pdf":
+                text = _pdf_text(path)
+                if text is None:
+                    unreadable.append(path.name)
+                else:
+                    parts.append(text)
                 continue
-    return "\n".join(parts)
+            if path.suffix.lower() in _TEXT_SUFFIXES:
+                try:
+                    if path.stat().st_size < _MAX_TEXT_BYTES:
+                        parts.append(path.read_text(encoding="utf-8", errors="replace"))
+                except OSError:
+                    unreadable.append(path.name)
+    return "\n".join(parts), unreadable
 
 
 def main() -> int:
@@ -103,12 +151,19 @@ def main() -> int:
     print(f"{len(hard)} criteria no arm scores above {_FLOOR}: "
           f"{hard_weight:.2f} of {total_weight:.1f} weight ({hard_weight / total_weight:.1%})\n")
 
-    present = absent = 0
+    present = absent = refused = 0
     for weight, task, index in hard:
         matches = glob.glob(f"{args.runs}/{task}_*/")
         if not matches:
             continue
-        text = supplied_text(Path(matches[0])).lower()
+        raw, unreadable = supplied_text(Path(matches[0]))
+        if unreadable:
+            print(f"  w={weight:.2f} {task}#{index}: REFUSING — could not read "
+                  f"{len(unreadable)} supplied file(s): {', '.join(unreadable[:3])}. "
+                  "An input this tool cannot open is not an input that lacks the term.")
+            refused += 1
+            continue
+        text = raw.lower()
         content = per_arm[0][task]["items"][index]["content"]
         terms = [w for w in dict.fromkeys(_IDENTIFIER.findall(content)) if w not in _GENERIC][:8]
         if not terms:
@@ -123,7 +178,10 @@ def main() -> int:
 
     print(f"\n{present}/{present + absent} of these criteria's distinctive identifiers appear "
           f"anywhere in what the benchmark supplies.")
-    print("The rest name things that exist only in the target paper, which is not shipped.")
+    if refused:
+        print(f"{refused} criteria not judged: their supplied files could not be read.")
+    print("What is present and unscored is headroom nobody mined. What is absent names "
+          "something the workspace does not contain, and is the floor.")
     return 0
 
 


### PR DESCRIPTION
**Correcting #241, which I merged an hour ago.** Its central number is wrong.

#241 said 10% of the benchmark's weight is unreachable because the criteria name things — `SHAP`, `CAPRI`, `HADDOCK3` — that live only in a target paper the workspace does not ship, and reported **2 of 30** identifiers present in the supplied inputs.

The tool shelled out to `pdftotext`, **which is not installed on the machine it ran on**, and caught the `FileNotFoundError` under `except (OSError, ...)`. Every PDF contributed the empty string. Every term in every paper came back absent — and the number agreed with the conclusion its author had already reached.

## Read with an extractor that works: 14 of 30

| in the supplied papers, unmined | occurrences | not on disk |
|:---|---:|:---|
| `SHAP` (Neuroscience_000) | **17** | `FlyWire`, `FAFB`, `FlyTracing` |
| `CAPRI` (Chemistry_002) | **37** | `NeoAgDT`, `EmbedNet` |
| `HADDOCK3` (Chemistry_002) | **25** | `DIDS`, `MFL`, `CSDS` |
| `NetMHCpan` (Life_001) | **5** | `Lab1` / `Lab2`, `Qwen2.5-3B` |

So the tenth splits in half, and both halves matter:

- **The present half is headroom nobody mined.** Three agents — including one with no harness at all — each failed to read a supplied paper for the analyses it names. That is a real, addressable gap, and #241 declared it unreachable.
- **The absent half is the floor** for an agent not given the document it is graded against.

## The fix is to the tool's epistemics, not its regex

`_pdf_text` returns `None` rather than `""` when no extractor is available, prefers `pymupdf` over a subprocess, and `supplied_text` hands back the list of files it could not open. The tool now **refuses to judge** a task whose supplied files it could not read, instead of scoring them as empty.

> An input a tool cannot open is not an input that lacks the term. Silence counted as absence is how a measurement tells you what you already believed.

The docstring keeps all three versions, because the shape recurs and each error moved the number toward the expected answer:

1. read only the top level of two directories → undercount;
2. recurse the whole workspace → **30 of 30 "present"**, because it was reading `_score.json`, the judge's own output, which contains the criteria verbatim;
3. swallow a missing binary → **2 of 30**.

Each was found by re-running, never by rereading.

3146 tests pass, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)