### PR TITLE
Let the run config keep a field none of its three writers owns

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -805,6 +805,15 @@ def load_run_config(paths: RunPaths) -> dict[str, Any]:
     created_at = payload.get("created_at")
     if isinstance(created_at, str) and created_at.strip():
         config["created_at"] = created_at
+    # Fields this function does not own, carried through rather than dropped. The dict
+    # above names every key it normalises, and `save_run_config` does the same, so the
+    # pair silently deletes anything a third writer records. `Manager._install_skills`
+    # records `skill_pins` -- the statement that a run's skills were chosen by its task
+    # identifier rather than by its task statement -- and it did not survive one
+    # load/save round trip, while the matching log line did. That is the wrong half to
+    # keep: the log is read by someone already suspicious; the config is what a later
+    # reader parses.
+    config = {**{k: v for k, v in payload.items() if k not in config}, **config}
     return config
 
 
@@ -843,6 +852,17 @@ def save_run_config(paths: RunPaths, config: dict[str, Any]) -> None:
         normalized["created_at"] = created_at
     else:
         normalized["created_at"] = datetime.now().isoformat(timespec="seconds")
+    # Fields this function does not own, carried through rather than dropped.
+    #
+    # Everything above is named explicitly, so a key any other writer puts in the config
+    # does not survive one call to this. `Manager._install_skills` records `skill_pins`
+    # -- the statement that a run's skills were chosen by its task identifier rather
+    # than by its task statement -- and the key was gone before the file was written,
+    # while the matching log line survived. That is the wrong half to lose: the log is
+    # read by someone already suspicious, and the config is what a later reader parses.
+    #
+    # Merged under the normalised fields, so nothing here can override one of them.
+    normalized = {**{k: v for k, v in config.items() if k not in normalized}, **normalized}
     write_text(paths.run_config, json.dumps(normalized, indent=2, ensure_ascii=False))
 
 
@@ -884,6 +904,11 @@ def ensure_run_config(
         "web_search": normalize_web_search_mode(web_search or current.get("web_search")),
         "created_at": current.get("created_at") or datetime.now().isoformat(timespec="seconds"),
     }
+    # And the same carry-through here, because this builds its own dict from `current`
+    # field by field: an unknown key survives the load and is then dropped before
+    # `save_run_config` ever sees it. Three functions name their fields explicitly and
+    # all three have to carry what they do not own, or the round trip loses it.
+    updated = {**{k: v for k, v in current.items() if k not in updated}, **updated}
     save_run_config(paths, updated)
     return updated
 

--- a/tests/test_run_skills.py
+++ b/tests/test_run_skills.py
@@ -637,3 +637,33 @@ class PinTableTest(unittest.TestCase):
         self.assertIn("Physics_000", note)
         self.assertIn("a, b", note)
         self.assertEqual(pinned_skills_note("Physics_000", frozenset()), "")
+
+
+class ThePinRecordSurvivesTest(unittest.TestCase):
+    """`skill_pins` has to still be in the config after the run finishes starting.
+
+    `Manager._install_skills` writes it and `ensure_run_config` used to run on the very
+    next line of `create_run`, rebuilding the config field by field and dropping
+    everything it does not name. So a pinned run logged that it was pinned and then
+    published a config saying it was not — and the config is the half a later reader
+    parses. Both halves or neither.
+    """
+
+    def test_ensure_run_config_keeps_a_key_it_does_not_manage(self) -> None:
+        from src.utils import ensure_run_config, load_run_config, save_run_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = build_run_paths(Path(tmp) / "run_0001")
+            ensure_run_layout(paths)
+            ensure_run_config(paths, model="opus")
+            config = load_run_config(paths)
+            config["skill_pins"] = ["a-skill"]
+            config["skill_pin_task_id"] = "Physics_000"
+            save_run_config(paths, config)
+
+            ensure_run_config(paths, model="opus", venue="neurips_2025")
+
+            after = load_run_config(paths)
+            self.assertEqual(after.get("skill_pins"), ["a-skill"])
+            self.assertEqual(after.get("skill_pin_task_id"), "Physics_000")
+            self.assertEqual(after.get("venue"), "neurips_2025", "a managed field still wins")


### PR DESCRIPTION
`configs/task_skill_pins.json` landed with two halves: a log line and a
`skill_pins` key in `run_config.json`, so a score taken from a pinned run says on
its face that it was pinned. Launching the arm showed only one half arriving.
Every run of the new arm logs `skills pinned_by_task_id`, and every one of their
configs says nothing.

Three functions, each naming its fields explicitly, each dropping what it does
not name:

* `load_run_config` rebuilds the dict from `payload` field by field, so an
  unknown key does not survive being read;
* `save_run_config` does the same from its `config` argument, so it does not
  survive being written either;
* `ensure_run_config` builds a third dict from `current`, so a key that survived
  the first two is gone before `save_run_config` is called.

All three now carry through what they do not own, merged *under* the normalised
fields so nothing can override one of them. Each of the three is separately
load-bearing: removing any one drops the key, which the new test's three
mutations confirm.

The arm already running is not affected in what it does — the pins install, and
`Chemistry_000`'s `.claude/skills/` carries `the-attribution-is-the-deliverable`
while an unpinned task's does not. It is affected in what it records: those runs
will carry the pin only in `logs.txt`, not in `run_config.json`. That is the
worse half to lose, because the log is read by someone already suspicious and the
config is what a later reader parses.

`python3 -m unittest discover -s tests -p "test_*.py"`: Ran 3162, OK (skipped=1).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)