### PR TITLE
A degree sign in a CSV ends the run

### DIFF
--- a/src/artifact_index.py
+++ b/src/artifact_index.py
@@ -323,10 +323,42 @@ def _scan_artifacts(paths: RunPaths) -> list[ArtifactRecord]:
 
 
 def _infer_schema(path: Path, category: str, workspace_root: Path) -> dict[str, object]:
+    """A description of `path`, or a description of why there is not one. Never raises.
+
+    This walks every file the agent has written, of any type, in any encoding, at any
+    moment -- including while it is being written. It is called from `_scan_artifacts`,
+    which is called from `write_artifact_index`, which is called by the `artifact_index`
+    channel while a stage prompt is being built. So an exception here does not spoil an
+    index entry; it propagates out of `_build_stage_prompt` and ends the run.
+
+    That is not hypothetical. On the `full40_pins` arm, Life_002 wrote a CSV containing
+    byte 0xb0 -- a degree sign in the platform encoding -- and `_infer_tabular_schema`
+    read it as strict UTF-8. The `UnicodeDecodeError` travelled through `_scan_artifacts`,
+    `write_artifact_index`, `render_inbound` and `_run_stage_attempts` and killed the
+    pipeline at Stage 03 of 7, nine hours in. The adapter caught it at the top, exported a
+    synthesised report, and the batch runner recorded the task as `completed`; it was
+    scored, and the score entered the arm. One unreadable byte in a file nobody reads cost
+    a whole run and produced a number that looked like a result.
+
+    The lenient decoding below is the first half of the fix. This is the second, and it is
+    the one that generalises: schema inference is a convenience, and a convenience may not
+    have the power to end a run.
+    """
+    try:
+        return _infer_schema_or_raise(path, category, workspace_root)
+    except (OSError, UnicodeError, ValueError, csv.Error, RecursionError) as exc:
+        return {
+            "source": "inferred",
+            "kind": "unreadable",
+            "error": f"{type(exc).__name__}",
+        }
+
+
+def _infer_schema_or_raise(path: Path, category: str, workspace_root: Path) -> dict[str, object]:
     sidecar_path = path.parent / f"{path.name}.schema.json"
     if sidecar_path.exists():
         try:
