### PR TITLE
An aborted run is not a completed one

### DIFF
--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -677,6 +677,7 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
     manager.skill_task_id = _task_id or None
 
     pipeline_completed = False
+    aborted_with = ""
     try:
         pipeline_completed = manager.run(
             goal,
@@ -686,7 +687,11 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
             resources=collect_reference_resources(workspace) or None,
             final_stage=resolve_stage(args.final_stage),
         )
-    except Exception:  # noqa: BLE001 - a crashed pipeline must still export what it produced
+    except Exception as exc:  # noqa: BLE001 - a crashed pipeline must still export what it produced
+        # Exporting the salvage is right. Reporting the salvage as a finished run is not,
+        # and that is what happened until this line existed: the exception was recorded in
+        # `_agent_output.jsonl` and nowhere a downstream reader looks.
+        aborted_with = f"{type(exc).__name__}: {exc}"[:500]
         emit_event({"type": "error", "where": "pipeline", "traceback": traceback.format_exc()})
 
     paths = build_run_paths_for_workspace(workspace)
@@ -710,23 +715,33 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         auto_skipped_stages=manager.auto_skipped_stages,
         synthesize=synthesizer,
     )
-    write_run_meta(
-        workspace,
-        task_id=infer_task_id(workspace),
-        run_id=paths.run_root.name,
-        # The harness scores the report, so a report is what "completed" means here.
-        status="completed" if export.report_path.exists() else "failed",
-        duration_seconds=round(time.monotonic() - started_at),
-        model=model,
-        extra={"report_source": export.report_source, "pipeline_completed": pipeline_completed},
-    )
-    return BenchmarkResult(
+    result = BenchmarkResult(
         workspace=workspace,
         run_root=paths.run_root,
         pipeline_completed=pipeline_completed,
         export=export,
         auto_skipped_stages=list(manager.auto_skipped_stages),
+        aborted_with=aborted_with,
     )
+    # Written once, after the result exists, because the result is the only thing that
+    # knows whether the walk finished -- and `status` is the field every downstream
+    # reader gates on. `run_arm.py` skips a task whose meta says `completed`, and
+    # `score_arm.py` scores one; both were being handed `completed` for a run that had
+    # stopped at Stage 03 of 7.
+    write_run_meta(
+        workspace,
+        task_id=infer_task_id(workspace),
+        run_id=paths.run_root.name,
+        status=result.status,
+        duration_seconds=round(time.monotonic() - started_at),
+        model=model,
+        extra={
+            "report_source": export.report_source,
+            "pipeline_completed": pipeline_completed,
+            "aborted_with": aborted_with,
+        },
+    )
+    return result
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -741,7 +756,7 @@ def main(argv: list[str] | None = None) -> int:
     emit_event(
         {
             "type": "result",
-            "status": "completed" if result.exit_code == 0 else "failed",
+            "status": result.status,
             "pipeline_completed": result.pipeline_completed,
             "auto_skipped_stages": result.auto_skipped_stages,
             "run_root": str(result.run_root),

--- a/src/rcb.py
+++ b/src/rcb.py
@@ -126,27 +126,67 @@ class BenchmarkResult:
     pipeline_completed: bool
     export: ExportResult
     auto_skipped_stages: list[str] = field(default_factory=list)
+    #: The exception that ended the stage walk, as ``"TypeName: message"``, or ``""`` when
+    #: the walk finished on its own terms. This is the field that separates a run which
+    #: degraded from one which stopped, and they are not the same outcome however similar
+    #: the directory looks afterwards.
+    aborted_with: str = ""
+
+    @property
+    def aborted(self) -> bool:
+        return bool(self.aborted_with)
+
+    @property
+    def status(self) -> str:
+        """What `_meta.json` should say. Three outcomes, not two.
+
+        ``completed`` -- the walk finished and the report is substantive.
+        ``aborted``   -- an exception ended the walk. A report may still exist, because
+                         the adapter exports whatever the run produced before it died;
+                         that report is a salvage, not a result.
+        ``failed``    -- the walk finished but produced no substantive report.
+        """
+        if self.aborted:
+            return "aborted"
+        return "completed" if self._report_is_substantive() else "failed"
+
+    def _report_is_substantive(self) -> bool:
+        path = self.export.report_path
+        if not path.exists():
+            return False
+        return len(read_text(path).strip()) >= MIN_REPORT_CHARS
 
     @property
     def exit_code(self) -> int:
-        """0 when a real report reached the harness.
+        """0 when a real report reached the harness *and* the run got there on its own.
 
-        The pipeline completing is not the bar: ResearchClawBench scores the report, so a
-        run that auto-skipped a stage but still produced a substantive report is a success,
-        and a "completed" run with an empty report is not.
+        An auto-skipped stage is not disqualifying: ResearchClawBench scores the report,
+        and a run that lost a stage to its recovery path and still produced a substantive
+        report is a degraded success. That was this property's whole argument, and it
+        holds -- for a walk that finished.
 
-        That second half was the docstring's claim and not the code's: this tested
-        ``.exists()``, and a 197-byte "No completed stage output was produced" stub exists.
-        Eight of forty benchmark runs therefore reported ``exit_code: 0, status:
-        completed`` while shipping nothing, and the batch log, the run metadata and the
-        harness all agreed the runs had succeeded. Nothing surfaced it until the scoring
-        pass, thirteen hours later. Hold the file to ``MIN_REPORT_CHARS``, the same floor
-        every source inside :func:`export_run` is already held to.
+        It does not hold for a walk that was ended by an exception, and the difference was
+        invisible here. On the `full40_pins` arm, Life_002 died at Stage 03 of 7 on a
+        `UnicodeDecodeError` raised while assembling a prompt. Four stages were never
+        attempted. The adapter caught it at the top, synthesised a report from the partial
+        state, and this property returned 0 because a 40 KB file existed -- so
+        `_meta.json` said `completed`, the batch runner logged `DONE ... completed`, the
+        scorer scored it 22.6, and that number entered a 40-task arm mean indistinguishable
+        from the runs that finished. It took reading `_agent_output.jsonl` by hand to find
+        `"pipeline_completed": false` next to `"report_source": "synthesized"`.
+
+        So: a substantive report is still necessary and is no longer sufficient.
+
+        The report floor has its own history. This once tested ``.exists()``, and a
+        197-byte "No completed stage output was produced" stub exists. Eight of forty
+        benchmark runs therefore reported ``exit_code: 0, status: completed`` while
+        shipping nothing, and the batch log, the run metadata and the harness all agreed
+        the runs had succeeded; nothing surfaced it until the scoring pass thirteen hours
+        later. Hold the file to ``MIN_REPORT_CHARS``, the same floor every source inside
+        :func:`export_run` is already held to. The abort case above is the same defect one
+        level up, found the same way and costing the same thirteen hours.
         """
-        path = self.export.report_path
-        if not path.exists():
-            return 1
-        return 0 if len(read_text(path).strip()) >= MIN_REPORT_CHARS else 1
+        return 0 if self.status == "completed" else 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rcb.py
+++ b/tests/test_rcb.py
@@ -1,0 +1,83 @@
+"""What the benchmark adapter records about how a run ended.
+
+`ResearchClawBench` scores `report/report.md`, so for a long time the adapter treated
+"a substantive report exists" as the definition of success. That is right about a run
+which lost a stage to its own recovery path and finished anyway. It is wrong about a
+run that stopped, and the two were indistinguishable in every artifact a reader
+consults.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.rcb import MIN_REPORT_CHARS, BenchmarkResult, ExportResult
+
+
+
+
+class AnAbortedRunIsNotACompletedOneTest(unittest.TestCase):
+    """A crashed walk and a finished one must not produce the same record.
+
+    Measured on the `full40_pins` arm. Life_002 died at Stage 03 of 7 on a
+    `UnicodeDecodeError` raised while a prompt was being assembled; four stages were
+    never attempted. The adapter caught it, exported a synthesised report from the
+    partial state, and `exit_code` returned 0 because a 40 KB file existed. So
+    `_meta.json` said `completed`, `run_arm.py` logged `DONE Life_002: completed`, the
+    judge scored it 22.6, and that number entered a 40-task arm mean beside runs that
+    had finished. The evidence was in `_agent_output.jsonl` -- `"pipeline_completed":
+    false` next to `"report_source": "synthesized"` -- and nothing downstream read
+    either field.
+
+    An auto-skipped stage is deliberately still `completed`: the recovery path is
+    designed, the walk reached the end, and the report is what the benchmark scores.
+    The distinction here is finishing versus stopping, not degraded versus perfect.
+    """
+
+    def _result(self, body: str, *, aborted: str = "", skips: list[str] | None = None):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        report = root / "report.md"
+        report.write_text(body, encoding="utf-8")
+        return BenchmarkResult(
+            workspace=root,
+            run_root=root / ".autor" / "r",
+            pipeline_completed=not aborted,
+            export=ExportResult(
+                report_path=report, report_source="stage_07", figures=[], code_files=0,
+                output_files=0,
+            ),
+            auto_skipped_stages=list(skips or []),
+            aborted_with=aborted,
+        )
+
+    def test_a_finished_walk_with_a_real_report_is_completed(self) -> None:
+        r = self._result("x" * (MIN_REPORT_CHARS + 10))
+        self.assertEqual(r.status, "completed")
+        self.assertEqual(r.exit_code, 0)
+        self.assertFalse(r.aborted)
+
+    def test_an_auto_skipped_stage_is_still_completed(self) -> None:
+        """The existing argument, kept: the benchmark scores the report."""
+        r = self._result("x" * (MIN_REPORT_CHARS + 10), skips=["02_hypothesis_generation"])
+        self.assertEqual(r.status, "completed")
+        self.assertEqual(r.exit_code, 0)
+
+    def test_an_aborted_walk_is_not_completed_however_big_the_report(self) -> None:
+        r = self._result("x" * 40_000, aborted="UnicodeDecodeError: invalid start byte")
+        self.assertTrue(r.aborted)
+        self.assertEqual(r.status, "aborted")
+        self.assertEqual(r.exit_code, 1)
+
+    def test_a_finished_walk_with_a_stub_report_is_failed(self) -> None:
+        r = self._result("too short")
+        self.assertEqual(r.status, "failed")
+        self.assertEqual(r.exit_code, 1)
+
+    def test_an_aborted_walk_with_no_report_is_aborted_not_failed(self) -> None:
+        """Which one it is matters: `failed` means it tried and produced nothing."""
+        r = self._result("", aborted="MemoryError: ")
+        self.assertEqual(r.status, "aborted")


### PR DESCRIPTION
Life_002 on the `full40_pins` arm died at Stage 03 of 7 — a `UnicodeDecodeError`
raised while a prompt was being assembled — with four stages never attempted.
Every artifact a reader consults said it was fine. `_meta.json` said
`status: completed`. `run_arm.py` logged `DONE Life_002: completed`. The judge
scored it **22.6** and that number entered a 40-task arm mean beside runs that had
finished. Finding it took reading `_agent_output.jsonl` by hand for
`"pipeline_completed": false` next to `"report_source": "synthesized"` — two
fields nothing downstream reads.

The adapter is right to export the salvage: work already paid for should survive a
crash. It was wrong to file the salvage as a finished run.

`BenchmarkResult` gains `aborted_with` — the exception that ended the walk — and a
`status` with three outcomes instead of two:

* `completed` — the walk finished and the report clears `MIN_REPORT_CHARS`;
* `aborted` — an exception ended it, however substantive the salvaged report;
* `failed` — it finished and produced nothing worth scoring.

`exit_code` is 0 only for the first. **An auto-skipped stage is deliberately still
`completed`**: that recovery path is designed, the walk reached the end, and the
report is what the benchmark scores. This property's original argument was about
that case and it survives untouched. The distinction being added is finishing
versus stopping, not degraded versus perfect.

`rcb_agent.py` records the exception in the `except` that already existed, and
writes `_meta.json` once, after the result exists, instead of before it — the old
call computed `status` from `report_path.exists()`, which is a fact about a file
rather than about a run.

**The harness needed almost nothing**, which is the good news and also why this
went unnoticed for so long: `run_arm.py` already skips only tasks whose meta says
`completed`, so an aborted run is now re-run on the next visit instead of being
counted; `score_arm.py` already scores only `completed`. The one change there is
that its refusal now names the reason — `run aborted: the stage walk was ended by
an exception` — rather than falling through a branch that only knew about
`running`.

Five tests, two caught mutations: dropping the abort check from `status`, and
letting `exit_code` go back to asking only whether the report is substantive.

Related: the `UnicodeDecodeError` itself is #261. This is the reason it cost a run
rather than an index entry, and it would have hidden the next one too.

`python3 -m unittest discover -s tests -p "test_*.py"`: Ran 3761, OK (skipped=1).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)