### PR TITLE
Give a retry back the two things it was silently losing

### DIFF
--- a/src/operator.py
+++ b/src/operator.py
@@ -1484,6 +1484,20 @@ Original stderr:
         continue_session: bool,
         allow_create: bool = True,
     ) -> str | None:
+        # A persisted id is good for a *continuation* and for nothing else. `--session-id`
+        # accepts a uuid once; the second time the CLI answers `Error: Session ID <uuid>
+        # is already in use.`, which matches none of `_looks_like_resume_failure`'s
+        # patterns, so no fallback fires and the attempt burns with nothing written.
+        #
+        # A stage can be entered more than once -- a revisit edge, `--redo-stage`,
+        # `--resume-run` into an unapproved stage -- and every entry starts the attempt
+        # loop at `continue_session = False` in `_run_stage`, with `build_prompt` rather
+        # than `build_continuation_prompt`. That is a new conversation and it needs a new
+        # id. The one entry that deliberately resumes, Studio's pending feedback, sets the
+        # flag to True and still gets the persisted id and `--resume`.
+        if not continue_session:
+            return str(uuid.uuid4())
+
         broken_session_id: str | None = None
         session_state_path = paths.stage_session_state_file(stage)
         if session_state_path.exists():

--- a/src/utils.py
+++ b/src/utils.py
@@ -1212,6 +1212,16 @@ def build_continuation_prompt(
     _deliverables = format_deliverables_for_prompt(task_statement(read_text(paths.user_input)))
     if _deliverables:
         sections.extend(["# What the Task Asks For", _deliverables])
+    # An obligation is a debt a reviewer attached to an approval and only a reviewer may
+    # discharge, so the stage that owes it has to be able to read it on the attempt that
+    # pays it. This block was a parameter the manager passed and this function never
+    # rendered: `# Obligations Carried Forward` reached attempt 1 through `build_prompt`
+    # and vanished from attempt 2 on, which is every attempt that exists because the
+    # first one was refused. The stage was then judged against a spec its prompt no
+    # longer carried, and `format_for_review_prompt` asked the inheriting reviewer
+    # whether a debt the doer could not see had been met.
+    if obligations_context:
+        sections.extend(["# Obligations Carried Forward", obligations_context.strip()])
     if intake_context_text:
         sections.extend([
             "# Intake Context (User-Provided Resources and Clarifications)",

--- a/tests/test_obligations.py
+++ b/tests/test_obligations.py
@@ -25,7 +25,15 @@ from src.obligations import (
     record_obligations,
 )
 from src.terminal_ui import TerminalUI
-from src.utils import STAGES, build_run_paths, ensure_run_layout, read_text, write_text
+from src.utils import (
+    STAGES,
+    build_continuation_prompt,
+    build_prompt,
+    build_run_paths,
+    ensure_run_layout,
+    read_text,
+    write_text,
+)
 
 
 STAGE_01, STAGE_03, STAGE_05 = STAGES[0], STAGES[2], STAGES[4]
@@ -189,6 +197,80 @@ class RenderingTest(LedgerTestBase):
         record_obligations(self.paths, stage=STAGE_01, entries=[DEBT, OTHER])
         discharge_obligations(self.paths, stage=STAGE_03, obligation_ids=["O001"])
         self.assertIn("1 open / 2 total", ledger_summary(load_ledger(self.paths)))
+
+
+class ReachesEveryAttemptTest(LedgerTestBase):
+    """A debt the doer cannot read on the attempt that pays it is not carried forward.
+
+    `build_prompt` rendered `# Obligations Carried Forward` and
+    `build_continuation_prompt` took the same parameter, was passed it by
+    `ResearchManager._build_stage_prompt`, and never rendered it. So the block reached
+    attempt 1 and vanished from attempt 2 on -- which is every attempt that exists
+    because the previous one was refused -- while `format_for_review_prompt` went on
+    asking the inheriting reviewer whether the debt had been met.
+
+    The parity test below is the general form and is what would have caught it: the two
+    builders take five of the same optional content parameters, and a parameter one of
+    them accepts and drops is the same defect under a different name. Dropping the
+    `obligations` row from it leaves the specific test above still failing, which is the
+    point -- the two are not one check written twice.
+    """
+
+    #: The optional content parameters both builders accept. Each is passed a sentinel
+    #: and required to survive into both prompts. `stage_template` and `handoff_context`
+    #: are positional in one and keyword in the other, so they are driven by name here.
+    SHARED_CONTENT_PARAMS = (
+        "handoff_context",
+        "revision_feedback",
+        "intake_context_text",
+        "web_search_context",
+        "obligations_context",
+    )
+
+    def _build_both(self, **overrides: str) -> tuple[str, str]:
+        kwargs = {name: f"SENTINEL-{name}" for name in self.SHARED_CONTENT_PARAMS}
+        kwargs.update(overrides)
+        fresh = build_prompt(
+            STAGE_03,
+            "stage template",
+            "the user goal",
+            # Empty, because `build_prompt` withholds the handoff when memory is
+            # non-empty -- the one shared parameter with a documented reason to be
+            # dropped, and the reason is duplication rather than forgetting.
+            "",
+            **kwargs,
+        )
+        continuation = build_continuation_prompt(
+            STAGE_03,
+            "stage template",
+            self.paths,
+            attempt_no=2,
+            **kwargs,
+        )
+        return fresh, continuation
+
+    def test_an_obligation_survives_into_a_retry(self) -> None:
+        record_obligations(self.paths, stage=STAGE_01, entries=[DEBT])
+        rendered = format_for_stage_prompt(load_ledger(self.paths), STAGE_03)
+        fresh, continuation = self._build_both(obligations_context=rendered)
+        for prompt in (fresh, continuation):
+            self.assertIn("# Obligations Carried Forward", prompt)
+            self.assertIn(DEBT, prompt)
+
+    def test_every_shared_content_parameter_survives_into_both_prompts(self) -> None:
+        fresh, continuation = self._build_both()
+        missing = [
+            f"{name} is dropped by {builder}"
+            for name in self.SHARED_CONTENT_PARAMS
+            for builder, prompt in (("build_prompt", fresh), ("build_continuation_prompt", continuation))
+            if f"SENTINEL-{name}" not in prompt
+        ]
+        self.assertEqual(missing, [], "\n".join(missing))
+
+    def test_the_sentinel_scan_can_fail(self) -> None:
+        """Control: a parameter that is genuinely absent is reported, not passed over."""
+        fresh, _ = self._build_both()
+        self.assertNotIn("SENTINEL-a-parameter-nobody-passes", fresh)
 
 
 class ReviewSchemaTest(LedgerTestBase):

--- a/tests/test_operator_recovery.py
+++ b/tests/test_operator_recovery.py
@@ -262,6 +262,73 @@ class OperatorRecoveryTests(unittest.TestCase):
             self.assertIsNone(resolved)
 
 
+class SecondEntryToAStageTests(unittest.TestCase):
+    """A session id is spent once, and a stage is entered more than once.
+
+    `--session-id` accepts a uuid the first time and answers `Error: Session ID <uuid>
+    is already in use.` the second. That string matches none of the four patterns in
+    `_looks_like_resume_failure`, so the fallback in `_run_real` never fires and the
+    attempt burns with nothing written. Every entry to a stage other than Studio's
+    pending-feedback path starts the attempt loop at `continue_session = False` and
+    builds a fresh prompt, so a revisit edge, `--redo-stage` and `--resume-run` into an
+    unapproved stage all reached the CLI with an id it had already seen.
+    """
+
+    def _session_flag(self, command: list[str]) -> tuple[str, str]:
+        for flag in ("--session-id", "--resume"):
+            if flag in command:
+                return flag, command[command.index(flag) + 1]
+        self.fail(f"No session flag found in command: {command}")
+
+    def _operator_and_paths(self, tmp_dir: str):
+        paths = build_run_paths(Path(tmp_dir) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Second entry")
+        initialize_memory(paths, "Second entry")
+        return ClaudeOperator(fake_mode=False, output_stream=io.StringIO()), paths
+
+    def _run(self, operator, paths, stage, *, continue_session: bool, seen: list) -> None:
+        def fake_stream(*args, **kwargs):
+            seen.append(self._session_flag(kwargs["command"]))
+            write_text(paths.stage_tmp_file(stage), "# Stage 01: Literature Survey\n")
+            return (0, "completed", "", None,
+                    {"raw_line_count": 1, "non_json_line_count": 0, "malformed_json_count": 0})
+
+        with patch("src.operator.shutil.which", return_value="/usr/bin/claude"), patch.object(
+            operator, "_run_streaming_command", side_effect=fake_stream
+        ):
+            operator._run_real(stage, "prompt", paths, attempt_no=1, continue_session=continue_session)
+
+    def test_a_second_entry_does_not_replay_the_first_entrys_session_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operator, paths = self._operator_and_paths(tmp_dir)
+            seen: list[tuple[str, str]] = []
+            self._run(operator, paths, STAGE_01, continue_session=False, seen=seen)
+            self._run(operator, paths, STAGE_01, continue_session=False, seen=seen)
+
+            self.assertEqual([flag for flag, _ in seen], ["--session-id", "--session-id"])
+            self.assertNotEqual(seen[0][1], seen[1][1])
+
+    def test_a_continuation_still_resumes_the_id_the_entry_persisted(self) -> None:
+        """The control. Fixing the entry must not stop a retry continuing its session."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operator, paths = self._operator_and_paths(tmp_dir)
+            seen: list[tuple[str, str]] = []
+            self._run(operator, paths, STAGE_01, continue_session=False, seen=seen)
+            self._run(operator, paths, STAGE_01, continue_session=True, seen=seen)
+
+            self.assertEqual([flag for flag, _ in seen], ["--session-id", "--resume"])
+            self.assertEqual(seen[0][1], seen[1][1])
+
+    def test_two_stages_never_share_one_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            operator, paths = self._operator_and_paths(tmp_dir)
+            seen: list[tuple[str, str]] = []
+            self._run(operator, paths, STAGE_01, continue_session=False, seen=seen)
+            self._run(operator, paths, STAGE_05, continue_session=False, seen=seen)
+            self.assertNotEqual(seen[0][1], seen[1][1])
+
+
 class TestResumeFailureDetection(unittest.TestCase):
     def setUp(self) -> None:
         self.op = ClaudeOperator(fake_mode=True)


### PR DESCRIPTION
Two defects with the same shape, both turned up by [#254](https://github.com/tangxiangru/AutoR/pull/254)'s
reading of LongHorizon-Harness against this repository: state the run holds that the **second** attempt at
a stage never sees.

## 1. An obligation stopped at attempt 1

`obligations_context` was a parameter of `build_continuation_prompt` that
`ResearchManager._build_stage_prompt` passed and the body never rendered — the only occurrence inside the
function was its own signature. `# Obligations Carried Forward` reached the first attempt through
`build_prompt` and disappeared from every attempt that exists *because the previous one was refused*.

Meanwhile `format_for_review_prompt` kept asking the inheriting reviewer whether the debt had been met. And
since only a reviewer may discharge an obligation, the stage could not close it by noticing either — it was
judged against a spec its prompt no longer carried.

## 2. A second entry to a stage replayed a spent session id

`_resolve_stage_session_id` returned a persisted, non-broken id regardless of `continue_session`. Every
entry to a stage except Studio's pending-feedback path starts `_run_stage`'s attempt loop at
`continue_session = False` and builds a fresh `build_prompt` — a new conversation — and it went out as
`--session-id <uuid the CLI has already seen>`.

```
$ claude --session-id <uuid> -p ...   # second time
Error: Session ID <uuid> is already in use.
```

That string matches none of the four patterns in `_looks_like_resume_failure`, so the fallback in
`_run_real` never fired and the attempt burned with nothing written. A stage is entered more than once *by
design* — a revisit edge, `--redo-stage`, `--resume-run` into an unapproved stage — so this sat on the path
the graph exists to take.

The fix is at the cause: a persisted id is good for a continuation and nothing else. The one entry that
deliberately resumes (Studio's pending feedback) sets the flag to `True`, gets the persisted id and
`--resume`, and is unchanged — that is the control test.

**A recovery rung was considered and refused.** After the cause is fixed, nothing in the tree can hand
`--session-id` an id it has already spent, and a rung with no caller is the mistake
`docs/iclr/composable-stage-graphs.md` names in its own "not yet implemented" section.

## Tests

Six, `+6` against this tree's baseline of 3247.

- `ReachesEveryAttemptTest.test_an_obligation_survives_into_a_retry` — the specific case.
- `…test_every_shared_content_parameter_survives_into_both_prompts` — **the general form, and what would
  have caught this**: the two builders take five of the same optional content parameters, each is passed a
  sentinel, and both prompts must carry all five. A parameter one builder accepts and drops is the same
  defect under another name. Deleting the `obligations` row from it leaves the specific test still failing,
  so the two are not one check written twice.
- `…test_the_sentinel_scan_can_fail` — control: a parser that finds nothing passes anything.
- `SecondEntryToAStageTests.test_a_second_entry_does_not_replay_the_first_entrys_session_id`.
- `…test_a_continuation_still_resumes_the_id_the_entry_persisted` — control, passes either way.
- `…test_two_stages_never_share_one_id` — control on the keying.

Both new assertions were checked **red** against the unfixed tree (`obligations_context is dropped by
build_continuation_prompt`, and the two entries returning one uuid). Full suite: 3253 tests, OK
(skipped=1), `umask 022`, `TMPDIR=/tmp`.

Not fixed here, recorded in #254 §4.7: the continuation prompt's opening sentence asserts *"you are
continuing in the same AutoR conversation"*, which is false on the resume-failure fallback path, and the
goal and approved memory are `read them if needed` pointers rather than inlined text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)