-            declared = json.loads(sidecar_path.read_text(encoding="utf-8"))
+            declared = json.loads(sidecar_path.read_text(encoding="utf-8", errors="replace"))
             return {
                 "source": "declared",
                 "sidecar_path": str(sidecar_path.relative_to(workspace_root)),
@@ -361,7 +393,7 @@ def _infer_schema(path: Path, category: str, workspace_root: Path) -> dict[str, 
 
 def _infer_json_schema(path: Path) -> dict[str, object]:
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8", errors="replace"))
     except json.JSONDecodeError:
         return {"source": "inferred", "kind": "json", "error": "invalid_json"}
 
@@ -393,7 +425,7 @@ def _infer_json_schema(path: Path) -> dict[str, object]:
 def _infer_jsonl_schema(path: Path) -> dict[str, object]:
     row_count = 0
     keys: set[str] = set()
-    with path.open("r", encoding="utf-8") as handle:
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
         for raw_line in handle:
             line = raw_line.strip()
             if not line:
@@ -417,7 +449,10 @@ def _infer_jsonl_schema(path: Path) -> dict[str, object]:
 
 
 def _infer_tabular_schema(path: Path, delimiter: str) -> dict[str, object]:
-    with path.open("r", encoding="utf-8", newline="") as handle:
+    # `errors="replace"`, because this is describing a file the agent wrote and has no
+    # say over. A degree sign written by pandas in the platform's own encoding is not a
+    # reason to stop reading the table, and it certainly is not a reason to end the run.
+    with path.open("r", encoding="utf-8", errors="replace", newline="") as handle:
         reader = csv.reader(handle, delimiter=delimiter)
         rows = list(reader)
 

--- a/tests/test_artifact_index.py
+++ b/tests/test_artifact_index.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import json
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
-from src.artifact_index import format_artifact_index_for_prompt, load_artifact_index, write_artifact_index
+from src.artifact_index import (
+    _infer_schema,
+    _infer_schema_or_raise,
+    format_artifact_index_for_prompt,
+    load_artifact_index,
+    write_artifact_index,
+)
 from src.utils import build_run_paths, ensure_run_layout, write_text
 from src.writing_manifest import build_writing_manifest
 
@@ -78,3 +85,87 @@ class ArtifactIndexTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SchemaInferenceCannotEndARunTest(unittest.TestCase):
+    """A byte the scanner cannot decode must cost an index entry, not the run.
+
+    `_infer_schema` is reached from `write_artifact_index`, which the `artifact_index`
+    channel calls while a stage prompt is being assembled. So anything it raises leaves
+    `_build_stage_prompt` and ends the pipeline.
+
+    Measured, on the `full40_pins` arm: Life_002 wrote a CSV holding byte 0xb0 -- a
+    degree sign in the platform encoding -- and the strict UTF-8 read raised
+    `UnicodeDecodeError` at Stage 03 of 7, nine hours in. The adapter caught it at the
+    top, synthesised a report from what existed, and the batch runner filed the task as
+    `completed`. It was scored 22.6 with one approved stage, and that number entered the
+    arm looking like every other.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def _schema(self, name: str, payload: bytes) -> dict:
+        path = self.root / name
+        path.write_bytes(payload)
+        return _infer_schema(path, "results", self.root)
+
+    def test_a_degree_sign_in_a_csv_does_not_raise(self) -> None:
+        schema = self._schema("t.csv", b"temp_C,site\n21.5\xb0,north\n")
+        self.assertIsInstance(schema, dict)
+        self.assertIn("columns", schema, schema)
+        self.assertEqual(schema.get("row_count"), 1)
+
+    def test_an_undecodable_json_is_described_not_raised(self) -> None:
+        schema = self._schema("t.json", b'{"a": "\xb0"}')
+        self.assertIsInstance(schema, dict)
+
+    def test_the_helpers_decode_leniently_on_their_own(self) -> None:
+        """Both layers, held separately.
+
+        The outer guard turns anything into an entry, which means a test that only calls
+        `_infer_schema` passes whether or not the decoding was fixed. These call the
+        raising variant, so the lenient reads are what is under test.
+        """
+        for name, payload, kind in (
+            ("t.jsonl", b'{"a": 1}\n{"b": "\xff\xfe"}\n', "jsonl"),
+            ("t.csv", b"temp_C,site\n21.5\xb0,north\n", "table"),
+            ("t.json", b'{"a": "\xb0"}', "object"),
+        ):
+            with self.subTest(file=name):
+                path = self.root / name
+                path.write_bytes(payload)
+                schema = _infer_schema_or_raise(path, "results", self.root)
+                self.assertEqual(schema.get("kind"), kind)
+
+    def test_arbitrary_bytes_under_a_table_suffix_are_survived(self) -> None:
+        """The scanner walks whatever the agent wrote, including a mislabelled binary."""
+        schema = self._schema("t.tsv", bytes(range(256)) * 8)
+        self.assertIsInstance(schema, dict)
+
+    def test_a_helper_that_throws_becomes_an_entry_not_an_exception(self) -> None:
+        """The general guarantee, independent of which decode is at fault."""
+        with mock.patch(
+            "src.artifact_index._infer_schema_or_raise", side_effect=MemoryError("boom")
+        ):
+            with self.assertRaises(MemoryError):
+                _infer_schema(self.root / "x.csv", "results", self.root)
+        with mock.patch(
+            "src.artifact_index._infer_schema_or_raise", side_effect=ValueError("boom")
+        ):
+            schema = _infer_schema(self.root / "x.csv", "results", self.root)
+        self.assertEqual(schema.get("kind"), "unreadable")
+        self.assertEqual(schema.get("error"), "ValueError")
+
+    def test_a_whole_scan_survives_one_bad_file(self) -> None:
+        """The entry degrades; its neighbours keep their schemas."""
+        paths = build_run_paths(self.root / "run_0001")
+        ensure_run_layout(paths)
+        (paths.results_dir / "good.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+        (paths.results_dir / "bad.csv").write_bytes(b"a,b\n21.5\xb0,2\n")
+        index = write_artifact_index(paths)
+        names = {r.filename for r in index.live_artifacts}
+        self.assertIn("good.csv", names)
+        self.assertIn("bad.csv", names)


### PR DESCRIPTION
Nine hours into the `full40_pins` arm, Life_002 stopped at Stage 03 of 7. The
manifest still says `running` and carries no error, the batch runner recorded
`DONE Life_002: completed`, the adapter exported a synthesised report, and the
judge scored it **22.6** — a number that entered the arm looking like every other
one, off a run with one approved stage.

The cause is one byte. The agent wrote a CSV containing `0xb0`, a degree sign in
the platform encoding, and `_infer_tabular_schema` read it as strict UTF-8. The
`UnicodeDecodeError` travelled `_infer_schema` -> `_scan_artifacts` ->
`write_artifact_index` -> the `artifact_index` channel -> `render_inbound` ->
`_build_stage_prompt` -> `_run_stage_attempts`, and out of `manager.run`. Schema
inference is a convenience that describes files nobody reads; it had the power to
end a nine-hour run.

Two layers, because the decoding is the instance and the reach is the defect.

**Decode leniently.** `errors="replace"` on all four reads in the inference
helpers. Three of them sit under an `except json.JSONDecodeError`, which does not
catch `UnicodeDecodeError` — so the guard that looked like it covered them never
did.

**Make the walk total.** `_infer_schema` now wraps `_infer_schema_or_raise` and
turns `OSError`, `UnicodeError`, `ValueError`, `csv.Error` and `RecursionError`
into `{"kind": "unreadable", "error": ...}`. This is the half that generalises:
the scanner walks every file the agent has written, of any type, in any encoding,
including while it is being written, and the next unreadable thing will not be a
degree sign. `MemoryError` and `KeyboardInterrupt` deliberately still propagate.

Six tests. Three call `_infer_schema_or_raise` directly so the lenient reads are
what is under test rather than the outer guard — without that, reverting any one
decode still passed. Each of the three decodes and the guard is a caught mutation.

What this does not fix, and should be looked at next: `run_arm.py` files a task as
`completed` when `rcb_agent.py` exits zero, and the adapter exits zero after
catching a pipeline exception and synthesising a report from whatever exists. So
an aborted run is indistinguishable from a finished one in the batch state, and
its score is indistinguishable in the arm. The `_agent_output.jsonl` carries
`"pipeline_completed": false` and `"report_source": "synthesized"`; nothing reads
either.

`python3 -m unittest discover -s tests -p "test_*.py"`: Ran 3284, OK (skipped=1).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)