### PR TITLE
Seventy-five skills from twenty-five losses, and a pin budget that can hold them

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,8 +635,9 @@ Alongside the prompt, AutoR installs an agent skill pack from [src/skills/](src/
 `runs/<run_id>/.claude/skills/` — the operator's working directory — so the agent can *pull*
 long-form craft guidance when it needs it. A skill costs nothing in the prompts that do not use it.
 
-Forty-five skills ship today: twenty-five general ones and twenty field-specific ones. **A run is
-not offered all of them.** Two filters narrow the pack, and a skill has to survive both:
+120 skills ship today: 65 general ones and 55 field-specific ones. Seventy-five of them were written against a scored arm's per-criterion losses on the
+twenty-five ResearchClawBench tasks that lost, three per task. **A run is not offered all of
+them.** Two filters narrow the pack, and a skill has to survive both:
 
 1. **Field.** A skill named `<field>-...` is installed only for a run in that field, so twenty
    become two. A materials run does not benefit from being offered advice about observational

--- a/configs/task_skill_pins.json
+++ b/configs/task_skill_pins.json
@@ -1,194 +1,377 @@
 {
   "_what": "Skills forced into a run by its task identifier. Everything else AutoR routes on is derived from the task statement; this is derived from a previous run's SCORE, so it names identifiers and generalises to nothing outside them.",
-  "_provenance": "Built from the ResearchClawBench arm pinned at 2ffaeb4 (/rmeng_data/robtang/rcb_runs/arm_2ffaeb4), scored with gpt-5.1 under the 15-image window: AutoR 31.35 against bare Claude Code 31.53 over 40 tasks. Each entry was assigned criterion by criterion from that arm's per-criterion scores and the judge's written reasoning for BOTH arms, then adversarially re-checked against the skill bodies. 23 tasks that scored below 26 or lost to the bare agent were assessed; 8 were given no pin, because their remaining gap is below the 3.4-point single-draw rescoring noise or the shipped data cannot support the criteria at all. Three pins across Material_001 and Life_001 were left unverified when their checking agent died mid-response; a later pass dropped all three -- two as already installed and already named at the right stage, one as aimed 1.01 sd below the rescoring noise at a criterion of a task AutoR had won. Life_001 came out of the table entirely.",
+  "_provenance": "Rebuilt from the ResearchClawBench arm pinned at 1069e77 (/rmeng_data/robtang/rcb_runs/full40_v220), scored with gpt-5.1 under the 15-image window: AutoR 27.23 against bare Claude Code 27.44 over 40 tasks. 25 tasks were assessed -- the 12 that scored below the pre-fix arm and the 20 that lost to the bare agent. Each was re-scored per checklist item for BOTH arms (rcb_results/items_v220, items_control), so a pin is assigned against a named criterion and its recoverable weight rather than against a total. Across those 25 tasks the paired per-item comparison recovers 176.3 weighted points on image criteria and 92.1 on text: the loss is mostly figures, and not for lack of them -- on every task whose image criteria lost badly AutoR published MORE figures than the control, usually twice as many, all planned and almost none dropped. It draws its own workflow diagnostics and omits the figure the field expects. Each task's three new skills were written from its per-item losses, then adversarially reviewed for whether they hand over an answer rather than a method, whether an agent that has never seen the rubric could act on them, and whether they restate a shipped skill. 17 of 69 were told to drop and 45 to rewrite; all were revised against those verdicts. The existing skills each entry also names are the ones that review said already carry the advice for that task's losses -- pinned because being in the pack was demonstrably not enough: over 40 runs the pack offered 16 skills and the model opened a median of 1, with 27% of runs opening none and a single skill (citation-discipline) taking half of all reads.",
   "_declares_itself": "A run that matches an entry writes `skill_pins` into its run_config.json and a `skills pinned_by_task_id` line into its log. A pinned arm and an unpinned arm are two configurations; a score from one is not a score from the other, and the artifact says so without anyone having to remember.",
-  "_maximum": "Three per task. The measured failure of this pack is that a run reads 1.75 skills out of about thirty offered; handing one eight more descriptions reproduces the problem a pin is meant to solve.",
+  "_maximum": "Fifteen per task, and they must name their stages. Three was the number while a pin was announced in every stage prompt: at that size the listing cost was 3 lines x 7 prompts and the alternative -- handing a run eight more descriptions to read past -- reproduced the problem a pin is meant to solve. `format_skills_for_prompt` now routes a pin to the stages its SKILL.md names, so the cost is the pin count times its stage span divided by seven rather than the pin count itself. At the pack's measured 3.2 stages per skill that is 7 announcements per stage prompt at fifteen pins, against 9.3 at twenty, which is back on the curve this cap exists to stay off. The read rate is what makes fifteen worth having: over a 40-task arm the one skill a prompt told the operator to READ fired in 31 of 40 runs, and the three a prompt said were 'installed for this stage' fired in none. A pin is announced imperatively, so fifteen pins at 78% is about twelve skills actually read per run against the 1.75 the undifferentiated listing produced. A pin that names no stage still falls back to every stage, so raising the cap cannot make a pin silent -- but a pin written without stages spends the whole budget it was routed to save, and a table of fifteen stageless pins is the old problem with a new number.",
   "_columns": "task id -> skill names. Commentary per task is in _rationale: `autor` and `control` are that task's two scores, `net` is autor - control over the whole task, `recoverable` is the sum of weight x (control - autor) over only the criteria where the control scored higher, `headroom` is the sum of weight x (100 - autor) over every criterion, and `new_to_this_run` lists the pins the two routing filters would not have installed. `recoverable` and `net` differ whenever AutoR wins some criteria and loses others, which is most tasks; `net` is the number that says whether the task was lost.",
   "_rationale": {
-    "Physics_000": {
-      "autor": 18.7,
-      "control": 53.4,
-      "new_to_this_run": [],
-      "net": -34.7,
-      "recoverable": 34.7,
-      "headroom": 81.3
+    "Astronomy_000": {
+      "pins": 13
     },
-    "Information_002": {
-      "autor": 9,
-      "control": 33.1,
-      "new_to_this_run": [],
-      "net": -24.1,
-      "recoverable": 24.1,
-      "headroom": 91.0
-    },
-    "Neuroscience_003": {
-      "autor": 35.25,
-      "control": 55.55,
-      "new_to_this_run": [],
-      "net": -20.3,
-      "recoverable": 22.1,
-      "headroom": 64.8
-    },
-    "Chemistry_003": {
-      "autor": 24.5,
-      "control": 39.3,
-      "new_to_this_run": [],
-      "net": -14.8,
-      "recoverable": 16.3,
-      "headroom": 75.5
-    },
-    "Material_000": {
-      "autor": 4.5,
-      "control": 17.9,
-      "new_to_this_run": [],
-      "net": -13.4,
-      "recoverable": 13.4,
-      "headroom": 95.5
-    },
-    "Material_003": {
-      "autor": 35.7,
-      "control": 47.2,
-      "new_to_this_run": [
-        "life-full-study-skeleton-including-the-wet-lab-half"
-      ],
-      "net": -11.5,
-      "recoverable": 11.5,
-      "headroom": 64.3
-    },
-    "Life_002": {
-      "autor": 17,
-      "control": 26.5,
-      "new_to_this_run": [
-        "information-exhibit-the-intermediate-objects"
-      ],
-      "net": -9.5,
-      "recoverable": 15.5,
-      "headroom": 83.0
-    },
-    "Energy_000": {
-      "autor": 20.3,
-      "control": 27.8,
-      "new_to_this_run": [
-        "material-as-specified-run-and-stage-diagnostics"
-      ],
-      "net": -7.5,
-      "recoverable": 7.5,
-      "headroom": 79.7
+    "Astronomy_003": {
+      "pins": 12
     },
     "Chemistry_000": {
-      "autor": 36,
-      "control": 41.3,
-      "new_to_this_run": [],
-      "net": -5.3,
-      "recoverable": 13.0,
-      "headroom": 64.0
+      "pins": 7
     },
-    "Math_003": {
-      "autor": 23.75,
-      "control": 27.25,
-      "new_to_this_run": [],
-      "net": -3.5,
-      "recoverable": 5.25,
-      "headroom": 76.2
+    "Chemistry_001": {
+      "pins": 10
+    },
+    "Chemistry_003": {
+      "pins": 11
+    },
+    "Earth_000": {
+      "pins": 7
+    },
+    "Earth_001": {
+      "pins": 9
     },
     "Earth_002": {
-      "autor": 33,
-      "control": 35.4,
-      "new_to_this_run": [
-        "information-fill-the-whole-results-grid"
-      ],
-      "net": -2.4,
-      "recoverable": 10.6,
-      "headroom": 67.0
+      "pins": 8
     },
-    "Material_002": {
-      "autor": 48.45,
-      "control": 49.22,
-      "new_to_this_run": [],
-      "net": -0.77,
-      "recoverable": 9.9,
-      "headroom": 51.6
+    "Energy_001": {
+      "pins": 12
+    },
+    "Energy_002": {
+      "pins": 13
+    },
+    "Energy_003": {
+      "pins": 11
+    },
+    "Information_000": {
+      "pins": 9
+    },
+    "Information_001": {
+      "pins": 7
+    },
+    "Information_002": {
+      "pins": 11
+    },
+    "Life_002": {
+      "pins": 10
+    },
+    "Life_003": {
+      "pins": 10
+    },
+    "Material_000": {
+      "pins": 15
     },
     "Material_001": {
-      "autor": 11.9,
-      "control": 12,
-      "new_to_this_run": [],
-      "net": -0.1,
-      "recoverable": 9.55,
-      "headroom": 88.1,
-      "note": "Net -0.10: a tie, not a loss, and it is here for one criterion. Index 1 (weight 0.35, AutoR 2, control 25, 8.05 recoverable) wanted the generated lattice parameters in angstrom with a KL divergence and a coverage fraction; AutoR reported an entropy in bits instead, and the shipped file's two 101-value lattice arrays -- which it parsed -- are plotted nowhere. The pinned skill is the only one in the pack that says to print the landmark scalar in the property's own physical unit, it is a material skill so a Material run installs it anyway, and no prompt names it -- so the pin is the only channel that puts it in front of this run."
+      "pins": 8
     },
-    "Neuroscience_000": {
-      "autor": 14,
-      "control": 9.4,
-      "new_to_this_run": [],
-      "net": 4.6,
-      "recoverable": 0,
-      "headroom": 86.0,
-      "note": "Recoverable is 0.00: there is no criterion here where the control scored higher. The pin aims at uncontested zero instead -- criteria both arms scored 0 on, worth 0.60 of Neuroscience_000's weight and 0.40 of Astronomy_001's. That is the best target on the board for raising a score and the worst for demonstrating anything, because there is no second measurement to compare against."
+    "Material_002": {
+      "pins": 13
     },
-    "Astronomy_001": {
-      "autor": 26,
-      "control": 20.2,
-      "new_to_this_run": [],
-      "net": 5.8,
-      "recoverable": 0,
-      "headroom": 74.0,
-      "note": "Recoverable is 0.00: there is no criterion here where the control scored higher. The pin aims at uncontested zero instead -- criteria both arms scored 0 on, worth 0.60 of Neuroscience_000's weight and 0.40 of Astronomy_001's. That is the best target on the board for raising a score and the worst for demonstrating anything, because there is no second measurement to compare against."
+    "Material_003": {
+      "pins": 9
+    },
+    "Math_002": {
+      "pins": 9
+    },
+    "Neuroscience_001": {
+      "pins": 13
+    },
+    "Neuroscience_003": {
+      "pins": 10
+    },
+    "Physics_000": {
+      "pins": 3
+    },
+    "Physics_001": {
+      "pins": 3
     }
   },
-  "Physics_000": [
+  "Astronomy_000": [
+    "publish-the-input-summary-in-its-measured-unit",
+    "every-variant-persists-the-same-object",
+    "do-not-grade-your-own-result-down",
+    "a-value-you-did-not-measure-still-has-a-source",
+    "astronomy-error-budget-is-the-audit-trail",
+    "astronomy-figure-is-the-unit-of-result",
+    "reproduce-then-extend",
+    "evidence-not-assertion",
+    "close-the-gap-to-the-published-number",
+    "draw-the-source-figure-panel-for-panel",
+    "publish-what-the-run-already-computed",
+    "the-canonical-figure",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Astronomy_003": [
+    "the-supplied-arm-owns-figure-one",
+    "every-claim-in-the-data-description-is-a-result",
+    "presence-before-consistency-in-the-final-review",
+    "chemistry-canonical-units-thresholds-incumbent",
+    "citation-discipline",
+    "information-fill-the-whole-results-grid",
+    "use-the-sources-own-names",
+    "run-the-requested-analysis",
+    "close-the-gap-to-the-published-number",
+    "cover-what-the-task-named",
+    "publish-what-the-run-already-computed",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Chemistry_000": [
+    "price-the-grid-in-wall-clock-and-fill-it-breadth-first",
+    "rebuild-the-sources-headline-table-row-for-row",
+    "chemistry-group-attribution-over-the-split-and-the-baseline-model",
+    "the-attribution-is-the-deliverable",
+    "result-table",
+    "information-fill-the-whole-results-grid",
+    "train-the-named-architecture"
+  ],
+  "Chemistry_001": [
+    "chemistry-interaction-inventory-of-the-modelled-complex",
+    "chemistry-ablations-and-curves-without-an-accelerator",
+    "chemistry-fill-every-row-of-the-comparator-table",
+    "math-canonical-curve-on-the-cost-counter",
+    "chemistry-ranked-entities-and-property-curves",
+    "math-equal-effort-baselines-and-knob-sweeps",
+    "material-as-specified-run-and-stage-diagnostics",
+    "train-the-named-architecture",
+    "publish-what-the-run-already-computed",
+    "the-canonical-figure"
+  ],
+  "Chemistry_003": [
+    "query-the-checkpoint-off-its-own-split",
+    "keep-the-pipeline-vocabulary-off-the-canvas",
+    "the-limiting-component-not-the-step-count",
+    "chemistry-canonical-units-thresholds-incumbent",
+    "chemistry-ranked-entities-and-property-curves",
+    "use-the-sources-own-names",
+    "train-the-named-architecture",
+    "close-the-gap-to-the-published-number",
+    "draw-the-source-figure-panel-for-panel",
+    "the-canonical-figure",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Earth_000": [
+    "earth-window-mismatch-is-an-alignment-problem",
+    "earth-shape-of-the-record-and-share-of-the-budget",
+    "earth-inter-technique-spread-is-a-result-not-a-caveat",
+    "earth-comparator-set-lives-outside-the-supplied-archive",
+    "earth-report-the-lattice-and-show-the-field",
+    "result-table",
+    "publish-what-the-run-already-computed"
+  ],
+  "Earth_001": [
+    "reconstruct-the-figure-layer-you-cannot-source",
+    "disclose-by-construction-not-by-absence",
+    "verify-against-the-publication-not-the-authors-code",
+    "earth-report-the-lattice-and-show-the-field",
+    "paper-writing",
+    "evidence-not-assertion",
+    "cover-what-the-task-named",
+    "draw-the-source-figure-panel-for-panel",
+    "the-canonical-figure"
+  ],
+  "Earth_002": [
+    "read-the-pilot-run-as-a-result",
+    "late-budget-goes-to-the-task-not-the-method",
+    "a-null-test-bounds-the-instrument-not-the-answer",
+    "earth-report-the-lattice-and-show-the-field",
+    "paper-writing",
+    "reproduce-then-extend",
+    "close-the-gap-to-the-published-number",
+    "draw-the-source-figure-panel-for-panel"
+  ],
+  "Energy_001": [
+    "energy-dispatch-quantities-on-the-native-time-index",
+    "energy-utilisation-per-named-element-when-a-limit-binds",
+    "energy-the-terms-behind-the-rate",
+    "the-attribution-is-the-deliverable",
+    "energy-counterfactual-pair-and-hierarchy-closure",
+    "energy-canonical-configuration-before-the-enhanced-variant",
+    "use-the-sources-own-names",
+    "run-the-requested-analysis",
+    "cover-what-the-task-named",
+    "draw-the-source-figure-panel-for-panel",
+    "the-canonical-figure",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Energy_002": [
+    "energy-build-the-domain-the-question-names",
+    "energy-cost-surface-before-the-verdict-map",
+    "energy-publish-the-ordering-when-the-level-fails",
+    "earth-comparator-set-lives-outside-the-supplied-archive",
+    "energy-counterfactual-pair-and-hierarchy-closure",
+    "mine-the-papers-you-were-given",
+    "energy-canonical-configuration-before-the-enhanced-variant",
+    "use-the-sources-own-names",
+    "close-the-gap-to-the-published-number",
+    "cover-what-the-task-named",
+    "publish-what-the-run-already-computed",
+    "the-canonical-figure",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Energy_003": [
+    "energy-inject-the-defect-the-algorithm-claims-to-fix",
+    "energy-dependence-statistics-move-with-the-averaging-window",
+    "energy-spend-the-figure-budget-on-the-named-checks",
+    "citation-discipline",
+    "energy-counterfactual-pair-and-hierarchy-closure",
+    "energy-canonical-configuration-before-the-enhanced-variant",
+    "run-the-conditions-the-source-ran",
+    "material-landmark-scalars-in-physical-units",
+    "run-the-requested-analysis",
+    "close-the-gap-to-the-published-number",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Information_000": [
+    "extract-the-pdf-text-layer-then-read-every-figure",
+    "the-headline-entry-is-the-canonical-outcome",
+    "price-the-missing-object-before-you-deepen-an-arm",
+    "astronomy-figure-is-the-unit-of-result",
+    "information-exhibit-the-intermediate-objects",
+    "evidence-not-assertion",
+    "draw-the-source-figure-panel-for-panel",
+    "the-canonical-figure",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Information_001": [
+    "price-the-queue-and-preempt-your-own-arms",
+    "information-a-training-free-method-owes-a-second-backbone",
+    "put-the-study-controls-in-the-demo-panel",
+    "information-fill-the-whole-results-grid",
+    "information-exhibit-the-intermediate-objects",
     "run-the-conditions-the-source-ran",
     "draw-the-source-figure-panel-for-panel"
   ],
   "Information_002": [
+    "information-transformation-ledger-for-a-multi-step-derivation",
+    "information-state-the-technique-and-what-it-discards",
+    "information-check-the-steps-yourself-not-only-their-scores",
+    "reproducibility-check",
+    "the-reproduction-is-a-hypothesis",
+    "information-exhibit-the-intermediate-objects",
+    "use-the-sources-own-names",
+    "evidence-not-assertion",
+    "run-the-requested-analysis",
+    "cover-what-the-task-named",
     "the-supplied-item-is-the-graded-unit"
   ],
-  "Neuroscience_003": [
-    "run-the-conditions-the-source-ran"
-  ],
-  "Chemistry_003": [
+  "Life_002": [
+    "life-the-correspondence-is-a-table-not-a-score",
+    "time-the-operation-not-the-invocation",
+    "the-firing-instance-gets-the-full-record",
+    "life-benchmark-against-the-incumbent",
+    "earth-comparator-set-lives-outside-the-supplied-archive",
+    "neuroscience-comparator-ladder-and-per-unit-predictions",
+    "run-the-conditions-the-source-ran",
     "close-the-gap-to-the-published-number",
-    "draw-the-source-figure-panel-for-panel"
+    "publish-what-the-run-already-computed",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Life_003": [
+    "a-refutation-banner-over-a-confirming-panel",
+    "a-detection-score-is-a-claim-about-its-population",
+    "write-the-result-sentence-before-the-statistic",
+    "life-benchmark-against-the-incumbent",
+    "the-reproduction-is-a-hypothesis",
+    "information-exhibit-the-intermediate-objects",
+    "reproduce-then-extend",
+    "run-the-requested-analysis",
+    "close-the-gap-to-the-published-number",
+    "publish-what-the-run-already-computed"
   ],
   "Material_000": [
+    "write-the-model-section-from-the-code",
+    "the-figure-plan-is-a-purchase-order",
+    "measure-every-clause-of-the-data-description",
+    "reproducibility-check",
+    "paper-writing",
+    "result-table",
+    "information-exhibit-the-intermediate-objects",
+    "material-as-specified-run-and-stage-diagnostics",
+    "evidence-not-assertion",
+    "material-landmark-scalars-in-physical-units",
+    "train-the-named-architecture",
+    "run-the-requested-analysis",
+    "publish-what-the-run-already-computed",
+    "the-canonical-figure",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Material_001": [
+    "material-decode-the-stub-into-its-reference-runs",
+    "material-object-over-reference-figure-gate",
+    "material-front-load-one-result-block-per-deliverable",
+    "mine-the-papers-you-were-given",
+    "material-as-specified-run-and-stage-diagnostics",
+    "material-landmark-scalars-in-physical-units",
+    "run-the-requested-analysis",
+    "the-canonical-figure"
+  ],
+  "Material_002": [
+    "material-same-estimator-same-slot",
+    "material-power-the-contrast-you-invented",
+    "material-trajectory-health-is-a-panel",
+    "math-equal-effort-baselines-and-knob-sweeps",
+    "energy-canonical-configuration-before-the-enhanced-variant",
+    "material-as-specified-run-and-stage-diagnostics",
+    "reproduce-then-extend",
+    "evidence-not-assertion",
+    "material-landmark-scalars-in-physical-units",
+    "cover-what-the-task-named",
+    "draw-the-source-figure-panel-for-panel",
+    "publish-what-the-run-already-computed",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Material_003": [
+    "material-design-targets-span-the-property-range",
+    "material-deliver-a-candidate-a-chemist-could-make",
+    "material-draw-the-framework-and-rebuild-its-corpus",
+    "life-full-study-skeleton-including-the-wet-lab-half",
+    "chemistry-ranked-entities-and-property-curves",
+    "material-as-specified-run-and-stage-diagnostics",
+    "material-landmark-scalars-in-physical-units",
     "train-the-named-architecture",
     "the-canonical-figure"
   ],
-  "Material_003": [
-    "a-value-you-did-not-measure-still-has-a-source",
-    "life-full-study-skeleton-including-the-wet-lab-half"
+  "Math_002": [
+    "math-budget-the-grid-before-the-cell",
+    "math-register-every-metric-a-run-emits",
+    "math-train-distribution-is-a-reporting-axis",
+    "the-unit-of-analysis",
+    "math-equal-effort-baselines-and-knob-sweeps",
+    "neuroscience-stratify-and-report-detection-metrics",
+    "information-fill-the-whole-results-grid",
+    "run-the-conditions-the-source-ran",
+    "train-the-named-architecture"
   ],
-  "Life_002": [
-    "the-supplied-item-is-the-graded-unit",
-    "information-exhibit-the-intermediate-objects"
-  ],
-  "Energy_000": [
-    "material-as-specified-run-and-stage-diagnostics",
-    "run-the-conditions-the-source-ran"
-  ],
-  "Chemistry_000": [
-    "the-attribution-is-the-deliverable"
-  ],
-  "Math_003": [
-    "run-the-conditions-the-source-ran"
-  ],
-  "Earth_002": [
+  "Neuroscience_001": [
+    "tuning-curves-report-the-argmax-and-its-error",
+    "the-expected-negatives-are-the-discrimination",
+    "draw-the-system-not-your-study",
+    "the-unit-of-analysis",
+    "citation-discipline",
+    "neuroscience-comparator-ladder-and-per-unit-predictions",
+    "neuroscience-stratify-and-report-detection-metrics",
+    "material-landmark-scalars-in-physical-units",
+    "cover-what-the-task-named",
     "draw-the-source-figure-panel-for-panel",
-    "information-fill-the-whole-results-grid"
-  ],
-  "Material_002": [
-    "draw-the-source-figure-panel-for-panel",
-    "close-the-gap-to-the-published-number"
-  ],
-  "Material_001": [
-    "material-landmark-scalars-in-physical-units"
-  ],
-  "Neuroscience_000": [
-    "the-attribution-is-the-deliverable"
-  ],
-  "Astronomy_001": [
+    "publish-what-the-run-already-computed",
     "the-canonical-figure",
+    "the-supplied-item-is-the-graded-unit"
+  ],
+  "Neuroscience_003": [
+    "plant-decoys-and-report-what-each-method-admits",
+    "neuroscience-colour-the-embedding-by-the-shipped-labels",
+    "claims-before-harness-forensics",
+    "mine-the-papers-you-were-given",
+    "neuroscience-comparator-ladder-and-per-unit-predictions",
+    "neuroscience-stratify-and-report-detection-metrics",
+    "reproduce-then-extend",
+    "run-the-conditions-the-source-ran",
+    "cover-what-the-task-named",
     "draw-the-source-figure-panel-for-panel"
+  ],
+  "Physics_000": [
+    "a-supplied-parameter-file-is-a-list-of-questions",
+    "the-process-deliverable-is-the-labelled-state-at-every-step",
+    "the-axis-carries-the-observable-not-the-verdict"
+  ],
+  "Physics_001": [
+    "every-supplied-array-is-a-series-in-a-results-panel",
+    "physics-plot-the-named-quantity-and-declare-the-calibration",
+    "the-results-panel-is-not-where-the-run-argues-with-itself"
   ]
 }

--- a/src/run_skills.py
+++ b/src/run_skills.py
@@ -439,9 +439,17 @@ def format_skills_for_prompt(
     * **shape** -- a predicate over this run's brief matched, and the skill named this
       stage. An inference, and it can be wrong about this task.
     * **pinned** -- this run's identifier is in the pin table. Not an inference: a
-      record of what a previous run of the same task lost. Announced at every stage,
-      because a pin is short by construction and the stage that needed it is usually
-      the one that had already gone wrong before anyone looked.
+      record of what a previous run of the same task lost.
+
+    A pin is announced at the stages it names, and at every stage only when it names
+    none. That used to be unconditional, and it was affordable because the table capped
+    a task at three: three lines in each of seven prompts. It stops being affordable at
+    the size the table is now, and in the direction that matters -- a description
+    competes against every other description in the prompt, so fifteen pins announced
+    seven times over is the listing problem the cap existed to avoid, reintroduced by
+    the mechanism meant to solve it. Routing them costs nothing: a pin that says which
+    stage it is for is announced there, and the stage that needed it is the stage it
+    names.
 
     Named imperatively, because that is the form measured to work: over a 40-task arm
     the one skill a rendered prompt told the operator to *read* fired in 31 of 40 runs,
@@ -456,7 +464,12 @@ def format_skills_for_prompt(
         key=lambda entry: entry.name,
     )
     by_pin = sorted(
-        (entry for entry in entries if entry.name in pinned), key=lambda entry: entry.name
+        (
+            entry
+            for entry in entries
+            if entry.name in pinned and (not entry.stages or stage_slug in entry.stages)
+        ),
+        key=lambda entry: entry.name,
     )
     if not by_shape and not by_pin:
         return ""
@@ -479,11 +492,20 @@ def format_skills_for_prompt(
             "a stronger reason than any of the others in your context: it is not advice about "
             "tasks like this one, it is a record of this one. **Read every one of them before "
             "you plan this stage**, and treat what they describe as the failure most likely to "
-            "be repeated here.",
+            "be repeated here. This is the subset of the task's pins that names this stage; "
+            "others are announced at the stages they name.",
             "",
         ]
         lines += [f"- `{entry.name}` — {entry.description}" for entry in by_pin]
     return "\n".join(lines)
+
+
+#: Pins one task may carry. See the table's own ``_maximum`` for the arithmetic; the
+#: short version is that a pin is announced imperatively at the stages it names, the
+#: pack averages 3.2 stages per skill, and fifteen pins is seven announcements per stage
+#: prompt against twenty's nine. Enforced rather than written down, because the previous
+#: cap was written down and the only thing stopping a sixteenth pin was whoever noticed.
+MAX_PINS_PER_TASK = 15
 
 
 def validate_task_pins(table: dict[str, list[str]], source_dir: Path) -> list[str]:
@@ -493,8 +515,14 @@ def validate_task_pins(table: dict[str, list[str]], source_dir: Path) -> list[st
     is silent otherwise: `select_run_skills` filters the pack, so an unknown name
     simply selects nothing and the task runs with the pack it would have had anyway.
     A renamed skill breaks every pin that names it.
+
+    The two size rules are here for the same reason: both are silent at run time. A task
+    over :data:`MAX_PINS_PER_TASK` still runs, and so does one whose pins name no stage
+    -- the second one just quietly spends the whole per-prompt budget the routing exists
+    to save, which is the failure the cap was raised on the assumption of avoiding.
     """
     known = {entry.name for entry in read_skill_pack(source_dir)}
+    stages_by_name = {entry.name: entry.stages for entry in read_skill_pack(source_dir)}
     problems: list[str] = []
     for task_id, names in sorted(table.items()):
         if not names:
@@ -504,6 +532,18 @@ def validate_task_pins(table: dict[str, list[str]], source_dir: Path) -> list[st
                 problems.append(f"{task_id} is pinned to {name!r}, which is not in {source_dir}.")
         if len(set(names)) != len(names):
             problems.append(f"{task_id} names the same skill twice.")
+        if len(names) > MAX_PINS_PER_TASK:
+            problems.append(
+                f"{task_id} carries {len(names)} pins, over the maximum of "
+                f"{MAX_PINS_PER_TASK}. See the table's `_maximum`."
+            )
+        stageless = sorted(n for n in names if n in known and not stages_by_name.get(n))
+        if len(names) > 3 and stageless:
+            problems.append(
+                f"{task_id} carries {len(names)} pins and {len(stageless)} of them name no "
+                f"stage, so they are announced in every stage prompt: {', '.join(stageless)}. "
+                f"A table this size is only affordable because pins are routed."
+            )
     return problems
 
 

--- a/src/skills/a-detection-score-is-a-claim-about-its-population/SKILL.md
+++ b/src/skills/a-detection-score-is-a-claim-about-its-population/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: a-detection-score-is-a-claim-about-its-population
+description: Use at study design and at analysis whenever a detection or ranking score (area under a precision-recall or ROC curve, recall at a fixed precision) is about to be compared against another study's number, or when one arm detects items the other misses. Covers publishing the population beside the score, the prevalence ladder to run when the source never states its own, and the characterisation of the extra detections that needs no annotation.
+stages: 03_study_design, 06_analysis
+---
+
+# A detection score is a claim about the population it was computed on
+
+## What goes wrong
+
+Two arms are scored on the same candidates, one is better, and the result ships as two
+areas under two curves. Areas are the least transferable statistic available. The area
+under a precision-recall curve moves with the positive rate; the area under an ROC curve
+moves with the composition of the negatives. Your candidate set is almost never the set
+another study scored on. So when your area and theirs disagree, neither you nor the reader
+can tell whether you disagree about the method or about the denominator - and the run
+writes the arithmetic up as a substantive contradiction of the source, which is a false
+claim that also displaces the true one.
+
+The second failure sits underneath it. "More sensitive" is a claim about a *set*: the items
+one arm found and the other did not. Reported as two scalars, the set is never opened, so
+nothing is ever said about what the extra detections are or whether they are real.
+
+Curve craft, the operating-point sweep and the count-of-additional-true-positives headline
+are `life-benchmark-against-the-incumbent`; the general population/split discriminator is
+`close-the-gap-to-the-published-number`. This skill starts where both stop: what to do when
+the source never states its own population, and what to publish about the extra detections
+when the items carry no annotation you can join to.
+
+## Publish the population with the number
+
+Every detection score in the report, in the table and on the panel, carries: n candidates,
+positive count, positive rate, and the rule by which candidates entered the set. Do the
+same for the source's number wherever the source states it, on the same row. A
+precision-recall statistic quoted without its positive rate is not a comparable number,
+and the chance line on your curve is that rate - draw it and label it with the value.
+
+## When the source does not state its population, walk a ladder
+
+The source usually will not. "The source does not report its candidate-set composition" is
+where most runs stop, and stopping there converts the largest number in the report into an
+unresolved limitation. Do this instead:
+
+1. Resample the majority class of your own evaluation set to a ladder of positive rates -
+   a geometric sequence from your own rate down to the smallest rate the source's setting
+   plausibly implies, several seeds per rung.
+2. Recompute the metric for *both* arms at every rung. Report value and across-seed spread
+   per rung, as a small table or a second panel with rate on the x-axis.
+3. Read three things off it, in writing: the rung (if any) at which your value meets the
+   source's; whether the ordering of the arms is stable across the ladder; whether the
+   size of the between-arm gap is stable across the ladder.
+4. State which of three holds - prevalence explains the whole difference from the source,
+   part of it, or none of it - and give the residual after matching.
+
+The between-arm difference is usually far more stable across the ladder than either
+absolute value. That is the sentence worth writing, because it is the one that survives a
+reader who holds a different anchor for what the source's number was.
+
+## Open the set, and characterise it with what you have
+
+Materialise the comparison as an artifact before you summarise it: one row per candidate,
+with each arm's score, each arm's call at the operating point you report, the label if you
+have one, and a membership column over {both, method-only, baseline-only, neither}. Report
+all three counts, not one - an arm that finds extra items while losing items the other had
+is a different result from one that loses none.
+
+Then characterise the method-only set against the shared set. This part needs no
+annotation and is therefore never blocked:
+
+- **Label composition.** Of the method-only calls, how many are true positives; the same
+  for the baseline-only calls. A pile of extra detections that are mostly correct and a
+  pile that is mostly noise are opposite results and cost the same to compute.
+- **Score placement.** Where the extra detections sit in each arm's score range, and how
+  close the losing arm came on them - which distinguishes items the baseline ranked just
+  below its threshold from items it did not see at all.
+- **Any covariate the supplied tables already carry** - depth, coverage, length, category,
+  batch - as a distribution for the method-only set beside the shared set.
+
+These go in Results, next to the metric they explain, not in an appendix.
+
+## The annotation route is optional, and its failure is reported, not assumed
+
+If the items can be joined to named biological or physical units, do it: the extras'
+distribution over those units, tested against the shared set as background, with counts.
+Two routes exist before you conclude they cannot - the source's supplementary tables,
+which is where its own item-level version of the claim usually lives, and the reference
+annotation the task names, which maps coordinates or ids to units. Attempt both, name the
+join key each needs, and record what was missing. "Not attempted, inputs missing" written
+in a run that successfully parsed the source's supplement is not a finding, it is a stage
+that did not look. And if both genuinely fail, say which units the source itself reports
+its extras in, so the reader can see exactly what is absent.
+
+## Checklist
+
+- [ ] n, positive count, positive rate and inclusion rule printed beside every detection
+      score, for every arm.
+- [ ] Chance line drawn on the curve at the actual positive rate and labelled with it.
+- [ ] Prevalence ladder computed for both arms with seed spread, whenever a score is
+      compared against another study's.
+- [ ] Written verdict: prevalence explains all / part / none of the difference, with the
+      residual.
+- [ ] Membership artifact on disk; all three set sizes reported.
+- [ ] Label composition and score placement of the method-only set reported in Results.
+- [ ] Annotation join attempted by both routes, or its impossibility stated with the
+      missing key named.

--- a/src/skills/a-null-test-bounds-the-instrument-not-the-answer/SKILL.md
+++ b/src/skills/a-null-test-bounds-the-instrument-not-the-answer/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: a-null-test-bounds-the-instrument-not-the-answer
+description: Use at analysis and again at writing whenever you run a permutation, shuffle, placebo, unforced-control or power test against your own headline result, especially when it comes back saying the result is not distinguishable from noise. Covers giving every condition the task names its own value line and stating the relation across them as a result, keeping the estimate and the bound as two results with two different subjects, and the sentence order that stops a bound replacing the answer.
+stages: 06_analysis, 07_writing
+---
+
+# Give every condition its value line, then bound it
+
+## The spine
+
+For every condition the task names — every scenario, arm, dose, cohort, model,
+regime — the report carries one line of this shape:
+
+    condition: value [interval] vs reference value, gap
+
+Including conditions you could only reach by derivation, interpolation or
+borrowing. A derived condition gets its line with the derivation named in the
+same clause. It does not get a footnote in place of a number.
+
+Then, in its own sentence, **the relation across conditions, stated as a
+result**: the ordering, the monotonicity, the crossing — whichever relation the
+task's comparison is about. Over all the conditions the task named, not the
+subset your claim structure happened to scope.
+
+This is where runs holding correct numbers lose. The results file has the values
+in the right relation; the preregistration scoped the ordering claim to a subset
+because one condition arrived late or by derivation; and the report never states
+the full relation anywhere. The relation is a separate result from the values,
+and having the values on disk is not stating it. A condition your hypothesis
+excluded is still a condition the task asked about.
+
+`reproduce-then-extend` owns the shape of the published-versus-ours table these
+lines live in. Do not restate it; fill it.
+
+## Two results with two different subjects
+
+Building a no-signal null against your own criterion — permuting the labels that
+carry the contrast, an unforced control run, a placebo condition, a
+within-population split — is right, and most runs never do it. Then it comes back
+saying your headline sits inside it, and the run has to decide what that means.
+
+It means two things, and the loss is in fusing them.
+
+- **The estimate.** "Under condition C, X% of the population falls in the high
+  class, interval [l, u], against a published Y%." Subject: the world.
+- **The bound.** "At this sample size, window length and threshold, the same
+  criterion returns Z ± s from labels carrying no signal." Subject: your
+  instrument.
+
+The bound does not delete the estimate. It says how much of the estimate is
+attributable to signal. Fuse them and you publish a verdict where the task asked
+for a quantity, and a reader looking for the number finds a non-result.
+
+## At analysis
+
+1. Keep the two in separate artifacts with separate decision rules. The null's
+   verdict never overwrites the estimate's field.
+2. Choose the null that matches the claim, and say why. Where the field has a
+   standard no-signal instrument — an unforced control run, a scrambled decoy
+   set, a permutation over a held-out population — prefer it to one you invented.
+   A permutation *within* the same sample confounds internal variability with the
+   effect and is the widest, least informative null available.
+3. Calibrate it before believing it. Run it on a case known to carry signal. A
+   null that also swallows that case is measuring its own width, and that is a
+   finding about your criterion rather than about your result.
+4. Express it as a quantity in the headline's units: the false-positive floor,
+   the configuration that produced it, and — if one more run is affordable — the
+   sample size, window or threshold at which the result would clear. A floor with
+   a number is a contribution. "Not significant" is a label.
+5. Name the construction feature that produces the floor: a ratio threshold at
+   small counts, a floor near the quantisation step, a fixed denominator. Show
+   the sweep, so a reader can tell whether the floor belongs to your
+   reconstruction or to the published method.
+6. Separate "no power to detect" from "no effect". They imply opposite next
+   actions. State which one your evidence supports, and what would distinguish
+   them.
+
+## At writing: the order inside the sentence
+
+The bound is not banned from the abstract, the title or the conclusion. A run can
+lead with its noise floor and still read as having answered — provided that
+everywhere the reader meets the quantity, **the requested value comes first in
+the sentence and the bound comes second, in the same sentence.** Estimate, then
+bound. Never bound alone.
+
+What loses is the reverse order, and substitution:
+
+- a sentence whose subject is the verdict and whose object is the value;
+- a verdict standing where the value should be, with the value deferred;
+- the caveat re-attached to quantities the null was never computed for.
+
+The third is a correctness problem, not a matter of tone. A bound is computed for
+specific quantities under a specific configuration. Restating it over a regional
+breakdown, a downstream comparison or a secondary arm that never entered the null
+asserts something you did not measure. Attach it where it was computed;
+elsewhere, cross-reference it.
+
+If the null is the most interesting thing the run found, it is an *additional*
+result. The conclusion still opens with what the task asked for.
+
+## The checks
+
+- One value line per condition the task names. A missing line is a missing
+  result, and a caveat does not substitute for it.
+- The relation across conditions is written as a sentence, early, and covers
+  every condition — including the derived ones.
+- Read the first results sentence of the abstract. Is the first quantity in it
+  the one the task asked for, or is it a p-value or an interpolation error?
+- Grep for the bound's label. Every occurrence outside its own section is either
+  a cross-reference or a quantity the null was actually computed for.

--- a/src/skills/a-refutation-banner-over-a-confirming-panel/SKILL.md
+++ b/src/skills/a-refutation-banner-over-a-confirming-panel/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: a-refutation-banner-over-a-confirming-panel
+description: Use at hypothesis freeze, and again after the last revision pass, when a run has found that the supplied data or your own reproduction disagrees with the source it names. Covers the branch-name test that stops an agreement being printed as a refutation, and the enumerate-and-search sweep that keeps fidelity verdicts and internal labels out of the title, the headings and the figure banners.
+stages: 02_hypothesis_generation, 07_writing
+---
+
+# A refutation banner over a confirming panel
+
+## What goes wrong
+
+You investigate the supplied bundle, find something real about it, and the finding is
+sharper and easier to measure than the analysis you were asked for. Two library skills
+already cover the consequence: run the requested analysis anyway and add the audit as its
+own section (`run-the-requested-analysis`), and kill the cheap explanations for a gap
+before calling it a disagreement (`close-the-gap-to-the-published-number`, whose first two
+discriminators are units/normalisation and population/split). Read both.
+
+This skill is the residue those two do not touch, and it is purely lexical: the word a
+hypothesis branch is given before any data exists, and the words that end up in the few
+slots a reader actually reads. Both are invisible from the inside. Both survive an
+intention to avoid them - a run can carry an explicit written objective to lead with the
+requested analysis, ship the fidelity verdict in its title anyway, and then spend its one
+revision pass making that verdict more precise. Intent does not fire here. Enumerate and
+search does.
+
+## Check 1 - the branch-name test, at hypothesis freeze
+
+Before any hypothesis is frozen, write one line for it:
+
+> If the source's published claim is exactly true of my data, branch ____ fires, and that
+> branch is called ____.
+
+Read the branch name. If it contains *refuted*, *rejected*, *diverges*, *inconsistent*,
+*not reproduced*, *fails*, *synthetic*, *surrogate* or *inauthentic*, the hypothesis's
+subject is the file rather than the phenomenon, and every artifact downstream of it will
+stamp a failure word across a panel whose data agrees with the source. Prose cannot undo
+this: the heading and the figure banner are what get read.
+
+The fix is to change the subject, not the wording. The hypothesis asks about the thing the
+task named - does this variable dominate the response, does this ordering hold across
+conditions, does this arm detect more - phrased so that the source's claim being true
+fires a branch you would be happy to title a panel with.
+
+Provenance hypotheses are legitimate and stay. They are *separate*: their own hypothesis
+id, their own statistic, their own figure slot, their own section. The specific sentence
+to refuse is any variant of "computed once, this statistic is both the deliverable and a
+provenance test". A statistic with two jobs resolves as the audit every time, because the
+audit is the branch with the interesting name.
+
+## Check 2 - the verdict-word sweep, after the last revision
+
+Do not do this by reading. Build the list, then search it.
+
+1. Enumerate, as literal strings: the report title; the first two sentences of the
+   abstract; every section and subsection heading; every figure suptitle and panel title;
+   the first sentence of every caption.
+2. Case-insensitively search each string for verdict words - refuted, supported, confirms,
+   diverges, divergence, overshoots, undershoots, inflated, discrepancy, deviation, not
+   reproduced, fails to reproduce, provenance, authentic, synthetic, surrogate,
+   mislabelled - and for anything of the form "X vs published".
+3. Search the same strings for internal labels: hypothesis ids, slot numbers, proposition
+   or obligation ids, branch names, stage names.
+
+Every hit is a defect unless it sits inside the single section that *is* the fidelity
+accounting, or the word states the requested analysis's own outcome in plain language: an
+exemption on that ground has to name the phenomenon and a number, so "H1 refuted" and "the
+supplied numbers diverge from the published ones" do not qualify. Two fixes, and only
+these two:
+
+- **Internal label in a title.** Delete it. A reader has no copy of your numbering. The
+  label belongs in the caption body or a plan appendix.
+- **Verdict word in a title.** Replace it with what the panel or section shows, in the
+  source's vocabulary and units. A suptitle states the quantity, the comparison and the
+  conditions. It is not a place to adjudicate anything.
+
+Then check the positive space, which is where the graded result usually went missing: for
+every claim of the source's that your data speaks to, one plain sentence exists saying
+whether your data reproduces it, with your number and the source's - **including every
+claim that does reproduce**. A confirmation that appears only as the premise of a
+refutation ("the effect sits where the source said it does, so the divergence hypothesis
+fails") is not in the report as a result. Give it its own sentence, in the lead of the
+section that owns it.
+
+## Checklist
+
+- [ ] Every frozen hypothesis has its branch-name line written, and no confirming branch
+      carries a failure word.
+- [ ] No statistic and no figure slot serves both a requested analysis and a provenance
+      test.
+- [ ] Title, abstract's first two sentences, all headings, all suptitles and panel titles,
+      all caption openings: enumerated as a list and searched, not skimmed.
+- [ ] Zero verdict words and zero internal labels among them, outside the one fidelity
+      section.
+- [ ] One sentence per source claim stating whether your data reproduces it, with both
+      numbers, including the ones that agree.
+- [ ] The fidelity finding is complete, in one place, and is not the first thing a reader
+      meets.

--- a/src/skills/a-supplied-parameter-file-is-a-list-of-questions/SKILL.md
+++ b/src/skills/a-supplied-parameter-file-is-a-list-of-questions/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: a-supplied-parameter-file-is-a-list-of-questions
+description: Use at study design, analysis and writing when the task ships a small file of named constants, ranges, entity tables, case lists or run settings. Covers treating each entry as a question your run must answer in the file's own labels and units — including entries your own audit shows are wrong — and why an agreement count is not an answer.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# A shipped parameter file is a list of questions, not a source to trust or discard
+
+A small file in `data/` that reads like a dump of settings — named constants,
+per-case or per-transition values, acceptance windows, a table of entity pairs,
+a list of starting configurations, precomputed summary counts — is not raw data
+and it is not documentation. It is the list of quantities somebody expects your
+report to contain, written in that person's own labels. Reproducing more of the
+upstream source than the file covers does not answer them.
+
+This is the row-level companion to `the-supplied-item-is-the-graded-unit`. That
+skill is about one named *object* keeping its own subsection and its own numbers.
+This one is about a file whose every entry is a separate claim, where the unit is
+the entry, and about what to do with entries your own audit shows are wrong.
+`run-the-conditions-the-source-ran` indexes the *source paper's* named
+experiments; the conditions in this file are ones the run may already have
+dismissed, which is exactly why that skill does not fire on them.
+
+## What goes wrong
+
+A run opens the shipped file, recomputes each block, and finds several blocks
+wrong: a compatibility or property column that recomputation contradicts and that
+in places carries the wrong sign; a named composite whose size is not admissible
+under the theory; a summary-statistics block whose counts reproduce the weights
+printed beside them to the digit, with no sampling noise in any cell. The run
+concludes the file is a generated companion rather than the study's data, refuses
+to anchor on it, goes upstream to the real source's data release, and reproduces
+that — more of the paper than any comparator recovers.
+
+Its report then contains no value from any block of the shipped file. The
+per-case optima the file names are never printed. The entity pairs it names are
+recomputed under a better convention, disagreed with, and published as different
+numbers under different labels. The starting configurations it names are audited
+and never run. The whole file gets one paragraph in Methods.
+
+Every particular of that audit was correct. Two different questions had been
+collapsed into one. *Is this value correct?* is an audit, and the audit answered
+it. *What is this value?* is a result, and nothing answered it. A comparator that
+does weaker science, runs the same audit, reaches the same verdicts, and still
+tabulates its own value beside each supplied one beats that run on every
+requirement written from the file's contents.
+
+## What to produce
+
+**Stage 03 — parse the file into a claim ledger.** With code, not by eye, write
+`notes/supplied_claims.json`, one row per *entry*, not per block:
+
+| field | content |
+|---|---|
+| `block` | the block or section name as written in the file |
+| `label` | the entry's own key, verbatim — the case name, the pair, the step type |
+| `supplied` | the value as shipped, with its unit if one is stated |
+| `kind` | `constant` / `range` / `sequence` / `case` / `condition` |
+| `counterpart` | which planned computation of yours produces the same quantity |
+| `mine` | blank until Stage 06 |
+| `verdict` | blank until Stage 06 |
+
+A block with no counterpart in your plan is a hole in the plan. Add the
+computation, or write one sentence saying why that quantity is out of scope. Do
+not leave a row unpaired.
+
+**Stage 03 — the `case` and `condition` rows are experiments.** A seed structure,
+a named composite, a run sequence, a temperature-and-rate setting is a condition
+to execute, not a number to check. Put one row in the experiment grid per such
+entry, before any variant of your own is costed. Where the entry as written is
+unphysical, run it as written *and* run the corrected version, and report the
+pair; that is a stronger result than the correction alone.
+
+**Stage 06 — fill `mine` with a value, never with an error.** The counterpart
+goes in the same unit and under the same label as the supplied entry. A residual,
+a pass/fail, a tolerance flag, a rank or a count is not a counterpart. If your
+quantity is only defined under a convention different from the file's, give it
+under both.
+
+**Stage 07 — the ledger is a Results table.** Columns: label, supplied, this run,
+verdict. One row per entry, in the file's own order, placed where the
+corresponding science is discussed. A data-provenance appendix is not that place;
+a reader looking for a quantity looks in the section about that quantity.
+
+## The aggregate clause
+
+"N of M published values reproduced to within eps" is a statement about your
+implementation. It is worth reporting and it says nothing about the system. It
+may sit beside the table of values; it may not stand in for it. When the design
+document names the primary metric as a fraction, a coverage, a hit rate or a
+worst-family score, that framing propagates into every downstream deliverable —
+the figure manifest, the results table, the abstract — and by Stage 07 no
+sentence in the report states a value at all. Name the metric as a fraction if
+you want one; name the values themselves as deliverables in the same paragraph.
+
+Every constant that survives the audit should then appear *inside* the figure
+that shows the matching result, as a labelled reference line or an annotated
+point carrying its numeral, under the file's own name for it.
+
+## When the supplied value is wrong
+
+Print both, state the discrepancy and its size, and still give your value in the
+supplied entry's own labels and units. "Contradicted" is a verdict on a row, not
+permission to delete the row. If the only occurrence of a quantity in your report
+is inside a list of blocks you rejected, the quantity is missing from your
+report.
+
+## Before you finish
+
+- Every row of `supplied_claims.json` has a non-empty `mine`.
+- Every `condition` row has a run, or one sentence saying why not.
+- Grep the report for each `label`. Zero hits is an unanswered question.
+- No quantity the task's output list names exists in the report only as a
+  fraction-reproduced or a residual.

--- a/src/skills/answer-the-why-not-only-the-what/SKILL.md
+++ b/src/skills/answer-the-why-not-only-the-what/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: answer-the-why-not-only-the-what
 description: Use when writing results and discussion, and when a task or a reviewer asks why an effect happens rather than whether it does. Covers the difference between reporting an effect and accounting for it, and what a mechanism claim needs behind it.
+stages: 05_experimentation, 06_analysis, 07_writing
 ---
 
 # A measured effect is half the result

--- a/src/skills/astronomy-error-budget-is-the-audit-trail/SKILL.md
+++ b/src/skills/astronomy-error-budget-is-the-audit-trail/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: astronomy-error-budget-is-the-audit-trail
 description: Use at analysis and writing when a result rests on a fit or a calibration chain and you are about to quote it with a single uncertainty. Covers itemising the error budget term by term, keeping the fit's own bookkeeping visible, and why the audit trail is the result a referee checks first.
+stages: 03_study_design, 06_analysis, 07_writing
 ---
 
 # Astronomy: the error budget and fit bookkeeping are the audit trail

--- a/src/skills/astronomy-figure-is-the-unit-of-result/SKILL.md
+++ b/src/skills/astronomy-figure-is-the-unit-of-result/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: astronomy-figure-is-the-unit-of-result
 description: Use at study design when choosing the figure list, and again before writing, when a result is about to be reported as a pooled number or a table. Covers why the figure is the unit a result is delivered in here, which panels a paper of this kind is expected to carry, and what a pooled number hides.
+stages: 03_study_design, 06_analysis, 07_writing
 ---
 
 # Astronomy: the figure is the unit of result, and nothing is reported pooled

--- a/src/skills/chemistry-ablations-and-curves-without-an-accelerator/SKILL.md
+++ b/src/skills/chemistry-ablations-and-curves-without-an-accelerator/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: chemistry-ablations-and-curves-without-an-accelerator
+description: Use at study design after you have priced a scaled-down training arm and found the machine cannot carry it — no accelerator visible, or no wall clock for one arm. Covers the one-row-per-named-component table with the inference switch that removes each part, why an input ablation does not answer a component criterion, and the ladder of curves that still ships when nothing can be trained.
+stages: 03_study_design, 05_experimentation, 06_analysis
+---
+
+# Ablations and curves when the sandbox has no accelerator
+
+**Price the training arm first.** `train-the-named-architecture` is the primary
+instruction: when the brief names an architecture, a small honest re-implementation
+trained at whatever scale you can afford answers every architecture-shaped criterion.
+So before this skill applies, measure the machine — device query, cores, RAM, wall
+clock left — and price one scaled-down training arm against it, in writing. What
+follows sits **on top of** that arm wherever it is affordable, and replaces it only
+where there is genuinely no accelerator and no time.
+
+## What goes wrong
+
+The task names an architecture by its parts. The run uses a released implementation,
+decides that removing a part means retraining, prices retraining, finds it
+unaffordable, and records the ablation as *not attempted*. The report then describes
+the parts in prose and labels the description as not a measurement made in this run.
+Nothing in the run varies the thing the task is about, and every prediction it makes
+is made at one identical configuration.
+
+Two habits make the omission permanent:
+
+- **The ablation serves no hypothesis, so the descope ladder cuts it first.** Arms
+  that buy breadth across targets survive; the one arm that would show which part
+  carries the result is the cheapest thing to drop and the first thing dropped.
+- **A slot is refused because it has no content yet.** Declining to reserve a table
+  row or a figure slot for an arm you have not run guarantees the arm is never run,
+  because nothing downstream is missing it.
+
+## One row per named component, switch or no switch
+
+Take the component list from the nouns in the brief's architecture sentence and from
+the reference method's own block diagram. Every one gets a row, written before
+anything runs:
+
+| component | switch available at inference | what the arm is no longer | if no switch: price of the real arm |
+
+A component with no inference switch does not fall off the table. Its row reads "no
+switch exposed; the only arm is a trained control, priced at N accelerator-hours" —
+that sentence is the deliverable for that component, and it is worth much more than
+silence.
+
+Switch shapes present in most released implementations:
+
+| component shape | the switch | what the arm is no longer |
+|---|---|---|
+| iterative sampler or denoiser | step count to its minimum | an iterative process; it is single-shot |
+| recycling or refinement loop | iterations to zero | iteratively refined; it is one forward pass |
+| submodule behind a config flag | switch it off | using that submodule |
+| learned head or scorer | replace with the trivial predictor it was introduced to beat | learned at that stage |
+| ensemble or multi-sample selection | one sample, fixed seed | a selection over candidates |
+| internal data-dependent feature | shuffle or randomise it, keeping shapes | using the information in that feature |
+
+Write the third column **before** you run the arm. That sentence is what makes the
+run an ablation of a named component rather than a hyper-parameter change, and it is
+the claim the report will make.
+
+**Removing an input is a different experiment.** Withholding an alignment, a
+template, a conformer, a charge set or an auxiliary channel is an *input* ablation.
+It is worth running and worth reporting, and it does **not** answer a criterion about
+a component — `train-the-named-architecture` is explicit on this point. Give it its
+own row, labelled as an input ablation, and do not let it stand in for a component
+row.
+
+**Say what the proxy cannot show.** A sampler turned down to its minimum step count
+tests the module's use at inference, not its contribution during training. One honest
+sentence on the row; a measured row with a stated limit beats an absent row.
+
+## Budget rule
+
+Reserve one arm per named component before buying any breadth in the main panel. All
+the components on a fixed subset of a handful of targets is almost always cheaper
+than one more stratum, and it is the difference between a report that measures the
+architecture and one that measures a dataset. Run every ablated arm on exactly the
+targets the full arm ran, so the deltas are paired. If the plan has a descope ladder,
+the component arms sit above the breadth arms on it and the plan says why.
+
+Report the arms in the shape `math-equal-effort-baselines-and-knob-sweeps` already
+specifies — degradation ranked, quality paired with cost. Add one thing to it: a
+geometric or validity statistic beside the accuracy (extent, spread, output norm,
+validity rate). A collapsed, averaged or truncated output can score well on a
+permissive metric, and a degenerate arm that wins is worse than no arm at all.
+
+## At least one curve ships
+
+A learned or iterative model is expected to be shown against its own counter, and "no
+accelerator" does not discharge that. Work down this ladder, shipping the first rung
+you can reach and any further rung that is cheap:
+
+1. **A toy training run on the hardware you actually have.** Loss and one validation
+   metric against step, appended inside the loop, every arm overlaid on one axis. A
+   curve from a model small enough to train in twenty minutes on the CPU you were
+   given is strictly better evidence than no curve, and the overlay doubles as the
+   ablation figure.
+2. **An inference-counter sweep.** Sweep each exposed counter — denoising steps,
+   refinement iterations, samples, seeds — on a fixed subset with everything else
+   held constant, and plot the metric *and* the wall clock against the counter. Mark
+   the setting the main results used and say whether it sits before, at or past the
+   knee. Flat or non-monotone is itself a finding: it says the limit is the learned
+   map, not the sampler. Usually minutes per point.
+3. **A single-step corruption curve**, wherever the model exposes one denoise or
+   refinement call: corrupt the reference at a known level, apply one step, plot
+   recovered accuracy against corruption level. It separates a bad objective from a
+   bad trajectory.
+4. **Accuracy against the number of samples drawn**, best-of-N beside a selection
+   rule that does not peek at the answer. Every generative model has this one.
+
+At least one of the four ships as a figure. A sentence explaining the absent curve,
+placed where the curve would have gone, is the outcome this ladder exists to prevent.
+
+## Checklist
+
+- [ ] The scaled-down training arm was priced first against a measured device and
+      time budget, and the price is in the report.
+- [ ] Every named component has a row, including the ones with no inference switch.
+- [ ] Each arm carries its "what it is no longer" sentence, written before it ran.
+- [ ] Input ablations are labelled as such and do not occupy a component's row.
+- [ ] Ablated arms ran on exactly the targets the full arm ran; deltas are paired.
+- [ ] A validity or geometry statistic sits beside the metric on every arm.
+- [ ] At least one counter curve ships as a figure, with cost on the same plot.
+- [ ] Empty rows carry a price and a reason, never a blank.

--- a/src/skills/chemistry-canonical-units-thresholds-incumbent/SKILL.md
+++ b/src/skills/chemistry-canonical-units-thresholds-incumbent/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: chemistry-canonical-units-thresholds-incumbent
 description: Use at study design and analysis when a chemistry result is about to be reported in the units your code happens to produce, or without the program the field already uses. Covers anchoring to the incumbent, converting to the canonical unit, and turning an error distribution into a threshold success rate.
+stages: 03_study_design, 04_implementation, 06_analysis
 ---
 
 # Anchor to the incumbent program, report in the canonical unit, convert error into a threshold success rate

--- a/src/skills/chemistry-fill-every-row-of-the-comparator-table/SKILL.md
+++ b/src/skills/chemistry-fill-every-row-of-the-comparator-table/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: chemistry-fill-every-row-of-the-comparator-table
+description: Use at literature stage and study design when the source publishes performance broken out by class of system, and you are about to choose your evaluation panel with a filter written for throughput. Covers transcribing the table as rows, auditing the inclusion filter against those rows before it is frozen, and buying one target per row before a second target for any row.
+stages: 01_literature_survey, 03_study_design, 05_experimentation
+---
+
+# Every row of the comparator table needs an arm of yours
+
+## What goes wrong
+
+At literature stage you extract the incumbent's performance table — the one that
+breaks accuracy out by class of system — and you put it in a comparator section,
+correctly cited. Then you choose the panel you will actually run, and you choose it
+with a filter written for throughput: a size window, a component or chain count cap,
+"whatever the implementation supports as input", an availability or deposit-date cut,
+a per-target runtime ceiling. Finally you stratify your own results along an axis
+your hypotheses distinguish, which is not the table's axis.
+
+Each step is defensible. Together they delete whole rows of the table, and nothing
+downstream notices, because the filter is written in a vocabulary the rows do not use
+— it selects on size or on tooling, and the rows are classes. The published number
+for the deleted row survives in your report as a quotation with nothing of yours
+beside it. A reader looking for your result on that class finds a citation.
+
+This costs more than it looks. A per-class claim is graded per class, so a missing
+row reads as work not done rather than as coverage foregone. And a claim that one
+method handles several classes — "general-purpose", "unified", "one model for all of
+them" — is supported only by the same model run unchanged on each class. Depth inside
+one class does not substitute, however many targets that depth contains.
+
+## What to do
+
+**1. Transcribe the table as rows, while the paper is open.** Not as prose. One row
+per class the source's own table distinguishes, each carrying: the class name in the
+source's words, the published value, the metric's exact definition, its threshold and
+its N. Write it to `notes/comparator_rows.json` before any design exists. A prose
+paraphrase loses the axis, and the axis is the only part that matters here.
+
+**2. State the inclusion filter as an explicit predicate, then run it against the
+rows.** Before the panel is frozen, write the filter as a list of conditions a
+candidate system must satisfy. For each row of the table, name at least one candidate
+that satisfies all of them. A row with no passing candidate has been deleted by your
+filter, and you now have three options, each of which is a decision taken on purpose:
+
+- widen the filter, or carve an exception for that row — usually the right answer,
+  because one target costs one run;
+- fill the row with a cheaper surrogate and label it as a surrogate;
+- record the row as unfillable, naming the exact condition that excludes it and the
+  price of relaxing that condition.
+
+Filters that delete rows silently, in rough order of frequency: a size or length
+window; a component, chain or subunit count cap; what your chosen implementation
+happens to accept as input; data or structure availability; a per-target runtime or
+memory ceiling; licence. Every one of them correlates with class membership, which is
+exactly why the deletion is invisible from inside the filter.
+
+**3. Allocate one target per row before a second target for any row.** The panel's
+first N runs buy N classes, not N members of the most convenient class. Breadth along
+the table's axis is the deliverable; breadth within a row is a refinement of a row you
+already have.
+
+**4. Stratify the reported results on the table's axis.** Add your own stratification
+— by input type, by data source, by whatever your hypotheses distinguish — as a second
+cut. It does not replace the first. If the primary results figure is broken out along
+an axis the comparator table does not use, the reader cannot lay the two side by side,
+which was the point of extracting the table.
+
+**5. Compute your value in the row's own metric definition and threshold**, so it
+lands in the same column as the published one; your preferred metric goes beside it,
+never instead of it. `chemistry-canonical-units-thresholds-incumbent` covers the unit
+and threshold discipline, `use-the-sources-own-names` covers carrying the class names
+into your headings.
+
+## What ships
+
+One table, every row of the source's present, your column beside theirs:
+
+| class (source's name) | published value | N | your value, same definition | N | delta, or the reason the cell is empty |
+
+An empty cell carries the reason and the price of filling it, never a blank. A row you
+decided not to run is a decision reported in one clause; a row nobody noticed is an
+absence.
+
+## The check, before writing
+
+Take the class names out of `comparator_rows.json` and grep the report for each, with
+word boundaries. A class that appears only in the related-work or comparator section,
+and never in a results heading, a table row or a figure label, is one you cited
+instead of measured. The check takes a minute, and it is the last point at which one
+extra run can still close the gap.
+
+## How this differs from its neighbours
+
+`mine-the-papers-you-were-given` builds the list of proper nouns the supplied papers
+attach to results and forces a run / compare / say-why-not decision on each.
+`run-the-conditions-the-source-ran` covers the named experiments and scenarios.
+`information-fill-the-whole-results-grid` covers filling a published grid at reduced
+N. What is here and not in any of them is the **filter audit**: the population you
+allowed yourself to draw from was chosen for cost, in a different vocabulary from the
+table's rows, and that is the mechanism by which a run that read the table carefully
+still finishes with no arm behind half of it.

--- a/src/skills/chemistry-group-attribution-over-the-split-and-the-baseline-model/SKILL.md
+++ b/src/skills/chemistry-group-attribution-over-the-split-and-the-baseline-model/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: chemistry-group-attribution-over-the-split-and-the-baseline-model
+description: Use at study design, experimentation and analysis when the deliverable includes which substructures, functional groups or motifs drive the model's predictions, once the attribution estimator is already chosen. Covers widening from the one molecule the source drew to the whole evaluation split with per-molecule normalisation, running the identical attribution on the comparator model so a claim of better interpretability becomes measurable, and treating a learned edge or subgraph mask as a first-class output.
+stages: 03_study_design, 05_experimentation, 06_analysis
+---
+
+# A group ranking from one molecule has no n, and "more interpretable" is a comparison
+
+This picks up after the estimator is chosen. `the-attribution-is-the-deliverable`
+covers which estimator to use, computing two of them and reporting their
+disagreement, the trivial-feature control, and the fact that the output has to be
+a figure. None of that is repeated here. What that skill leaves open, and what
+loses the interpretability criterion, is three things: the population, the
+comparator model, and the mask.
+
+The failure shape is always the same. The source drew a saliency map for one named
+molecule; the run computes its own map for the same molecule, sums the per-atom
+scores into the named functional groups, gets a different ranking from the
+source's, and reports the disagreement. Both halves fail. A ranking of a few
+groups derived from the atoms of a single molecule has no sample size, so a
+disagreement cannot be distinguished from that molecule's noise. And the claim
+under test is comparative -- the method highlights chemically meaningful
+substructures *more than the conventional architecture does* -- which one model's
+map cannot address at all.
+
+## 1. The population is the evaluation split, not the drawn molecule
+
+Write a SMARTS pattern for every group the analysis names and match it against
+**every molecule in the held-out split** (`Chem.MolFromSmarts`,
+`GetSubstructMatches`). Report one table:
+
+- molecules containing the group (n) and matched atoms (m);
+- mean attribution of matched atoms, **normalised within each molecule before
+  averaging across molecules**. Raw scores are not comparable between molecules;
+  per-molecule max-normalisation or a z-score is the difference between a
+  statistic and an artefact of molecule size;
+- the dispersion across molecules, so the ranking carries an interval;
+- the same figures for atoms matched by no named pattern, as the contrast.
+
+State the normalisation and the overlap rule -- an atom matched by two patterns is
+assigned to both, or to neither -- in the caption. A source's group totals are
+frequently not reconstructible from its per-atom column without them, and when
+your ranking disagrees with the published one, the normalisation and the
+population are the first two suspects, ahead of the model.
+
+The molecule the source drew keeps its own panel and its own numbers. Widening to
+the split is additive, never a replacement. If that molecule is in your training
+split, say so and add one that is not.
+
+## 2. The comparator model gets the identical attribution
+
+Same estimator, same molecules, same normalisation, run on the conventional
+architecture already sitting in your main results table. You trained it; the
+attribution is a forward and a backward pass. Put the two group tables side by
+side and report the per-group delta.
+
+Without that column, a claim that the method is more interpretable than the
+conventional one has no measurement anywhere in the report. With it, the answer is
+a result in either direction: a map no more concentrated on the named groups than
+the baseline's is a finding, and a stronger one than a ranking that merely fails
+to match the source's.
+
+## 3. The learned mask is an output, not a sentence
+
+Where the method or the source produces a learned edge or subgraph mask, that mask
+is a second deliverable and takes the same three treatments as the atom map:
+aggregated over the split, computed on the comparator model, and drawn. A
+correlation coefficient between your mask and a deposited one, reported in prose
+and never plotted, discharges nothing.
+
+- Extract the mask per molecule over the split; state the sparsity or size
+  constraint and the optimisation budget.
+- Describe the retained subgraph as chemistry: how many edges retained, which
+  named groups the retained edges fall in, ring versus acyclic, by bond order.
+- Report agreement two ways: against the source's mask where one is deposited,
+  and against your own atom-level map. Whether two estimators of your own select
+  the same substructures is the internal-consistency check, and it exists whether
+  or not the source deposited anything.
+- Draw the retained subgraph on the structure for the depicted molecules.
+- Run the identical extraction on the comparator model.
+
+Bond-level attributions get the same aggregation: by bond order, ring versus
+acyclic, and by the groups at each end. A per-bond correlation with nothing
+aggregated behind it is a diagnostic, not a result.
+
+## 4. Depiction, and choosing what to depict
+
+At least one panel shows the attribution painted on a rendered 2D structure
+(`Draw.SimilarityMaps.GetSimilarityMapFromWeights`, or `MolToImage` with
+`highlightAtomColors`), not only scatters and bar pairs.
+
+Pick the depicted molecules by a **stated rule** -- the median-agreement molecule,
+the best, the worst, the highest-scoring true positive -- and name the rule in the
+caption. Choosing the exemplar by which one came out well is selecting the exhibit
+on the outcome; naming the rule costs one clause and removes the objection.
+
+## Order in the report
+
+Set-level statistic first as the evidence, the source's named molecule second as
+the illustration, in the figure layout and in the prose. State the group ranking
+with its n and its spread, then show the molecule that exemplifies it.
+
+## Checklist
+
+- [ ] A SMARTS pattern is written for every group the analysis names, with its
+      match count over the held-out split.
+- [ ] Per-molecule normalisation applied before cross-molecule averaging, and
+      named in the caption, along with the overlap rule.
+- [ ] The group table carries n and a dispersion per group, not bare means.
+- [ ] The identical attribution is computed on the comparator model and tabulated
+      beside the proposed one, with a per-group delta.
+- [ ] The learned mask, if the method has one, is aggregated over the split,
+      computed on the comparator, and appears in a figure.
+- [ ] At least one panel shows attribution on a rendered chemical structure.
+- [ ] The rule used to pick the depicted molecules is stated.
+
+Related: `the-attribution-is-the-deliverable` for estimator choice, two
+estimators, the trivial-feature control and the figure requirement;
+`chemistry-ranked-entities-and-property-curves` for the named-entity ranked list.
+What is here and not there is the population, the comparator-model arm, and the
+mask as an aggregated, compared, drawn output.

--- a/src/skills/chemistry-interaction-inventory-of-the-modelled-complex/SKILL.md
+++ b/src/skills/chemistry-interaction-inventory-of-the-modelled-complex/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: chemistry-interaction-inventory-of-the-modelled-complex
+description: Use at study design, analysis and writing when the result is a modelled or predicted molecular complex — a docked pose, a co-folded assembly, a binding interface — and RMSD, DockQ or lDDT is about to be the whole answer. Covers the reference-versus-prediction contact inventory per interaction class, the pocket-cropped figure with the interactions drawn, and the mechanism sentence.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Interaction inventory of the modelled complex
+
+## What goes wrong
+
+When the deliverable is a modelled molecular complex — a docked pose, a co-folded
+assembly, a predicted interface — the report stops at aggregate distances: RMSD,
+DockQ, lDDT, "fraction under the accepted cut". Those say how far the partner is
+from where it belongs. None of them says whether the model found the right pocket,
+reproduced the recognition chemistry, or kept the specific contacts that hold the
+complex together. A reader who wants to know what the model got right about the
+chemistry finds nothing to read.
+
+Three symptoms:
+
+- **The only structural figure is a whole-complex superposition.** The interface is
+  10–15 Å across inside a 60–80 Å frame, so it occupies a few percent of the canvas.
+  No residue is labelled and no contact is drawn. The figure shows that two clouds
+  overlap.
+- **The contact-level number was computed and dropped.** The fraction of native
+  contacts is a term inside DockQ, so any run reporting DockQ already has it, and
+  burial counts fall out of any interface routine. This is
+  `publish-what-the-run-already-computed`'s sweep, applied to the interface.
+- **The prose says the partner is "placed correctly but imprecisely".** That is an
+  eyeball claim about a picture with no measurement under it.
+
+A figure list generated from your own hypotheses will not contain this slot, because
+no hypothesis asks for it. Reserve it at study design as a deliverable of the subject
+matter, not of a hypothesis.
+
+## What to produce
+
+**One table.** The same inventory computed twice — on the experimental reference and
+on the prediction — with recovered / missed / spurious columns:
+
+| class | in reference | in prediction | recovered | missed | spurious |
+
+One row per interaction class the system actually has. A complex with no aromatic
+partner has no stacking row, and saying so explicitly is part of the inventory. The
+classes are the standard non-covalent taxonomy every interaction-fingerprint tool
+implements, and each is a distance-and-angle computation over heavy atoms:
+
+- **All heavy-atom contacts** across the interface, under the conventional cut. The
+  recovered fraction is the native-contact fraction: print it as a published number,
+  not only as an input to a composite score.
+- **Hydrogen bonds**: donor N/O to acceptor N/O within the conventional heavy-atom
+  distance, with a donor–H–acceptor angle criterion where hydrogens exist and a
+  donor-antecedent angle criterion where they do not.
+- **Hydrophobic contacts**: apolar carbon pairs within the conventional cut, grouped
+  by residue pair. Add buried surface area if a SASA routine is available.
+- **Aromatic stacking and cation–π**: enumerate rings on both sides from the bond
+  graph, then centroid–centroid distance with the interplanar angle separating
+  parallel from T-shaped; for cation–π, a charged or quaternary centroid near a ring
+  centroid.
+- **Salt bridges**: oppositely charged group pairs within the conventional cut.
+- **Per-residue**: contact count and deviation for every residue of the partner, so
+  you can name which residue lost its contacts.
+  `chemistry-ranked-entities-and-property-curves` owns the shape of that list; what
+  is added here is that it is computed on both structures and differenced.
+
+List the contacts by residue and atom name at least once. A count is not an inventory.
+
+## The figure
+
+No other figure skill covers this, and it is the part the deliverable turns on.
+
+- **Crop to the pocket, not to the complex.** Centre the view on the centroid of the
+  reference contact set and take the extent from the contacting atoms plus a small
+  margin. If the partner occupies less than about a third of the panel, the crop is
+  wrong.
+- **Two panels, identical axes, identical orientation, identical colouring**:
+  reference and prediction, each superposed on the receptor in the same frame. A
+  third panel overlaying both partners makes the displacement readable directly.
+- **Draw the interactions.** A dashed line per hydrogen bond and per salt bridge, a
+  centroid connector per stacking pair, a shaded patch for a hydrophobic cluster.
+  Colour by class and put the key inside the panel.
+- **Label the site residues** with their identifiers from the source structure, and
+  the partner's key atoms or fragments with theirs. An unlabelled pocket cannot be
+  checked against the literature by the reader who knows the system.
+- **Caption**: what was superposed on what, the alignment used, every cut-off, and
+  the recovered / missed / spurious counts, so the panel stands without the table.
+
+If no molecular renderer is installed, the figure is still available and still cheap:
+draw the **interface contact map** — partner residues on one axis, receptor site
+residues on the other, cells shaded for present-in-reference, present-in-prediction,
+and both. That is a distance matrix and matplotlib, it carries recovered / missed /
+spurious per residue pair, and it beats a whole-complex projection by a wide margin.
+
+## Two or three sentences of mechanism
+
+Name the recognition element the site is built around — the residues that form it, in
+the source's own naming — and say whether the model reproduced it, partially
+reproduced it, or replaced it with something else. That is the sentence a domain
+reader is looking for, and it cannot be written from an RMSD.
+
+## Calibration
+
+A contact either exists or it does not, and the cut-offs decide it.
+
+- State every cut-off and where it came from, in the caption and in the methods.
+- Run the inventory on the reference against itself: it must recover everything.
+- Where the reference has replicates — an ensemble, several copies in the asymmetric
+  unit, more than one deposit of the same complex — run the inventory across them
+  first. The recovery a reference achieves against itself is the band your
+  prediction should be read against.
+
+## Checklist
+
+- [ ] Contact set computed for reference and prediction; the native-contact fraction
+      appears in the report as a number.
+- [ ] Every interaction class present in the system has a row; absent classes are
+      named as absent.
+- [ ] Contacts listed by residue and atom name at least once, not only counted.
+- [ ] Per-residue contact counts and deviations exist for the whole partner.
+- [ ] The structural figure is cropped to the interface, identically oriented across
+      panels, labelled, with contacts drawn — or is a contact map if no renderer exists.
+- [ ] Cut-offs stated with a source; reference-against-itself returns full recovery.
+- [ ] The report names the recognition element and says what happened to it.

--- a/src/skills/chemistry-ranked-entities-and-property-curves/SKILL.md
+++ b/src/skills/chemistry-ranked-entities-and-property-curves/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: chemistry-ranked-entities-and-property-curves
 description: Use at analysis and figure planning when the computation ranks entities — molecules, poses, fragments, atoms — or sweeps a property along a coordinate. Covers printing the named ranked list and the property-versus-coordinate curve, the two artifacts most often computed here and least often reported.
+stages: 03_study_design, 05_experimentation, 06_analysis
 ---
 
 # Print the named-entity ranked list and the property-versus-coordinate curve -- chemistry's two most-computed, least-reported artifacts

--- a/src/skills/citation-discipline/SKILL.md
+++ b/src/skills/citation-discipline/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: citation-discipline
 description: Use when adding, verifying or cleaning citations and BibTeX entries in Stage 07 (Writing), when a reference cannot be resolved cleanly from DBLP or CrossRef, when checking that a cited paper actually supports the claim attributed to it, or when filling citation_verification.json.
+stages: 01_literature_survey, 07_writing
 ---
 
 # Citation discipline

--- a/src/skills/claims-before-harness-forensics/SKILL.md
+++ b/src/skills/claims-before-harness-forensics/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: claims-before-harness-forensics
+description: Use at hypothesis generation and study design on reproduction and method-evaluation tasks, once close reading of the release has turned up defects, ambiguities or under-specification, and again when ordering the report. Covers labelling every planned experiment as a test of a claim or a test of self-consistency, the count gate that follows, and where reproduction-fidelity statistics belong.
+stages: 02_hypothesis_generation, 03_study_design, 07_writing
+---
+
+# Claims before harness forensics
+
+## The failure this prevents
+
+Reading a release closely turns up real problems. A parameter documented two
+ways. A configuration that returns fewer items than the protocol needs. A
+headline comparison that changes two factors at once and therefore identifies
+neither. An evaluator whose denominator moves with input size. These findings
+are genuine, they are satisfying, and they are cheap — each one is a short
+script against code you have already vendored.
+
+So the run drifts. The frozen hypothesis set fills with tests of whether the
+released code is self-consistent. Figure slots fill with protocol panels. The
+headline numbers become agreement statistics: how many printed cells fell
+inside a replicate band, how a published gap decomposes across a lattice, how
+far two documented settings diverge. The first result in the abstract is a
+reproduction-fidelity score.
+
+Meanwhile the source's own claims — the ones anyone opening the report will
+look for — never get a producer. What ships is a competent audit of somebody's
+repository, submitted in place of an answer to the question. It is also
+self-defeating in tone: a run that spent its budget locating where the method
+is weaker than advertised has manufactured evidence against the claim it was
+asked to establish, and says nothing about the conditions under which the claim
+holds.
+
+## Build the row list elsewhere
+
+`run-the-conditions-the-source-ran` already gives the procedure: one row per
+named system, scenario, stress axis, ablation and worked case study, with the
+baselines it is compared against; run every row before any variant of your own;
+a row you cannot run still gets its subsection. Do that first — this skill is
+about what happens to that list when forensic work competes with it. Two
+additions:
+
+* The dataset shipped with the task is **one row, not the list.** Arms that
+  live behind a generator or an accession are rows too, and they are usually
+  the cheapest rows, because a generator gives exact ground truth at a size you
+  choose.
+* Do not plan around fetching. When an arm is out of reach, the cut is a
+  locally written, scaled-down instance of **the same result class** — fewer
+  units, fewer conditions, fewer replicates. The class is what the claim is
+  about; the size is not.
+
+## The C/F label
+
+Label every planned hypothesis and every planned figure:
+
+* **C** — it tests a claim the source makes about the world: this method beats
+  those under this condition, this structure is recovered, this effect
+  survives.
+* **F** — it tests whether the released code or paper is internally consistent:
+  a parameter specified twice, a config that truncates, an unidentified
+  contrast, our numbers landing inside our own replicate bands.
+
+F items rationalise into C if you let them, so use the operational test: **if
+neither answer to this experiment can change whether the source's claim about
+the world is true or false, it is F.** "Does the published contrast identify
+the mechanism?" is F — the claim stands either way. "Does the method still lead
+when the input is degraded?" is C.
+
+Write the labelled table out as an artifact, with the two counts in it. A count
+asserted in a stage summary is not auditable and will not survive contact with
+the next stage's rewrite.
+
+**The gate:** F must not outnumber C, and no F job enters the run queue while a
+C row still has no producer. Apply it before the plan is frozen, when the fix
+costs nothing.
+
+## Forensics that belongs inside a row
+
+A forensic finding that changes **how a claim row must be run** — a parameter,
+a root, a denominator, a preprocessing choice — is not a separate result. It is
+part of that row: reported inside it, and sized by its effect on the claim's
+number rather than on its own scale.
+
+A forensic finding with no consequence for any row is a real contribution and
+gets a named subsection plus a limitations line — after the claim rows, not
+before them.
+
+## Report ordering
+
+* The first two results a reader meets are claim rows: what the method
+  achieves, on what, against what baseline, in the metric's own units.
+* Reproduction-fidelity statistics — coverage counts, containment fractions,
+  median absolute deviation from published values — are statements about **your
+  harness**, not about the method. They belong in the reproduction section.
+  They must not be the first number in the abstract and must not be the title
+  of the main comparison figure; a headline that leads with a partial-coverage
+  verdict is read as a declined reproduction whatever the tables underneath say.
+* When a claim does not reproduce, report the shortfall **and** report what the
+  claim does hold at: the level, the ordering, the margin. A run that reports
+  only where the method fails has deleted the claim rather than measured it.
+* An uncovered row is named in limitations, by name, with the source's number
+  beside the blank.
+
+## Relation to task-coverage discipline
+
+`cover-what-the-task-named` keys coverage on the sentences you were handed;
+this keys on the source's result classes. Both tables, kept separately. A run
+can bind every clause of the brief to a measured artifact, declare full
+coverage and be right about it, and still have left most of the source's
+evidence base untouched — the brief is one paragraph and the study is six
+experiments. (`material-as-specified-run-and-stage-diagnostics` carries the
+same ordering rule for the narrower case of auditing a supplied protocol.)
+
+## Checklist
+
+- [ ] **hypothesis generation** — every candidate hypothesis carries a C or F
+      label and the two counts are written down before the set is frozen.
+- [ ] **hypothesis generation** — anything you quoted from the source about its
+      own evidence base is a row with a producer, not a sentence in a novelty
+      argument.
+- [ ] **study design** — F does not outnumber C; every C row has a producer or
+      a named scaled-down surrogate; F jobs are queued last.
+- [ ] **writing** — the abstract opens on claim rows; fidelity statistics sit
+      in the reproduction section and title no comparison figure.
+- [ ] **writing** — every non-reproducing claim carries both the shortfall and
+      the conditions under which it holds.

--- a/src/skills/close-the-gap-to-the-published-number/SKILL.md
+++ b/src/skills/close-the-gap-to-the-published-number/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: close-the-gap-to-the-published-number
 description: Use at Stage 05 and Stage 06 the moment a reproduction lands materially off a number the source study published — a different order of magnitude, an inverted trend, a collapsed estimate. Covers why the gap is a defect in your pipeline until you have shown otherwise, how much of the remaining budget to spend closing it, and what to write when it will not close.
+stages: 05_experimentation, 06_analysis
 ---
 
 # A disagreement with the published number is a bug report addressed to you

--- a/src/skills/cover-what-the-task-named/SKILL.md
+++ b/src/skills/cover-what-the-task-named/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cover-what-the-task-named
 description: Use at study design and again before writing, to check that every deliverable the task statement names has been produced. Covers how to enumerate what was asked for, why partial coverage scores worse than it feels, and what to do when a named deliverable is out of reach.
+stages: 03_study_design, 07_writing
 ---
 
 # The task named its outputs. Produce all of them.

--- a/src/skills/disclose-by-construction-not-by-absence/SKILL.md
+++ b/src/skills/disclose-by-construction-not-by-absence/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: disclose-by-construction-not-by-absence
+description: Use at analysis when figures are rendered and at writing when they are captioned, and whenever an internal review asks you to disclose something you could not do. Covers why a disclaimer drawn inside a figure's axes destroys the result it annotates, the single location a caveat is stated in and what counts as a second copy, and how to describe the substitute you built instead of the gap you had.
+stages: 06_analysis, 07_writing
+---
+
+# Disclose by construction, not by absence
+
+## The failure this prevents
+
+Two runs shipped the same panel with the same layer missing, because neither had
+the inputs for it. One wrote the omission into the figure's axes, into the
+figure's caption, into its design ledger and into its limitations section. The
+other wrote nothing anywhere — the word does not occur in its report. The reader
+graded the first as not having reproduced the missing element, and the second as
+matching the source qualitatively, on two pictures missing the same thing. The
+disclosure was the entire difference on that requirement, and it was one of the
+headline requirements of the task.
+
+The conclusion is not "say less". A silent gap is a defect and a reader is
+entitled to find it. The conclusion is that a gap you filled is a construction
+note, a gap you did not fill is one sentence, and every copy after the first is
+subtracted from the result it is attached to.
+
+## Say what you built, not what you lacked
+
+Where you produced a substitute for something you could not source, describe the
+object that exists:
+
+- "Positions are constructed from the per-category counts, not measured; they
+  carry no within-category information." Checkable, and it describes something
+  that is in the figure.
+- "The measured positions are unavailable, so that layer is omitted." Describes
+  a hole, and a hole can only be graded as a hole.
+
+Before writing either sentence, ask whether the missing thing can be produced
+instead. `reconstruct-the-figure-layer-you-cannot-source` is that question in
+full, and it is the version of this advice that raises the result rather than
+trading transparency for score.
+
+## Never draw an absence inside the axes
+
+On-figure text is not the problem — it is usually what wins a figure
+requirement. The value on every mark, the category names, `n`, the denominator,
+the reference line, the source's published constant beside yours: all of that
+belongs inside the axes, and in the run above the highest-scoring figure of all
+was one that carried several lines of its own on-panel annotation. What does not
+belong inside the axes is text about what the figure does **not** show.
+
+A figure is read as the result. Text drawn into the axes is part of the result,
+so a disclaimer rendered there replaces the finding with its absence at the one
+moment the reader is looking at the picture instead of the prose. It also
+survives every crop, thumbnail, excerpt and re-use the image appears in, long
+after the caveat has stopped being interesting.
+
+## One statement, at the point of absence
+
+`evidence-not-assertion`, `the-canonical-figure` and `cover-what-the-task-named`
+already fix the location: something you did not produce is stated plainly, in
+one sentence, in the section where the result would have gone. Keep that
+sentence — this skill is about the second and third copies.
+
+| location | first statement | any repeat |
+| --- | --- | --- |
+| the section where the result would have gone | required | — |
+| inside a figure's axes | never | never |
+| figure caption | only as a construction clause, when the figure itself is the substitute | no |
+| abstract | no | no |
+| limitations | a pointer, not a restatement | no |
+
+A caveat with four homes reads as the run's main finding. A reader has no way to
+tell a thoroughly disclosed minor gap from a major one, and prices it as major.
+
+## Do not let a review loop harden a caveat into an artifact
+
+Self-critique and internal review will ask for disclosure, and the discharge
+they deserve is the sentence you already wrote. Rendering that sentence into the
+figure, promoting it into a heading, or adding it to the abstract are not three
+discharges of one obligation; they are three more charges against the
+deliverable. Close such an obligation by naming the single location that holds
+the statement, and record that location in the review ledger so the next pass
+does not re-open it.
+
+When a review asks for a disclosure, run the cheaper test first: can the missing
+thing be produced under a stated construction? If yes, the caveat becomes a
+construction note and stops being a caveat.
+
+## Checklist, before the report is finished
+
+- Walk every string your plotting code draws inside the axes. Anything that
+  describes what the panel does not show, what was unavailable, or why something
+  is approximate: delete it from the render.
+- For each gap you did not fill, grep the draft for its key phrase. One hit, in
+  the section where the result would have gone, plus at most one pointer. Three
+  or more hits means the caveat is eating the result it is attached to.
+- Every construction note says what was built and from what, in one clause.
+- Every caption describes what is in the figure. No caption opens with what is
+  not.

--- a/src/skills/do-not-grade-your-own-result-down/SKILL.md
+++ b/src/skills/do-not-grade-your-own-result-down/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: do-not-grade-your-own-result-down
+description: Use when drafting limitations, the discussion or the abstract, and any time you are about to call your own result unimproved, inconclusive or unverifiable. Covers the hedge that contradicts the run's own decision record, and the check a caveat has to fail before it is published.
+stages: 02_hypothesis_generation, 06_analysis, 07_writing
+---
+
+# Do not grade your own result down
+
+A report acquires a defensive register in its last hour. Sentences appear that
+grade the work instead of reporting it:
+
+- "This matches the published work rather than improving on it."
+- "No check available here discriminates between the two admissible
+  conventions."
+- "We cannot be confident that our value is competitive."
+
+Each is a claim about the evidence the run holds, written from memory at the end
+of a long run by the one reader who will never check it against the artifacts.
+Two things follow. A grader will not be more confident in your number than you
+are, and will hand your own sentence back as the reason the criterion did not
+pass. And the sentences are often false: in one run a question that
+implementation had settled with a verbatim source quotation plus a second
+independent route shipped as the first limitation, unresolved, warning the reader
+that the headline number might be off by orders of magnitude.
+
+This is not a licence to overclaim. State the comparison and let it carry the
+verdict. If your number is worse than the published one, say by how much — that
+is a measurement. "Not better", with no number beside it, is a verdict you
+awarded yourself, and it costs the criterion whether or not it is true.
+
+## The three states
+
+One pass over every sentence in the draft that expresses doubt. Each resolves
+into exactly one of three, in the text:
+
+- **Settled.** Name the artifact and the evidence in one clause, then delete the
+  hedge: "the convention is the one the source states in §2, and the independent
+  route through Eq. (n) agrees (`notes/units_decision.json`)".
+- **Open and bounded.** Say what the alternative would do to the headline number,
+  and name the one measurement or comparison that would close it. A bounded doubt
+  is a service to the reader.
+- **Open and unbounded.** Rare. It has to say why no available check reaches it,
+  and it may not sit under a deliverable the task named — see the checklist.
+
+## Provenance of the thing you failed against
+
+"Refuted", "inconsistent", "an order of magnitude off" is only as good as the
+value you compared against. Before writing any of those words, check where that
+value came from. An axis range on a figure, an illustrative setting in a caption,
+a round number in a worked example, a default in a code repository: none of these
+is a claim the source made. A mismatch against one of them is not a finding, and
+writing it up as a refutation turns a correct answer into a self-inflicted
+failure — the more so when it reaches the abstract as a count of hypotheses.
+
+The comparator you *do* need — the source's published value for the quantity the
+task asks about, printed beside yours in the same unit, under the same criterion
+— is `close-the-gap-to-the-published-number` and `reproduce-then-extend`. Build
+that row there. This skill is about not talking the reader out of it afterwards.
+
+## Checklist, writing stage
+
+1. Grep the draft for `unresolved`, `cannot`, `no check`, `either way`, `not
+   verified`, `ambiguous`, `we assume`, `may be`, `not better`, `rather than an
+   improvement`, `at best`. Every hit takes one of the three states.
+2. For each hit, search the run's notes and decision artifacts for that question
+   by name before keeping the sentence. A doubt you cannot support with an
+   artifact is either already resolved on disk or never examined; find out which.
+   In a long run, already-resolved is the common case, because the stage that
+   settled it is hours behind you.
+3. Any sentence that rates the work as a whole — competent, adequate, standard,
+   not an improvement, a reimplementation — comes out. Rating is the reader's
+   job; yours is the comparison that lets them do it.
+4. The abstract states the headline quantity, its uncertainty and its comparator
+   before it states anything about your own hypotheses. A count of supported and
+   refuted internal hypotheses describes your process, and putting it first
+   displaces the number the task asked for.
+5. The limitation list holds no item that would, if true, make a named
+   deliverable wrong by orders of magnitude and is left undecided. Decide it or
+   withdraw the deliverable; an undecided one is a retraction printed under a
+   softer heading.
+6. Last pass, per named deliverable: read the sentence a reader would quote, and
+   ask whether it lets them judge how good the number is. If it only describes
+   your method, the comparator is missing. If it tells them not to trust the
+   number, go back to step 2.
+
+## Where the inputs to this pass come from
+
+At hypothesis time, every preregistered threshold or window records where it was
+read from and whether the source states it as a result — that record is what the
+provenance check above reads later. At analysis, every choice between two
+admissible conventions (factors of two, normalisations, reference constants, log
+bases, per-mole versus per-particle) gets a small decision artifact holding the
+alternatives, the evidence, the verdict, and how far the headline moves if the
+verdict is wrong. Writing then has something to check against instead of a memory
+of having once been unsure.

--- a/src/skills/draw-the-source-figure-panel-for-panel/SKILL.md
+++ b/src/skills/draw-the-source-figure-panel-for-panel/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: draw-the-source-figure-panel-for-panel
 description: Use at study design when planning figures for a reproduction, replication or validation task, and again before the report is written. Covers deriving each panel's series list and axis ranges from the source's rendered figure, giving every source result a panel before your own hypotheses claim the slots, and printing the source's named constants as labelled values.
+stages: 01_literature_survey, 03_study_design, 06_analysis
 ---
 
 # Every result the source drew, you draw

--- a/src/skills/draw-the-system-not-your-study/SKILL.md
+++ b/src/skills/draw-the-system-not-your-study/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: draw-the-system-not-your-study
+description: Use at study design when allocating figure slots, and again at analysis and writing, on tasks where the source's own rendered figures are not available to copy. Covers the four slots reserved for the system before any hypothesis claims one, drawing the loaded arrays instead of their counts, why a panel that reports a shortfall is not the panel carrying the result, and why a deliverable marked covered_by an artifact path is not covered.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Draw the system, not your study
+
+If the source's own figures are on disk, follow `draw-the-source-figure-panel-for-panel`
+first and use this skill only for the slots it leaves unassigned. This one is the
+index to use when they are not: the target paper is absent from the supplied
+related work, the task is specified in prose, or the field has no standard figure
+for this object. Then the system itself is the only index available, and a plan
+built by walking your own hypothesis list will pass every coverage check it owns
+while leaving a reader unable to see the thing that was studied.
+
+## Three rules that decide this before the slot list does
+
+**A count belongs in the caption; the array belongs in the panel.** If your
+caption can state how many entities, edges, samples, atoms or pixels there are,
+then you are holding an object with that many of something, and you can draw its
+matrix, its distribution or its map. A bar whose height *is* a count carries only
+the number you already wrote beside it. The usual form of this failure is a
+"data overview" figure whose source is an inventory or a file-hash manifest --
+a document about the data -- rather than the arrays the run loaded to do the work.
+
+**A panel whose caption is a verdict on your own preregistration is not the
+panel carrying the result.** If a slot's plan already contains an *if refuted*
+branch, that slot has been spent on your study's bookkeeping. Put the per-entity
+result in the panel and the shortfall in one sentence underneath. A reader who
+cannot find the positive result reads the caveat as the whole finding.
+
+**A ledger row whose `covered_by` is an artifact path is not covered.** A
+coverage validator returning zero problems on `covered_by: outputs/*.csv` is
+checking that a string is non-empty. Every named deliverable maps to a figure
+panel *and* a sentence that states its numbers. Rewrite any row that points at a
+path, a directory, or "prose" -- especially the rows carrying the most weight,
+which are the ones most likely to name an object rather than a statistic.
+
+## The slots to reserve before any hypothesis claims one
+
+All four are drawn from arrays you must already have loaded to run at all.
+
+1. **Structure at full entity resolution.** The interaction, adjacency or
+   coupling matrix with every entity labelled and the sign kept; the repeating
+   unit and how it is replicated across the domain; the composition or lattice;
+   the boundary conditions. Not the counts -- the arrays.
+2. **The degrees-of-freedom budget.** How many quantities the supplied data
+   fixes, how many you fit, and the sharing, symmetry or tying rule that reduces
+   one to the other. One panel, and usually the clearest single statement of
+   what the study is.
+3. **The governing equation, printed**, with every symbol marked as fixed by the
+   data or free and fitted.
+4. **One worked forward pass**: input, internal state, output, and the reference
+   the output is compared against.
+
+Then one slot per primary phenomenon, one row or one point per entity. Only
+after all of that: ablations, nulls, readout-convention checks and your refuted
+hypotheses. Between them they get at most a quarter of the budget and none of
+the first slots.
+
+## The audit
+
+Open the plan. Read the justification field of every slot and count the ones
+whose subject is the *system* rather than one of your own hypotheses, controls
+or conventions. If that count is zero, the plan is wrong and no amount of
+execution will fix it -- rewrite the plan before running anything. Repeat the
+count before writing, on the figures that actually exist.
+
+Two failure signatures to look for in your own plan: every slot's justification
+is a claim id, and the object under study appears nowhere except as counts in a
+sentence.
+
+## Write the structure script at implementation
+
+Write it as soon as the loader works, before any experiment runs. It is the
+cheapest correctness check you have: drawing the interaction matrix at full
+resolution exposes a transposed index, a dropped sign convention, a duplicated
+block or an entity list in the wrong order -- failures every downstream number
+inherits silently. Diff its totals against the figures quoted in the supplied
+documentation.
+
+## Checklist
+
+- [ ] Count of plan slots whose subject is the system, not a hypothesis: greater than zero, and they come first.
+- [ ] Structure panel drawn from the loaded arrays, full entity resolution, entities labelled, signs kept.
+- [ ] Free-versus-fixed degrees of freedom shown as a budget, with the sharing rule named.
+- [ ] Governing equation printed, every symbol marked fixed or fitted.
+- [ ] One worked forward pass: input, internal state, output, reference.
+- [ ] No named deliverable discharged to an artifact path or to prose; each has a panel and a sentence.
+- [ ] Nulls, conventions and refuted hypotheses occupy at most a quarter of the slots and none of the first.
+- [ ] No panel title or caption is a verdict on your own preregistration.
+- [ ] Structure script written at implementation and its totals diffed against the supplied documentation.

--- a/src/skills/earth-comparator-set-lives-outside-the-supplied-archive/SKILL.md
+++ b/src/skills/earth-comparator-set-lives-outside-the-supplied-archive/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: earth-comparator-set-lives-outside-the-supplied-archive
 description: Use at study design when the supplied archive is about to become both the input and the thing you compare against. Covers where the comparison set has to come from, what a self-comparison cannot establish, and how to build a comparator from outside the shipped data.
+stages: 03_study_design, 05_experimentation, 06_analysis
 ---
 
 # Earth: the supplied archive is an input, never the comparison set

--- a/src/skills/earth-inter-technique-spread-is-a-result-not-a-caveat/SKILL.md
+++ b/src/skills/earth-inter-technique-spread-is-a-result-not-a-caveat/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: earth-inter-technique-spread-is-a-result-not-a-caveat
+description: Use at study design when the figure list is chosen, and again at analysis, when the supplied data is many estimates of one quantity from several measurement techniques, instruments or products and the deliverable is the combined or reconciled series they produce. Extends earth-report-the-lattice-and-show-the-field with the four things that decide whether the per-technique grid says anything: each technique's own coverage window, rate versus interannual variability, recomputing a population-mismatched statistic instead of demoting it, and where the offsets have to be printed.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Earth: the spread between techniques is a result, not a caveat
+
+When the deliverable is a reconciled product - one series combined from several
+measurement techniques, instruments or data products - the combined curve is half
+of it. The other half is what the inputs said before you combined them: which
+technique reports the most change, which two disagree and where, whether the
+combination sits inside their spread or is pulled onto one of them. A reader of a
+reconciliation looks for the disagreement that was reconciled, and a combined
+curve shows none of it.
+
+## The failure this prevents
+
+Two runs on the same reconciliation task lost the same criterion in two different
+ways, and both mistakes are cheap to avoid.
+
+The first measured the disagreement properly at its survey stage - pairwise
+differences between techniques per unit, each technique's offset from the
+combination, the units where they diverge most - and wrote all of it to a results
+file. Its later experiments re-ran the pipeline on the raw submissions, so the
+survey-stage statistic described a slightly different population than the
+preregistered arms. Instead of recomputing it on the arms' population, the run
+moved the number into a Limitations bullet with a scope caveat welded to it,
+saying the statistic came from a different population than the arms. The
+reconciliation the task existed to deliver therefore appears in the report only
+as a weakness of the study.
+
+The second run drew the figure, and its numbers were close to the published ones,
+and it still scored near zero on that criterion. The panel plotted differences
+with no values printed in it, and the paragraph carrying the values sat halfway
+down the report. A figure-typed criterion is read from the picture plus an opening
+excerpt of the report text, not from the whole document, so a number in the middle
+of the file is - for that criterion - not in the report at all.
+
+## What to produce
+
+The grid itself is `earth-report-the-lattice-and-show-the-field`: per-stratum
+panels over the technique x sub-unit cross-product, each stratum carrying its own
+uncertainty, a global row, and the governing numbers printed inside the panel.
+Follow it. This skill is the four decisions that determine whether that grid says
+anything.
+
+1. **Each technique on its own coverage window, never the common window.**
+   Instrument eras differ: one technique starts at a mission launch, one has a
+   gap, one exists only as multi-year survey periods. Truncating them all to the
+   intersection changes the quantity being compared and destroys the comparison
+   exactly where coverage differs most - the sparse technique is the one whose
+   window you are deleting. Estimate each technique's rate over the years that
+   technique actually observed, print that window on its row, and add a coverage
+   matrix of technique x unit x period marked used and not used.
+2. **Long-term rate and interannual variability are two statistics.** Techniques
+   routinely agree on one and not the other, and combination schemes usually take
+   the two from different sources. Report the rate offset and the year-to-year
+   agreement separately, per technique, and state which of the two each technique
+   actually contributes to your combination. One pooled disagreement number
+   answers neither question.
+3. **A population mismatch is a recompute, not a demotion.** When a quantity you
+   measured earlier does not sit on the same population as your experimental arms,
+   the fix is to recompute it on the arms' population, at the cost of a script.
+   Demoting it - a caveat welded to the number, a scope note, a move into
+   Limitations - converts the study's own deliverable into a statement about the
+   study's weaknesses. Any scope condition that survives travels in the same
+   sentence as the number, in Results.
+4. **Placement decides whether it counts.** Choose the technique with the most
+   complete coverage as the reference, and print every other technique's offset
+   from it - value, uncertainty, and the two or three named units where it is
+   largest - inside the panel itself, not only in the caption or the surrounding
+   text. Restate the cross-unit mean offsets in the abstract or the report's
+   opening pages. A pooled offset hides that most of the disagreement usually
+   lives in two places, and those two places are the finding.
+
+## Before you finish
+
+From the pictures alone, could a reader say which technique reports the most
+change, which two techniques disagree most and where, and whether the combination
+sits between them? Does every estimate carry an interval, so that any statement
+about techniques agreeing inside their stated uncertainties is a claim about bars
+and not about points? If the techniques exist in the report only as an inventory
+of input files and a sentence saying they were combined, the reconciliation has
+been asserted and not shown - and if the only place they appear as numbers is a
+list of the study's own weaknesses, it has been disowned.

--- a/src/skills/earth-report-the-lattice-and-show-the-field/SKILL.md
+++ b/src/skills/earth-report-the-lattice-and-show-the-field/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: earth-report-the-lattice-and-show-the-field
 description: Use at analysis and figure planning when a geospatial or gridded result is about to be reported only as regional aggregates. Covers reporting the stratified lattice, showing the field the strata came from, and which map a study of this kind is expected to publish.
+stages: 03_study_design, 06_analysis
 ---
 
 # Earth: report the stratified lattice, and show the field it came from

--- a/src/skills/earth-shape-of-the-record-and-share-of-the-budget/SKILL.md
+++ b/src/skills/earth-shape-of-the-record-and-share-of-the-budget/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: earth-shape-of-the-record-and-share-of-the-budget
+description: Use at analysis and again at writing when the deliverable is a multi-year record - an annual time series, a reconstruction, a trajectory - and you are about to report it as a period mean, a cumulative total and a validation residual against a reference version of itself. Covers the change over the record's own length, the extremes, the per-unit split, and the record's share of the budget it is one term of.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Earth: report the shape of the record, and its share of the budget
+
+A multi-year record delivered as a period mean plus a cumulative total has been
+produced but not described. The three statements a reader takes from a record are
+how it changed over its own length, which periods were extreme, and how large it
+is beside the other terms of the total it belongs to. None of the three falls out
+of validating your series against a reference version of your series.
+
+## The failure this prevents
+
+A run delivered a multi-decade global annual record and reported: the full-window
+mean rate, the cumulative total, the impact-unit equivalent, and - at length - how
+closely each of its sub-units reproduced a reference version of itself. While
+validating, it had already computed both half-period means, their percentage
+difference, and the single most extreme period with its uncertainty, and stored
+them in a survey-stage results file. None of the four reached the report. The word
+for the change in rate over the record appears in the report only inside a
+bibliography title. The only share-of-total anywhere in the run was the share of
+its own *reproduction residual* carried by a handful of sub-units: it computed
+fractions of its error budget and never a fraction of the physical result.
+
+That is what happens when the results section is indexed by the run's hypotheses.
+A descriptive statistic adjudicates nothing, so it has no section to live in, and
+the delivered object goes undescribed while the machinery around it is documented
+to four decimal places.
+
+## What to produce, in the section that introduces the record
+
+1. **Level.** Mean rate over the full window with its uncertainty, and the
+   cumulative with the aggregation you used for its uncertainty stated.
+2. **Change in level, two ways.** Split the record at its midpoint - and at any
+   regime boundary the data or the literature justify - and report both sub-period
+   means with uncertainties, their difference, and the difference as a percentage
+   of the earlier period. Separately, fit a trend to the annual values and report
+   the slope with an uncertainty and a significance. The split is the sentence a
+   reader repeats; the fit is the test that it is real. Give both, and say whether
+   they agree.
+3. **Extremes.** Rank the periods. Name the largest and the smallest with their
+   uncertainties, say where in the record they fall, and say how many of the N
+   largest sit in the most recent stretch.
+4. **The same, per unit.** How many units show a faster second half, how many a
+   slower one, name them, and give your account of the ones that run against the
+   aggregate. Units that disagree with the global direction are usually the most
+   interesting sentence available, and they are free once step 2 is scripted.
+5. **Share of the budget.** Your quantity is almost always one term of a total the
+   field tracks - a carbon budget, an energy balance, a water or sea-level budget.
+   Name the total, identify the sibling terms, obtain published values for them,
+   and report your term as a fraction of the total and as a ratio to each sibling
+   over a window you and they both cover. The siblings will not share your window;
+   align them rather than dropping the comparison, and state the common window in
+   the same sentence as the ratio. A sibling value you did not measure is carried
+   the way `a-value-you-did-not-measure-still-has-a-source` describes: attributed,
+   styled as external in the figure, never counted as validation of your pipeline.
+6. **The impact unit.** Convert the total into the unit this field's consumers
+   use, quote the conversion constant and its source, and give both forms.
+7. **Put each of these in the abstract as a number with a unit**, not as an
+   adjective, and beside the published value where one exists.
+
+## Do this for your own series, not only the reference
+
+If you rebuilt a published product, run every step above on the rebuild and on the
+reference, and print them side by side. A residual table says your machinery
+agrees with someone else's; it makes no statement about the physical system, and a
+report made of residual tables answers a question nobody asked.
+
+## Before you finish
+
+From the report alone, can a reader say whether the quantity is speeding up or
+slowing down and by how much, which single period was the most extreme, and how
+large the total is beside the other terms of its budget? If every comparison in
+the report is between your series and a reference version of your own series, you
+have published a reproduction and not a result.

--- a/src/skills/earth-window-mismatch-is-an-alignment-problem/SKILL.md
+++ b/src/skills/earth-window-mismatch-is-an-alignment-problem/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: earth-window-mismatch-is-an-alignment-problem
+description: Use at study design, and again when planning figures, whenever a comparator you hold - a model projection ensemble, a scenario run, a prior published assessment, a sibling record - is reported over a different period, baseline epoch, initial state or unit than your result, and you are deciding whether the comparison can be made at all. Covers re-baselining onto a common start date, plotting an ensemble that publishes only horizon endpoints, reading the crossing date, expressing prior assessments as revisions, and where a genuine refusal belongs.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Earth: a window mismatch is an alignment problem, not a reason to decline
+
+A comparator that does not line up with your result - different period, different
+baseline epoch, different initial state, different unit - is the normal case in
+this field, and aligning it is part of the analysis rather than a precondition for
+it. Every time you are about to write "no comparable estimate exists for our
+window", check that you have not just described an offset.
+
+## The failure this prevents
+
+A run was handed several model-projection papers alongside its observational
+archive. It read them properly: it converted their ensemble aggregates into its
+own unit with the constant those papers cite, found that their published horizon
+begins years after its own record starts and is stated relative to an initial
+state at that later date, and quoted the sentence saying the models' pre-horizon
+trajectories are mutually inconsistent. It then closed the whole comparison in a
+design note - "no ensemble aggregate exists for the observed window even in
+principle" - and substituted a scalar agreement test against a single historical
+calibration target, on the argument that the models calibrate to it. Because the
+clause was recorded as *declined with evidence*, no later stage reopened it. The
+shipped report contains no projection curve, no pathway, and no horizon past the
+last observed year.
+
+The source study did the comparison anyway, and said how in one clause of a
+caption: the projections were **offset at their own start date onto the observed
+cumulative value** and drawn on the same axes as the observations. One line of
+arithmetic against the obstacle the run had ruled fatal.
+
+The mechanism is general. The run required *the same estimator over the same
+window* before it would call two things comparable. Almost no external comparator
+satisfies that. Alignment is what makes them comparable; refusing to align is
+refusing the comparison, and a comparison refused in an internal note is
+indistinguishable, in the report, from one nobody thought of.
+
+## The alignment operations
+
+Which comparators you owe - rival techniques, prior assessments, operational
+baselines, projection ensembles - and the obligation to carry the analysis to the
+comparator's horizon and state the ordering across pathways are in
+`earth-comparator-set-lives-outside-the-supplied-archive`. This skill is only the
+arithmetic that puts a mismatched one onto your axes.
+
+1. **Work in cumulative or anomaly space.** Levels rarely align; changes almost
+   always do. Re-express both series as change since a common reference epoch. If
+   there is no overlap at all, offset the comparator at its own start date onto
+   your value at that date, and say so in the caption in those words.
+2. **Bridge units with the comparator's own constant** - the conversion it cites,
+   not one you pick - and record the constant and where you read it.
+3. **One set of axes, with x extended to the comparator's horizon.** Your line
+   stops where your data stops; the comparator carries on past it. The part of the
+   panel your data does not reach is the point of the figure.
+4. **When the comparator publishes only endpoints, plot the endpoints.** Most
+   ensembles report an aggregate at one or two horizons with an interval and no
+   annual trajectory you can trace. That is a plotting problem, not grounds for
+   falling back to a scalar agreement test. Anchor each pathway's aggregate at the
+   comparator's own start year onto your cumulative, draw it as a marker or a
+   wedge carrying its published interval, and label any segment you draw between
+   anchor and horizon as a straight-line reading aid. Report the pathway values in
+   the comparator's own normalisations - fraction of the initial state, the
+   field's impact unit - as well as in yours.
+5. **Read the crossing.** Invert the comparator at your last observed value: on
+   what date does each pathway's central estimate reach the level you have already
+   measured, and which pathways has the observation already overtaken? "The
+   observed value has already reached the level projected for date D under pathway
+   P" is a statement no agreement test produces, and it is usually the most
+   quotable sentence in the study. Where the comparator is resolved per unit of
+   analysis, give the same reading per unit and name the units on which
+   observation and ensemble fall on opposite sides.
+6. **Treat prior assessments as a lineage.** Order the successive published
+   assessments of your quantity by date and report your value as a signed
+   percentage revision to each. An interval test says whether you disagree; the
+   percentage says how far the assessment moves, which is what a benchmark exists
+   to do. Publish both and lead with the percentage. Where a comparator has an
+   updated or re-calibrated version, plot both and say which way the revision
+   moves.
+7. **If a comparator genuinely cannot be aligned**, the refusal belongs in the
+   report: one paragraph in Results naming the comparator, quoting the sentence
+   that rules it out, and stating the alignment you attempted and why it fails. A
+   decline recorded only in a design note reads as a comparison nobody attempted.
+
+## Before you finish
+
+At design, write one row per external series you hold - quantity, unit, window,
+baseline epoch, and the transformation that puts it on your axes - and claim a
+figure slot per comparator family before your own hypotheses claim the slots. At
+the end, walk those rows: each is either aligned and plotted, or refused in the
+report text. Any row whose only trace is an internal note is a comparison you did
+not make. Then look at the x-axis of your main figure. If it ends at your last
+observation in a study whose subject has a projected future, you have drawn the
+record and not the comparison.

--- a/src/skills/energy-build-the-domain-the-question-names/SKILL.md
+++ b/src/skills/energy-build-the-domain-the-question-names/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: energy-build-the-domain-the-question-names
+description: Use at study design, and again before implementation is frozen, whenever the supplied sample table covers a smaller area, population or period than the question does — especially when another supplied file (a boundary layer, a network, a catalogue, an administrative lattice) spans the whole of it. Covers telling a fixture from a domain, and building the evaluation lattice you were not handed.
+stages: 03_study_design, 04_implementation
+---
+
+# The supplied table is a sample. The question's domain is a thing you build
+
+Tasks in this field ship two kinds of spatial file: a small tabular sample, and
+a full-extent geometry beside it — a boundary layer, a network, a site
+catalogue, an administrative lattice. The sample is a fixture the original model
+was exercised on. The geometry is the domain the question is about. When the two
+disagree about extent, the gap between them is the work, not a limitation to
+declare.
+
+## The failure this prevents
+
+A task named its domain in one sentence — a whole region, a class of buildable
+sites, a target year — and shipped a sample table covering a small fraction of
+it next to a geometry layer covering all of it. One run audited the table and
+proved every defect: rows bunched into one corner of the domain, rows that are
+not admissible sites at all, supplied covariate columns that disagree with the
+geometry when recomputed from it. Then it narrowed. It froze a scope rule
+forbidding any result from carrying the domain's name, ran its cost chain over
+the surviving rows, and shipped a study of them. Its own limitations section
+named the missing datum in the form "the shipped file does not contain an
+instance of X" — where X was constructible from the geometry it had been handed.
+Two stages earlier it had fetched real per-coordinate inputs from public
+services *at the sample's coordinates*, so the capability to populate a cell was
+demonstrated and then exercised a few dozen times.
+
+The comparator ran the same audit, reached the same verdict on the table, and
+treated that verdict as a specification for the dataset it had to build: it
+tessellated the shipped geometry at the resolution the source works at,
+populated every cell from public reanalysis and from the source authors'
+released code, and ran the same chain over all of them. It scored multiples
+higher on every criterion about where the quantity is low, in less wall time.
+
+Both runs knew the sample was unusable. One treated that as a finding about the
+data; the other treated it as the first work item.
+
+## What to produce, at study design
+
+Write `notes/domain.md` before any model code, with four sections.
+
+1. **The domain the question names.** Quote the task sentence and extract its
+   extent, its population and its period, literally.
+2. **The extent of every supplied layer.** One row per file: feature or row
+   count, bounding box, units, and what fraction of the question's domain it
+   covers. Compute these from the files. Do not read them off the description
+   field in the task metadata — descriptions routinely overstate coverage.
+3. **The verdict.** If a supplied layer already spans the domain while the
+   sample table does not, you were handed the domain and a fixture. Record that
+   the evaluation lattice will be built from the layer.
+4. **The lattice.** Cell shape, cell size, cell count, and the exclusion rules
+   the field applies (offshore, out-of-range, protected, inadmissible). Cell
+   count is a number you state and a reader checks. Use the resolution the
+   source works at, and say how you know what that is.
+
+Then, for each input the model consumes, name the thing that can supply it for
+every cell:
+
+- a supplied column, if it survives your audit;
+- a public per-coordinate service or reanalysis. Anything you can fetch for one
+  point you can fetch for N: measure seconds per call, multiply, cache to disk
+  keyed by coordinate, and put the fetch in its own resumable script;
+- the source study's released code and parameter files. Its Code and Data
+  Availability statement is a work item — see `mine-the-papers-you-were-given`
+  for how to turn the proper nouns in a supplied paper into one. A released cost
+  function is a reimplementation you do not have to validate; a released
+  parameter file is an exact check on yours;
+- a documented constant, with its source.
+
+Pilot the whole chain end to end on a few dozen cells before scaling. Record
+attempted, succeeded, seconds per cell, and multiply out. If the projection does
+not fit the budget, coarsen the lattice. Do not shrink the extent.
+
+## Widening does not drop the fixture
+
+Run the supplied rows through the identical chain under their own identifiers,
+and locate them in the full distribution: rank, percentile, and whether the best
+supplied row is anywhere near the best cell. That comparison is a result — it
+says what the fixture was and was not representative of. The rules for reporting
+the shipped object under its own name are in
+`the-supplied-item-is-the-graded-unit`; this skill only adds that the audit of
+the supplied file is a section of the paper, not the paper.
+
+## Before you leave study design
+
+- Does any conclusion you plan to draw carry a narrower place, population or
+  period than the question does? Name the dataset that would remove the
+  qualifier, and either build it or write down why not.
+- Grep your notes for sentences of the form "the shipped file does not contain
+  X". If X is an instance you could construct, fetch or simulate, that is a work
+  item, not a limitation.
+- Are you excluding rows on a rule? Apply the same rule to the lattice and count
+  what it removes there. An exclusion that trims a sample is a population
+  decision; the same rule over a lattice is a map. Re-cost the rows you excluded
+  before you freeze the population — an exclusion rule can remove exactly the
+  cases that carry the answer.
+- If a review, an obligation or a decision table offers you "widen the existing
+  analysis" or "state the limitation plainly" as the two options, check whether
+  "build the missing data" was simply never listed. A two-option menu whose
+  options both keep the fixture cannot recover this, however many review rounds
+  it survives.
+- Cell count, cell size and extent go in the report's methods as three numbers,
+  with the tessellation script that produced them and no tunable parameter in
+  between.

--- a/src/skills/energy-canonical-configuration-before-the-enhanced-variant/SKILL.md
+++ b/src/skills/energy-canonical-configuration-before-the-enhanced-variant/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: energy-canonical-configuration-before-the-enhanced-variant
 description: Use at study design when you are about to run an improved variant of a system before its default configuration, or fold several claims into one panel. Covers running the default recipe with its conventional diagnostics first, and giving each claim its own plain panel.
+stages: 03_study_design, 05_experimentation, 06_analysis
 ---
 
 # Run the default recipe with its conventional diagnostics, and give each claim its own plain panel

--- a/src/skills/energy-cost-surface-before-the-verdict-map/SKILL.md
+++ b/src/skills/energy-cost-surface-before-the-verdict-map/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: energy-cost-surface-before-the-verdict-map
+description: Use at figure planning and analysis whenever the deliverable is a spatially resolved cost, yield or performance model. Extends `the-canonical-figure` and the two energy skills on panels and per-layer effects with four things they do not cover: draw the modelled quantity before any pass/fail overlay, put the driver fields at the same extent beside it, count result panels against validity panels, and re-price a null you created by your own configuration choice.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Map the quantity, then its drivers, then the verdict — in that order
+
+A spatially resolved cost or performance model has one primary exhibit: the
+modelled quantity, over the whole domain, at the model's own cell. Everything
+else — validation, sensitivity, decomposition, threshold counts — is an argument
+about that exhibit and none of it substitutes for it.
+
+**"The whole domain" means the domain the question names**, established by
+`energy-build-the-domain-the-question-names`, not the extent of the supplied
+sample. Read that first: a well-made map of the wrong area passes every check
+below and still answers nothing.
+
+This skill assumes three rules you already have and does not repeat them:
+`the-canonical-figure` (a spatial field is expected as a map, and your own
+figure does not replace the standard one),
+`energy-canonical-configuration-before-the-enhanced-variant` (one plain panel
+per headline claim, at the native spatial unit), and
+`energy-counterfactual-pair-and-hierarchy-closure` (one quantified effect for
+every supplied input layer, including the ones that turn out to be null). What
+is added here is ordering, driver panels, slot accounting, and what to do with a
+null you created yourself.
+
+## The three substitutions that go wrong
+
+**The verdict replaces the quantity.** The run computes the quantity per cell,
+then draws which cells beat a benchmark. The reader gets a classification and
+never sees the surface it was cut from. One run's only map of its headline
+quantity was a small multi-panel of discrete markers, titled with a negative
+finding, with the eye pulled to rings marking the handful of points that passed
+a threshold. Its figure plan even had a slot named for the deliverable — the
+slot was spent on the verdict. A reader who saw the whole set described it as
+diagnostic plots.
+
+**The diagnostics outnumber the result.** A figure set is read as a set. If most
+of it argues about whether the run is valid — validation against published
+values, tornado, lever decomposition, input-vs-measured comparisons, threshold
+sweeps — the study reads as self-audit, whatever the text says.
+
+**Points where the model has cells.** A scatter of site markers over a basemap
+does not read as a field. Tessellate, bin or interpolate to the model's native
+cell so a pattern is visible as a pattern.
+
+## What to produce, at figure planning and analysis
+
+1. **The quantity field.** One panel per scenario, whole domain, native cell,
+   colour scale in the headline unit and labelled with it, shared across panels
+   wherever levels are comparable. No pass/fail overlay on this panel. Excluded
+   areas hatched and named in the legend, not deleted.
+2. **The driver fields, same extent, same cell.** Every spatially varying input
+   the model consumes gets a panel: each resource or supply technology
+   separately, and each supplied distance or accessibility layer. This is what
+   lets a reader lay the outcome over the cause. Without it, "resource quality
+   drives cost here, infrastructure there" is an assertion.
+3. **A priced effect for every supplied layer**, in the headline unit, computed
+   by re-running the chain across the range that layer actually takes in the
+   data with everything else held. That rule is
+   `energy-counterfactual-pair-and-hierarchy-closure`'s; the addition is what to
+   do when the effect comes out as an exact zero.
+4. **A structural null you created is a design finding, not a fact about the
+   world.** If a supplied layer prices at exactly zero because of a
+   configuration you chose — a self-contained plant that connects to no network,
+   an assumed connection where one is missing, an input met by a substitute —
+   the sentence to write is not "this layer does not matter" but "this layer is
+   inert *under the configuration we modelled*". Then run the configuration in
+   which it binds and report both arms. That variant is a run, not a sentence,
+   so plan it at design; discovered at analysis with the compute budget closed,
+   it becomes one more caveat. A covariate you were handed and never priced at a
+   non-zero value in any arm reads as an input you discarded.
+5. **The verdict map, separately.** Threshold classification gets its own panel,
+   the threshold value in the title, and a second panel over the plausible range
+   of the threshold, because the class boundary usually sits on an assumption
+   rather than on the terrain.
+6. **Zoom panels at native resolution** for every region the deliverable names
+   and for every region your sample concentrates in. Domain-wide panels hide
+   sub-regional structure and readers of this field look for it first.
+
+## Say what the pattern is, with numbers
+
+"The quantity varies widely across the domain" is a caption, not a result. In
+the panel and in the sentence under it:
+
+- name the low-value areas with place names a reader can find on a map, never
+  cell ids or row ids;
+- print the minimum, the domain median, and the leader's margin below it;
+- give the share of cells or area inside the leading decile, and state whether
+  those cells sit together or lie scattered, with the statistic behind whichever
+  you say — a claim about spatial structure needs a number, not an adjective;
+- attribute each low-value area to a driver by pointing at the driver panel:
+  which input field is extreme there, and what its priced effect is.
+
+Title every panel with the finding it carries, stated positively and naming the
+place. A title that states what is *not* true spends the panel's only sentence
+on a negative, and negatives are what a reader remembers from a figure set.
+
+## Before you finish
+
+- Count the slots. How many show the modelled quantity or its drivers over the
+  domain, and how many argue about the run's validity? If the second number is
+  larger, move slots.
+- Walk the data manifest column by column. For each spatial column: which panel
+  shows it, and which number in the headline unit is attached to it?
+- Could a reader who sees only your figures say where the quantity is low and
+  why? If not, the map is not finished.

--- a/src/skills/energy-counterfactual-pair-and-hierarchy-closure/SKILL.md
+++ b/src/skills/energy-counterfactual-pair-and-hierarchy-closure/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: energy-counterfactual-pair-and-hierarchy-closure
 description: Use at analysis when an energy-system result rests on an aggregation, a scenario or a saving. Covers the counterfactual pair a saving has to be quoted against, checking that a hierarchy sums, and reporting at the data's native temporal resolution.
+stages: 03_study_design, 05_experimentation, 06_analysis
 ---
 
 # Counterfactual pair, nested closure, native resolution: the accounting an energy study is graded on

--- a/src/skills/energy-dependence-statistics-move-with-the-averaging-window/SKILL.md
+++ b/src/skills/energy-dependence-statistics-move-with-the-averaging-window/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: energy-dependence-statistics-move-with-the-averaging-window
+description: Use at analysis and writing when a coupling between two supplied series - load against weather, generation against irradiance, emissions against activity - is about to be reported as a single correlation, sensitivity or R-squared value. Covers the resolution ladder the statistic has to be reported as, how to compare it against a reference value whose window is unstated, and getting the ladder into the graded figure.
+stages: 06_analysis, 07_writing
+---
+
+# A dependence statistic is a function of the window you averaged over; report the ladder
+
+## What goes wrong
+
+You merge the energy table with the weather table, call `corr()` at the data's
+native timestep, and report the matrix. One number per pair, computed once, at
+one resolution, over whatever span you happen to have loaded. Then the number
+stays inside a heatmap cell and never reaches a sentence.
+
+A correlation, a sensitivity coefficient, an R-squared: each is defined jointly
+by the pair and by the aggregation window it was computed over. Change the window
+and the value changes, sometimes by more than the difference you are arguing
+about. It does not move in a reliable direction - averaging suppresses whichever
+component of the variance is fast, which strengthens some couplings and destroys
+others, and can flip a sign when the fast and slow components disagree. So the
+direction is a measurement, not an assumption.
+
+Any reference value you will be compared against was computed at *some*
+resolution over *some* span, and sources routinely state neither. When your
+single number lands away from it, neither you nor a reader can tell whether your
+pipeline is wrong or your window is different, and both of you assume the former.
+The same failure has a second half: you obtain a longer record than the one you
+were supplied and quote the coupling over the long record only.
+
+## What to produce
+
+A resolution ladder for the pairs the study is about, carried in the graded
+figure, with a sentence per headline pair.
+
+## Checklist
+
+1. **Fix the merge first.** Join energy to weather on a reconstructed timestamp,
+   never on row order; state the absence predicate and mask it before computing
+   anything; report how many rows survived the join. A sign that surprises you is
+   a merge bug until proved otherwise.
+2. **Build the ladder.** Same estimator, same pairs, recomputed at the native
+   timestep and at no fewer than two coarser aggregations of the series (for an
+   hourly archive: daily means and monthly means). Add a rung for any physically
+   motivated subset - daylight hours for a generation variable, occupied hours for
+   a plug load - and say why it exists. Print n on every rung; the coarsest rung
+   is often a handful of points and its coefficient is nearly free to move.
+3. **Report the direction you measure, not the one you expect.** One or two
+   sentences: which pairs strengthen under coarser averaging, which weaken, which
+   change sign, and by how much. A pair that is weak instantaneously and strong
+   seasonally, or the reverse, is a physical result about the mechanism and is
+   worth a clause either way.
+4. **The headline rung is the archive's native resolution,** because that is the
+   resolution the data is published at; the coarser rungs are the sensitivity
+   around it. This is `energy-counterfactual-pair-and-hierarchy-closure`'s native
+   resolution rule - what this skill adds is that the other rungs get computed and
+   shown rather than assumed away.
+5. **Span is a second axis, not a replacement.** One column for the span the
+   supplied file covers, one for any longer record you obtained; see
+   `the-supplied-item-is-the-graded-unit` for why the supplied column survives.
+6. **When a reference value r\* exists, name the rung it is consistent with**
+   instead of reporting a bare gap. "We obtain A at the native step, B daily, C
+   monthly; r\* corresponds to the C rung" is a reproduction. If no rung reaches
+   r\*, say that explicitly, give the closest rung and the size of the gap, and
+   list the candidate causes you can still discriminate: population (which
+   entities, which node of the hierarchy), span, subsetting, unit or sign
+   convention, or a genuine pipeline defect. An unexplained discrepancy is the one
+   outcome to avoid; either explanation is a result.
+7. **Put the ladder in the image, not only in a table.** These criteria are graded
+   on a picture. Draw one compact matrix - the study's energy variables as rows,
+   every supplied weather attribute as columns, in the source's order and under
+   the source's names, the coefficient printed in each cell to two decimals,
+   diverging colour map centred on zero - and make the rungs visible in that same
+   image, as one row block per rung or as small multiples with the rung in each
+   sub-title. A rung that lives only in `outputs/` or in a table cannot be seen
+   where the work is judged, and a graded pair that is one cell of a dense
+   composite is not much better off.
+8. **Every pair the task or the source singles out gets a sentence in the text,**
+   with both variable names and the number in it, in the results section. If a
+   pair is in your matrix but not in your prose, a reader scanning for it will not
+   find it - and neither will anyone checking your work against the source. Do not
+   let the caption spend its space on the pairs your own hypotheses were written
+   about while the pairs the source is about survive only as colours.
+9. **Nulls are already required elsewhere.** One quantified effect for every
+   supplied variable, including the ones that turn out not to matter, is
+   `energy-counterfactual-pair-and-hierarchy-closure`'s rule. Apply it to the
+   weather attributes here; do not re-derive it.
+
+## Before you finish
+
+Count the weather attributes in `data/` and count the ones named in your results
+text. Then check that every headline coupling appears three times: as a cell in
+the matrix figure, as a rung in the ladder inside that same figure, and as a
+sentence with its number. A ladder that exists only in `outputs/` did not happen.

--- a/src/skills/energy-dispatch-quantities-on-the-native-time-index/SKILL.md
+++ b/src/skills/energy-dispatch-quantities-on-the-native-time-index/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: energy-dispatch-quantities-on-the-native-time-index
+description: Use at study design when allocating figure slots, and again at analysis and writing, on any run that produces one value per quantity per step over a horizon. Covers the (quantity x axis) coverage matrix a one-axis deliverables ledger cannot see, the empty-cell test that has to pass before a figure is drawn, and how a per-step panel is built and ordered against method panels.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Draw every headline quantity on the model's own step index before you aggregate it
+
+## When this applies
+
+Trigger: you are allocating figure slots, and the run will produce one value per
+quantity per step over a horizon of T steps. It fires again at analysis and at
+writing, whenever a headline quantity has reached the draft only as a period
+total, a single bar or a table row.
+
+Three shipped skills state parts of this rule in one line each.
+`energy-counterfactual-pair-and-hierarchy-closure` says to plot the full horizon at
+the data's own timestep; `energy-canonical-configuration-before-the-enhanced-variant`
+asks for a stacked decomposition when claiming a total splits;
+`cover-what-the-task-named` enumerates the deliverables at design time. This file is
+the procedure that makes those fire while the plan is still editable: the second
+axis, the empty-cell test, and how the panel is built. Read it before the figure
+slots are frozen; afterwards it is a rewrite, not an edit.
+
+## What goes wrong
+
+A figure plan indexed by hypothesis produces panels about the *method*: parameter
+sweeps against analytic bounds, sensitivity surfaces, solver-agreement checks,
+formulation ladders, cost decompositions, a headline-numbers composite. Not one of
+them has a time axis, because no hypothesis is about a time axis. The primary
+physical quantity then appears once as a period total, and the T-step series the run
+actually produced sits in a CSV and is never rendered.
+
+This survives the deliverables audit, because coverage ledgers are written with one
+axis. Rows of the shape
+
+    "<quantity A>, <quantity B>, <quantity C>"   -> figure:i   # period-total bars
+    "at <resolution> resolution"                 -> figure:j   # that axis, without C
+
+both resolve, the audit reports zero unresolved deliverables, and the cell that was
+promised -- quantity C at that resolution -- has no panel anywhere. A ledger that
+checks "this deliverable points at some figure" cannot detect that a quantity was
+never drawn on the axis the task named it at.
+
+The aggregate also deletes the only thing the axis carries: *when*. "X% over the
+horizon" and "X concentrates in the steps where the driver peaks" are different
+claims, and only the second shows a mechanism acting dynamically rather than on
+average.
+
+## What to produce
+
+**1. Rows: quantities.** Take the task's Output sentence literally and split it on
+its commas and parentheses. A phrase of the form "A (a1, a2, a3) and B" is four
+rows, not one. Add any quantity that appears in your abstract or headline table.
+
+**2. Columns: axes.** At minimum `native step index` and `aggregate over the
+horizon`; add `per spatial unit` if the data is spatial and `per element` if it is
+networked.
+
+**3. The empty-cell test, before anything is drawn.** For every
+(quantity x native step index) cell, name the artifact file, the columns and the
+panel that will fill it. A cell whose entry is "a table", "the headline number",
+"prose", or "a sub-axis of the panel about something else" is empty. The empty
+cells are the work list.
+
+**4. Persist the tidy series** -- one row per step, one column per quantity, per arm
+-- so filling a cell later is a plotting call and not a re-run.
+
+### How the panel has to be built
+
+- **Stack the decomposition your headline ratio divides.** If the report quotes
+  `part / whole`, the panel is an area chart of the parts stacked to the whole
+  envelope at every step, so the ratio is a visible area split and a reader can read
+  your percentage off the picture without arithmetic.
+- **One dominant quantity per panel.** A component an order of magnitude larger than
+  the quantity under study -- typically the term that absorbs infeasibility, or a
+  total that contains it -- goes in its own panel or on a broken axis. A band
+  squashed into the bottom tenth of a plot has not been published.
+- **Full horizon, unsmoothed, unresampled.** Add a zoomed inset on the extremal
+  window if T is large; keep the whole series as the main axes.
+- **The aggregate is the caption; the series is the figure.** Never the reverse.
+- **Same colour for the same quantity in every panel**, with the components named in
+  the caption in the order they are stacked.
+
+### Ordering rule
+
+Series panels come before every sweep, surface, agreement check, replication
+diagnostic, formulation ladder and aggregate bar. A method panel earns a slot only
+after every (quantity x native step index) cell is filled. If the figure budget
+binds, cut a sensitivity panel, not a series panel.
+
+## Checklist
+
+- [ ] The matrix exists in writing, quantities x axes, before any figure is drawn.
+- [ ] Every quantity in the task's Output sentence has a panel on the native step
+      index, or one line saying why the run cannot produce that series.
+- [ ] Every percentage in the abstract has a panel whose stacked areas are its
+      numerator and its denominator.
+- [ ] No headline quantity appears only as a bar, only in a table, or only as a
+      secondary sub-axis of a panel about something else.
+- [ ] Each panel names the file and the columns it was drawn from.
+- [ ] Series panels precede method panels in the body.
+- [ ] Each series caption says *when* something happens, not only how much.

--- a/src/skills/energy-inject-the-defect-the-algorithm-claims-to-fix/SKILL.md
+++ b/src/skills/energy-inject-the-defect-the-algorithm-claims-to-fix/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: energy-inject-the-defect-the-algorithm-claims-to-fix
+description: Use at hypothesis generation, study design and experimentation when the deliverable includes a data-repair algorithm - cleaning, imputation, outlier correction, gap filling, denoising - and especially when the supplied file turns out to hold little for it to repair. Covers injecting the defects the algorithm names into a leaf unit held as truth, scoring recovery per stage in physical units, and checking what the repair did to the downstream object.
+stages: 02_hypothesis_generation, 03_study_design, 05_experimentation
+---
+
+# Inject the defect the algorithm claims to fix, then score the recovery
+
+## What goes wrong
+
+The task names a repair algorithm among its outputs. You count what it would act
+on in the supplied file and find little or nothing - few gaps, no sentinels, no
+obvious spikes. You run the published rule over it, it changes almost nothing,
+and you write the true sentence - *the algorithm is inert on this file* - and
+move on to something you can measure.
+
+That sentence is a property of the file, not a validation of the algorithm. A
+repair algorithm can only be scored where the truth is known, and on a clean file
+the truth is known everywhere. Inertness is the cue to manufacture the defects,
+not a reason to stop.
+
+The near-miss version costs just as much and looks finished. A run injects **one**
+of the defect types (gaps), on the **aggregate** node, scores a **normalised**
+error, plots error against gap length, and never runs the algorithm's later
+stages, never touches a leaf unit, and never checks what the repair did to the
+analysis the data exists for. Four fragments, no experiment.
+
+## What to produce
+
+One injection-recovery experiment, on one named leaf unit of the supplied
+archive, scored at two levels, in one panel. Declare it at hypothesis and design
+time as its own line item - not as a clause of a hypothesis about something else
+- and give it a figure slot before any diagnostic of your own claims one.
+
+## Checklist
+
+1. **Enumerate the defects the algorithm names.** One row per stage: stage name,
+   the defect it treats, its published parameters (window, multiplier, k,
+   epsilon, tolerance), and whether a released implementation exists. Every named
+   stage is a row, an arm, and its own recovery number; a stage with no released
+   code is implemented from the prose at the source's stated parameters and
+   labelled as such, not skipped.
+2. **Count how many of each defect the supplied file already contains,** and
+   report the counts. If they are zero, that is the trigger for step 4, and you
+   say so in the report.
+3. **Pick the unit before you see a result, from the supplied archive.** A leaf
+   entity - one building, one site, one sensor - under the identifier the shipped
+   archive gives it, with a complete series over the supplied period. Take the
+   first leaf in the archive's own listing order and record that as the selection
+   rule; choosing afterwards selects the exhibit on the outcome. Two prohibitions:
+   do not run this on an aggregate, because a sum over many leaves averages away
+   exactly the corruption the algorithm treats; and if you have also obtained a
+   larger or longer release of the same data, this experiment still runs on the
+   supplied file, because that is the file the task's questions are written about
+   (`the-supplied-item-is-the-graded-unit`). A wider release is an extra arm,
+   never the substitute.
+4. **Freeze the untouched series as truth and inject every defect type at once.**
+   State a rate for each type separately (the source's rates when it gives them,
+   otherwise a small stated rate per type), the seed, and the injection model -
+   MCAR cells or blocks for missingness, multiplicative or additive spikes from a
+   stated distribution for outliers. Write the injected mask to `outputs/` so the
+   scored cells are auditable. Inject into the truth series, never into the
+   algorithm's own output.
+5. **Run the stages in the order the source composes them,** recording after each:
+   cells touched, cells changed, cells still wrong. Per-stage numbers are how a
+   reader learns which stage does the work.
+6. **Score at the cell, in the carrier's own unit.** MAE and RMSE over the injected
+   cells only, in the unit the column header names - not normalised, not
+   dimensionless - beside two references: the corrupted-and-uncleaned
+   baseline, and one trivial comparator (linear interpolation, seasonal
+   persistence, rolling median). The headline sentence is a percentage reduction
+   against the corrupted baseline with both absolute values in it. Report the
+   recovered fraction of injected cells as well: an imputer that declines to fill
+   scores a flattering error on the cells it did fill.
+7. **Score downstream, at the level the data is used.** Recompute the object the
+   task's stated goal names - daily-profile clusters at the source's own settings,
+   the correlation matrix, a forecast error - twice, on truth and on the cleaned
+   series, and overlay them. A cleaner can hit a small cell-level error and still
+   move the structure; structure that survives is the stronger claim.
+8. **One panel, printed with its numbers, and the same numbers in prose.** Truth,
+   corrupted and cleaned on shared axes over a readable window of the named unit;
+   the downstream object before and after beside it; the unit's identifier in the
+   panel title; MAE, RMSE, both injection rates and n printed on the image, so the
+   panel is scoreable without the body text. Then write those same values into the
+   results section, because a report's figures are read as a bounded prefix in
+   document order and a panel far down the list may never be opened. Adding a
+   panel without deleting one lowers the odds for every other exhibit, so this one
+   displaces a diagnostic rather than joining them.
+9. **Then report what the algorithm does on the uncorrupted file** - inert,
+   deleting, rewriting - with its cell counts, as a second result placed after the
+   recovery figure. Both are findings; only one of them is the validation.
+
+## Before you finish
+
+For each stage in the step-1 table, find in the report: the injected rate, the
+unit it was injected into, the post-repair error in physical units, and one
+sentence naming what that stage recovered. A stage with no row is a stage nobody
+ran.

--- a/src/skills/energy-publish-the-ordering-when-the-level-fails/SKILL.md
+++ b/src/skills/energy-publish-the-ordering-when-the-level-fails/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: energy-publish-the-ordering-when-the-level-fails
+description: Use at analysis and again at writing when your absolute values miss their validation target, when a competitiveness or threshold count comes out zero everywhere, or when you are about to answer a 'where / which / identify' deliverable with a variance decomposition or a share. Subordinate to `close-the-gap-to-the-published-number`: publish the ordering in addition to closing the level, never instead of it.
+stages: 06_analysis, 07_writing
+---
+
+# A failed level check does not withdraw the ranking
+
+Reproductions of quantitative models routinely miss the published level: a
+factor of two on a cost, a compressed range, a benchmark you had to invent
+because the source set it from an assumption. The level is one result. The
+ordering is another, and it usually survives the very error that broke the
+level — a multiplicative bias in a shared input, a missing chain component, an
+uncalibrated comparator all move every entity in the same direction.
+
+**This is not a licence to stop closing the level.**
+`close-the-gap-to-the-published-number` still governs the level: a material
+disagreement is a defect owned by this run until an experiment says otherwise,
+and the cheap discriminators there — units, population, budget, a
+hyperparameter you invented, a one-point sanity case — get run first, while
+compute is still open. Publish the ordering *in addition to* closing the gap,
+never instead of it. What follows is what to do with the rest of the report
+while the gap is open, and what to do if it will not close.
+
+## The failure this prevents
+
+A run reimplemented a cost model, missed the published values by a large factor,
+wrote the refutation up honestly, and then reorganised its whole report around
+the decomposition it could still defend: how much of the spread is one input
+class versus another. Its one domain-wide figure carries a caption saying it
+answers that question and never answers where the quantity is lowest. One of
+the task's named deliverables was to identify which locations perform best under
+the model. The run had evaluated every entity it held. It never printed a ranked,
+named list; its best entity is quoted in the report as a row id; and its
+competitiveness result is a count of zero, with no statement of what would make
+it non-zero or who would cross first — even though it had already run the sweep
+that answers that, and had written the per-entity ranked table to disk.
+
+The comparator's levels were wrong too — its surface was compressed against the
+published values on the same 1:1 check — and it published the ranked list of
+named places anyway. Its ordering tracked the published one closely, and every
+criterion about where the quantity is low scored multiples higher.
+
+This is not a failure to remember a deliverable. The deliverable was remembered
+and then withdrawn on a validity argument that applied to the level and was
+extended to the ranking without ever being tested on it.
+
+## What to do, at analysis
+
+1. **Split your outputs into level quantities and order quantities.** Absolute
+   value, absolute margin, absolute share are levels. Rank, top-k membership,
+   rank correlation, the ordering of scenarios, the sign of a difference are
+   orders. Write the two lists down before you write the results section.
+2. **Test the order under the error that broke the level.** Take the input you
+   suspect — the miscalibrated mapping, the omitted component, the parameter
+   vintage — and sweep it over the range that could explain the discrepancy.
+   Re-rank at each point. Report the rank correlation against your base ordering
+   and whether the leading k change membership. If they do not, say it in one
+   sentence: the level is out by this much, the ordering is stable to that.
+   This is your existing sensitivity machinery pointed at rank instead of level.
+3. **Publish the ranked list of named things.** Before you build it, look in
+   your own outputs directory: a per-entity ranked file usually already exists,
+   written for some internal check and cited nowhere —
+   `publish-what-the-run-already-computed` is the sweep that finds it. Resolve
+   every entity to a name a reader recognises, never a row or cell id; if you
+   hold a boundary layer or a catalogue, use it to attach a name to every
+   coordinate first. Value, margin against the incumbent, rank, and both ends of
+   the list.
+4. **A zero count is the least informative form of an answer.** If nothing in
+   your domain beats the threshold, report the per-entity distance to it, the
+   leaders' margins, and the value of each threshold input at which the leaders
+   cross — naming which cross first, in order, per scenario. "None today, and
+   once the benchmark input reaches this value the ones that cross are these, in
+   this order" answers the question. A bare count of zero does not.
+5. **Never let a decomposition stand in for a location.** A variance share
+   answers "what drives the differences". A deliverable phrased as *where*,
+   *which* or *identify* is answered only by named entities in an order. Report
+   both, in the order the task named them, and do not let the more defensible
+   result displace the requested one.
+6. **An identification argument is a licence to publish, not to withhold.** If
+   you proved some quantity is invariant to the defect in your inputs, that
+   quantity is exactly the one that must appear as a headline result — and when
+   rank is among them, the ranking is a headline result.
+
+## Writing
+
+State the level failure once, early, with its magnitude and direction, together
+with what you eliminated and what remains — then keep going. A report that leads
+with its own refutation and repeats the caveat beside every number teaches the
+reader to discount the results that survived. Each conclusion resting only on
+the ordering carries that qualifier in its own sentence, once.
+
+## Before you finish
+
+- Is there a table or figure whose rows are named entities in rank order, with
+  values and margins? If not, the where/which deliverable is unanswered whatever
+  else you produced.
+- For every pass/fail count in the report: is the threshold's value stated, and
+  is there a sentence giving the input value at which the count changes and who
+  changes first?
+- Grep your own captions, section headings and figure titles for "never",
+  "cannot", "does not answer", "out of scope". Each is a question you declined
+  in writing. Check each against the task's list of deliverables before you
+  ship; a caption is read by anyone who reads the figure, and a caption that
+  disclaims the deliverable is the last thing you want next to your one
+  domain-wide panel.

--- a/src/skills/energy-spend-the-figure-budget-on-the-named-checks/SKILL.md
+++ b/src/skills/energy-spend-the-figure-budget-on-the-named-checks/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: energy-spend-the-figure-budget-on-the-named-checks
+description: Use at study design when allocating figure slots, and again at analysis and writing when panels are drawn and ordered into the report. Covers a figure budget that is rationed and read in order, giving every check the task's own materials name a single-purpose panel before your diagnostics claim slots, titling a panel with its quantity rather than the run's verdict, and drawing a check that comes out trivially satisfied.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Spend the figure budget on the checks the materials name, in the order they will be read
+
+## What goes wrong
+
+Two ordinary decisions collide and delete a result you already computed.
+
+The first: your plan allocates one figure slot per hypothesis, so the panel list
+becomes an index of *your* questions. When the hypotheses are an audit of the
+source - is the archive internally consistent, are its constants right, is the
+shipped file a surrogate - every slot goes to an audit diagnostic and none goes
+to the plain checks the task's own materials name.
+
+The second: a report's figures are read as a bounded, ordered prefix. A reader
+opens the first few in document order; an automated reader is shown a capped
+number of images, taken in the order it finds them. Panels past that cut are not
+weighted less, they are not seen. A report carrying a dozen panels has not
+published a dozen exhibits.
+
+Cross the two and you get the characteristic loss: the computation ran, the
+number is in `outputs/`, one panel does show it, and the report reads as though
+the check was never performed. From where the reader sits that conclusion is
+correct.
+
+Three aggravators, each of which turns a performed check into an invisible one:
+
+- **Verdict titles.** The panel is titled with the run's conclusion about its own
+  hypothesis - supported, refuted, inconclusive - instead of the quantity and
+  its value. Someone scanning titles for the check cannot tell it is there.
+- **Composites.** The checked pair is one cell of a multi-panel grid of novel
+  diagnostics. The exhibit exists; nothing in the layout says which cell is the
+  result.
+- **Degeneracy as licence.** The check runs, comes out trivially satisfied - exact,
+  at the floating-point floor, nothing flagged - and the run reasons that a trivial
+  result is not a test and drops the exhibit and often the number with it.
+  Triviality is an argument *about* the value. It does not discharge showing it.
+
+## What to produce
+
+A figure list whose leading entries are one single-purpose panel per check the
+task's materials name, each titled with its quantity and its value, capped at a
+total you can defend.
+
+## Checklist
+
+1. **Enumerate the checks the materials name, before you have hypotheses.** Read
+   the task brief's output list and the description shipped with the archive, and
+   copy out every operation they say the data supports or the paper performed -
+   verification, consistency, correlation, cleaning, clustering, forecasting. One
+   row each, in their words. This list is not derived from your questions and does
+   not change when your questions do.
+2. **Allocate those slots first.** Fill them before any hypothesis claims one. If
+   the plan schema demands a claim id, use `exploratory:` plus the row name.
+   `draw-the-source-figure-panel-for-panel` states this rule for panels the source
+   *drew*; the rows here are the checks the source only *describes*, which is why
+   they are the ones that lose their slot.
+3. **Cap the total and treat every new panel as a trade.** Write the cap into the
+   plan. Roughly one panel per named check, plus a small number of diagnostics, is
+   defensible; past that each addition pushes something below the cut. When a new
+   diagnostic is worth drawing, name the panel it replaces.
+4. **Order the document by that list.** The named-check panels come first in the
+   results, in the order of the deliverable list. Dataset overviews, pipeline
+   schematics and sensitivity sweeps are not free: they consume the leading slots
+   that decide what is seen.
+5. **One claim per panel.** A check that shares a panel with three of your
+   diagnostics does not have a panel. Reserve composites for material that is
+   genuinely one object.
+6. **Title with the quantity, the population and the value.** The pattern is
+   `<quantity>, <unit>, <population>: <statistic> = <value>`. The verdict goes in
+   the body text - never the title, never an axis annotation. A title that states
+   your conclusion tells the reader what you think and hides what you measured;
+   worse, a dismissive annotation on a correct exhibit is read as the exhibit not
+   counting.
+7. **Print on the panel what the caption would otherwise have to carry:** n, the
+   unit, the statistic and its value, entity names as row labels rather than codes
+   decoded somewhere else. Then repeat those numbers in the prose beside the
+   figure link, so the result survives whether the reader reads the image or the
+   text.
+8. **A trivially satisfied check is drawn exactly like a contested one.** Report
+   the measured value at the precision you measured it, with the relevant floor
+   beside it - float64 epsilon, sensor resolution, the rounding of the stored
+   column - and put the argument for why it had to come out that way in the next
+   sentence, not in place of the number and not in the title.
+9. **Legibility beats density on an image criterion.** Named rows, an axis in a
+   unit a reader thinks in or an explicit relative axis in percent, the headline
+   number printed on the panel. A log axis over signed residuals, a scatter of
+   every cell, or a count of breaches against a tolerance you invented may each be
+   the better diagnostic, and none of them shows a reader whether two things
+   agree. What the agreement exhibit itself must contain is specified in
+   `energy-counterfactual-pair-and-hierarchy-closure`; this skill governs whether
+   it gets a slot, where in the order, and under what title.
+10. **Audit findings are additive, and they come second.** If you conclude the
+    supplied materials are degenerate, synthetic or defective, the named check
+    still runs on the supplied materials and still gets its panel first; the
+    critique follows in its own section, with its own panels only if the budget
+    allows. Deleting the check because you distrust the input deletes the evidence
+    for your own critique.
+
+## Before you finish
+
+List your figures in document order with the title of each, as a reader would see
+them. Against every row of step 1, write the position of its panel. Any row whose
+panel is missing, below your cap, shared with something else, or titled with a
+verdict is a check you performed and did not deliver.

--- a/src/skills/energy-the-terms-behind-the-rate/SKILL.md
+++ b/src/skills/energy-the-terms-behind-the-rate/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: energy-the-terms-behind-the-rate
+description: Use at analysis and writing whenever a headline number is a share, rate or fraction, and especially when your share lands close to a published one. Covers choosing the denominator's population by where the mechanism acts rather than by the model's outer edge, publishing the absolute terms of the balance beside every share, and reconciling with a published study term by term instead of on the ratio.
+stages: 06_analysis, 07_writing
+---
+
+# A share is not a result until its terms and its population are published
+
+## When this applies
+
+Analysis and writing, from the moment a headline number is a share, rate, fraction
+or percentage of something -- and especially when your share lands close to a
+published one.
+
+Two shipped skills touch this. `energy-counterfactual-pair-and-hierarchy-closure`
+requires every rate to be stated with its numerator, its denominator and the
+population the denominator covers, and requires components to sum.
+`the-unit-of-analysis` requires per-unit reporting instead of one pooled number.
+This file is the part neither states: the population is chosen by *where the
+mechanism acts*, which is usually neither the whole modelled system nor a grouping
+column the data hands you; and the comparison with a published study is done term
+by term, because a share can agree while both of its terms are wrong.
+
+## What goes wrong
+
+### The denominator defaults to the widest population available
+
+The solved model hands you totals over everything, so the share gets computed over
+everything. The mechanism acts on a subset -- the units behind the binding element,
+the assets downstream of the intervention, the exposed stratum -- and members
+outside that subset dilute numerator and denominator unequally. Your number then
+differs from anyone else's for a reason that is not physical, and the difference
+reads as a modelling error rather than a denominator choice.
+
+### The share agrees and the terms do not
+
+Two studies can report the same percentage from totals that differ by a fifth. That
+is not a reproduction, it is a coincidence you have not ruled out; and it is how a
+construction error hides, because if numerator and denominator are inflated by the
+same factor the ratio is immune to it and so is every check you run on the ratio.
+The reverse case is as common: the terms match and the share does not, which
+localises the defect in the definition of the share.
+
+### Only the share reaches the prose
+
+The per-unit arrays are on disk, the totals are one sum away, and the body text
+carries percentages. A quantity that exists only in an output file, or only inside a
+figure annotation, has not been reported: a reader cannot rebuild your case from it
+and cannot line your terms up against the source's. Every share in the body gets its
+absolute terms, in the input's or the source's units, beside it.
+
+## What to produce
+
+### 1. Define the affected population before you sum anything
+
+Write it as a list of ids taken from the input files -- which units, which nodes,
+which steps -- and persist that list beside the results. Where membership is a
+judgement call, compute both readings rather than picking one silently.
+
+### 2. A term table: one block per population, one per arm
+
+Rows are the terms of the conservation identity your share is built on: what was
+available, what was realised, each loss or rejection channel, and the residual.
+Columns are your value in physical units, the source's published value where it has
+one, and the difference. The rows must sum to the total; a residual you cannot name
+is a channel you are not tracking, so add the row rather than rounding it away.
+State the share under each block with its denominator named in words, so the reading
+over the affected population and the reading over the whole system are both on the
+page and cannot be confused for each other.
+
+### 3. Reconcile term by term, then the share
+
+- Both terms off by roughly the same factor: a population or scaling mismatch. Name
+  the population you summed and the one you believe the source summed.
+- One term off: a different mechanism, or a loss channel you are not modelling.
+- Terms agree, share disagrees: the definition of the share differs -- check what is
+  excluded from the denominator.
+- Share agrees, terms disagree: say so in the sentence that reports the agreement,
+  and do not present it as confirmation until the terms are reconciled.
+
+### 4. Keep the source's name for the population
+
+Where the shipped data contradicts the brief's or the source's name for a region,
+era, scenario or entity, keep the name, add one sentence stating the contradiction,
+and say what you refuse to do because of it. Substituting a neutral name of your own
+removes the only key a reader has for aligning your rows with the source's, and buys
+nothing a footnote does not. See `use-the-sources-own-names`.
+
+## Checklist
+
+- [ ] The affected population is defined by input-file ids and written down before
+      the sums are taken.
+- [ ] Every headline share appears once per population, with its denominator named
+      in words.
+- [ ] The term table is in the body, in physical units, and its rows sum.
+- [ ] Every share in the body has its absolute terms adjacent; nothing quantitative
+      lives only in a figure annotation or an output file.
+- [ ] Each arm you solved has a block with the same rows.
+- [ ] Every term the source publishes has a comparison line of its own, not only the
+      headline share.
+- [ ] Populations carry the brief's and the source's names, with contradictions
+      footnoted rather than renamed.

--- a/src/skills/energy-utilisation-per-named-element-when-a-limit-binds/SKILL.md
+++ b/src/skills/energy-utilisation-per-named-element-when-a-limit-binds/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: energy-utilisation-per-named-element-when-a-limit-binds
+description: Use at experimentation, analysis and figure planning whenever a result is explained by something reaching a limit -- a transfer capacity, a storage power or energy limit, a ramp rate, a cap, a budget. Covers reading per-element flows out of the solved object under their input ids, the normalised utilisation series and ranked binding-frequency table, and the cross-tab that tests the attribution instead of asserting it.
+stages: 05_experimentation, 06_analysis, 07_writing
+---
+
+# If a limit explains your result, publish utilisation per named element
+
+## When this applies
+
+Trigger: the draft contains a sentence of the form "X happens because C is binding"
+-- a transfer capacity, a storage power or energy limit, a ramp rate, an emission
+cap, a budget, any constraint with a right-hand side. The moment that sentence
+exists you owe the reader the utilisation of C. It fires at experimentation too,
+because the per-element quantities have to be read out of the solved object before
+it goes out of scope.
+
+`energy-canonical-configuration-before-the-enhanced-variant` states the panel rule
+in one clause -- a utilisation-ratio time series when claiming a limit binds. This
+file is the rest of it: what to persist and under which ids, the ranked table, and
+the cross-tab that tests the attribution instead of asserting it. The arm that
+removes the constraint altogether belongs to
+`energy-counterfactual-pair-and-hierarchy-closure`; run it there, do not re-derive
+it here.
+
+## What goes wrong
+
+**The claim is made in prose and shown nowhere.** "The corridor sits at its rating
+in every step" appears in a caption, and no axis in the report carries the ratio.
+Search your own draft for *loading*, *utilisation*, *saturated*, *binding*, *at its
+limit*. If those words appear in prose and no figure has a dimensionless axis, this
+is you.
+
+**The raw quantity is plotted against its rating.** A flow drawn in raw units on an
+axis scaled to several times its rating reads as a flat line low in the panel; the
+reader has to divide by eye, and the thing that explains the result occupies a
+fraction of the panel height. Plot the ratio, not the flow.
+
+**A set of named elements is collapsed into one derived aggregate.** Noticing that
+several parallel elements share one effective limit is a real analytical result.
+Reporting only the aggregate deletes every element the input files and the source
+literature name, and no reader can match your rows to theirs. The input file spells
+out its element ids; an aggregate you invented is not among them.
+
+## What to produce
+
+### 1. A utilisation artifact: every rated element, every step
+
+    u[e, t] = |flow[e, t]| / rating[e]      for each element e with a finite rating
+
+Persist it as one row per (element, step), carrying the element id **exactly as the
+input file spells it**, the rating in the input's units, the signed flow, and `u`.
+Read the per-element series out of the solved object at solve time -- solvers hold
+them and then discard them, and re-solving later to recover them costs an hour you
+will not have.
+
+### 2. A ranked utilisation table in the report body
+
+One row per element, sorted by binding frequency, the top handful plus every element
+the task brief or the source study names:
+
+| element (input id) | rating | mean u | max u | steps with u >= 0.99 | share of horizon |
+
+This is what turns "the network is congested" into a measurement, and it names the
+bottleneck instead of describing it.
+
+### 3. A figure with a dimensionless axis
+
+- y in [0, 1.05], with a horizontal reference line at 1.0 labelled as the rating.
+- x is the native step index, over the full horizon.
+- One line per named element for the top few; where there are many elements, add an
+  element x step heatmap on a shared 0-1 colour scale beside it.
+- Title the panel with the element id and the ratio, not with the raw capacity.
+
+### 4. The attribution test, reported either way
+
+An attribution is falsifiable, so test it rather than asserting it. Cross-tabulate
+the steps where the effect occurs against the steps where the constraint is at its
+limit:
+
+    effect > 0 and u >= 0.99     attribution holds
+    effect > 0 and u <  0.99     something else is binding
+    effect = 0 and u >= 0.99     binding but harmless
+
+Publish the counts, the inconvenient ones included. If the off-diagonal is large,
+rank every element by `u` restricted to those steps and name the one that is
+actually binding there.
+
+## Checklist
+
+- [ ] Per-element, per-step flows were read out of the solved model and persisted,
+      not discarded.
+- [ ] `u = |flow| / rating` exists as a column for every rated element.
+- [ ] The ranked utilisation table, with a binding-frequency column, is in the body.
+- [ ] At least one figure has a dimensionless axis in [0, 1.05] with a line at 1.0.
+- [ ] Every element in the table and the figure carries its input-file id; an
+      aggregate you defined is reported in addition to its members, never instead of
+      them.
+- [ ] The attribution counts are published.
+- [ ] Grep the finished report for "saturat", "binding", "at its limit", "congest":
+      every hit has a utilisation number or figure within one paragraph.

--- a/src/skills/every-claim-in-the-data-description-is-a-result/SKILL.md
+++ b/src/skills/every-claim-in-the-data-description-is-a-result/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: every-claim-in-the-data-description-is-a-result
+description: Use at literature survey and study design, when you first read the task's description of each supplied data file, and again at analysis. Covers turning the description's counts, values, shapes and purpose clauses into a verification list the report answers row by row, on the supplied rows themselves.
+stages: 01_literature_survey, 03_study_design, 06_analysis
+---
+
+---
+name: every-claim-in-the-data-description-is-a-result
+description: Use at literature survey and study design, when you first read the task's description of each supplied data file, and again at analysis. Covers turning the description's counts, values, shapes and purpose clauses into a verification list the report answers row by row, on the supplied rows themselves.
+stages: 01_literature_survey, 03_study_design, 06_analysis
+---
+
+# The description of a supplied file is a list of claims you can test
+
+The brief describes each file it ships: how many rows and columns, what a row
+is, what value it centres on, what shape and span it has, what trend runs across
+its columns — and, in the clause almost everyone skips, what the analysis it
+stands in for is *for* ("such data are used to ...", "critical for understanding
+... and for guiding ...", "used to evaluate ...").
+
+Every one of those is a checkable assertion, and the purpose clauses are an
+analysis specification. They are also the shortest route to the quantities a
+reader of this task expects, because whoever wrote the description wrote it from
+the analysis you are being asked to reproduce.
+
+Two rules below carry most of the value and are the ones runs skip: a claim
+about *spread* needs an interval drawn on the axes, not an adjective in prose;
+and a verification list whose every verdict is "differs" is a fidelity audit,
+which is a different document from the one you were asked for.
+
+## The failure this prevents
+
+A run profiled every supplied file in its first stage and wrote each median,
+quartile, span and trend to a results JSON — the deliverable numbers existed on
+disk within the hour. They reached the report only inside a deviation table,
+measured against values the run had recomputed from an external release it had
+found. So the descriptions' claims were never answered in the affirmative form:
+no "the file's centre is X, as described", no shape check, no span check, and
+not one purpose clause became a named analysis with a figure slot. Its coverage
+table was complete — one row per demand, every row filled — and every row was
+filled with the other population's number.
+
+The tell is a verdict column with no "as described" in it.
+
+Where a description said the scatter widens across an index, the run drew
+interval bands on the external curves and no interval at all on the supplied
+series, so the claim it was asked to check was not visible on any axes in the
+report.
+
+## What to do
+
+1. At literature survey, write `notes/supplied_claims.json`: one row per
+   assertion in each file's description, tagged by kind.
+   - **structure**: row count, column count, what one row is, what one column is.
+   - **numeric**: a stated centre, a stated range or span, a stated per-group
+     value, a stated ratio between columns.
+   - **shape/trend**: the distribution family, monotonicity across an index,
+     "the scatter also grows", "a long tail toward".
+   - **purpose**: the "such data are used to ..." clause, verbatim.
+2. Test the structure, numeric and shape rows **on the supplied file itself**,
+   one measured number each, and record `stated`, `measured`, `verdict`.
+   - `stated` is the brief's own value and nothing else. Substituting a value
+     you recovered externally — the release's number, the paper's number, your
+     recomputation — turns a verification into a fidelity audit and guarantees a
+     column of "differs". If you want that comparison, it is a fourth column
+     called something else, in a later section.
+   - Do not round the measured value onto the stated one. A brief that says a
+     job takes "about 30 minutes" against a measured 32.4 minutes is an
+     agreement worth printing, and 32.4 is the number you quote from then on.
+3. A shape or trend claim needs a statistic, not an adjective. A named
+   distribution family is a fit and a goodness measure; "the scatter grows
+   across the index" is a named percentile interval at each index level and its
+   width; "a long tail" is a quantile ratio. **Draw the interval on the figure**,
+   not only in prose — a location curve with no band cannot show a claim about
+   spread, and a reader checking a spread claim looks at the axes first.
+4. Promote every purpose clause to a named analysis with its own figure slot at
+   study design. "Used to assess the overall uncertainty of X" is an instruction
+   to produce the overall-uncertainty statement for X. "Critical for
+   understanding how A varies across B, and for guiding C" is two deliverables:
+   the variation of A across B, and what it implies for C.
+   The figure that discharges a purpose clause about file X is drawn from X's
+   own rows and carries X's filename in the caption. A purpose clause answered
+   from any other population — a bigger corpus, an authentic release, your own
+   simulation — leaves the row open, no matter how much better that population
+   is.
+5. Where two descriptions refer to the same reference quantity, or one is
+   described relative to another, the comparison between the files is itself a
+   claim. Produce it: put the channels on one axis, mark the reference value as
+   a labelled line, and state the ordering and the factor — measured on the
+   supplied files, both sides.
+6. Publish the verification list in the report as a short stated/measured/verdict
+   table, and make sure each affirmative row also appears as a sentence or an
+   in-panel annotation beside the figure it belongs to. A number that lives only
+   in `outputs/` has not been reported, and a number that lives only in a
+   coverage table has been reported to a reader who is not reading that table.
+7. A claim you find false is a result: give the measured value, the direction and
+   the size, and leave the affirmative rows standing around it. One falsified row
+   does not license reframing the rest of the list as an exposé.
+
+## Before you finish
+
+Walk `notes/supplied_claims.json`. Every row needs a measured number in the
+report, a verdict, and — for purpose rows — the named figure, drawn from that
+file, that answers it. Then count the verdicts: if none of them is "as
+described", you audited the data instead of using it.

--- a/src/skills/every-supplied-array-is-a-series-in-a-results-panel/SKILL.md
+++ b/src/skills/every-supplied-array-is-a-series-in-a-results-panel/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: every-supplied-array-is-a-series-in-a-results-panel
+description: Use at study design when the figure plan is written, and again before the report is finalised, whenever the task ships a data file holding several named arrays, columns or blocks. Covers building the deliverable inventory from inside the file rather than from the directory listing, grouping the supplied series by shared abscissa into panels, and the grep sweep that finds the arrays you measured and never drew.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# The inventory is inside the file, not in the directory listing
+
+A task that ships one file in `data/` looks like one deliverable. It is not.
+The file holds N named arrays, and the results you are judged on are claims
+about those arrays. Any inventory built by listing `data/` discharges in one
+line and misses every one of them.
+
+Two shipped skills stop the directory-level version of this and neither reaches
+inside a file. `the-supplied-item-is-the-graded-unit` covers reporting a named
+object from `data/` under its own name. `draw-the-source-figure-panel-for-panel`
+covers deriving each panel's series list from the source's rendered figure, and
+its rule that a curve you disqualified stays on the panel annotated is the rule
+this failure breaks most often. What follows is the same discipline applied to
+the arrays, columns and blocks *within* one supplied file, plus the sweep that
+finds the ones you never drew.
+
+## The failure this prevents
+
+A run was handed a single plain-text file holding a few dozen named arrays in
+several blocks, each block a set of series sharing one abscissa. It shipped six
+figures. Its three results figures carried about a quarter of the supplied
+series between them; several arrays — model curves and a second abscissa —
+appear in no figure script anywhere in the run.
+
+None of it was an oversight. Every missing array had been measured first, and
+the measurement was the stated reason for dropping it: this series carries no
+information the neighbouring one does not, this theory array is a
+reparameterisation of another, this family of shipped model curves was fitted
+and disqualified in a section of its own. Each of those findings was correct.
+Each of them is a caption clause. A comparator ran the same audits, reached the
+same conclusions, plotted every supplied array anyway, and scored higher on both
+graded items where the two reports differed.
+
+An array you measured and did not draw costs you twice: the panel is missing
+the comparison, and the finding that justified the omission has no reader,
+because the reader cannot see the curve it is about.
+
+## What to produce
+
+**At study design, before any figure slot is claimed:**
+
+1. Parse the supplied file(s) and write `notes/supplied_series.csv`: one row per
+   named array, column or block. Columns — the name exactly as the file writes
+   it, length, stated units, which grid or abscissa it belongs to, and its kind:
+   `measurement`, `model/theory`, or `abscissa`.
+2. Group the rows by shared abscissa. **Each group is one panel.** Every
+   measurement in the group goes on as markers, every supplied model or theory
+   array in the group goes on as a line, on one pair of axes, in the file's own
+   numbers.
+3. Record the group-to-slot binding in the plan. A group with no slot is a block
+   of the supplied file that your deliverable does not mention.
+
+**Four rules that decide the hard cases:**
+
+4. **A supplied independent-variable array is an abscissa you owe a panel.** If
+   the file ships two axes for one response — an amplitude and a power, a
+   density and a filling factor — you owe a panel in each, plus the conversion
+   between them written down and checked against the relation the source states.
+   A fitted exponent quoted against the axis the source did not use differs from
+   the published one by a factor and reads as a disagreement you never had.
+5. **Anything you build is an added series, never a replacement.** A regenerated
+   model family, a closed form you coded from the source's equations, a derived
+   bound: these go on the panel *beside* the supplied array they correspond to.
+   If your substitute is on the panel and the array it stands in for is not, you
+   have plotted your own reasoning instead of the data you were given.
+6. **A defect in a supplied array is an annotation, not a deletion.** Whatever
+   the audit found — a duplicate, a mislabel, a rescaling, a ragged length, a
+   fit that fails — write it into the caption or onto the panel in one clause
+   and keep the curve. The annotated panel is worth more than the clean panel
+   and more than the paragraph that replaces it.
+
+7. A data-overview or small-multiples figure **discharges none of this.** It
+   shows that the arrays exist. A results panel shows what they mean.
+
+## The sweep, before the report is written
+
+For every row of `supplied_series.csv`:
+
+```
+grep -l "<array name>" code/*.py
+```
+
+- Zero hits: a supplied series you never drew and never fitted.
+- Hits only in the parser or the overview script: half-drawn — read, plotted as
+  a thumbnail, absent from every result.
+
+For each, either put it on the panel its group owns, or write one sentence in
+that panel's caption saying why it is absent. "It is redundant with another
+series" is a legitimate sentence; it is not a reason to omit the sentence.
+
+Then, per panel, diff the series you actually plotted against the group's row
+list and write the two counts in your notes: *k of n supplied series on this
+panel*. Any panel below n needs the sentence. Do this once at design time
+against the plan and once against the figures you actually produced; the two
+answers are routinely different.
+
+See also `publish-what-the-run-already-computed`, which is the same sweep over
+the run's own *outputs* rather than its inputs. Run both.

--- a/src/skills/every-variant-persists-the-same-object/SKILL.md
+++ b/src/skills/every-variant-persists-the-same-object/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: every-variant-persists-the-same-object
+description: Use at implementation when you write the routine that reduces a scan to a scalar, at experimentation when the sweep over alternative treatments runs, and at writing before any comparison figure is finalised. Covers persisting the full curve for every variant on a shared grid rather than only its threshold crossings, why a ragged results file makes the field's comparison figure undrawable after the compute is gone, and diffing the rendered image against the plan slot that named it.
+stages: 04_implementation, 05_experimentation, 07_writing
+---
+
+# Every variant persists the same object
+
+**Upstream of the figure skills.** `astronomy-figure-is-the-unit-of-result` and
+`draw-the-source-figure-panel-for-panel` say what the comparison figure must
+contain: every competing treatment of one quantity overlaid on a single set of
+axes, over the full scanned range, with the decision threshold drawn as a
+labelled line. Neither is executable at writing time if the curves are not on
+disk, and by then the sweep is over. This skill is about what the analysis writes
+down, so that they are.
+
+## What goes wrong
+
+You compute one quantity under several treatments of the input: the full
+distribution, a Gaussian approximation, an uncorrelated version, a coarse
+interval, a point estimate, a larger or smaller model space. For each you scan a
+parameter and reduce the scan to the thing you actually want — where the curve
+crosses a threshold, the interval it excludes, the argmax, the first failure
+point.
+
+The reduction is correct, and it is what you persist. For the primary treatment
+you also keep the underlying trace, because you plotted it while debugging. For
+the alternatives you keep the reduced scalars only, because that is all the
+comparison table needs.
+
+Nothing errors. The results file ends up with ragged keys — one entry carrying an
+array, the rest carrying pairs of numbers — and no counter anywhere records that.
+At writing time the figure the field expects cannot be drawn from what exists, so
+the alternatives degrade into a bar chart of scalar displacements beside a single
+curve, and the panel quietly changes what it is a figure of. Re-running the sweep
+is not affordable at that point in the run.
+
+Two things are then unrecoverable for the reader: the **shape** of each
+alternative — whether it degrades gradually or catastrophically, whether it has a
+second feature elsewhere in the domain, whether it is flat where you claim it is
+informative — and the **rest of the domain**, which is the only evidence that
+your scan was wide enough to contain the answer.
+
+## The rule
+
+One schema for every variant of one computation.
+
+- Fix a deterministic grid over the whole domain you intend to scan, before the
+  sweep runs. Record its endpoints and spacing once, in the results file.
+- Evaluate every variant on that grid, including the ones your estimator can
+  answer analytically without a grid. An exact crossing point is cheaper and is
+  not a substitute; keep both.
+- Persist the whole array per variant — `.npz`, a CSV column, a JSON list — under
+  the same key as the primary carries. Name variants at persist time the way the
+  field names them, so the legend does not have to be reinvented later.
+- Include the degenerate treatments as variants: the crudest summary of the
+  input, the naive approximation, the no-model baseline. They cost almost nothing
+  and they carry the argument for why the careful treatment was worth doing.
+
+## A name-matched completeness check is not a check
+
+The same run usually has a coverage gate — a plan, a deliverables list, a slot
+per figure. If that gate matches on a heading string and an image filename, it
+goes green on a figure that contradicts the plan slot that named it: the file
+exists, the heading is present, and nothing opened either. Existence checks pass
+on the wrong artifact.
+
+Whatever sentence you wrote to declare a figure is a falsifiable statement about
+a PNG. Re-read it and diff it against the rendered image clause by clause: number
+of series, what each series is, the x-range, whether the threshold line is drawn
+and labelled, whether anything declared as a curve came out as a bar. It costs a
+minute, and it is the only step that catches a plan violated by the plotting
+code.
+
+## Checklist
+
+Implementation and experimentation:
+
+1. After the sweep, load the results file and print the key set per variant.
+   Assert the sets are equal. Ragged keys are the defect and this is the whole
+   test; write it as an assertion, not as an intention.
+2. Draw one throwaway overlay of every variant **from the persisted file alone**,
+   in a fresh interpreter. If you cannot, the file is incomplete and the sweep is
+   still cheap to re-run.
+3. Set the scanned domain from the question and the physics, before you know
+   where the feature is.
+
+Writing:
+
+4. Axis limits come from the domain you scanned, including the saturated regions
+   at both ends. If a feature runs off the edge of the plotted range, the scan
+   was too narrow — widen it and re-run rather than cropping.
+5. Anything you can only draw as a bar, an arrow or an annotated displacement is
+   a variant whose curve was not saved. If it cannot be fixed, say so in the
+   caption so the bar is not read as the comparison.
+6. No panel of a results figure is a block of prose. A panel listing headline
+   numbers is a table occupying a panel's space; move it and give the space back
+   to the curves.

--- a/src/skills/evidence-not-assertion/SKILL.md
+++ b/src/skills/evidence-not-assertion/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: evidence-not-assertion
 description: Use whenever a number, a comparison or a claim is about to enter a stage summary or the report — at analysis and writing, and any time you are tempted to state a value you have not computed in this run. Covers where a number must come from, what to do when the experiment did not run, and why an honest gap outscores a plausible sentence.
+stages: 06_analysis, 07_writing
 ---
 
 # Every number comes from a file this run wrote

--- a/src/skills/extract-the-pdf-text-layer-then-read-every-figure/SKILL.md
+++ b/src/skills/extract-the-pdf-text-layer-then-read-every-figure/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: extract-the-pdf-text-layer-then-read-every-figure
+description: Use at literature survey, and again as a study-design gate, when the source demonstrates a capability by example - generated samples, transcripts, worked cases, before/after pairs - and those inputs are printed inside the figure graphics. Covers extracting every obtainable PDF's text layer before calling an input unrecoverable, building the figure inventory as the coverage denominator, opening as images only what the text layer misses, and the demonstration ledger study design has to spend.
+stages: 01_literature_survey, 03_study_design
+---
+
+# Get the source as a PDF and read its text layer before you call an input unavailable
+
+A paper's quantitative results live in its tables and its prose. Its qualitative
+results usually do not: the prompt, the query, the input case and the system's
+printed answer are typeset *inside the figure graphic*. Fetch the article as
+HTML and you get the caption and the paragraph that cites the figure - enough to
+write "the source gives qualitative examples of this capability", not enough to
+run a single one of them.
+
+What happens next is the expensive part. The arm gets designed anyway, and it is
+sourced from whatever inputs were machine-readable: a benchmark's prompt list, a
+public evaluation split, the one file the task happened to ship. The
+substitution measures a real thing and reproduces nothing, and the exhibit a
+reader would lay beside the source's own panel does not exist.
+
+The correction is a few minutes of work, in the right order.
+
+## Order of operations
+
+1. **Inventory first, from the rendered source.** List every figure graphic in
+   the article body - in HTML, every `<img src=...>` between the abstract and the
+   references; in a PDF, every numbered float. The filenames are usually named
+   after what they show. That count is the denominator of your coverage line.
+2. **Text layer next.** Run a PDF text extractor page by page over every PDF of
+   the source you can obtain: the copy the task ships, and the preprint or
+   publisher copy of the same work. In-figure strings are frequently ordinary
+   text objects positioned over the graphic, so an extractor returns them
+   verbatim. Long strings that appear nowhere in the running prose are exactly
+   the demonstration inputs and printed outputs you are after. This costs
+   seconds, and it is the step that gets skipped because the HTML was already in
+   hand.
+3. **Pixels for the remainder.** Whatever the text layer does not carry - raster
+   panels, screenshots, outlined type - render the page at >=110 dpi and open it
+   as an image, or download the figure graphic and open that. Do this for every
+   remaining figure, not only the ones you already have a use for.
+4. **Fallbacks.** The project page, the model or dataset card, the release
+   repository's `assets/` and README, and the appendix frequently carry the same
+   showcase inputs as plain text.
+
+Versions differ in which figures they carry. If the shipped copy and the public
+copy disagree, take the union and record which copy each row came from.
+
+## The partial read
+
+The failure is rarely skipping the figures. It is opening the ones that match
+the files the task shipped, and stopping. The shipped files tell you which
+demonstrations you can re-run **with a supplied input**. They say nothing about
+which demonstrations the source published, and the half of the brief that ships
+no input file is the half that ends the survey with no source material at all.
+
+Read the brief's list of named capabilities against the figure inventory before
+you close the stage.
+
+## What to produce
+
+`literature/source_demonstrations.jsonl`, written before the first hypothesis is
+drafted, one row per demonstration the source publishes:
+
+```
+{"figure": "<figure and panel, as the source labels them>",
+ "capability": "<which capability named in the brief it demonstrates>",
+ "input": "<the input string or file, transcribed verbatim>",
+ "printed_output": "<what the source prints as the result, or the artifact type>",
+ "baselines_printed": ["<competitor outputs shown in the same panel>"],
+ "settings_printed": "<any run settings printed in the figure or caption>",
+ "recovered_from": "text layer | figure image | project page",
+ "runnable_here": true}
+```
+
+Close the stage with one coverage line: *F figures found, T whose printed strings
+the text layer carried, I opened as images, D demonstrations transcribed, K
+inputs recovered verbatim.* If T + I is short of F, name the figures you did not
+read and why.
+
+## Then spend it
+
+The ledger is an input to study design, not a note. Every row is assigned to an
+arm or declined in writing - see `draw-the-source-figure-panel-for-panel` step 2
+for slot assignment and `cover-what-the-task-named` for the enumeration it has to
+match. Two non-reasons for declining: that the demonstration carries no metric
+(a demonstration is reproduced by re-running the input and showing the output,
+not by scoring it), and that a benchmark covers the same capability (a benchmark
+measures a population; the demonstration is a named case with a published
+expected output, and it is the only comparison a reader can make by looking).
+
+An input you could not recover is an open question that names the figure it sits
+in. It is never silently replaced by a list you could download.
+
+## Checklist
+
+- [ ] Figure inventory built from the rendered source; count recorded.
+- [ ] A text extractor was run over every obtainable PDF of the source before any
+      input was called unrecoverable.
+- [ ] Every figure the text layer did not cover was opened as an image.
+- [ ] `source_demonstrations.jsonl` exists, with verbatim inputs, before Stage 02.
+- [ ] Coverage line recorded: found / in text layer / opened / transcribed.
+- [ ] Every capability the brief names has at least one ledger row, including the
+      ones with no shipped input file.
+- [ ] At study design, each row is assigned to an arm or declined with a reason.

--- a/src/skills/information-a-training-free-method-owes-a-second-backbone/SKILL.md
+++ b/src/skills/information-a-training-free-method-owes-a-second-backbone/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: information-a-training-free-method-owes-a-second-backbone
+description: Use when the method under study is training-free, plug-in, prompt-level or described as model-agnostic: at literature survey to enumerate which host models the released code actually supports and where that support came from, at study design to price the second host, at experimentation to run it. Covers finding hosts in dispatch tables and third-party contributions, choosing the cheapest one, and the three readings a two-host table owes.
+stages: 01_literature_survey, 03_study_design, 05_experimentation
+---
+
+# A training-free method owes a second backbone
+
+"Training-free", "plug-and-play", "model-agnostic", "requires no fine-tuning",
+"works with any MLLM/LLM/encoder", "wraps the frozen model" — these are one
+claim, and the claim is about a set of host models, not about one of them. A
+study that measures one host has measured that host. It cannot separate "the
+method works" from "this host was weak on this benchmark", which is the first
+question a reader asks of a wrapper.
+
+This is an axis, not a nicety. If the source's tables carry a backbone column or
+a second model block, that structure *is* the paper's generality argument, and a
+study confined to one cell of it has not attempted the headline claim.
+`information-fill-the-whole-results-grid` lists backbones as one grid dimension
+among several; this skill is the part it leaves out — how to find out which
+hosts are reachable, which one to pick, and what to report about the pair.
+
+## Enumerate the hosts from the code, not from the paper
+
+At literature survey, when you fetch the reference implementation, enumerate its
+host models before you enumerate anything else. Do this from the repository
+listing, not from the paper's method section:
+
+- the `--model` / `--backbone` argparse `choices`, and the name-to-function
+  dispatch dict it feeds;
+- per-model implementation files and notebooks — one file per supported host is
+  the usual layout, and the file names are the host names;
+- config enums, YAML keys, registry decorators, entries in a run-all script;
+- **the repository's open and merged pull requests, forks, branches, issues and
+  the README's news or changelog section.** Support for host models released
+  after the paper lands as third-party contributions and appears nowhere in the
+  paper. This is frequently the only place a cheap, modern host exists, and the
+  contribution route is itself a reportable fact about the method's modularity.
+
+Write it down as a literature-survey deliverable: one line per supported host
+with its parameter count, the file that implements it, the exact invocation, and
+whether it came from the authors or a contributor (with the PR or fork it came
+in through). A host that exists in the tree and is absent from this list is a
+host you will never budget.
+
+## Pick the smallest supported host, not the most impressive
+
+The deliverable is the second row. Cost scales with the host, so take the
+smallest one the code supports, run it on the cheapest slice in the study, at a
+reduced and labelled N. A two-host table at small N answers a question a
+one-host table at large N cannot. Price it as a ledger row like any other and
+put it above every condition you invented.
+
+## What to produce
+
+One table, the same conditions on both hosts, same slice, same N:
+
+| host | params | source of support | baseline | variant 1 | variant 2 | ... | delta |
+
+Then three readings, in the text, each of which is a measurement you make and
+not a conclusion you assume:
+
+1. **Both baselines, printed.** State each host's unmodified accuracy on the
+   shared slice. Then say what the difference between them implies for this
+   study: what room each host leaves the method to work in, and whether deltas
+   measured on top of two different baselines are comparable at all. Write that
+   reading out; a reader will not derive it from your table.
+2. **Does the variant ordering survive the host swap?** Rank the variants on
+   each host and compare the rankings in both directions. Whether the ordering
+   is preserved is the portability result, and it must be stated as a sentence,
+   not left implicit in two tables.
+3. **A coincidence is a result; go find its cause in the code.** If two or more
+   variants return the same score on a host, do not write it off as noise or as
+   a small-N artifact. Check whether their intermediate objects also coincide —
+   the same selected region, the same retrieved set, the same routing, the same
+   token subset — and then read that host's adapter in the released source
+   and report what its code path actually does with each variant. Report the
+   mechanism you found in the code, not a plausible story about it. The numbers
+   alone cannot settle it; the adapter can.
+
+## Checklist
+
+- [ ] Supported-host list extracted from the code, run scripts, PRs, forks and
+      README news at literature survey, with parameter counts and provenance.
+- [ ] Second host chosen as the smallest supported one, priced per item on the
+      cheapest slice, and entered in the ledger above any condition I invented.
+- [ ] The same variant set run on both hosts, same slice, same N, labelled.
+- [ ] Both baselines printed, with an explicit sentence on what their gap means
+      for the deltas measured on top of them.
+- [ ] Variant ordering compared across hosts, stated in words.
+- [ ] Any exact tie between variants chased first into the intermediate objects
+      and then into that host's adapter source, with the code-level finding
+      written down.
+- [ ] Provenance of the second host's support named in the report — authors or
+      contributor, and through what route.
+- [ ] If the second host is genuinely unreachable, the reason is a measured
+      per-item cost against a clock, not a sentence in Limitations.
+
+## Why this is here
+
+Inference-time and wrapper methods are graded on portability, and a run that
+measures one host deeply reads as never having attempted the generality claim —
+usually the paper's headline claim. The second host is also the cheapest large
+result available: a smaller model, the light slice, a small labelled N, and a
+port that already exists in the released code, sometimes only on a branch or in
+a merged contribution.

--- a/src/skills/information-check-the-steps-yourself-not-only-their-scores/SKILL.md
+++ b/src/skills/information-check-the-steps-yourself-not-only-their-scores/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: information-check-the-steps-yourself-not-only-their-scores
+description: Use at implementation and experimentation when the deliverable is a multi-step symbolic or analytic calculation whose correctness would otherwise rest on a grader, a rubric or a similarity score. Covers the cheapest mechanical check that applies to each class of step, the time cap that stops checking from displacing the write-up, and reporting the table with one worked failure beside the grader's verdict.
+stages: 04_implementation, 05_experimentation
+---
+
+# A step you only scored is a step nobody checked
+
+When the deliverable is algebra or a symbolic pipeline, correctness is usually
+established by comparison: score each step against a reference with a model
+instrument, a rubric, a string or embedding similarity, a human key. That gives a
+rate. It does not give a reason, and it inherits the instrument's weaknesses -
+graders of this kind accept an object of the right shape for the wrong problem,
+and reject a correct expression written in different index names.
+
+A cheap mechanical check per step buys three things the rate cannot: a reason, a
+located failure, and a case where you and the grader disagree.
+
+## Cheapest check that applies, in this order
+
+Do not build one check per step, and do not build the expensive kind first.
+
+1. **Numeric instantiation.** Default, and it applies to most steps. Build one
+   small explicit instance - the smallest system with more than one of every index
+   - fix sizes, parameter values, seed and tolerance once, and evaluate both sides
+   of the step on it. This catches dropped factors, wrong normalisations,
+   transposed indices and sign errors, which are the common failures.
+2. **Brute-force enumeration.** For any step that reduces or renames indices under
+   a constraint: enumerate a small index set, evaluate the unreduced and the
+   reduced form, assert equality. Overapplying a constraint is exactly the failure
+   here and it is invisible in the final expression.
+3. **Symbolic term comparison, only with a library that does the bookkeeping.**
+   Where an established symbolic package covers your algebra, expand both sides
+   and compare term sets with signs. Do not hand-roll a term algebra for a
+   one-off; that is a multi-hour build and its own source of errors.
+4. **Invariants and limits on the assembled object.** Symmetry, positivity,
+   dimensional consistency, conserved counts, and the limit in which a parameter
+   goes to zero and the object must collapse to the simpler known one. If the
+   object is defined by a fixed-point condition, iterate it and report whether it
+   converges and to what.
+
+Reuse the one small instance across steps so the checks compose: the output of
+step k is the input of step k+1 on the same numbers.
+
+## The cap, and what outranks the check
+
+Time-box each check. If it is not working inside the box, stop, write the
+operation account for that step, and move on. **The check never displaces the
+prose that names what the step did** - that prose is the graded object, the check
+is evidence for it. A run that spends its budget building verification machinery
+and ships no step accounts has repeated the failure it was trying to avoid, one
+level up.
+
+Build the checks against the reference material first, before your own output. A
+check that fails on the known-correct expression is a bug in the check, and
+finding that out afterwards costs you the result.
+
+Where no cheap check exists, one line saying so and why is a result about the
+step, not a gap.
+
+## How to report it
+
+One table in the report body:
+
+| step (the source's name) | check | what it would catch | result |
+
+and then **one failing check written out in full**: the term, the index, the sign,
+the value on each side, and the condition under which the two would agree. A table
+of green ticks is worth much less than a single worked failure, because the
+failure is what proves the checks have teeth.
+
+If the task also asks for graded or scored outputs, produce them - a task-named
+deliverable is never withheld on principle. Report the grader's rate with the
+mechanical check beside it wherever a cheap check exists, and reconcile them.
+Every disagreement is a second, sharper result: a measured case where the
+instrument accepted a wrong object or rejected a right one, with the object
+attached.
+
+## Rules
+
+1. A rate whose only support is a model's judgement is reported together with the
+   check, where a cheap check applies. Where none applies, say which steps are
+   grader-only.
+2. Checks live in `code/` behind a single entry point, and its summary line goes
+   in the report, so a reader knows the table came from a program rather than from
+   reading.
+3. The check's job is to locate a failure, not to award a mark. Report which term
+   is wrong, not how many steps passed.
+
+## Boundary with the neighbouring skills
+
+`reproducibility-check` is about your pipeline re-running and yielding the same
+numbers; a perfectly reproducible pipeline reproduces wrong algebra forever.
+`evidence-not-assertion` is about sourcing each number to a file this run wrote.
+This skill builds an independent oracle for the deliverable itself, so the report
+can say the derivation is right rather than that it was scored as right. Its
+output feeds the `Delta` and `vs ref` lines of
+`information-transformation-ledger-for-a-multi-step-derivation`.

--- a/src/skills/information-exhibit-the-intermediate-objects/SKILL.md
+++ b/src/skills/information-exhibit-the-intermediate-objects/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: information-exhibit-the-intermediate-objects
 description: Use at analysis and writing when a multi-stage pipeline is about to be reported by its end-to-end metric alone. Covers exhibiting each stage's intermediate object, and re-running the source's own demonstrations on the source's own inputs rather than on yours.
+stages: 05_experimentation, 06_analysis, 07_writing
 ---
 
 # Show every stage's intermediate object and re-run the demos on the original's own inputs

--- a/src/skills/information-fill-the-whole-results-grid/SKILL.md
+++ b/src/skills/information-fill-the-whole-results-grid/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: information-fill-the-whole-results-grid
 description: Use at study design and again at writing when the source reports a grid — variants crossed with backbones, datasets or metrics — and you are about to fill part of it. Covers reproducing the whole grid at reduced N where you must, and why a labelled reduced-N cell beats an empty one.
+stages: 03_study_design, 05_experimentation, 07_writing
 ---
 
 # Reproduce the whole (variant x backbone x dataset x metric) grid, reduced-N where you must

--- a/src/skills/information-state-the-technique-and-what-it-discards/SKILL.md
+++ b/src/skills/information-state-the-technique-and-what-it-discards/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: information-state-the-technique-and-what-it-discards
+description: Use at analysis and writing whenever the work invokes a standard technique of the field by name - a transformation, an identity, an approximation, an estimator, a decomposition. Covers stating the rule and its convention before applying it, naming what the technique costs, showing the expansion it generates before simplification, and what to do with conditional steps you skipped.
+stages: 06_analysis, 07_writing
+---
+
+# Naming a technique is citing it; the report has to show it executed
+
+Standard machinery gets invoked in one clause - "applying <technique>, we obtain"
+- and the next line is the result. The technique is named and never stated, the
+intermediate expansion never appears, and the assumption it introduced is never
+written down. From that, a reader cannot tell whether you executed the technique,
+copied its output out of the source, or asked a model for it.
+
+This is the loss that survives after the objects are printed. A chain of correct
+expressions with the operations only implicit in them is graded as equations
+without analysis: the criterion asks how the operation was performed, and the
+report answers what came out of it.
+
+## What an account of a technique contains
+
+Four parts, for every named technique the work invokes. Together they are a short
+paragraph plus one displayed expansion - not a section.
+
+1. **The name the field uses**, not a paraphrase, and the source's words for it
+   where the source names it. A report that says "we transformed the expression"
+   is unsearchable by anyone looking for the technique.
+2. **The rule, stated once in general form, before it is applied**, together with
+   the convention you adopted: sign, ordering, prefactor, normalisation,
+   direction, discretisation, boundary or gauge choice. Most standard techniques
+   have two or more conventions in circulation, and an unstated convention is
+   where two otherwise correct derivations silently disagree.
+3. **What it costs.** Exact identity or approximation? If exact, name the property
+   of your object that licenses it. If approximate, name the neglected object and
+   the parameter or regime that makes it small, and say what the result would look
+   like if that parameter were not small. "Standard" is not a licence; a technique
+   applied outside its condition is the most common wrong step in a long chain.
+4. **The applied instance, shown before simplification.** The complete set of
+   terms the rule generates on your input - all of them, with signs - and then the
+   surviving set, with one clause per dropped term saying why it went.
+
+## The pre-simplification expansion is the proof of execution
+
+A final expression can be copied from anywhere. A full expansion cannot: it has
+the right number of terms, the right signs and the right index structure only if
+the rule was applied to your object. Where a technique generates several terms and
+only some survive, the intermediate costs a few lines and is the whole difference
+between a derivation and an assertion.
+
+Put it at the step where it happens, inside that step's block, not in a methods
+appendix and not in a preamble. The account and the object are read together or
+neither is read.
+
+## Conventions, collected
+
+Keep one small table: technique, convention chosen, where it is first used. It
+costs five minutes and it catches the failure that no correctness check finds -
+the same technique applied twice under two different conventions, each locally
+right, the composition wrong.
+
+## Conditional and skipped steps
+
+Procedures written as templates contain steps that apply only to some instances.
+A conditional step you skipped still needs its line: name it, say it does not
+apply here, and give the property of this instance that makes it unnecessary. An
+omitted conditional step is indistinguishable from a forgotten one.
+
+## Provenance per step
+
+If a step's output was produced by a tool, a solver or a model rather than by you,
+say so at that step. That does not excuse you from parts 1-3 - the rule, the
+convention and the cost are still yours to state - and it makes part 4 the object
+you checked rather than the object you claim to have produced. A step whose
+provenance is unstated is read as your own work and graded as such.
+
+## Checklist
+
+- [ ] Every technique the chain invokes appears in the report body by name. Grep
+      for each one; zero hits means the step is invisible, whatever ran.
+- [ ] Each has its rule in general form and its convention, stated before use.
+- [ ] Each says exact-or-approximate, and the approximate ones name what they
+      discard and under what condition that is safe.
+- [ ] At least the techniques that generate multiple terms show the expansion
+      before simplification.
+- [ ] Conditional steps that were skipped are named with the reason.
+- [ ] No technique is introduced for the first time in a figure caption or an
+      appendix.
+
+## Boundary with the neighbouring skills
+
+`information-transformation-ledger-for-a-multi-step-derivation` is coverage: one
+entry per step across the whole chain, so nothing is missing. This skill is depth
+at the few steps that invoke standard machinery, and it is what fills their
+`Does`, `Delta` and pre-simplification lines. `use-the-sources-own-names` covers
+carrying the source's names for reproduced objects; a technique needs its name
+*and* its statement, because the name alone is a citation.

--- a/src/skills/information-transformation-ledger-for-a-multi-step-derivation/SKILL.md
+++ b/src/skills/information-transformation-ledger-for-a-multi-step-derivation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: information-transformation-ledger-for-a-multi-step-derivation
+description: Use at study design, analysis and writing whenever the result is produced by a chain of named steps - a symbolic derivation, a transform pipeline, a staged extraction. Covers lifting the step list verbatim from the supplied material, the per-step block that states the operation and not only the object, which steps earn a full block, and the stop condition on how much of the chain actually reached the report.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# A chain is graded step by step, and the operation is the sentence
+
+A multi-step result reported by its last line is an unshown derivation. So is one
+reported as a pass/fail column, a per-step score, or a pointer to a file of
+workings. What reads as an account of the work is the ledger: for each step, what
+went in, what operation was applied, what came out, and what is different about
+the output.
+
+## The headline rule
+
+An exhibited object with no sentence whose subject is the operation is read as a
+dump. A verdict with no object is read as a score. Neither is an account of how
+the result was obtained, and a criterion asking how the transformations were
+carried out is scored near zero against either.
+
+Every step you show carries both halves. The sentence is the cheaper half - one
+line - and it is the half missing from nearly every report that loses this.
+
+## The step list is not yours to invent
+
+Lift it verbatim - from the annotation file with one record per step, the prompt
+template, or the source's numbered equations and supplement headings - print the
+count, and use those exact strings as headings. Your own stage names and your
+arm labels destroy the correspondence. See `use-the-sources-own-names`.
+
+## The block per step
+
+```
+### Step k - <verbatim step name from the source>
+In:    <the object this step consumes, in symbols>
+Does:  <the operation, as a rule a reader could apply to a different input>
+Out:   <the emitted object, inline, in the source's notation>
+Delta: <one sentence: which index was summed or renamed, which basis or domain
+        the object now lives in, which approximation entered, which term
+        vanished and why>
+vs ref:<if a reference exists: the difference at the level of one symbol, index
+        or argument, and what would have to hold for the two to agree>
+```
+
+`Does` and `Delta` are the lines that get read as mechanistic. Write `Does` so it
+would apply to a different input - "each <object> is replaced by <what> under
+<condition>" - not "we transformed the expression".
+
+## Which steps get a full block
+
+A long chain does not need a full block per step. Every step gets one table row
+carrying its emitted object in compact form. Full blocks go to four classes:
+
+- **Representation change** - the object moves to another basis, domain,
+  coordinate system or index convention, or a compact form is written out in
+  components. State the convention and the direction.
+- **Approximation or truncation** - state what is neglected and the parameter or
+  regime that makes it small.
+- **Index reduction under a constraint** - a conservation condition, selection
+  rule or symmetry collapses a sum or identifies two indices. State the
+  constraint and the range it leaves behind.
+- **Assembly** - the step that combines the pieces into the final object. Say
+  which earlier step contributes which term, and what distinguishes each term
+  from its neighbour.
+
+Those four are what a specialist checks. Steps that only restate definitions can
+stay table rows.
+
+## Never a pointer
+
+A side file of any size is not in the document a grader reads. If the report is
+getting long, cut method and instrument prose, never the chain. See
+`information-exhibit-the-intermediate-objects`.
+
+## Divergence is content, not a tick
+
+When your chain disagrees with a reference, the disagreement is the most valuable
+thing you hold, and it is a sentence about a term: which symbol differs, which
+index or argument carries the difference, and the condition under which the two
+would coincide. A column reading `incorrect` communicates none of that. Neither
+does a defect list about your own output - that is a verdict, and a verdict is
+graded as quality control, not as analysis. Write the account of what the step
+does first, then the verdict.
+
+## Budget
+
+This extends `run-the-requested-analysis` for the case where `data/` ships the
+harness for an underlying procedure: prompt templates, gold answers, per-item
+human scores, a released results notebook. The study of the harness is then
+legitimate and usually requested. The failure is that it crowds out the chain.
+
+- Before writing, count body characters spent on the chain against those spent on
+  the harness, its aggregation and its graders. At least a third of the body, and
+  at least one figure slot, belongs to the chain.
+- Every finding about the instrument gets a second sentence whose subject is the
+  object. Not "the correction loop is worth k points" alone, but "without it the
+  chain survives the change of basis and fails at the index reduction; here is the
+  expression it produces and the one it should". Keep both sentences.
+- Anything you compute per step is plotted and tabulated against the step's own
+  name, never against an integer position, so the axis and the caption carry the
+  vocabulary too.
+
+## Stop condition
+
+Count the steps whose emitted object **and** operation sentence both appear in the
+report body, over the number of steps in the source's list. Below one half, fix
+that before touching anything else. A couple of blocks out of many steps is a
+summary, whatever exists under `outputs/`; `publish-what-the-run-already-computed`
+is the sweep that finds the objects the run already produced.

--- a/src/skills/keep-the-pipeline-vocabulary-off-the-canvas/SKILL.md
+++ b/src/skills/keep-the-pipeline-vocabulary-off-the-canvas/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: keep-the-pipeline-vocabulary-off-the-canvas
+description: Use at analysis and writing when your run carries internal scaffolding — numbered hypotheses, arm codes, clause verdicts, preregistered decision rules, provenance tags on input files — and you are about to save figures. Covers what may not appear inside the frame, what must, where the scaffolding does belong, and a four-question test on the image alone.
+stages: 06_analysis, 07_writing
+---
+
+# Keep the pipeline's vocabulary off the canvas
+
+## What goes wrong
+
+A run with internal scaffolding — numbered hypotheses, arm codes, clause tables, preregistered
+decision rules, provenance tags on its input files — renders that scaffolding into the images.
+
+An invented but typical example, from a hydrology run comparing two channel-routing schemes: the
+figure is titled `H4 arm B - routing choice dominates (REFUTED)`; the x-ticks read `arm A pre-patch`,
+`arm A post-patch`, `arm B pre-patch`, `arm B post-patch`; a legend entry says `seed-matched null`;
+and a grey box in the corner lists `clause (a) FAILS / clause (b) FAILS / clause (c) —`. Every
+element is true, traceable and correctly computed. The words *catchment*, *discharge* and *m³/s*
+appear nowhere on the image.
+
+You can read it because you wrote the preregistration. Nobody else has it. A reader with the task
+brief and the picture cannot tell which experiment this is, and records the experiment as one that
+was not run — which, from the image, it was not. Images are routinely read detached from the report
+body, with little or none of the prose that would decode them, and the filename is not shown.
+(`draw-the-source-figure-panel-for-panel` §7 and `use-the-sources-own-names` cover where the prose
+and the source's names have to go; this skill is only about what is inside the frame.)
+
+Verdict words make it worse. `REFUTED` or `INCONCLUSIVE` as the largest text on the canvas says what
+your decision rule did, not what the system does. It reads as process, and it primes a reader to
+score the panel as a negative result about your run rather than as a measurement of anything.
+
+## Off the canvas, always
+
+- Hypothesis, claim and obligation ids.
+- Arm, run and configuration codes, anywhere a reader looks first: title, axis label, tick label,
+  legend entry.
+- Verdict words for your own decision rules — refuted, supported, inconclusive, pass, fail.
+- Clause tables and pass/fail boxes.
+- Internal provenance tags for your inputs, of the "as-supplied vs. mirrored" kind. If the
+  distinction matters, it is a series name in physical terms plus one sentence of caption.
+- Digests, artifact paths, `if_supported` placeholders and anything else that is a message from one
+  of your stages to another.
+
+## On the canvas, always
+
+- **The system's name.** Somewhere visible — title, axis label, an annotation, or a legend that
+  names it. The title is the strongest position and the default. A panel whose axes are already
+  physical can carry the system name as an annotation instead, but "no name anywhere" is the failure
+  mode, and it is common.
+- **A physical quantity with a unit on every axis.** If a tick has to carry a categorical label, the
+  category is a physical treatment ("no correction term", "with the correction term"), never an arm
+  code.
+- **A title of the form `<system> — <quantity> vs <coordinate or condition>`**, in the vocabulary the
+  field uses for all three.
+
+## Where the scaffolding does belong
+
+Keep it, all of it. It goes in the preregistration file, in the artifact JSON, and in one appendix
+table mapping hypothesis → figure → verdict → artifact path. That table is worth having and costs
+the figures nothing. This is a rule about the image, not about the discipline behind it. A caveat
+that genuinely matters is a sentence of caption, and any verdict is the caption's last clause.
+
+## The stranger test
+
+Before saving each figure, cover the report and ask of the image alone:
+
+1. What system is this? If the answer is only in the filename or the surrounding prose, the canvas
+   is wrong.
+2. What is plotted, in what units?
+3. Which series is the thing under test, which is the reference, which is the baseline?
+4. What would this panel look like if the result had come out the other way? If there is no visible
+   difference, the panel is showing a verdict rather than a measurement.
+
+If any answer needs your report text, fix the figure, not the text.
+
+## Checklist
+
+- [ ] Every figure names its system somewhere inside the frame.
+- [ ] No hypothesis id, arm code, clause table, pass/fail box or verdict word appears in any title,
+      axis label, tick label or legend entry.
+- [ ] Every axis carries a physical quantity and a unit.
+- [ ] Every categorical tick names a treatment in physical terms.
+- [ ] The hypothesis → figure → verdict mapping exists, in the appendix, not on the canvas.
+- [ ] The stranger test was run on every figure that ships.

--- a/src/skills/late-budget-goes-to-the-task-not-the-method/SKILL.md
+++ b/src/skills/late-budget-goes-to-the-task-not-the-method/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: late-budget-goes-to-the-task-not-the-method
+description: Use at the head of the analysis stage and again during the writing stage's review passes, whenever a figure slot, an attempt or a redraw is still available. Covers re-deriving the reporting slate from the result tables that now exist rather than from the design note, why a label column joined for another purpose is a reporting axis you already paid for, how to rank a spare exhibit against the task's descriptive clauses, and why a review pass that only finds bookkeeping spends an attempt for nothing.
+stages: 06_analysis, 07_writing
+---
+
+# The last slot goes to the task, not to your method
+
+A plan frozen at study design is rarely a hard ceiling. Runs add to it — an extra
+panel appears at analysis, a review pass has attempts left, a figure gets
+redrawn. So the question is not whether you may add. It is what the addition gets
+spent on, and the default is wrong.
+
+By analysis you have spent two stages arguing with your own method: a sensitivity
+grid, a null, a diagnostic, a robustness check. Those have an advocate. The
+task's descriptive clauses — *where*, *which*, *for whom*, *how much of each* —
+have none. They carry no hypothesis, so a hypothesis-allocated plan gave them no
+slot and no headline number, and the coverage table discharged them by pointing
+at whichever panel was nearest. With one slot left, the run adds a second defence
+of its instrument and ships with no exhibit for a clause in the task's first
+sentence.
+
+## Two lists, at the head of analysis
+
+Fifteen minutes, derived from two things, neither of which is the plan.
+
+**List A — the task's clauses, verbatim.** Split the task statement at its verbs
+and conjunctions and keep every clause, including the ones that read as framing.
+Mark the descriptive ones. They are graded like the analytical ones, and they are
+exactly what a hypothesis-allocated plan drops.
+
+**List B — the axes that now exist.** Read the columns of the result tables on
+disk, not the design note. Every categorical axis and every level of it:
+conditions, regions, classes, models, periods, subsets. Include levels that
+arrived late by derivation or interpolation — a level design believed impossible
+is the commonest silent hole, because nothing reopens the slot that was narrowed
+around it.
+
+**Include every label column you joined for another purpose.** If you attached a
+country, a site, a cohort, a family or a class to every row in order to compute
+one aggregate somewhere, that label is a reporting axis and you have already paid
+for it. It goes unused because the join lives in one arm of the analysis and the
+primary result table lives in another; nothing is broken except that nobody ran
+the groupby. Every statistic on that table can now be reported per label for the
+cost of one line.
+
+## The standard for a descriptive clause
+
+An overview that renders each unit at one pixel does not discharge a *where* or
+*which* clause. Neither does a share appearing as a reference column inside a
+table about something else, nor a name that occurs only in prose. What discharges
+it is an exhibit a reader can read names and numbers off, a ranked table of the
+leading entities with the values printed on it, and those leaders named in the
+caption and in the abstract.
+
+## Ranking the addition
+
+When a slot, an attempt or a redraw is available, rank candidates:
+
+1. a task clause with no exhibit at all;
+2. a task clause whose only exhibit is a pooled aggregate;
+3. an axis one level short of the levels that now exist;
+4. a result already published, drawn better;
+5. a defence of your method — a null, a sensitivity, a diagnostic.
+
+A second exhibit arguing about your instrument ranks below the first exhibit
+answering a clause. That ordering is the whole page.
+
+## Adding without losing the plan's audit trail
+
+The plan's value is that results were not chosen after being seen. Keep it by
+recording an addition exactly the way you record a drop: new slot id, source
+artifact, one-line reason, and the clause or axis level it covers. You are adding
+coverage of something the task already declared, not promoting a result you liked
+the look of, and writing the reason down is what makes that difference visible to
+a reader.
+
+## The review pass has the same failure
+
+Late review passes generate findings about entry counts, a stale timestamp, an
+index whose file count disagrees with the directory by one. Those are real, and
+they are bookkeeping. A pass whose findings are all bookkeeping consumes an
+attempt and changes nothing that is graded.
+
+Require at least one finding per pass about the content of the deliverable, in
+one of two forms: "clause X has no exhibit" or "axis Y is one level short". If
+neither is true, say so explicitly — that is a finding too, and it is what
+licenses spending the remaining attempts on prose.
+
+## What this extends
+
+This page is only about *which* addition wins. For what to put in it:
+`earth-report-the-lattice-and-show-the-field` for per-stratum tables, zoomed
+panels over the places a result names, ranked entities and numbers printed inside
+the panel; `draw-the-source-figure-panel-for-panel` for deriving panels from the
+source's rendered figures and filling slots before hypotheses claim them;
+`publish-what-the-run-already-computed` for the same sweep run over files instead
+of axes; `cover-what-the-task-named` for building list A at design time.
+
+## Before you finish
+
+Walk A and B. For every clause and every axis level, name the file and the panel.
+Anything whose answer is "a table", "prose", "the neighbouring panel" or "the
+caption mentions it" is a hole — and the cheapest one left in the run, because
+the data is already on disk.

--- a/src/skills/latex-repair/SKILL.md
+++ b/src/skills/latex-repair/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: latex-repair
 description: Use when a LaTeX build fails or produces a broken PDF in Stage 07 (Writing) — undefined control sequences, missing style packages, unresolved citations or references, float placement blowing the page budget, or a build_log.txt full of errors you need to triage.
+stages: 07_writing
 ---
 
 # LaTeX repair

--- a/src/skills/life-benchmark-against-the-incumbent/SKILL.md
+++ b/src/skills/life-benchmark-against-the-incumbent/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: life-benchmark-against-the-incumbent
 description: Use at study design when a life-science method result is about to be reported on its own numbers. Covers the head-to-head against the incumbent tool, the cost table that goes with it, and finding an orthogonal truth set the method was not fitted to.
+stages: 03_study_design, 05_experimentation, 06_analysis
 ---
 
 # A life-science method result is a head-to-head, a cost table, and an orthogonal truth set

--- a/src/skills/life-full-study-skeleton-including-the-wet-lab-half/SKILL.md
+++ b/src/skills/life-full-study-skeleton-including-the-wet-lab-half/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: life-full-study-skeleton-including-the-wet-lab-half
 description: Use at study design and again when laying out the results section, to check every slot of a life-science study is filled. Covers the skeleton a paper of this kind carries, and what to put in the slots this run cannot compute rather than leaving them out.
+stages: 03_study_design, 06_analysis, 07_writing
 ---
 
 # Fill every slot of the life-science results skeleton, including the parts you cannot compute

--- a/src/skills/life-the-correspondence-is-a-table-not-a-score/SKILL.md
+++ b/src/skills/life-the-correspondence-is-a-table-not-a-score/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: life-the-correspondence-is-a-table-not-a-score
+description: Use at implementation, analysis and writing when the task's named output is a correspondence between the parts of two objects — chain-to-chain pairings, matched cells, mapped reads, docked poses, aligned residues — and it is about to be reported as one best-match score. Covers the per-row record schema including unmatched parts and every column the tool emits, and the numbers computed across rows: coverage, spread of the auxiliary fields, and whether the per-part transforms agree.
+stages: 04_implementation, 06_analysis, 07_writing
+---
+
+# The correspondence is a table, not a score
+
+A matcher — a structural aligner, a chain mapper, a cell-type matcher, a read
+mapper, a pose ranker — emits one record per candidate correspondence between
+the parts of two objects. When the task's named output *is* that correspondence,
+the set of records is the deliverable. A best-match scalar cannot stand in for
+it, and neither can a heatmap.
+
+## What goes wrong
+
+The same deliverable is lost three times, at three stages, and each loss is
+cheap to prevent.
+
+**Implementation — a parser that keeps the fields it wanted and bins the rest.**
+The tool's tabular report is read into a schema with named columns for the score
+and the two identifiers, and placeholder names — `col9`, `col10`, `extra` — for
+everything after them. The transform, the per-pair error, the per-pair identity,
+the per-pair cost are discarded at the point of parsing, and nothing downstream
+can recover them. A second variant: the field is genuinely absent because the
+convenience one-shot command does not emit it, nobody checks the tool's other
+output modes, and the quantity is later described in the report as unavailable.
+
+**Analysis — nothing is computed across the rows.** The records survive to disk;
+a figure script may even plot the per-part matrix. The quantities that turn a
+dump into a result — how many matched, how consistent the per-part solutions
+are, how the auxiliary fields are distributed — exist nowhere in the run, so the
+writing stage cannot print them. `publish-what-the-run-already-computed` is the
+general sweep that finds unpublished outputs; this skill is the specific row
+schema and the specific across-row numbers.
+
+**Writing — the argmax substitutes for the table.** The report gives one scalar
+and one identifier pair: *score 0.0X, best pair Q1->T1*. From that a reader
+cannot tell how many parts matched, which were left out, or whether the per-part
+solutions agree with each other.
+
+## What to produce
+
+### 1. One row per candidate correspondence
+
+One artifact per aligned instance (`outputs/<instance>_record.json`, plus a flat
+TSV), with a row for every candidate the tool considered *and* a row for every
+part left unmatched, partner field empty. Columns:
+
+- identifier on the query side, identifier on the target side, `paired` boolean;
+- the score under **every** normalisation the tool offers, not only the one you
+  prefer, with the denominator named in the column header;
+- the transform in full — every element of the rotation/affine matrix and every
+  element of the translation — with the convention written beside it (row- or
+  column-major, `X = t + Ux` or `X = Ux + t`);
+- the size fields the score divides by: parts or residues on each side, aligned
+  length, coverage;
+- every auxiliary per-pair measurement the tool reports: error, identity,
+  e-value, rank, assignment index;
+- the cost of producing the row, if the tool reports per-pair cost.
+
+No placeholder column names survive into the artifact. Open the tool's output
+specification, name every field it documents, and if a field the task's output
+list mentions is missing from what you captured, re-invoke in the mode that
+emits it before concluding it is unavailable — a one-shot wrapper routinely
+deletes the per-pair file that carries exactly these columns.
+
+### 2. The across-row numbers
+
+Computed from the table and stated in prose, not left for the reader to infer.
+
+1. **Count and coverage.** How many correspondences were returned, and what
+   fraction of the query's parts and of the target's parts that covers. Name the
+   parts left out.
+2. **Spread of each auxiliary field.** Mean and min–max range across matched
+   rows, one sentence each. Where your field has a conventional interpretive
+   cut-off for that quantity — an identity below which the cheaper method is not
+   expected to detect the relationship, an error above which a fit is
+   meaningless — say where your rows sit relative to it and cite where the
+   cut-off comes from.
+3. **Do the transforms agree?** Most matchers of this kind work because true
+   correspondences share one superposition; the clustering or consensus step is
+   the method's operating principle. Nobody tests it. Compute the element-wise
+   spread of the rotation entries, the range of each translation component, or
+   the maximum pairwise rotation angle between rows, and state in one sentence
+   whether the matched rows are one solution or several. That sentence is the
+   run's only empirical evidence for or against the principle the method rests
+   on, and it is a few lines of numpy over a table you already have.
+4. **The incumbent's per-row score is another column in the same table.** Put it
+   there; `life-benchmark-against-the-incumbent` specifies the paired statistics
+   that then go in the text. Two threshold-crossing counts are not a paired
+   comparison.
+
+### 3. When the named instance's table is degenerate
+
+If the instance the task named returns one paired row, or none, print its table
+anyway — unmatched rows explicit, reason measured rather than inferred — because
+that instance is the graded one (`the-supplied-item-is-the-graded-unit`). Then
+compute the across-row numbers on the instances where the matcher does fire, at
+the same depth (`the-firing-instance-gets-the-full-record`). A one-row table on
+a negative satisfies the letter of this skill and measures nothing.
+
+## Checklist
+
+- [ ] One row per candidate correspondence, unmatched parts included, for every instance aligned.
+- [ ] Every field in the tool's documented output is a named column; no `colN` placeholders, nothing dropped as uninteresting.
+- [ ] A missing field was chased into another invocation mode before being called unavailable.
+- [ ] All score normalisations present, each with its denominator named.
+- [ ] Full transform per row, convention stated.
+- [ ] Count, coverage on both sides, and the named unmatched parts, in prose.
+- [ ] Mean and range for every auxiliary field, placed against a cited conventional cut-off.
+- [ ] An explicit statement of whether the transforms agree across rows, with the dispersion number behind it.
+- [ ] Incumbent's per-row score in the same table.
+- [ ] The table appears in the results section for the named instance, not only in an appendix.

--- a/src/skills/material-as-specified-run-and-stage-diagnostics/SKILL.md
+++ b/src/skills/material-as-specified-run-and-stage-diagnostics/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: material-as-specified-run-and-stage-diagnostics
 description: Use at study design and implementation when a protocol is specified and you have found a reason to deviate, or when a pipeline stage is about to run without its conventional diagnostic. Covers running the protocol as specified as the foreground result, and leaving every stage's default panel behind you.
+stages: 03_study_design, 04_implementation, 05_experimentation
 ---
 
 # Run the protocol as specified as the foreground result, and leave every stage's default diagnostic panel

--- a/src/skills/material-decode-the-stub-into-its-reference-runs/SKILL.md
+++ b/src/skills/material-decode-the-stub-into-its-reference-runs/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: material-decode-the-stub-into-its-reference-runs
+description: Use at literature survey, study design and implementation when the supplied data is a short file of bare numeric literals under headers naming scripts or workflows - no column names, no units, no provenance - and the plan is forming around what the numbers are rather than which reference run they were the input to. Covers the decode table (array -> call signature -> role -> unit -> source of unit), choosing estimators whose conventional diagnostic is producible, and composing the blocks into each other for held-out evidence.
+stages: 01_literature_survey, 03_study_design, 04_implementation
+---
+
+# Decode the block into the run it was the input to
+
+A few hundred bare numbers under headers that name scripts or workflows is not a
+dataset. It is the *argument list* of a reference implementation somebody ran,
+serialised. Every array in it was a variable with a name, a role and a unit, and
+the run that produced the results you are being compared against had all three.
+
+The failure this prevents: the run treats the file as a dataset, characterises it
+well - closed forms, periodicity, degeneracy, collision structure - and then
+reports every downstream quantity dimensionless: "in target units", "a normalised
+objective", "index-aligned". The characterisation is correct and earns nothing,
+because no number in it can be placed against any published number for the same
+workflow. A dimensionless error reads as the physical error never having been
+measured.
+
+## Build the decode table before any model code
+
+One row per array, written into the design document before the design is costed:
+
+| array (length, first values) | block header it sits under | role in that workflow | physical quantity | unit | how the unit was assigned |
+
+Fill **role** by writing out the call signature the block is the argument list
+for, in order. A block headed with a property-prediction name holding an integer
+array, a wide float array, a list of index pairs and a shorter float array is
+`(atomic numbers, node features, edge index, targets)`. A block headed with an
+optimisation name holding two 2-element arrays, two bare scalars, a small scalar
+and a round integer is `(bound_1, bound_2, x0_1, x0_2, noise, budget)`. Write the
+signature down. Where two readings survive, keep both rows and resolve it in the
+next step, in writing: an unresolved ambiguity silently becomes "dimensionless"
+three stages later.
+
+## Assigning a unit when the file supplies none
+
+The reporting rule - physical unit first, published band beside it - is already
+`material-landmark-scalars-in-physical-units`, and mining the supplied papers for
+the named quantity and the benchmark it is quoted on is already
+`mine-the-papers-you-were-given`. Read those for the rule. What both assume, and
+this file denies you, is that something in the workspace states the unit. Nothing
+does. Assign one, from these sources, and record in the table which one you used:
+
+1. **the numbers read against the process the header names** - a range that is
+   ordinary in one unit and absurd in another decides itself; a start point that
+   is round in one unit and ragged in the other is a second vote;
+2. **the supplied papers** - they run this workflow on real material, in a unit,
+   and quote an accuracy band in it. That is the unit a reader of this literature
+   will convert your number into before judging it;
+3. **the field's conventional unit for that quantity**, cited.
+
+A unit assigned by assumption and stated once in a sentence is a unit. Silence is
+not. "Target units", "normalised objective", "arbitrary units" and a bare index
+axis are the same non-answer, and they are unrecoverable at writing time because
+every table cell, axis label and abstract sentence inherits them.
+
+## Shipped scalars enter the design at their shipped values
+
+Every scalar the block ships - bounds, start point, noise level, budget, counts -
+appears in the plan at its value and in the results quoted against it, in the
+assigned units. The argument is
+`material-as-specified-run-and-stage-diagnostics`; the only thing to add for a
+stub file is the temptation specific to one. A synthetic block often looks
+degenerate, or too easy, and redesigning it into a better benchmark deletes the
+one piece of ground truth you were given. If you want the harder variant, run it
+as a second arm beside the as-shipped one, never instead of it.
+
+## Choose estimators whose conventional diagnostic is producible
+
+Each block names a workflow, and each workflow has a diagnostic the field always
+shows (`the-canonical-figure` lists them). Pick the estimator family at design
+time so that the diagnostic can exist at all:
+
+- a family with no iteration loop cannot emit an objective-versus-step trace.
+  Choosing one deletes that result for the whole run, and no later stage can
+  recover it - the numbers never existed;
+- a rank statistic, a correlation or a p-value is not an error in a physical
+  unit. If the field quotes an error, the estimator has to produce per-item
+  predictions to take one from;
+- a generative arm has to emit samples in the same coordinates as the population
+  it was fit on, not only summary rates computed over them.
+
+Cheaper families are good baselines beside the conventional one. They are not
+substitutes for it, and a substitution made here is invisible by the time anyone
+reads the report.
+
+## The blocks compose - that is where the held-out evidence comes from
+
+Blocks of one file are stages of one pipeline, and the cross-block runs are
+usually the only unseen-input evidence available anywhere in the workspace:
+
+- the generative block's samples are the predictive block's held-out input. Score
+  them, and report that number separately from the in-sample one;
+- the predictive block scores the optimisation block's proposals;
+- a population the file did not contain, pushed through a model the file did
+  train, is what "generalises beyond the supplied rows" means here.
+
+Plan those runs in the design. They cost minutes, and nothing else in the file
+supplies the evidence.
+
+## Checklist before study design closes
+
+- [ ] Every array has a row with a role, a quantity, a unit, and the source of that unit.
+- [ ] Every ambiguous reading is resolved in writing, with the reason.
+- [ ] No planned output is expressed in target units, a normalised objective, or an index.
+- [ ] For each block: the field's conventional metric and diagnostic panel are named, and the chosen estimator can produce both.
+- [ ] For each block: one published number in the same unit, taken from the supplied papers, is written down as the comparison target.
+- [ ] Every shipped scalar appears at its shipped value; none was engineered away to make the study more interesting.
+- [ ] At least one cross-block run is planned, with its own reported number.

--- a/src/skills/material-deliver-a-candidate-a-chemist-could-make/SKILL.md
+++ b/src/skills/material-deliver-a-candidate-a-chemist-could-make/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: material-deliver-a-candidate-a-chemist-could-make
+description: Use when a design, screening or generation task ends in candidates a human would have to synthesise or fabricate, and the brief asks for an experimental validation you cannot run. Covers the component-pinned search that makes a candidate orderable, drawing the delivered candidate as chemistry, and putting every existing measurement on the same property axis as your prediction.
+stages: 05_experimentation, 06_analysis, 07_writing
+---
+
+# Deliver a material, not a coordinate
+
+The design half finishes and the deliverable is reported as a count and a gap:
+so many new candidates, median such-and-such from target, none of them in the
+supplied set. No structure is drawn, no component is named, nothing could be
+ordered. And the one place in the whole problem where a real number from a real
+instrument exists — the candidate someone has already made and measured,
+reported in the source study — appears as a quoted sentence, or as one bar
+inside an aggregate error budget, or not at all.
+
+These briefs usually end with a clause you cannot execute: synthesise, measure,
+characterise, validate the selected candidates experimentally. You will not have
+a lab. That is not why that stage scores zero. It scores zero when nothing in
+the report *looks like* the step: no candidate rendered as chemistry, no
+comparison against any measurement, no engagement with the behaviours that
+define the material class. "Not performed — no wet lab exists here" is accurate,
+complete and worth nothing on its own. Produce the largest part of the stage
+that does not need the instrument, then say which part needed it.
+
+`a-value-you-did-not-measure-still-has-a-source` is the general form of that
+argument — cite the field's value, stand your own quantity beside it. What
+follows is the materials-side procedure it does not contain: how to end up with
+a candidate that could be ordered, and what the comparison has to look like as a
+picture.
+
+## Analysis: five things to produce, and most of them are panels
+
+Material criteria are read off images. A markdown table in the report body is
+not where they are read, so everything below that is described as a table is a
+table **and** a rendered panel.
+
+**1. A constrained design run beside the free one.** Pin one component to
+something that can actually be bought and search only the rest of the structure.
+Choose the pinned component the way a chemist would: the workhorse of this
+material class, named as such in a supplier catalogue, in the field's review
+literature, or from your own knowledge of the class. Do not pick it by frequency
+in the supplied pool — a combinatorially enumerated pool has no workhorse, its
+modal component may occur a handful of times across thousands of rows, and
+frequency then selects an arbitrary molecule. The pinned component is allowed to
+be absent from the supplied data entirely; your scorer consumes a structure, not
+a row index. Report both searches. The constraint costs you something in the
+target property, and that cost is a result — it is the price of synthesisability,
+stated as a number.
+
+**2. Each delivered candidate as chemistry, drawn.** For the best candidate at
+each target: component names, SMILES or formulae, molecular weight,
+functional-group counts, and a synthetic-accessibility or commercial-availability
+score per component shown against the distribution of that score over the pool.
+Render it as a structure grid — the drawn molecules, annotated with those
+numbers — and mark which components already occur in the supplied data and which
+are new.
+
+**3. The measurement axis.** Collect every value anyone has actually measured
+for this material or its nearest published relative — the source study's own
+experimental section, the related work, a handbook — and plot them on the **same
+property axis** as your predicted value for that same or nearest candidate, with
+your interval. One panel, physical units, every point labelled with the
+technique that produced it and attributed to whoever measured it. Quoting these
+numbers in prose does not do it, and neither does folding them into a log-scale
+error budget with everything else: the comparison has to be legible as a
+picture, at the scale of the property.
+
+**4. The class-defining behaviours, one row each, drawn as a panel.** A material
+class is named for behaviour beyond the single property you optimised — cycle
+life for an electrode, corrosion resistance for an alloy, turnover and
+selectivity for a catalyst, creep and fatigue for a structural composite.
+Derive your own class's list from the class name and from the behaviours the
+source study treats as definitional when it characterises the material;
+typically three to six. Fill each row with exactly one of: a computed structural
+proxy you can evaluate on the candidate (the bond or motif that enables the
+behaviour and its chemistry, network connectivity, crosslink density, a
+descriptor), a literature value for the closest measured system with its
+citation, or an explicit "no route in this environment" naming the instrument
+required. Draw the filled table as an annotated panel, keyed by which of the
+three each cell is. Rows, never a paragraph, and never a silent omission — the
+omission is what reads as the stage having been skipped.
+
+**5. The handover protocol.** Four to eight lines: components and stoichiometry,
+processing or cure conditions, the measurement that would confirm the design and
+the value it should return with your interval, and the observation that would
+falsify it. This converts the stage from a disclaimer into a deliverable and
+costs one paragraph.
+
+## Writing
+
+The experimental section is a section with figures in it, placed where the
+source's experimental results would be — not a two-sentence note at the end of
+the results. Its lead panel is item 3. If part of it genuinely could not be
+done, that sentence goes **after** the panels, naming the instrument, not
+instead of them. A section heading that announces the stage was not performed,
+sitting above no figures, is the cheapest way there is to score zero on work you
+could largely have delivered.
+
+## Checklist
+
+- [ ] Component-pinned design run exists beside the free one, the pinned
+      component justified by availability rather than pool frequency, and the
+      cost of the constraint measured in the target property.
+- [ ] Best candidate per target reported with names, SMILES/formulae and drawn
+      structures, rendered as a panel.
+- [ ] Availability or synthesisability score per component, against the pool's
+      own distribution.
+- [ ] One panel: every existing measured value for this material or its nearest
+      relative, on the same property axis as your prediction and its interval,
+      each point labelled with its technique and attributed.
+- [ ] Class-behaviour panel: one row each, computed proxy / cited value / named
+      missing instrument.
+- [ ] A synthesis-and-characterisation protocol a human could follow.
+- [ ] "Not performed" appears, if it must, after all of the above.

--- a/src/skills/material-design-targets-span-the-property-range/SKILL.md
+++ b/src/skills/material-design-targets-span-the-property-range/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: material-design-targets-span-the-property-range
+description: Use when a task asks you to generate, design or optimise candidates toward desired property values that the brief never enumerates. Covers deriving the target grid from the supplied property distribution, why the target outside your validator's fitted range must not be deleted, and how a source study's published designs may and may not be used as anchors.
+stages: 03_study_design, 05_experimentation, 06_analysis
+---
+
+# Design at the ends of the property range, not only in the middle
+
+A design brief usually says "achieve desired values of the property" and stops.
+The target list is then yours to choose, and the cheap choice is one or two
+values near the mode of the supplied distribution. Those get hit to three
+decimals, a tiny design error is reported, and the study has demonstrated
+something a lookup over the supplied rows already does. The claim an
+inverse-design paper is actually making is the opposite one: the ends of the
+range, and whether the generator reaches past the data it was fitted on.
+
+The second failure is more specific and more expensive. The run computes the
+property distribution, notices that one regime lies outside the range its own
+validator was fitted on, and deletes that target because it could not honestly
+call the result validated. Declining to *call* an extrapolation validated is
+correct. Deleting the *run* is not: it removes the only evidence about whether
+the generator extrapolates, which is the half of the claim that is not already
+in the training set. What is left is a defensible report with no answer in it.
+
+## Study design: write the target table before you generate
+
+Derive the grid from the data, not from taste. Compute the property distribution
+over the supplied labelled set — after whatever calibration or correction your
+pipeline applies, since that is the scale the targets live on — and write:
+
+| target | value | where it came from | inside the labelled range? | how it will be assessed |
+
+Rows, at minimum:
+
+- the **minimum** of the calibrated property over the supplied set;
+- the **maximum**, and one target **beyond** it, placed a stated multiple of the
+  labelled standard deviation above the maximum;
+- a **central** target: the mean, median or mode;
+- every **landmark** value named in something you are allowed to read — the task
+  text, the data dictionary, the related work, the source study: a service
+  temperature, a specification limit, the property of a candidate someone has
+  already made.
+
+Quote the computed min, max, mean and sd in the report. Three lines of code, and
+they turn the grid from a preference into something reproducible.
+
+**Reserve one figure slot per target row, in this stage.** Figure plans get
+frozen, and figure producers get written to refuse any filename not in the plan;
+a target row that acquires a population two stages later is then undrawable. If
+your producer enforces the plan, write the reopen procedure into the plan file
+at the same time.
+
+## The landmarks and the anchors live in the source study, not in the folder
+
+The papers shipped beside the data are usually background reading, not the study
+the brief was drawn from. Fetch the source study itself. It holds the landmark
+values, and it is usually the only place holding candidates whose property has
+been established by a method independent of yours.
+
+Those published candidates are an external test set for your validator and
+nothing else. Write the boundary down before you open the file:
+
+- **allowed** — score them with your validator and report your validator's
+  signed error on them, per regime;
+- **forbidden** — copying any of them into your candidate list, your delivered
+  designs or your target values, and treating agreement with them as validation
+  of a design of your own.
+
+A run that cannot state that boundary tends to resolve it by refusing to open
+the file at all, which deletes the only out-of-range anchor available and the
+extrapolation claim with it.
+
+## Experimentation: run every row at the same budget
+
+Out-of-range rows use the same code path and the same number of scored
+candidates as interior rows. State the per-target budget. Out-of-range is not a
+special case at generation time; it becomes one at assessment, and only there.
+
+## Assessment: apply the reporting rules, do not restate them
+
+Per-target values in the property's physical unit, each against an independent
+anchor, with the error outside the labelled range reported as its own number, is
+`material-landmark-scalars-in-physical-units`; this skill does not repeat it.
+Two things it adds. The anchor set must contain points at or beyond **both** ends
+— the top and bottom deciles of the labelled set, plus the independently
+established candidates above. And the out-of-range target is reported twice, as
+the design-time score and as the anchor-corrected value with the anchor spread
+as its interval, rather than dropped.
+
+## Analysis: one figure carries the whole grid
+
+Designed population per target, overlaid on the labelled distribution, on the
+property axis, with every target drawn as a line and the labelled min and max
+drawn as bounds. A reader must be able to see, without reading a number, whether
+any designed population lies outside the bounds of the training data. If a
+target produced nothing, that is written on the axis where its population would
+have been — not by deleting the category, and not by leaving the category empty
+with a note about which internal test disabled it.
+
+## Checklist
+
+- [ ] Target table exists, with min / max / beyond-max / central computed from
+      the supplied data and quoted in the report.
+- [ ] Every landmark value in the brief, the data dictionary or the source study
+      is a row.
+- [ ] At least one target lies outside the labelled range, and it was run.
+- [ ] Equal generation budget per target, stated.
+- [ ] A figure slot was reserved per target row before generation started.
+- [ ] Independently established candidates scored as an external test set; the
+      allowed/forbidden boundary stated in the report.
+- [ ] Per target: achieved value, gap, interval on the gap, anchor-corrected
+      value, and whether the candidate's components already occur in the
+      supplied set.
+- [ ] One figure: designed populations + target lines + labelled min/max, no
+      empty category.
+
+## The move that loses the point
+
+Reporting a minuscule gap between the optimiser and its own proxy at one
+interior target. That gap is a spacing statistic of the scoring budget — halve
+the candidate pool and it doubles — not a design accuracy. Compute the order
+statistic 1/(2·N·f) it should equal, put it beside the measured gap in one
+sentence, and spend the rest of the effort on the ends of the range.

--- a/src/skills/material-draw-the-framework-and-rebuild-its-corpus/SKILL.md
+++ b/src/skills/material-draw-the-framework-and-rebuild-its-corpus/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: material-draw-the-framework-and-rebuild-its-corpus
+description: Use when the brief asks for a framework combining several named components over a curated input resource, and only a labelled subset of that resource was supplied. Covers the overview figure no data script will ever emit, reconstructing the described corpus yourself, and the placeholders and empty panels that reach the delivered report.
+stages: 03_study_design, 04_implementation, 06_analysis, 07_writing
+---
+
+# The framework is a deliverable, and its picture has no dataframe behind it
+
+A brief that opens "develop a framework combining A, B and C" is asking for the
+assembled object, not only for the three components working separately. Every
+stage of the run then produces its own plots, and none of them produces the
+picture of the whole, because every figure a data pipeline emits comes from a
+table and the overview schematic comes from no table. Nothing in an
+analysis-driven figure script will ever create it. What ships instead is a
+Methods paragraph promising a diagram, or — often enough that it is worth
+grepping for — a placeholder comment left in the delivered report where the
+diagram was going to go.
+
+The other half of the same criterion is the input resource. The brief describes
+a curated design space of a stated size and hands you a small labelled subset of
+it. "The full corpus is not shipped" gets written down as a finding and the run
+stops there. It is not a finding, it is a task: that space is a combinatorial
+object over component pools you can obtain, enumerating it is cheap, and without
+it nothing in the report says anything about the reach of the framework — only
+about the subset someone else already scored.
+
+## Study design: reserve slot zero
+
+Before any hypothesis-driven or analysis-driven figure slot, reserve the first
+one for the framework overview, and write down its panels: the schematic, the
+input resource and its characterisation, then one panel per named component.
+First slot, not last — the last slot is the one the budget eats, and this is the
+figure the heaviest criterion is usually about.
+
+## Build the schematic from the brief's own sentence
+
+One box per noun in the brief's method chain, in the brief's own words, in the
+order the brief writes them. Each arrow carries the object that flows and the
+count that actually flowed: items supplied, items featurised, items simulated,
+items trained on, candidates generated, candidates scored, candidates delivered.
+Each box carries the metric that component actually reached, with the reference
+or published value beside it where one exists.
+
+Author it as code — graphviz, matplotlib patches, TikZ rendered to PNG —
+committed beside the analysis scripts and rendered into the image directory like
+any other figure, so it is regenerated rather than remembered.
+
+A component that ran at reduced scale appears here as a number in its box next
+to the reference number. That is readable, and it is a result. A hole is not.
+
+Forbidden in this figure and in every other: a placeholder token, an empty
+panel, an empty axis category held open for an arm that did not run, and a title
+that states the status of an internal hypothesis or plan item instead of what
+was found. Before the writing stage ends, grep the delivered report and the
+image directory for `TODO`, `PLACEHOLDER`, `FIXME` and unrendered comment
+markers, and grep your figure titles for internal identifiers. Fix or delete
+every hit; a placeholder in a shipped file is read as the section not existing.
+
+## Implementation: rebuild the resource the source describes
+
+If the brief or the source study describes an input resource of a stated size
+and you were handed a subset:
+
+1. Identify the component pools it is a product or a selection over, and the
+   rules that admit a component.
+2. Obtain those pools from public databases, applying the source's stated
+   filters, or your own filters stated explicitly.
+3. Enumerate to the stated order of magnitude, or as close as memory allows, and
+   say which of the two you did.
+4. Characterise the result: counts per component class, the property or
+   accessibility distribution over the whole space, how many of the supplied
+   labelled rows fall inside your reconstruction, and what fraction of the space
+   your generator can actually reach.
+5. Record provenance: database, version or access date, each filter with counts
+   before and after. A reconstructed resource without provenance cannot be used
+   by anyone, including you at writing time.
+
+If the rebuild is genuinely out of reach, the panel becomes the supplied subset
+characterised in exactly that form, with its size against the stated size and
+one sentence on what the gap prevents. That is much weaker, so take it only
+after an attempt you can describe.
+
+## Analysis: collect the components into one image
+
+One panel per named component, in the same figure as the schematic, each in the
+form its field uses: the primary simulated or measured trace the property was
+fitted from — not only the fitted scalar — the calibration parity against the
+reference, the learned component's reconstruction and validity, the search
+trace, the delivered candidates in the property space.
+
+`material-as-specified-run-and-stage-diagnostics` already requires each stage's
+default diagnostic to exist. What this adds is the collection: a criterion about
+a framework is about the assembled object, and a dozen conventional plots in a
+dozen separate files do not add up to one. `the-canonical-figure` will not
+produce it either — there is no field-standard plot whose data is "the
+framework", which is exactly why it goes missing.
+
+## Checklist
+
+- [ ] Overview slot reserved before any other figure slot.
+- [ ] Schematic authored as code, one box per component named in the brief, in
+      the brief's words.
+- [ ] Arrows carry realised counts; boxes carry realised metrics against
+      reference values.
+- [ ] Input resource rebuilt to its stated order of magnitude, or the shortfall
+      stated with the attempt described.
+- [ ] Provenance recorded for every external pool used in the rebuild.
+- [ ] Characterisation panel: composition, property or accessibility
+      distribution, overlap with the supplied subset, reachable fraction.
+- [ ] One panel per named component, collected into the overview figure.
+- [ ] Placeholder grep over the delivered report returns nothing; no empty
+      panel, no empty axis category, no internal identifier in a figure title.

--- a/src/skills/material-front-load-one-result-block-per-deliverable/SKILL.md
+++ b/src/skills/material-front-load-one-result-block-per-deliverable/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: material-front-load-one-result-block-per-deliverable
+description: Use at study design when the results outline is locked, and again at writing, when the report opens with an abstract, a data audit or a mechanism section and a figure-bearing deliverable is first referenced behind them. Covers the block-per-deliverable layout, the character-offset audit of report.md that proves it held, and the repair order when the audit fails.
+stages: 03_study_design, 07_writing
+---
+
+# One self-contained result block per deliverable, and the offset audit that proves it
+
+The failure: the results section is ordered by the run's narrative - the most
+interesting finding first, then the mechanism that explains it, then a validation
+of the pipeline, then whatever deliverables are left. A named deliverable ends up
+past the halfway mark, behind a long abstract, a data forensics section and an
+external anchor. Its figure exists and is correct. A reader working front-to-back
+with a bounded budget forms a view of what the run produced from the opening, and
+the workflows named there are the ones the report is taken to be about.
+
+This bites hardest on the deliverables whose result *is* a figure. A panel is read
+together with the prose around it, so a correct figure introduced after four pages
+of audit vocabulary is read as one more audit exhibit. Text-scored results are
+read further down the file and are not fixed by moving them; do not expect
+reordering to buy anything for a deliverable whose problem is that the number is
+missing or dimensionless.
+
+Three neighbouring arguments are already in the library and are not repeated here:
+run the requested analysis at all (`run-the-requested-analysis`), the audit must
+not take the title or the abstract's first sentence
+(`material-as-specified-run-and-stage-diagnostics`), and what has to be inside a
+panel (the object-over-reference figure gate). This skill is only about *where*
+the blocks sit, and the check that proves it.
+
+## The layout
+
+1. **Abstract**: one sentence per named deliverable, in the task's order, each
+   carrying that deliverable's landmark scalar in its physical unit and its
+   comparison. The framing device, the protocol and what is wrong with the inputs
+   do not get the opening sentences.
+2. **Results: one section per named deliverable, in the task's order, contiguous.**
+   Nothing interleaved - no mechanism section, no data forensics, no pipeline
+   validation, no external benchmark anchor between two deliverables. Those are
+   real contributions and they are numbered after the last deliverable section.
+3. Each deliverable section reads on one screen: one sentence naming the workflow
+   and the configuration it ran at, with the shipped constants quoted by value;
+   the object figure, referenced immediately; the landmark scalars in physical
+   units with their comparison; one sentence of interpretation, including a null
+   one if that is the result.
+4. Data, methods, mechanism, audits, limitations: after.
+
+## The offset audit
+
+An ordering intention does not survive drafting. Measure the file you actually
+wrote:
+
+```python
+import re, pathlib
+t = pathlib.Path("report/report.md").read_text()
+for m in re.finditer(r"(?m)^#{1,4} .*$|!\[[^\]]*\]\([^)]+\)|Figure\s+\d+", t):
+    print(f"{m.start():7d}  {m.group(0)[:90]}")
+print("total characters:", len(t))
+```
+
+Read the printout against the deliverable list you extracted from the task
+statement, and require three things:
+
+- **every named deliverable's first figure reference before character 10,000** -
+  an absolute budget, two to three printed pages, about as far as a bounded reader
+  gets before their view of the run sets. "In the first half" is not the check: in
+  a long report the halfway mark sits far past that point, so a reference that has
+  already lost the reader passes the test;
+- **every deliverable's figure reference before the first heading that is not a
+  deliverable**;
+- **nothing between the first and the last deliverable heading** that is about the
+  inputs, the pipeline, or the run's own process. This is the clause that catches a
+  mechanism section or an external anchor sitting between two deliverables and
+  pushing the later one out of the budget.
+
+## The repair, when the audit fails
+
+In this order, and none of them is deleting a deliverable:
+
+1. cut the abstract to one sentence per deliverable - a long abstract spends the
+   whole budget before the first result;
+2. move mechanism, forensics, pipeline validation and external anchors to after
+   the last deliverable heading, unchanged;
+3. move per-deliverable methods prose into a methods section at the back, leaving
+   the one configuration sentence in place;
+4. re-run the audit and print the new offsets. If a deliverable still misses the
+   budget, the report has more front matter than it can afford.
+
+## Adjacency
+
+The sentence immediately before each figure states, in words, the physical content
+of the picture: what is plotted against what, in what unit, and what the reader
+should see. A figure whose only nearby text is a caption of protocol prose is read
+as belonging to whatever section surrounds it. Do not stack figures - four in a row
+with no result sentence between them collapse into one exhibit.
+
+## Checklist before the report is final
+
+- [ ] The offset printout is in the run log, not only in your head.
+- [ ] Every named deliverable has a heading, in the task's order, and those headings are contiguous.
+- [ ] Every deliverable's first figure reference is before character 10,000 and before the first non-deliverable heading.
+- [ ] The abstract names every deliverable, each with a number in a physical unit.
+- [ ] No figure sits more than two sentences from the sentence stating its physical result.
+- [ ] Reading only as far as the first non-deliverable heading, a reader can list every workflow the run ran and one number for each.

--- a/src/skills/material-landmark-scalars-in-physical-units/SKILL.md
+++ b/src/skills/material-landmark-scalars-in-physical-units/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: material-landmark-scalars-in-physical-units
 description: Use at analysis when a materials result exists as a curve, a distribution or a trajectory and is about to be reported as one. Covers extracting the landmark scalar a reader compares — peak position, transition temperature, barrier height — in the property's physical unit, against a reference value.
+stages: 03_study_design, 06_analysis, 07_writing
 ---
 
 # Extract the landmark scalar, report it in the property's physical unit, and anchor it to a reference

--- a/src/skills/material-object-over-reference-figure-gate/SKILL.md
+++ b/src/skills/material-object-over-reference-figure-gate/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: material-object-over-reference-figure-gate
+description: Use when figures are being written or are about to be declared finished and no panel yet draws the run's own generated or predicted objects over their reference population in physical coordinates - the panels so far are rate bars, threshold curves, tables as graphics, or titles carrying hypothesis ids and verdict words. Covers an assertion gate over the plotting code that fails the figure stage until every named deliverable has an object-over-reference panel with units on both axes.
+stages: 04_implementation, 06_analysis
+---
+
+# Gate every deliverable on an object-over-reference panel, or fail the figure stage
+
+The failure: the figure plan is derived from the run's own hypothesis list, so
+each slot is "the claim this settles". What gets drawn is bar charts of rates,
+threshold curves, tables rendered as graphics, and titles carrying hypothesis
+identifiers, verdict words and a footer of protocol prose. Every panel is a
+picture of the run's bookkeeping. A reader looking for "did the generator produce
+reasonable objects?" finds a bar chart of pass rates and concludes the objects
+were never plotted - which is exactly what a metric-only panel means.
+
+The list of panels this kind of run owes is not new.
+`material-as-specified-run-and-stage-diagnostics` names the per-stage defaults
+and `the-canonical-figure` names the field-standard ones; read either for the
+list, and do not read this skill for it. This one exists because those lists have
+been installed, unread, on runs that then shipped none of the panels. Prose does
+not fire. An assertion does.
+
+## The rule the gate enforces
+
+For every named deliverable, at least one panel puts **both populations in one
+axes, in physical coordinates**: the objects your method produced and the
+reference objects they are supposed to resemble. Generated samples over the
+supplied support points. Predictions against truth on the identity line. Your
+trace and the baseline trace on one axes. The comparison lives inside the
+picture, with its scalar annotated in the panel - an overlap, a divergence or a
+coverage fraction that exists only as a bar height or a sentence is checkable
+against nothing.
+
+Aggregate-rate panels are legitimate as the *second* panel of a slot. They are
+never the whole slot.
+
+## The gate
+
+Write it before the plotting code, and call it in the same function as every
+`savefig`:
+
+```python
+# code/figure_gate.py
+import re
+
+BANNED = re.compile(
+    r"\b[HTC]\d+\b|\barm\s*\d+\b|SUPPORTED|REFUTED|INCONCLUSIVE|"
+    r"pre-?registrat|verdict|holm|bonferroni|westfall", re.I)
+REF = re.compile(r"refer|observ|supplied|measured|true|origin|target|baseline", re.I)
+
+def gate(ax, unit_tokens, slot, needs_reference=True):
+    """Call immediately before savefig. unit_tokens come from the decode table."""
+    series = list(ax.get_lines()) + list(ax.collections) + list(ax.patches)
+    labels = [str(s.get_label()) for s in series]
+    named = [l for l in labels if not l.startswith("_")]
+    if needs_reference:
+        ref = [l for l in named if REF.search(l)]
+        mine = [l for l in named if l not in ref]
+        assert ref and mine, f"{slot}: no reference+model pair in one axes; labels={named}"
+    for which, text in (("x", ax.get_xlabel()), ("y", ax.get_ylabel())):
+        assert any(u in text for u in unit_tokens), \
+            f"{slot}: {which}-label carries no unit from the decode table: {text!r}"
+    fig = ax.get_figure()
+    strings = [ax.get_title(), ax.get_xlabel(), ax.get_ylabel()] + named \
+              + [t.get_text() for t in fig.texts]
+    bad = [s for s in strings if BANNED.search(s)]
+    assert not bad, f"{slot}: run-internal vocabulary baked into the raster: {bad}"
+```
+
+Artists whose label sits on a container rather than on the artist - grouped bars
+are the common case - read as unlabelled and fail the reference assertion. That
+is the intended default: if a grouped-bar panel genuinely is your object
+comparison, label the patches explicitly and say so.
+
+Then once, before the figure stage is allowed to report success: iterate the
+deliverable list extracted from the task statement and assert that each entry has
+at least one panel that passed with `needs_reference=True`. A deliverable with
+zero is a stage failure, not a note in a log.
+
+If the plots come from scripts that do not keep the `Figure` object, gate the
+manifest instead: every figure writes a JSON row with `slot`, `series_labels`,
+`xlabel`, `ylabel`, `title`, `annotations`, and the same three assertions run over
+the rows. The gate is worth having in the weaker form; it is not worth skipping
+because the stronger form is awkward.
+
+## What the gate cannot check, and you have to
+
+- that the series labelled reference *is* the supplied population, drawn in its
+  own coordinates - a histogram of reference values in one panel and generated
+  values in another is two pictures, not a comparison;
+- that the unit token in the axis label is the unit you assigned for that array,
+  rather than one carried over from a template;
+- that the landmark scalar is annotated next to what it describes, inside the
+  axes, rather than in the caption.
+
+## Keep the run's vocabulary out of the raster
+
+Text baked into a PNG survives every later edit of the report, and none of the
+following means anything outside this run: hypothesis or claim identifiers;
+verdict words in a title or suptitle; multiplicity corrections and
+pre-registration footers; internal codenames for arms, splits or slots. The title
+says what the quantity did, in its unit; the axes carry quantity and unit; the
+legend names the method and the reference. A verdict belongs in body text, where
+it can be qualified.
+
+## Before the figure stage closes
+
+- [ ] `gate()` is called in the same function as every `savefig`, and a failure aborts the stage rather than printing a warning.
+- [ ] Every named deliverable has at least one panel that passed with `needs_reference=True`.
+- [ ] Every axis label contains a unit token from the decode table; none says normalised, arbitrary or index unless the caption states why nothing else exists.
+- [ ] Every panel's landmark scalar is annotated inside the axes, in units.
+- [ ] The banned-vocabulary assertion covers suptitles and figure-level text, not only the axes title.
+- [ ] Per deliverable: object panel first, aggregate-rate panel second, never only the second.

--- a/src/skills/material-power-the-contrast-you-invented/SKILL.md
+++ b/src/skills/material-power-the-contrast-you-invented/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: material-power-the-contrast-you-invented
+description: Use at hypothesis generation and study design when a contrast of your own design is about to define the observable, the plotted series or the framing of an experiment the task named, and again at writing when figures, sections and captions are being titled. Covers the pre-funding power check against the within-condition spread, and the slots a self-generated hypothesis may not occupy.
+stages: 02_hypothesis_generation, 03_study_design, 07_writing
+---
+
+# Power the contrast you invented, and keep it out of the named experiment's slot
+
+A hypothesis you wrote yourself is allowed to be sharper, better controlled and
+more interesting than the experiment the task named. It is not allowed to supply
+that experiment's observable, its plotted series, its axis range or its title.
+
+This extends `cover-what-the-task-named` (which gets the named experiment run)
+and `material-as-specified-run-and-stage-diagnostics` (which keeps an audit of a
+defective spec out of panel (a)). The case here is different and less obvious:
+nothing is broken and nothing is skipped. A self-generated contrast quietly
+becomes the thing the named experiment reports.
+
+## How it happens
+
+The task names an experiment of the form *does this artifact reproduce
+<external reference> on <system>*. At hypothesis generation you write something
+better posed: a contrast between two conditions you control — two cell sizes,
+two densities, two preprocessing variants, with and without a correction. It is
+internally controlled and genuinely falsifiable, which is why it wins the slot.
+From then on it supplies, without anyone deciding to let it:
+
+- **the observable** — the reported quantity becomes a ratio or difference
+  between your two conditions instead of the agreement with the reference;
+- **the plotted series** — the figure shows condition A and condition B, both
+  yours, and the external reference survives as a vertical line, a floating
+  marker, or nothing;
+- **the axis range** — the range is whatever your control condition supports,
+  not the range over which the reference is defined;
+- **the title, the caption headline and the section heading** — all three become
+  your hypothesis's identifier and its verdict;
+- **the framing** — the named experiment is delivered as an inconclusive result
+  about a question nobody asked.
+
+The last step is the giveaway. A contrast designed as a control is usually
+underpowered as a measurement: two conditions, two seeds, an effect smaller than
+the seed-to-seed spread. So the slot ends up occupied by a non-verdict.
+
+## Power it before you fund it
+
+Every two-condition contrast of your own design gets this check before it enters
+the design. It costs one smoke run.
+
+1. Measure the within-condition spread of the observable across seeds — or
+   restarts, shuffles, replicates, whatever the run's own randomness is — at the
+   smallest size you would actually ship.
+2. State the effect you expect, in the same unit.
+3. If the expected effect is smaller than roughly twice that spread, the
+   contrast cannot be resolved at that n. Raise n until it can, or demote it to
+   a stated limitation. Running it anyway and reporting the non-verdict spends
+   the compute and buys a sentence saying you learned nothing.
+4. Write both numbers into the design document. If you catch yourself printing
+   the effect-to-spread ratio in your own caption as an explanation of why the
+   result is inconclusive, the check was not skipped by accident — the answer
+   was available before the run and was not acted on.
+
+The same check applies to any comparison whose point is to separate two
+candidate values: the interval you can buy must be narrower than the gap you
+intend to claim. Write that clause per deliverable before running, in the form
+*to separate A from B I need an interval narrower than |A − B|*.
+
+## Slot rules
+
+A hypothesis you generated may not take, for an experiment the task named:
+
+- **the figure's subject or title.** The figure is about the named comparison.
+- **both plotted series.** One series is your result, one is the reference the
+  task named. Your second condition is a third series or its own figure.
+- **the axis range.** Set it by the range the reference spans, at the resolution
+  the comparison needs. A range truncated by a geometric limit of your own extra
+  condition removes part of the named result.
+- **the caption's first clause.**
+- **the section heading.** Sections are headed by the named experiment and the
+  system it ran on. A heading of the form *H4, inconclusive* names your
+  bookkeeping, not a result.
+- **the abstract's first result sentence.**
+
+## Say what the named experiment showed
+
+Before any verdict on your own hypotheses, the named experiment's paragraph
+answers the task's question in the task's own terms, positively: what was run,
+on what system, at what configuration, against which external reference, whether
+they agree and by how much, and what capability that demonstrates about the
+artifact under test. That last clause is a sentence, and it is the one most often
+missing from a run that is otherwise correct — an inventory of hypothesis
+verdicts leaves the reader to infer the claim the study was for.
+
+"Inconclusive" is a fact about your design, not a finding about the artifact.
+
+## Checklist
+
+- [ ] Every experiment the task named is stated as a one-line question that
+      contains an external reference, before any hypothesis is written.
+- [ ] Each self-generated contrast has a measured within-condition spread and an
+      expected effect recorded beside it.
+- [ ] No contrast whose expected effect is under ~2× the spread was funded.
+- [ ] For each named experiment: one series is the reference; the axis range is
+      the reference's.
+- [ ] No figure title, caption headline or section heading is a hypothesis id or
+      a verdict word.
+- [ ] The abstract's first result sentence is about a named experiment.
+- [ ] Each named experiment has a sentence stating what its result demonstrates
+      about the artifact, in the terms the task's goal is written in.

--- a/src/skills/material-same-estimator-same-slot/SKILL.md
+++ b/src/skills/material-same-estimator-same-slot/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: material-same-estimator-same-slot
+description: Use at the literature survey when you recompute a statistic out of the source's own tables, and again at analysis and writing when a reproduction result is being placed in a figure, a caption and a table. Covers republishing the source's summary statistic in the source's own estimator, set and n, sweeping the literature-stage artifacts for statistics that never reached the draft, and giving the reproduction the panel position and caption clause the audit tends to take. Extends material-as-specified-run-and-stage-diagnostics.
+stages: 01_literature_survey, 06_analysis, 07_writing
+---
+
+# Same estimator, same slot
+
+This extends `material-as-specified-run-and-stage-diagnostics`, which says the
+audit of a defective spec may not take the title, the abstract's first sentence
+or panel (a). It adds the two things that skill leaves unsaid: what *form* the
+source's number has to come back in, and what "panel (a)" means physically.
+
+## The two failures
+
+**The statistic changes form on the way into the report.** The source publishes
+a summary statistic over its own set — a mean absolute error over N benchmark
+cases, a mean absolute deviation in meV/atom, an RMS across sites. Your
+literature stage recovers it, parses the underlying table, validates the parse,
+and writes the recomputed value into an intermediate artifact. The report then
+publishes a different reduction of the same rows: a signed mean, an RMSE, a
+per-item table left for the reader to reduce, or your own error against the
+handful of cases that were shipped to you. Every number in the report is
+correct. The one a reader checks a reproduction with is not there. This failure
+hides itself, because the same digits usually do appear somewhere in the
+document attached to a different quantity, so searching for the value finds a
+hit.
+
+**The reproduction is drawn and then buried.** You reproduce the source's figure
+well — same entities, same ordering, values that match — and place it as the
+third panel of a composite at a third the width, on an axis range stretched by a
+neighbouring panel's outliers, under a caption whose first clause explains why
+the inputs behind it are unsound. Position, size and caption polarity are read
+before content is, and a correct reproduction in that position reads as a
+reproduction you declined to do.
+
+## What to do
+
+**Stage 01 — record the statistic as a form, not as a value.** For every summary
+statistic the source publishes that your task touches, write one row: estimator
+name, set, n, unit, the value as the source states it, your recomputation from
+the underlying table where the table is available, and the check that validated
+your parse (a column the source also publishes, which your recomputation must
+reproduce row by row). Mark each row *to publish*. That file is a publication
+queue, not a note.
+
+**Stage 06 — recompute in the source's own form.** Same estimator, same set,
+same n, same unit. Do not upgrade the statistic because you prefer a different
+one, and do not report a signed quantity where the source reported a magnitude:
+they answer different questions and the substitution is invisible to you and
+obvious to a reader. Then:
+
+- If you can only run part of the set, restrict the source's statistic to the
+  same part and report both, with both n's stated.
+- If the set cannot be rebuilt at all, republish the source's own value with its
+  n, attributed, and say your run does not contest it. A source statistic
+  reported as the source's is still the anchor the reader wanted; an absent one
+  is an experiment not done.
+- Where you have your own version, put them in one row:
+
+  | statistic (estimator, set, n) | source | this run | difference |
+
+**Before you ship — sweep the literature artifacts, not only the run outputs.**
+`publish-what-the-run-already-computed` sweeps what the run computed. This is the
+other pile, and it is missed more often, because a number recovered from a paper
+feels like background rather than a result. Open every literature-stage artifact,
+list each numeric field you recomputed or validated there, and grep the draft for
+it. Absent means not reported. Present only as some other quantity's value is
+worse than absent: it makes the missing statistic look present to you and to
+nobody else.
+
+**Stage 07 — slot geometry.** For each result the task names:
+
+- it is figure 1, or panel (a) of figure 1: first position, full width, axis
+  range chosen so the compared quantities fill the panel;
+- the caption's first clause states the comparison and its outcome, in the
+  source's units, with the source's value and yours both printed;
+- a defect in the supplied inputs comes after that clause, quantified against the
+  protocol's own threshold in the protocol's own units — "residual forces of X
+  against the Y the protocol's convergence criterion states", not "these inputs
+  are unusable";
+- the number the defective inputs give is still reported, because that is what
+  the named experiment measured;
+- a multi-panel composite is an addition. A named result appears once at full
+  size on its own before it appears as somebody's panel (c).
+
+## Checklist
+
+- [ ] Every source statistic your task touches has a row with estimator, set, n
+      and unit, written at the literature stage.
+- [ ] Each is republished in the source's own estimator, or explicitly deferred
+      to the source's value with attribution.
+- [ ] No signed mean, RMSE or per-item table stands in for a published magnitude.
+- [ ] The draft has been grepped for every value the literature stage recomputed.
+- [ ] No value appears in the report under a quantity it does not belong to.
+- [ ] Each named result is first position, full width, in its own figure.
+- [ ] Every caption's first clause is the comparison, not the complaint.
+- [ ] Every complaint is a number against the protocol's own threshold.

--- a/src/skills/material-trajectory-health-is-a-panel/SKILL.md
+++ b/src/skills/material-trajectory-health-is-a-panel/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: material-trajectory-health-is-a-panel
+description: Use at experimentation when a dynamics or sampling run is launched (MD, Monte Carlo, annealing, any iterative sampler), and again at analysis and writing when its result is drawn. Covers the health channels to append to disk while the loop is running, the numbers to state against thresholds you declared, and the trace panel that makes the run checkable — without changing the configuration the protocol specified.
+stages: 05_experimentation, 06_analysis, 07_writing
+---
+
+# The trajectory's health is a panel, not a boolean
+
+A result computed from a dynamics or sampling run carries a second claim
+underneath the first: that the run was a valid one. The distribution, average or
+landmark you plot does not carry it — a curve computed from a run that fell
+apart still looks like a curve — and neither does a flag in a results file.
+
+The standard-figure lists in `the-canonical-figure` and
+`material-as-specified-run-and-stage-diagnostics` are shaped for fitting
+pipelines: objective against epoch, parity against reference, best-so-far
+against evaluation count. For a trajectory this is the entry those lists are
+missing, and it is the one nobody draws.
+
+## This is not "run it longer"
+
+Run the length, step size, step count, temperature, cell and ensemble the
+protocol specifies. That run is the foreground result, and its numbers are the
+ones reported (`material-as-specified-run-and-stage-diagnostics`). A longer,
+better-equilibrated or larger run is an addition placed beside it, with its own
+length stated, and it does not silently replace the as-specified number — a
+reader comparing you against the specified protocol is comparing against the
+specified protocol.
+
+What is usually missing is not compute. It is any evidence that the specified
+run did what it was supposed to do, and that evidence costs nothing next to the
+force or energy evaluations you already paid for.
+
+## Log it while it exists
+
+Inside the loop, every few steps, append to a file on disk — not to a list in
+memory that goes out of scope when the function returns:
+
+- step index and elapsed simulated time in physical units;
+- every controlled variable instantaneously: temperature, pressure, chemical
+  potential, acceptance rate, whatever the ensemble or sampler holds;
+- total and potential energy, per particle where the system size varies;
+- one or two sanity quantities whose violation means the run stopped being
+  physical: closest approach between entities that should not overlap, longest
+  bond within a pair that started bonded, count of entities that changed
+  identity or left the box;
+- the index of the first frame entering the average.
+
+## Turn the log into numbers with declared thresholds
+
+Every one of these is a value against a bound. Declare the bound before the run;
+a number with no bound beside it is not a check.
+
+- steps completed against steps requested, and the simulated duration in
+  physical units;
+- mean and standard deviation of each controlled variable over the averaged
+  window, next to its setpoint. Report the gap whatever it is. A large gap is a
+  finding to state beside the as-specified result, not a reason to quietly swap
+  in a different run;
+- energy behaviour over the run: fluctuation amplitude, and drift measured as
+  the difference between block means rather than eyeballed;
+- closest approach against the floor you set; worst bond length against the
+  ceiling you set; number of dissociation or identity-change events;
+- frames entering the average and the length discarded;
+- the seed-to-seed spread of the reported landmark, from at least two
+  independent starts, quoted as its error bar.
+
+## Ship the panel and say the sentence
+
+The deliverable figure gets a companion panel — in the same figure, or the
+figure immediately beside it: controlled variable against time, energy against
+time, sanity quantity against time, with the discard boundary drawn as a
+vertical line and the setpoint as a horizontal one. Its caption states the
+simulated duration in physical units, the frame count, the mean controlled
+variable against its setpoint, and the two threshold comparisons as numbers.
+
+Then one sentence in the results prose that introduces the deliverable figure,
+in plain words: whether the run was stable, for how long in physical units, at
+what conditions, and against which thresholds. It goes there, next to the
+result, not in a later section and not only in a caption. A stability claim that
+arrives tens of thousands of characters after the figure is read as absent, and
+`stable: true` in a JSON artifact discharges nothing — nobody reading the report
+can see it.
+
+If the run genuinely was not sound, that sentence says so with the same numbers.
+An honest failure in physical units is a result; an unqualified curve is not.
+
+## Checklist
+
+- [ ] The as-specified configuration was run and is the foreground result.
+- [ ] Health channels were appended to disk inside the loop, not collected at
+      the end.
+- [ ] Simulated duration in physical units and frame count are stated in the
+      caption.
+- [ ] Each controlled variable's mean over the averaged window is printed next
+      to its setpoint.
+- [ ] Each sanity quantity is printed next to the bound declared before the run.
+- [ ] At least two independent seeds; the spread is the quoted error bar.
+- [ ] A trace panel exists in the shipped figure set, discard boundary and
+      setpoint drawn.
+- [ ] The words describing stability appear in the results prose beside the
+      deliverable figure, with numbers, not only in an artifact.

--- a/src/skills/math-budget-the-grid-before-the-cell/SKILL.md
+++ b/src/skills/math-budget-the-grid-before-the-cell/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: math-budget-the-grid-before-the-cell
+description: Use at hypothesis generation and study design when the supplied data is a factorial grid of conditions - one directory per family or environment, several condition levels inside each - and the source's protocol prices past the compute you have. Covers enumerating cells from the directories rather than from the protocol, calibrating the per-instance limit instead of inheriting it, breadth before depth with a per-cell cap, what to do when every arm floors, and the zero-compute figure that replaces an arm which never ran.
+stages: 02_hypothesis_generation, 03_study_design, 05_experimentation, 07_writing
+---
+
+# Budget the grid before the cell
+
+## What goes wrong
+
+The supplied data is a factorial grid: one directory per family or environment, several condition
+levels inside each (problem size, difficulty tier, noise level, scale). The source's protocol
+prices at one or two orders of magnitude past your compute, so you look for a defensible shrink.
+The tempting rule is **statistical power**: find the cell with the largest effect, show a small n
+resolves it, spend everything there, and mark the rest "not run" against the source's published
+values.
+
+That rule maximises the significance of one number and destroys the deliverable. What you were
+asked to support is a *trend across conditions* - which family, at which level, by how much,
+against which competitors. One cell cannot carry a trend at any p-value, and "not run" is correct
+bookkeeping and zero result.
+
+The tell is mechanical: a beautiful data-inventory figure - families down the rows, levels across
+the columns, instance counts in the cells - and then a results section in which no figure has
+either axis. **You drew the grid and left it empty.**
+
+## Enumerate from the directories, before a hypothesis is frozen
+
+Every directory x every level it ships, with the shipped instance count per cell. Print it. This
+is `ls` plus a header read, not an estimate from the source's protocol, and it is the enumeration
+your plan is scored against. The shipped levels are the starting ladder, not the whole ladder;
+leave space for rungs the data does not ship.
+
+## The limit is a measurement, not an inheritance
+
+The fork is explicit: *full fidelity at one cell, or a reduced per-instance budget across every
+cell.* Take the second. A missing cell cannot be recovered by any later analysis at any price; a
+shorter limit is a disclosed condition.
+
+Do not assume the ordering of arms is budget-invariant. For anytime methods - anything holding an
+incumbent and improving it, or switching strategy partway - arms cross as the limit grows, and the
+winner at a short limit need not be the winner at the source's. Calibrate:
+
+1. **Price the host.** One arm, one instance, one timed probe per family. Not the source's
+   hardware, not an estimate. Record the ratio to any runtime the source publishes; the plan turns
+   on it.
+2. **Two-limit probe** at one cell near the transition, where the incumbent is neither floored nor
+   saturated: every arm at L and at 3-5 L, two instances each. If the ordering or the sign of the
+   margin moves between them, L is below the regime the claim lives in, and numbers taken there
+   are about your budget rather than about the methods.
+3. **Solve for the largest L that fits the whole grid**,
+   `L = solver_budget / (cells x arms x n_first_pass)`, then check it against (2). If no L
+   satisfies both, cut n or arms per cell before you cut cells.
+4. **Log the running best objective per instance, timestamped.** That re-thresholds to any
+   *shorter* limit for free, and yields the limit sweep with no re-run. Upward is impossible,
+   which is what fixes step 3's direction.
+
+## Breadth before depth
+
+- First pass touches every cell: all arms, n = 5-10, the uniform L.
+- No cell gets a second pass until every cell has had a first.
+- Cap any single cell at one third of the solver budget, ever - including the late "one more arm
+  at the cell we already understand", which is how the cap usually breaks.
+
+## When every arm floors at a cell
+
+That cell is not a cell to defund. Its *condition level* sits outside the range where anything is
+measurable, and moving its budget away ships a panel that is a row of zeros.
+
+Add rungs: levels below the shipped ones until the incumbent comes off the floor (above them, for
+saturation), with the shipped level marked on the axis as a dotted line. A curve falling through
+the nominal level is a result; a flat zero at the nominal level is not. Caption which rungs are
+yours. A floored cell still carries continuous measurements - see
+`math-register-every-metric-a-run-emits` before concluding nothing happened there.
+
+## When a planned arm never runs
+
+Repointing the figure slot at some other existing image is not a repair: the axis stays unshown,
+and a validator that checks only that a slot is declared will pass while the demand goes
+unanswered.
+
+Replace it with the cheapest figure on the same axis - the source's published values across the
+whole grid, on the source's axes, one series per competitor it names, your measured cells
+overlaid, unmeasured cells left as visible gaps. If you parsed or digitised a reference table at
+literature stage you already hold that figure's data; ship it as a figure. Rendered instead as
+prose with the competitor columns dropped, it is the most expensive omission available at writing
+stage, and drawing it costs zero solver seconds.
+
+## Checklist, before an hour of solver time
+
+- [ ] Can I name the figure whose panels are the grid's rows and whose x-axis is its columns, one
+      series per arm? Does the plan produce the numbers that fill it?
+- [ ] Did I choose L by arithmetic over the whole grid and check it with a two-limit probe, or
+      inherit the source's limit for one cell?
+- [ ] Is the incumbent off the floor at the chosen L?
+- [ ] Is any single cell scheduled for more than a third of the budget?
+- [ ] Am I logging the running best objective per instance, so a shorter limit is free?
+- [ ] Cut off at half the plan, do I have a partial row for every family or a complete row for
+      one? Prefer the partial row everywhere.
+
+## Anti-patterns
+
+- *"A power calculation shows only cell X can decide anything."* Power is per metric and per
+  claim. Eight cells at p ~ 0.2 support a claim that spans conditions; one cell at p < 0.001 does
+  not.
+- *"The source ran at limit L, so we must."* Their L matters when you put an absolute number
+  beside theirs. It does not license spending the grid's budget on one cell.
+- *"The other families carry published values with a not-run marker."* Reference values belong on
+  the same axes as your measurements, as a second series - never as a substitute for one, and
+  never with the competitor columns dropped.
+
+Per-family and per-regime reporting rows, degenerate families included, are already covered by
+`math-equal-effort-baselines-and-knob-sweeps`. This skill buys the numbers that fill those rows.

--- a/src/skills/math-canonical-curve-on-the-cost-counter/SKILL.md
+++ b/src/skills/math-canonical-curve-on-the-cost-counter/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: math-canonical-curve-on-the-cost-counter
 description: Use at figure planning when a convergence or performance curve is about to be drawn against wall-clock, or folded into a composite panel. Covers the field's plain two-curve figure, plotting against the algorithm's own cost counter, and why it comes before any richer diagnostic.
+stages: 03_study_design, 05_experimentation, 06_analysis
 ---
 
 # Draw the field's plain two-curve figure against the algorithm's own cost counter, before any richer diagnostic

--- a/src/skills/math-equal-effort-baselines-and-knob-sweeps/SKILL.md
+++ b/src/skills/math-equal-effort-baselines-and-knob-sweeps/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: math-equal-effort-baselines-and-knob-sweeps
 description: Use at study design when the source names competing algorithms and they are about to become a related-work paragraph instead of arms. Covers running every named baseline at equal tuning effort, and sweeping the parameter you claim credit for.
+stages: 03_study_design, 04_implementation, 05_experimentation
 ---
 
 # Run every named baseline as a real arm at equal effort, and sweep the knob you claim credit for

--- a/src/skills/math-register-every-metric-a-run-emits/SKILL.md
+++ b/src/skills/math-register-every-metric-a-run-emits/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: math-register-every-metric-a-run-emits
+description: Use at study design when cells are about to be chosen on a binary per-run outcome - solved / converged / correct / within tolerance - and the same runs also emit continuous quantities. Covers the metric register, recording every row on failed and timed-out runs, sizing n from a two-instance paired pilot instead of from the rate, and per-cell paired reporting with both averaging conventions.
+stages: 03_study_design, 05_experimentation, 06_analysis
+---
+
+# Register every metric a run emits, then choose cells to cover the register
+
+## The two facts this skill exists for
+
+1. **A run that fails still produces the continuous metrics.** A run that solved nothing has a
+   final residual, a count of remaining violations, a best incumbent objective, an iteration
+   count and a wall clock. Recording the outcome as `False` and discarding the rest throws away
+   a measurement you already paid the solver for, and it is what turns a floored cell into an
+   empty cell.
+2. **A paired continuous difference resolves at a fraction of the n a rate needs.** Ten points of
+   separation in a binary rate needs n in the hundreds. The same two arms compared on a
+   continuous quantity, instance by instance, usually separate at n of 5 to 10, because the
+   pairing removes the instance-to-instance variance that dominates the rate.
+
+Together they say that a cell's informativeness is per metric, not per cell. A cell can be
+worthless for the headline rate - every arm floored, every arm saturated, or the arms tied - and
+be the cleanest cell in the study for something else. Check what the continuous metrics do there
+before you drop it.
+
+## What goes wrong
+
+The headline metric is binary per run: solved / converged / correct / within tolerance. It is the
+one the source's headline table reports, so it becomes the metric the *plan* is argued in. A
+power calculation over that rate ranks the cells, the top cell is declared primary, and the rest
+are skipped as uninformative.
+
+The rate is the coarsest possible read of a run, and it is the one metric that is guaranteed to
+be uninformative wherever the problem is too hard or too easy for every arm. Selecting cells by
+it systematically discards the regime where a source's *secondary* claims live - the mechanism
+claims, the "why it works" claims - because those are precisely the claims the authors made with
+a continuous quantity in a place where the rate had nothing to say.
+
+## The metric register
+
+At study design, before cells are chosen, write one row per metric the report will state:
+
+| metric | per-run type | emitted by the code where | present on a failed run? | paired? | n to resolve |
+
+Rules for filling it:
+
+- **Type.** binary / count / continuous / time. Anything the report will put a number on gets a
+  row, including quantities you think of as diagnostics.
+- **Emitted where.** Name the variable or the log line. If a metric is computed inside the solver
+  and thrown away at the boundary, that is a one-line change and you make it now, not after the
+  first full pass.
+- **Present on a failed run.** Answer honestly. If the answer is no and it could be yes cheaply,
+  change the code before the first real run.
+- **n to resolve.** For the rate, from a two-proportion or McNemar calculation. For each
+  continuous metric, from the paired standard deviation of a **two-instance pilot** - not from
+  the rate's number, which is the wrong scale by an order of magnitude and is what makes cheap
+  cells look unaffordable.
+
+Then choose cells to cover the register, not to maximise one row of it.
+
+## At experimentation
+
+Log every register row on every run: failed runs, timed-out arms, probe-only cells, the arms you
+ran twice by accident. It is free - the solver already computed them - and it is unrecoverable
+later.
+
+Persist **per-instance records**, not cell means. Pairing, the commonly-solved subset, the
+re-thresholding to a shorter limit and the dispersion all need the per-instance rows; a table of
+means supports none of them and cannot be un-averaged.
+
+## At analysis
+
+- One row per cell per arm per metric, including the cells where the rate ties, floors or
+  saturates. The tied cell is a result: same rate, different continuous behaviour, is a
+  mechanism finding and the strongest use of a cheap cell.
+- Report each continuous metric as a **paired change against the incumbent, per cell, with its n
+  and its dispersion** - not as two independent cell means with the reader left to subtract.
+  State the sign convention once, in the caption.
+- Report both averaging conventions when they differ: each arm averaged over its own successes,
+  and the subset of instances every arm solved. The stronger arm solves harder instances and is
+  penalised by its own success under the first convention. When the two disagree in sign, that
+  disagreement is a selection effect and is worth a sentence.
+- No pooled aggregate as the primary object. Per-cell values are the result; pooling hides sign
+  reversals between cells and the reader cannot un-pool it.
+
+Pairing a quality metric with the cost metric for the same comparison, and giving the break-even
+factor, is already required by `math-equal-effort-baselines-and-knob-sweeps`; the register is
+what guarantees both members of the pair were recorded on every run rather than one of them at
+one cell.
+
+## Checklist
+
+- [ ] Does the register have a row for every quantity the report will state?
+- [ ] For each row: is it emitted on unsolved and timed-out runs? If not, did I fix that before
+      the first real run?
+- [ ] Was any cell dropped because the *binary* rate there is tied, floored or saturated? What do
+      the continuous rows do there?
+- [ ] Is each continuous n sized from a paired pilot, or inherited from the rate's calculation?
+- [ ] Are records persisted per instance, so pairing and the commonly-solved subset survive to
+      analysis?
+- [ ] Is every continuous comparison reported per cell, paired, with n and dispersion?
+
+## Anti-patterns
+
+- Reporting the continuous metrics only at the cell that was selected on the rate. That cell was
+  chosen by the wrong criterion for them.
+- Treating a metric as unavailable because the run failed, when the solver printed it.
+- Averaging each arm over its own successes and presenting that alone as the comparison.
+- A single pooled number per metric over all cells, with the per-cell values only in a supplement
+  or not at all.

--- a/src/skills/math-train-distribution-is-a-reporting-axis/SKILL.md
+++ b/src/skills/math-train-distribution-is-a-reporting-axis/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: math-train-distribution-is-a-reporting-axis
+description: Use at study design before anything is trained or loaded, and again at analysis and writing, when the method contains a learned component - a released checkpoint you load or a model you train - and the supplied data splits into structurally distinct subsets. Covers the provenance record, labelling every evaluation cell IN/OUT/unknown with a count of distinct structures behind the label, splitting every results object by that label, and the Results paragraph that states the margin on each half.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# The training distribution is a reporting axis
+
+## What goes wrong
+
+The method has a learned component. There are two ways to lose the same result.
+
+1. **You load a released checkpoint and never establish what it was trained on.** Every
+   evaluation subset then reads as equivalent. Whether the method holds up outside the data its
+   parameters saw - usually the most interesting thing a learned component can be asked - goes
+   unstated, and a reader defaults to assuming everything was in-distribution. Establishing the
+   checkpoint's provenance in a methods note is not the same as using it: if the words "trained
+   on" never reach the report, the axis does not exist for anyone but you.
+2. **You train it yourself on everything you were given.** More expensive, because it destroys a
+   split you cannot rebuild without retraining. It is fatal when a subset ships only one
+   underlying structure: train on it and the model is evaluated on the instance it trained on,
+   and that subset can never serve as a held-out condition again.
+
+Either way the report contains no sentence of the form: *the parameters saw A; on B, which they
+did not see, the measured margin against the incumbent is M, over n instances.*
+
+## Study design: a provenance record for the learned component
+
+Before any run:
+
+- Where the parameters came from: release URL and file hash, or your own training script and
+  seed.
+- Exactly which subsets, which instance or index ranges, and which seed ranges the parameters
+  saw. If you did not train it, go and find out: the release README, the source's experimental
+  setup section, the training config in the repository, the checkpoint's own metadata. Record
+  the file and the line you read it from.
+- If it genuinely cannot be established, say so in one line and label every subset `unknown`. Do
+  not label subsets in-distribution by silence.
+
+## Study design: label the evaluation cells
+
+Every cell gets `IN`, `OUT` or `unknown`. Then count distinct structures per subset before you
+trust a label:
+
+- A subset whose files all replicate one underlying structure, varying only the instance
+  seed, is **one structure**, not a family. Its `OUT` label is real but its n of independent
+  structures is 1, and the report has to say so.
+- "Trained on A, tested on B" is only out-of-distribution if your B instances were not in the
+  training draw. Check index and seed ranges, not just subset names.
+
+Write the counts down. They are two lines of code over the shipped files and they change how
+every later number reads.
+
+If you are training: hold out every structurally distinct subset, name the held-out list in
+writing *before* training starts, and draw training instances from index and seed ranges
+disjoint from evaluation. State both ranges in the report. A small self-trained arm restricted to
+the IN subsets is also the only thing that answers a criterion about the architecture itself -
+see `train-the-named-architecture` - and it can sit beside the released checkpoint rather than
+replacing it.
+
+## Budget consequence
+
+If the learned component is the contribution, the OUT cells are the load-bearing evidence for it,
+not a robustness appendix. When the budget reaches only some of them, prefer one cell in each OUT
+subset over many cells in one. A single point per OUT subset supports the split; ten points in
+one OUT subset does not.
+
+## Analysis: split every results object by the label
+
+The per-cell table gets an IN/OUT column. The headline comparison against the incumbent is
+computed and reported once for each half, never only pooled. If the margin differs between the
+halves, that difference is a first-class result: its own number, its own sentence, and a panel or
+facet of the primary figure. A method that holds its margin on OUT cells and one that collapses
+there are different methods, and only the split tells you which one you have. Either outcome is a
+result; the procedure does not presume which one you will get.
+
+## Writing: one paragraph in Results
+
+In the task's own vocabulary, and in Results rather than Limitations, state: where the parameters
+came from; which evaluation subsets are outside that distribution and on what evidence; how many
+distinct structures each of those subsets contains; and the measured margin on each half with its
+n. Use the field's term for evaluation outside the training distribution rather than inventing
+one. Limitations is where a reader looks for what you could not do; this is something you did.
+
+## Checklist
+
+- [ ] Can I name the file and the line that says what the parameters were trained on?
+- [ ] Is every evaluation cell labelled IN / OUT / unknown, with the count of distinct structures
+      behind each label?
+- [ ] Did I measure at least one cell in every OUT subset?
+- [ ] Does the primary results table carry the IN/OUT column, and are the two halves aggregated
+      separately as well as together?
+- [ ] If I trained: is the held-out list written down from before training, and are the training
+      and evaluation index and seed ranges disjoint and stated?
+- [ ] Does Results contain the paragraph above, or is the training distribution mentioned only in
+      Methods - or nowhere?
+
+## Anti-patterns
+
+- Reporting only in-distribution cells and describing the result as if it covered the whole
+  supplied dataset.
+- Training on every supplied subset because more data is better. It is not, when one of those
+  subsets is the only held-out condition you will ever get.
+- Inferring the training distribution from the method's name, or from what seems natural. Read it
+  out of the release.
+- Establishing provenance thoroughly in a stage note and never carrying it into the report. The
+  axis exists only where a reader can see it.

--- a/src/skills/measure-every-clause-of-the-data-description/SKILL.md
+++ b/src/skills/measure-every-clause-of-the-data-description/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: measure-every-clause-of-the-data-description
+description: Use at study design when the task ships datasets with prose descriptions, and at analysis and writing before the data section is fixed. Covers turning every asserted clause into a measurement — including the qualitative ones about variety, structure and how the data was generated — and why a verdict on the data's fitness is weak until the characterisation under it exists.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# The data description is a list of claims, and each one is a measurement
+
+A supplied dataset arrives with prose that asserts what it is: how large it is, what fraction of
+it carries the label, how varied its contents are, how it was produced, and what all of that is
+supposed to make possible. Those clauses are the specification the data section is read against.
+A reader arrives at that section asking one question — is this data what it says it is? — and
+expects a number under every clause.
+
+What runs actually do is measure the two clauses that are already numbers, find one of them is
+slightly off, and spend the section on that. The clauses that require *describing* rather than
+*checking* — how varied the contents are, what structure the items have, whether the generating
+process is controlled and recoverable — are never measured at all. The section becomes a
+complaint where a characterisation was owed.
+
+## Build the clause table at design time
+
+Split each supplied file's description at its own conjunctions. A single sentence routinely
+carries three assertions and only the first one ever gets measured. One row per assertion:
+
+| asserted (verbatim) | quantity that would test it | how measured | measured value | agrees? |
+|---|---|---|---|---|
+
+Write the first three columns before any result exists. Every row must have a measurement named
+in it, including the rows that are adjectives.
+
+## The clauses that get skipped, and how to measure them
+
+Counts, class balance and the feature schema are the easy rows and usually the only ones anyone
+fills. Three families get dropped, and they are cheap:
+
+**Variety of contents.** How many distinct entities, categories, tokens or values occur; how
+concentrated they are — share held by the most common few, entropy, effective number of
+categories; whether that distribution differs between the splits. A count of distinct values with
+no distribution behind it is not a characterisation of variety.
+
+**Structural variety.** Item size (elements, nodes, tokens, residues, time steps): minimum,
+median, maximum and the histogram. Whatever the internal structure is — connectivity, degree,
+branching, sparsity, ordering — as a distribution. How many distinct structural patterns occur and
+how often each recurs. Then the same statistics per split, on shared axes, so drift is visible
+rather than assumed absent.
+
+**How the data was generated, and whether that is controlled.** Look for the generator before you
+conclude there isn't one: a seed, a script, a rule, parameter ranges, a version string, a
+provenance field inside the file itself. State what you found and what you were able to reproduce
+— can the file be regenerated; do the labelled and unlabelled portions come from one process or
+several; is there a recoverable rule separating the classes. If a generating rule is recoverable,
+state it: it bounds what any model can extract, and it is a genuine result about the data. If it
+is not recoverable, say which of the three (seed, rule, parameter ranges) is missing.
+
+Each of these is a handful of lines over files you already loaded, and cheaper than any modelling
+step in the run.
+
+## Describe first, adjudicate second
+
+Where a measurement disagrees with the prose, that is a row with two values in it and one sentence
+of comment. Then the table keeps going.
+
+The failure is the pivot: one contradicted clause becomes the section's thesis, the remaining
+clauses are never measured, and the section closes by concluding the data cannot support the
+study. That verdict may even be right, and it is still the weakest possible version of itself,
+because it rests on the two clauses that were easy to check and says nothing about the three that
+were not. A reader who asked whether the data is what it claims gets an argument that it isn't,
+based on a minority of its claims.
+
+An argument that the inputs are unfit is a strong claim and needs the full characterisation
+underneath it, not instead of it. (`run-the-requested-analysis` covers not letting that verdict
+replace the study. What is here is the measurement recipe that has to exist before the verdict is
+worth stating at all.)
+
+## What the data section contains
+
+- One subsection per supplied file, with the file's name in the heading.
+- That file's clause table, complete, with the measurement column filled in every row.
+- Two or three panels: the size or length distribution, the composition or category distribution,
+  the label distribution — every split on shared axes in each panel.
+- One paragraph per file on what its measured properties *enable and bound* for the rest of the
+  study: which analyses are supported at this size and balance, which are not, what the variety
+  and the generating process imply about what can be learned.
+- Where the file is synthetic or a simulation, what it does and does not reproduce about the real
+  thing, in the same terms the description uses.
+
+## Where this sits next to `the-supplied-item-is-the-graded-unit`
+
+That skill covers a single named object shipped in `data/` — report that object's own quantities
+under its own name, and print the object rather than pointing at a path. This is the corpus case:
+a whole file whose description makes several claims about a population, where the loss is not a
+missing identifier but the clauses nobody turned into a number. Run both when a task ships both.
+
+## Checklist
+
+- [ ] Every clause of every supplied file's description is a row in one table.
+- [ ] Each row names its measurement and puts the measured value beside the assertion.
+- [ ] The qualitative clauses have numbers under them: distinct counts, concentration,
+      distributions, structural pattern counts.
+- [ ] Generation and provenance were investigated, and the answer is stated either way.
+- [ ] Every split is measured the same way and plotted on shared axes.
+- [ ] A disagreement is a row, and the rest of the table is filled in anyway.
+- [ ] No verdict about the data's fitness appears before the characterisation it rests on.

--- a/src/skills/mine-the-papers-you-were-given/SKILL.md
+++ b/src/skills/mine-the-papers-you-were-given/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mine-the-papers-you-were-given
 description: Use when the task ships PDFs in related_work/, at literature stage and before the study plan is costed. Covers reading those papers for the named tools, benchmarks, events and metrics the work will be judged against — as a work list rather than as background — and what to record for each one.
+stages: 01_literature_survey, 03_study_design, 07_writing
 ---
 
 # The papers in `related_work/` are a work list, not background reading

--- a/src/skills/neuroscience-colour-the-embedding-by-the-shipped-labels/SKILL.md
+++ b/src/skills/neuroscience-colour-the-embedding-by-the-shipped-labels/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: neuroscience-colour-the-embedding-by-the-shipped-labels
+description: Use at study design when a figure specification fixes what a low-dimensional embedding is coloured by, and again at analysis and writing when that projection is drawn. Covers the metadata-label inventory that decides the panel grid, the unreduced and size-matched-random arms that belong in the same figure, and rendering each panel's scores into its axes.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Colour the embedding by the labels the file ships
+
+## The failure this prevents
+
+A run produces one low-dimensional embedding figure and colours it by whichever
+covariate the surrounding narrative is built on — an inferred continuous
+ordering, an age, an acquisition index — because that is the variable the
+section happens to be about. The discrete state label the file actually ships
+never becomes a colour.
+
+The figure then looks like a result and shows nothing. A continuous gradient
+along an arc tells a reader the embedding has a direction. It cannot tell them
+whether the representation **separates the states**, which is the question the
+biology is about and the only thing an embedding of a selected feature set is
+evidence for. Two panels that both show a gradient are indistinguishable; a
+panel with clean state blocks beside a panel that is a smear is a result you
+can see in one glance.
+
+Two companion failures travel with it. The scores that would settle the
+question are computed elsewhere in the run and land in an appendix, framed as
+agreement with a published value rather than as this figure's claim — and a
+figure is routinely read on the picture alone, without text that sits tens of
+kilobytes away. And the colouring was frozen into a figure specification at
+design time, before any data was seen, after which plan fidelity kept it.
+
+## 1. The label inventory
+
+This is the part of this skill that nothing else in the library carries. Do it
+before you draw anything.
+
+Enumerate every metadata column the file ships. For each: dtype, number of
+distinct levels, count per level, fraction missing. Print the table into the
+log and keep it as an artifact.
+
+Any column with roughly 2–15 levels and a usable majority non-missing is a
+**colouring**, and you owe the reader a panel in it. Decide from this table,
+not from the section you are currently writing. The column you had no plans for
+is often the one the source's own figure is coloured by — the people who built
+the file put it there for a reason, and a column you enumerated once and never
+plotted is the cheapest requirement in the task to lose.
+
+Continuous columns are colourings too, and they are *additional* rows — never a
+substitute for the categorical ones. If the file's level set disagrees with the
+source's prose, draw the file's levels and say so where the figure is
+introduced.
+
+## 2. A grid, not a panel
+
+The minimum grid is `{selected set, full unreduced set, size-matched random
+set} x the primary categorical label`, drawn as **one figure** with shared
+axes, shared embedding hyperparameters and one shared legend.
+
+The unreduced arm is what makes "the selected features preserve the structure"
+a comparison rather than an assertion. The random arm at the same size is what
+separates reduction from selection. If you are comparing several methods, each
+gets a small panel in the same grid — never one large figure per method, which
+makes the comparison a memory exercise. Add a row per further categorical
+label from the inventory.
+
+This is the paired-panel rule of
+`neuroscience-comparator-ladder-and-per-unit-predictions` widened to the whole
+comparator set: the deliberately poor panel is a required deliverable, not
+something the good panel excuses.
+
+## 3. Numbers rendered into the axes
+
+Compute each panel's scores in the same script that builds the embedding, write
+them to a JSON beside the image, and render them **from that JSON into the
+axes**, so the picture and the file cannot disagree and the numbers cannot be
+separated from the panel they describe. A caption is text; it travels
+separately, and sometimes it does not travel.
+
+Per panel, at minimum: agreement between this embedding's clustering and the
+panel's label, a supervised accuracy for that label under one fixed simple
+classifier, rank correlation against any continuous ground truth the file
+carries, and `n`.
+
+`draw-the-source-figure-panel-for-panel` covers the rest — printing the
+source's named constants as labelled values, and stating each panel's key
+numbers in the prose that introduces it, in the results section, early. Follow
+it; do not defer those numbers to an appendix because they already exist there
+under another framing.
+
+## 4. Re-open a frozen figure specification
+
+A colour, a panel count or a covariate chosen before the data was seen is a
+guess. Before the figures are final, re-read every frozen figure spec against
+the inventory. Plan fidelity protects a plan from drift; it does not protect a
+guess from evidence.
+
+If a spec's colouring is not in the inventory's categorical list, change the
+spec and record the change and its reason. Adding the panel is cheaper than
+defending its absence. A figure slot that supports no hypothesis is the one
+most likely to be wrong and the least likely to be checked — quality rules
+scoped to "figures that support a verdict" never reach it.
+
+## Checklist
+
+- [ ] **study design** — figure specs name a categorical colouring, not only a
+      continuous one, and are marked revisable once the inventory exists.
+- [ ] **analysis** — the label inventory is printed and kept; the panel grid is
+      derived from it.
+- [ ] **analysis** — the grid holds the unreduced set and a size-matched random
+      set on shared axes, shared hyperparameters, one legend, one figure.
+- [ ] **analysis** — every categorical column in the inventory has a colouring
+      somewhere; continuous colourings are extra, not substitutes.
+- [ ] **analysis** — per-panel scores computed in the same script, written to
+      JSON, rendered into the axes.
+- [ ] **writing** — the paragraph that introduces the figure states the
+      selected / unreduced / random numbers, in that order, per metric.
+- [ ] **writing** — no frozen spec survives that the inventory contradicts.

--- a/src/skills/neuroscience-comparator-ladder-and-per-unit-predictions/SKILL.md
+++ b/src/skills/neuroscience-comparator-ladder-and-per-unit-predictions/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: neuroscience-comparator-ladder-and-per-unit-predictions
 description: Use at study design and analysis when a model is about to be compared against one alternative, or a fit reported without a negative control. Covers the two-sided comparator ladder, the control representation panel, and splitting per-unit predictions into the ones a measurement validates and the ones that stay predictions.
+stages: 03_study_design, 05_experimentation, 06_analysis
 ---
 
 # Two-sided comparator ladder, the negative-control representation panel, and per-unit predictions

--- a/src/skills/neuroscience-stratify-and-report-detection-metrics/SKILL.md
+++ b/src/skills/neuroscience-stratify-and-report-detection-metrics/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: neuroscience-stratify-and-report-detection-metrics
 description: Use at analysis when a detection or classification result is about to be reported as one accuracy over a pooled population. Covers per-group and per-class precision, recall and confusion matrices at a stated threshold, and sweeping the degradations the recording modality actually suffers.
+stages: 03_study_design, 05_experimentation, 06_analysis
 ---
 
 # Report per-group and per-class detection metrics, and sweep the modality's own degradations

--- a/src/skills/paper-writing/SKILL.md
+++ b/src/skills/paper-writing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: paper-writing
 description: Use when drafting, structuring or revising the manuscript or report in Stage 07 (Writing) — shaping the contribution into one story, writing the abstract and introduction, fixing prose that reads generic or templated, ordering sentences for clarity, or deciding what Figure 1 should show.
+stages: 07_writing
 ---
 
 # Paper writing

--- a/src/skills/physics-discriminate-model-families-and-defend-the-fit/SKILL.md
+++ b/src/skills/physics-discriminate-model-families-and-defend-the-fit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: physics-discriminate-model-families-and-defend-the-fit
 description: Use at analysis when a fit is about to be reported as the answer without a rival model being excluded. Covers naming the competing model families, showing which the data rules out, and treating the fit protocol — range, weighting, priors — as part of the result rather than as a setting.
+stages: 03_study_design, 06_analysis, 07_writing
 ---
 
 # Physics: exclude a named model, and treat the fit protocol as part of the result

--- a/src/skills/physics-plot-the-named-quantity-and-declare-the-calibration/SKILL.md
+++ b/src/skills/physics-plot-the-named-quantity-and-declare-the-calibration/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: physics-plot-the-named-quantity-and-declare-the-calibration
+description: Use at study design when each figure's dependent variable is chosen, at analysis when an unknown calibration, an arbitrary unit or an invariance argument is about to change what goes on the y-axis, and before the report is finalised. Covers keeping the task's named quantity on the primary panel, resolving an unknown absolute scale with one declared constant instead of a veto, and where bounds, ratios and normalised deficits belong.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Physics: the named quantity owns the y-axis; declare the calibration and move on
+
+The task's Output or Scientific Goal sentence names a quantity — "the core
+extracted physical quantity is Q and its dependence on X and Y". That string is
+the y-axis label of the primary panel for every experiment the task names.
+Everything you derive from Q — a ratio, a normalised deficit, a bound, a
+residual — is a second panel.
+
+This extends `material-landmark-scalars-in-physical-units`, which says a
+dimensionless goodness-of-fit reported in place of a physical quantity reads as
+though the physical quantity was never measured. Same failure, moved from the
+scalar in the text to the axis of the figure, and with the case the materials
+skill does not cover: what to do when the physical scale is genuinely unknown.
+
+## The failure this prevents
+
+A run established two correct things about its supplied data: the quantity
+carried an unknown multiplicative factor, and under a second ambiguity in the
+file only scale-free statistics were exactly invariant. Both were verified by
+re-measurement; neither is in doubt.
+
+It then rebuilt every panel around scale-free surrogates. On the magnitude
+panel, a bound derived from a general inequality was drawn as the measurement,
+and the measured series appeared as a grey dashed line labelled *uncalibrated,
+rescaled for shape only*. On the second panel, a dimensionless ratio against the
+reference model. On every subsequent panel, the normalised deficit
+`1 − Q/Q(0)` in place of `Q`. Its recorded reason: fixing the scale against a
+published landmark would be circular.
+
+The outcome is a defensible report in which **Q appears on no y-axis**, and a
+reader looking for "Q against X" — the phrase in the task's own brief — finds a
+dimensionless deficit on log axes instead. A comparator hit the identical
+problem and spent three lines of its Methods on it: one global divisor, where
+it came from, the interval internal evidence brackets it to, and the note that
+the ratios below are unaffected by it. Then it plotted Q, and scored higher on
+both items where the two reports differed.
+
+Check the source's own axis label before you decide the scale is unusable.
+Papers publish this class of quantity in arbitrary units routinely, and a
+scruple that the source did not apply to its own figure is not a reason to
+delete yours.
+
+## What to produce
+
+**At study design.** Write down the quantity the task names, in the unit the
+source uses — including `a.u.` or `normalised` if that is what the source uses.
+Each experiment the task names gets one panel with that label on the y-axis, its
+control variable on the x-axis, both axes linear unless the source's own panel
+is not, and every supplied theory curve for that quantity on the same axes.
+
+**At analysis, when the absolute scale is unknown.** Three steps, not a veto:
+
+1. **Fix one constant for the whole report.** State in Methods and in the
+   caption how it was fixed: a published landmark, a physical bound, a
+   normalisation at one stated point, unity. One constant, named once, used
+   everywhere.
+2. **State the interval** that internal evidence puts on it, and carry that
+   interval into every absolute number you quote.
+3. **Split the claims.** List which results are invariant to the constant —
+   exponents, ratios, shapes, orderings, which series lies above which — and
+   which are not. The invariant list is your robustness argument. It is not your
+   figure.
+
+Circularity is a property of an *inference*, not of an axis. Fixing the scale
+and then claiming you have confirmed the value you fixed it with is circular;
+fixing the scale, saying so, and then comparing shapes and ratios is not. If you
+will adopt no external number at all, the fallback is an `a.u.` axis with every
+series divided by one declared reference value taken from inside the file. It is
+never the deletion of the series.
+
+## Where the derived forms go
+
+4. A calibration-free bound — an inequality, a floor from a general theorem, a
+   limiting case — is drawn **on** the primary panel as a labelled horizontal
+   line or a shaded band beside the data. It is never drawn *as* the data.
+5. Ratios, normalising factors, normalised deficits and residuals are secondary
+   panels, insets, or a right-hand axis. They answer "by how much", after the
+   primary panel has answered "what does it look like".
+6. If you invert the quantity — a deficit instead of a value, `1 − Q/Q(0)`
+   instead of `Q` — the un-inverted panel still has to exist. A reader laying
+   your figure beside the source's is matching shapes, and `y` and `1 − y` are
+   different shapes. The transformed view is an addition to the pair, not a
+   substitute for the raw one.
+7. A quantity the task names that you genuinely cannot produce still gets the
+   axis it would have had: plot the closest proxy you do hold, label it a proxy
+   in the legend, and say in one sentence what is missing.
+
+## The check
+
+Before the report is finalised, list the y-axis label of every panel you are
+about to ship, in one column. If the quantity the task names is not literally
+one of them, your result is not plotted, whatever the report says. Then confirm
+that each named experiment has at least one panel linear in both axes: a
+results section that is log–log throughout is a set of slopes, not a set of
+measurements.

--- a/src/skills/physics-two-estimators-propagation-and-a-forward-model/SKILL.md
+++ b/src/skills/physics-two-estimators-propagation-and-a-forward-model/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: physics-two-estimators-propagation-and-a-forward-model
 description: Use at study design and analysis when a physical quantity is about to be reported from one estimator, or an uncertainty quoted without propagation. Covers measuring it a second independent way, propagating the error through the chain, and generating the observable forward from the fitted model to check it.
+stages: 03_study_design, 05_experimentation, 06_analysis
 ---
 
 # Physics: measure it twice, propagate it, and generate it

--- a/src/skills/plant-decoys-and-report-what-each-method-admits/SKILL.md
+++ b/src/skills/plant-decoys-and-report-what-each-method-admits/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: plant-decoys-and-report-what-each-method-admits
+description: Use at study design and again at experimentation when a source claims robustness, resilience or degradation under worsening conditions, and the shipped data carries no knob to turn — or when the thing under test selects or ranks features rather than predicting a label. Extends run-the-conditions-the-source-ran: covers building a surrogate corruption axis, calibrating its worst level, and measuring what each method admits rather than only what it scores.
+stages: 03_study_design, 05_experimentation, 06_analysis
+---
+
+# Plant decoys and report what each method admits
+
+This extends `run-the-conditions-the-source-ran`, which says: enumerate the
+stress axes the source names and run each one by name. Read that first. This
+skill covers the two things it does not — what to build when the source's
+stress generator is out of reach, and what to measure when the thing under
+test selects or ranks features rather than predicting a label.
+
+## The failure this prevents
+
+A source's robustness claim gets answered with one statistic computed on the
+matrix as it shipped: a count of selected features associated with a nuisance
+column, a neighbourhood mixing purity, a variance ratio — each with a
+permutation null, a size-matched threshold and a negative control. All of that
+rigour describes **how much nuisance the supplied file happens to carry**. It
+is one point on an axis. It cannot rank methods by resilience, it cannot be
+plotted against anything, and a reader who asks "which of these survives a
+worse experiment" gets nothing back.
+
+The second shape is quieter. The run reads the source's stress protocol at
+literature stage, records it accurately, finds that reproducing it needs a
+generator or an accession it does not have, and never opens the row again. The
+claim ends the run with no producer, no figure slot and no line in any budget —
+not cut, just never scheduled.
+
+## Order of preference
+
+1. The source's axes, the source's generator, the source's levels.
+2. The source's axes, your own generator, fewer levels. Say which is yours.
+3. A surrogate axis you build, when the modality supports no version of the
+   source's. Name the axis you could not build and what you varied instead.
+
+A single-level statistic is never any of these. It is a description of the
+fixture.
+
+## Build the axis
+
+* One function, `corrupt(X, family, level, seed)`. Level 0 returns the input
+  bit-identical — assert it, in code.
+* At least four levels including 0, and the far end severe.
+* **Calibration rule:** at the worst level, at least one comparator must reach
+  the chance floor. If everything is still near ceiling you have measured
+  nothing and paid for it; extend the axis and rerun before writing a word.
+* Everything except the input is frozen across levels: same splits, seeds,
+  neighbourhood sizes, roots, metric code, hyperparameters.
+* Repeat each cell over seeds and carry the spread onto the plot. A crossing
+  between two curves inside the seed spread is not an ordering.
+
+## Decoy families
+
+Where the corruption is *planted features* rather than degraded ones, build at
+least two families:
+
+* **unstructured** — draws with no relationship to anything, and
+* **structured** — a decoy shaped like what the method keys on: a smooth
+  function of the embedding coordinates, a step keyed on a grouping column, a
+  real feature with its association to the quantity of interest permuted away.
+
+Unstructured decoys alone are too easy. Nearly every method rejects them, the
+curves sit on top of each other, and the ordering you publish is an artifact of
+having chosen the easy family. Structured decoys are what separate methods.
+
+## What to measure for a selector or a ranker
+
+The downstream metric is the second readout, not the first.
+
+* **Admission.** At each level, the fraction of each method's output that is
+  planted decoy, against the chance fraction (decoys / candidates) drawn as a
+  line. A method whose downstream score holds while its output fills with
+  planted decoys is failing in a way that score hides.
+* **Stability.** Overlap between each method's selection at this level and its
+  own selection at level 0.
+* **Downstream cost.** The task's own metric, recomputed on each method's
+  selection at each level.
+
+Three curves, one story: what it lets in, whether it keeps its mind, what that
+costs the analysis.
+
+## Run the whole ladder at every level
+
+Every comparator the source names, plus a random-selection arm as the
+degenerate floor, at every level of every family. The result *is* the ordering
+of the curves. If the budget will not carry the grid, cut levels and families —
+never comparators. A curve with nothing beside it is a shape, not a finding.
+
+## Report
+
+* One figure per family: level on x, the metric on y, one line per named
+  method, chance line drawn, seed spread shown, n in the panel.
+* One table: per method, value at level 0, value at the worst level, the
+  absolute drop, and the level at which it crosses chance ("never" is a
+  result). Rank on the drop.
+* One sentence in prose naming which comparators fall fastest and which is
+  flattest, with their numbers. That sentence is the finding; the curves are
+  its evidence.
+* An axis you could not build still gets a subsection: what the source varied,
+  what you varied instead, and why the substitution is fair.
+
+## Checklist
+
+- [ ] **study design** — the sweep is a row in the plan with a budget in
+      `families x levels x methods x seeds`, before any of your own variants
+      are costed.
+- [ ] **study design** — state which of the source's axes the shipped modality
+      cannot support, and the surrogate for each.
+- [ ] **experimentation** — level-0 identity assertion passes; every cell is
+      recorded, including the ones that collapse.
+- [ ] **analysis** — confirm something broke at the worst level; if not,
+      extend and rerun.
+- [ ] **analysis** — admission, stability and downstream cost, each per method
+      per level, each against its chance or level-0 reference.
+- [ ] **analysis** — the sweep figure is a results figure, not an appendix
+      figure.

--- a/src/skills/presence-before-consistency-in-the-final-review/SKILL.md
+++ b/src/skills/presence-before-consistency-in-the-final-review/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: presence-before-consistency-in-the-final-review
+description: Use at analysis and writing, when a self-review, an adversarial reviewer or a validator loop is generating the items you spend your remaining revision attempts on. Covers why an internal review cannot see a missing deliverable, how to sort review items into presence and consistency, and what a saturated internal quality score is actually measuring.
+stages: 06_analysis, 07_writing
+---
+
+---
+name: presence-before-consistency-in-the-final-review
+description: Use at analysis and writing, when a self-review, an adversarial reviewer or a validator loop is generating the items you spend your remaining revision attempts on. Covers why an internal review cannot see a missing deliverable, how to sort review items into presence and consistency, and what a saturated internal quality score is actually measuring.
+stages: 06_analysis, 07_writing
+---
+
+# A review that reads your artifacts cannot tell you the deliverable is missing
+
+The review loop at the end of a run grades the report against the run's own
+outputs: number registers, mirrored artifacts, provenance fields, locator tests,
+citation coverage, issue tallies. Every one of those checks is real, and every
+one of them is *internal*. None can tell you that a quantity the task asked for
+is a row in an appendix instead of a figure, or that a panel answers with the
+wrong population. So a report can pass every check the run can run, at a quality
+score pinned near the top, and still be missing the thing it is graded on.
+
+`cover-what-the-task-named` builds the produced-or-explained list at design
+time. This skill is about the endgame: which of the open items you spend a
+finite number of revision attempts on, and what to check that no internal
+checker is structurally able to see.
+
+## The failure this prevents
+
+A writing stage consumed every revision attempt it had and was auto-skipped
+without ever being approved. The items it spent those attempts on: a register
+that said it held one fewer entry than it did; a set of mirrored result files
+described as identical when one of them had drifted by a timestamp; one
+overclaimed reproducibility sentence. All three defects were real. None of them
+was visible to any reader of the report.
+
+In the same attempts the review affirmed that the report's structure was right
+and must not be reshuffled, and specifically protected the placement, in the
+opening pages, of the run's own novel result — a hypothesis the task had never
+asked for. The quantities the task did ask for sat in subsections behind it. The
+run's internal candidate scores across those attempts sat in a narrow band above
+0.96, moving by thousandths while the loss was structural and unmeasured. It
+lost the task, on every graded criterion, to a plain agent whose report was
+under half the length.
+
+The reasoning that produces this is sound at every step. Each item is a genuine
+defect; fixing it is honest; the register really was wrong. The error is
+allocation: attempts are the scarce resource, and every one spent on something a
+reader cannot see is one not spent on something the reader is looking for.
+
+## What to do
+
+1. **Run a presence pass before the first revision attempt.** Build it from the
+   task statement and the contents of `data/` — not from the run's artifacts,
+   not from the plan, not from the hypothesis manifest. For each named output
+   and each supplied file: the section, the figure and the sentence that carries
+   it. Write it to `notes/presence.md`. Anything you cannot fill is the item at
+   the top of the queue.
+2. **Sort every open review item into PRESENCE or CONSISTENCY.** PRESENCE: a
+   graded thing is absent, answered from the wrong population, or exists only in
+   `outputs/`, an appendix or a table. CONSISTENCY: two artifacts disagree, a
+   count is off, a locator is stale, a mirror has drifted, a claim overreaches.
+   Clear every PRESENCE item before any CONSISTENCY item, whatever order the
+   reviewer raised them in.
+3. **A consistency defect a reader cannot see is worth a sentence, not an
+   attempt.** Withdrawing or qualifying the claim in one line is almost always
+   the right trade against rebuilding the artifact — and it is the honest
+   version, because the disclosure is what a reader needed anyway.
+4. **Treat a saturated internal score as a broken instrument.** If your own
+   quality numbers sit in a narrow band near the ceiling across successive
+   attempts while items are still open, they are measuring internal consistency,
+   which you have already achieved. Stop reading them. Read the report instead
+   as a stranger holding only the task statement and `data/`, and ask what that
+   stranger cannot find.
+5. **The opening belongs to what was asked for.** A result you found and nobody
+   requested goes after the requested ones, however much better it is. Check
+   what the abstract, the first screenful and the first figure actually contain
+   against the presence list, and reorder rather than defending an ordering the
+   review has already blessed.
+6. **Never let the stage end by exhausting attempts.** Budget them: reserve the
+   last attempt for the presence list and nothing else. A stage that runs out is
+   a stage whose final state nobody chose, and the version that ships is
+   whichever draft the loop happened to be holding.
+7. **If you must ship with a known defect, ship with the disclosed consistency
+   defect, never with the missing deliverable.** One costs a limitation
+   paragraph; the other costs the criterion.
+
+## Before you finish
+
+Name the last three things you changed. If all three were internal — a count, a
+hash, a field, a locator — you spent the budget in the wrong place, and the
+presence list is still the document to read. Every line of it needs a section, a
+figure and a sentence, or an explicit paragraph saying why it does not exist.

--- a/src/skills/price-the-grid-in-wall-clock-and-fill-it-breadth-first/SKILL.md
+++ b/src/skills/price-the-grid-in-wall-clock-and-fill-it-breadth-first/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: price-the-grid-in-wall-clock-and-fill-it-breadth-first
+description: Use at the end of study design and through implementation and experimentation, when the experiment grid has more cells than you can obviously afford and the budget is a wall clock rather than a queue. Covers the hard gate on planning time, measuring one cell's cost to price the whole grid, choosing a first-pass fidelity from the quotient, the pass order, and deciding between buying cells and buying repeats.
+stages: 03_study_design, 04_implementation, 05_experimentation
+---
+
+# Stop planning and launch a cheap pass over every cell
+
+A grid run depth-first at the source's fidelity ends the same way every time: the
+first few cells are beautiful and the rest do not exist. The reasoning is sensible
+from the inside -- the source trained for N epochs so N epochs is the honest
+budget; the big dataset is expensive so start with the small ones; the second
+architecture profiled expensive so schedule it last. Each step is correct and the
+sequence is fatal.
+
+## The gate, before anything else
+
+Check the wall clock at the end of the literature and design work.
+
+**If a third of the run has gone and nothing is training, simulating or sampling,
+stop planning and launch pass 1 with the plan you have.** This is a gate, not a
+preference. Planning time is subtracted from experiment time and there is no
+other account it comes out of. A design refined for one more hour against a
+campaign that then does not fit is a net loss twice over.
+
+Two corollaries. A design or hypothesis stage on its third attempt is finished:
+ship what it holds and start the compute, because the design document is not a
+graded artifact and the cells are. And freeze decision rules over the campaign
+pass 1 will actually cover, not the one you hope to afford -- a rule quantified
+over a larger set than the one that runs becomes two rules with two answers, and
+the report ends up printing the unreachable branch instead of the estimate.
+
+## Price the grid; do not estimate it
+
+Do this in a file (`outputs/budget.json`), not in your head.
+
+1. **Deadline.** Wall-clock end minus time already spent. That number, not the
+   source's protocol, is the constraint.
+2. **Cells.** Every named model or variant x every dataset the results table needs
+   x every metric family. Count them. This is the denominator.
+3. **Cost, measured.** Run one cell at deliberately tiny fidelity and record
+   seconds. Cost is close to linear in epochs and in rows, so one measurement plus
+   two scaling factors prices the whole grid. Measure the arm you expect to be
+   expensive too: per-cell cost varies by an order of magnitude across model
+   families, and the expensive family is the one that silently gets dropped.
+4. **Fidelity from the quotient.** Pick the largest fidelity `f1` such that
+   `cells x t(f1)` fits in **40%** of the remaining time. Subsample the large
+   datasets to make it fit and record the subsample fraction as a column.
+5. **Reserve the rest**: ~35% for pass 2, ~25% for analysis, figures and writing.
+   Analysis and writing always overrun.
+
+If the arithmetic says the full-fidelity grid does not fit, that is the answer and
+it arrived early enough to act on. Cut fidelity, subsample rows, cut repeats. Do
+not cut cells; `information-fill-the-whole-results-grid` is the argument for why.
+
+## Pass order
+
+- **Cache once.** Featurise, preprocess and split every dataset before any model
+  runs, and persist it. It is a small fixed cost that makes every later cell
+  cheap, and it is what makes a late breadth pass possible at all.
+- **Pass 1: every cell, `f1`, one repeat.** No exceptions, including the arm you
+  expect to lose and the one that profiled expensive.
+- **Pass 2: deepen** the cells the headline claim rests on, towards the source's
+  fidelity, overwriting pass-1 rows and recording achieved budget per cell.
+- **Pass 3: repeats**, on the cells that carry a comparison.
+
+Start pass 1 running before the design prose is finished. The prose can be written
+while the campaign burns; the compute does not come back.
+
+## Before you buy a second repeat, work out what repeats can see
+
+Repeats and cells compete for the same seconds, and a comparison you cannot
+resolve costs exactly as much as one you can.
+
+1. From the literature stage you already have the source's proposed-minus-baseline
+   margin. Write it down.
+2. Pair the arms first: same seed, split, initialisation and data order. Pairing
+   is free and the relevant dispersion becomes the spread of per-cell
+   *differences*, usually several times smaller.
+3. Measure your own spread from two pilot runs at `f1`. Resolvable difference is
+   about `2.8 x sd / sqrt(n)`; solve for the `n` that gets below the margin.
+4. Multiply that `n` by the cell count. If it does not fit the reserve, buy cells
+   instead of repeats and report the sign pattern across cells: a consistent sign
+   on several independent datasets is evidence that one noisy cell is not.
+
+One line in Methods: *the source's margin is X, our paired spread is Y, resolving
+it needs n, we can afford m, therefore we bought cells / repeats.*
+
+## The source's budget is a target, not a constraint
+
+"N epochs because the paper used N" is how a complete grid becomes a third of one.
+Pass 1 answers "does every cell have a number in it", not "does this match the
+published value". Report the achieved budget per cell and its ratio to the
+source's, then let pass 2 close the gap where the headline claim rests.
+
+## Keep the deliverable renderable at every instant
+
+After every cell finishes, append one row to `outputs/results/grid.csv`:
+`(dataset, arm, fidelity, subsample, seed, metric, value, seconds)`. Regenerate
+both the results table and its figure from that CSV by script. If the clock ends
+in the middle of pass 2, the exhibit still contains every cell with the budget it
+actually got.
+
+## Checklist
+
+- [ ] Clock checked at the end of design; if past a third with nothing running,
+      pass 1 was launched instead of another planning attempt.
+- [ ] `outputs/budget.json`: deadline, cell count, measured seconds per cell for a
+      cheap and an expensive arm, chosen `f1`, reserve split.
+- [ ] Preprocessing cache built for every dataset, including ones you expect not
+      to reach.
+- [ ] Pass 1 covers 100% of cells before any pass-2 run starts.
+- [ ] Repeats-versus-cells arithmetic written down with the source's margin and
+      your measured spread.
+- [ ] `grid.csv` has a row per cell with fidelity, subsample and seed; the table
+      and figure are regenerated from it, not typed.
+- [ ] Every cell that got less than the source's budget says so in its own row.
+
+Related: `information-fill-the-whole-results-grid` for why a labelled reduced-N
+cell beats an empty one, `train-the-named-architecture` for cutting seeds before a
+named model, `result-table` for dispersion reporting. What is here and not there
+is the scheduling arithmetic: the gate, the measured cost, the fidelity quotient,
+the pass order and the repeats-versus-cells trade.

--- a/src/skills/price-the-missing-object-before-you-deepen-an-arm/SKILL.md
+++ b/src/skills/price-the-missing-object-before-you-deepen-an-arm/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: price-the-missing-object-before-you-deepen-an-arm
+description: Use at experimentation, analysis and writing, when a run that has a deliverable plan and an automatic coverage or completeness check. Covers auditing coverage against the object a reader opens rather than the path a checker sees, pricing every missing exhibit in wall-clock against the arm you are still deepening, and re-owning the obligations of a stage that was skipped or amended mid-run.
+stages: 05_experimentation, 06_analysis, 07_writing
+---
+
+# Price the missing object before you deepen an arm nobody asked for
+
+A long run rarely fails to produce a missing exhibit because it ran out of
+budget. It fails because the exhibit was never on a list that anything checked,
+and because nothing put a wall-clock price beside it while there was still
+budget to spend.
+
+Two mechanisms make that invisible. The first is a coverage check satisfied by
+paths: every named deliverable maps to a file, every file exists, green. The
+second is a plan slot filled by whichever arm happened to emit an artifact of
+roughly the right file type. Together they will certify a run whose central
+deliverable does not exist.
+
+## 1. Audit on objects, not on paths
+
+For every deliverable the brief names and every slot the plan opened, write the
+*object* down before you write a filename:
+
+- its kind - a rendered sample, a verbatim output, a curve with named axes, a
+  table with named rows;
+- the input condition it has to be under - the source's own input, the shipped
+  file, the named benchmark;
+- what it sits beside - the source's published value, panel or printed answer.
+
+Then bind a file to it and open the file. The test for the row is: *if a reader
+opens only this file, can they tell whether the system did the named thing?*
+"The path exists" is not that test, and a JSON of shapes, counts or configuration
+does not stand in for a capability the brief named among its outputs.
+
+Any slot whose own description says a number cannot replace it - a sample, a
+transcript, a picture of a field - is a slot no filename discharges. Re-open
+those rows every time the arm that feeds them changes.
+
+## 2. Put a price on every gap
+
+- Measure the per-unit cost of each production step **once, early**, and write it
+  down: seconds per generated sample, per decode, per fit, per render. You need
+  that number to make the trade later, and by then the run is busy.
+- At every stage boundary after implementation, re-diff planned objects against
+  what is on disk. Give each gap the wall-clock price of closing it. Sort
+  ascending.
+- Spend the tail of the budget from the top of that list. A handful of missing
+  exhibits at minutes each will routinely be cheaper than one more hour of the
+  arm currently running, and they are the ones the brief asked for.
+- Make the trade explicit in one sentence with both prices in it: an extension
+  nobody asked for, going deeper, against a named deliverable that does not
+  exist. See `the-reproduction-is-a-hypothesis` for the budget ordering and
+  `cover-what-the-task-named` for the list this diff runs against.
+
+A deliverable that costs minutes and is still missing at submission was never
+priced against anything. The defect is the missing price, not the shortage.
+
+## 3. Re-own the obligations of a stage that did not run
+
+Stages get skipped, exhaust a retry budget, or get amended in passing. Their
+obligations do not leave with them.
+
+- When a stage ends in a stub, a skip or an auto-continue, read that stage's own
+  brief before the next stage starts and list what it was supposed to emit. Carry
+  every item forward under the next stage's name, or record it as dropped with a
+  reason.
+- A plan amendment made while preparing something else is the same case. A slot
+  re-pointed after design is re-checked against the deliverable it was created to
+  carry, not against the artifact that now happens to fill it.
+- The last stage that can still spend compute owns the gap list. If the writing
+  stage is drawing figures an earlier stage was supposed to draw, it has
+  inherited that stage's audit as well as its plots.
+
+## Before you finish
+
+1. Planned objects against disk: every row present, or dropped with a reason and
+   a price beside it.
+2. For each capability the brief names, name the single file a reader opens to
+   see it. If the answer is a directory, a manifest or a coverage report, that
+   capability has no exhibit.
+3. Every gap you chose not to close carries its price and the thing you bought
+   instead.
+4. Every automatic coverage or completeness check that is green: open one file it
+   passed and confirm the object is what the row promised. A checker that reads
+   paths cannot tell you this.

--- a/src/skills/price-the-queue-and-preempt-your-own-arms/SKILL.md
+++ b/src/skills/price-the-queue-and-preempt-your-own-arms/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: price-the-queue-and-preempt-your-own-arms
+description: Use at study design when the run queue is priced and ordered, at implementation when the runner is launched, and again at every stage boundary while any condition the source names is still at N=0. Covers pricing per (condition x dataset slice) from measured seconds, a floor N per row, committed-hours arithmetic against the clock, and preempting your own invented arms when the queue is over-subscribed.
+stages: 03_study_design, 04_implementation, 05_experimentation
+---
+
+# Price every cell, then preempt your own arms to pay for the source's
+
+This extends two skills that already state the goal: `run-the-conditions-the-source-ran`
+("run every row before any variant of your own; if the budget cannot carry both,
+cut your variant") and `information-fill-the-whole-results-grid` ("a labelled
+reduced-N cell beats an empty one"). Runs that had both installed still left
+published conditions at N=0 while their own extra arms ran to completion. What
+was missing is not the principle. It is the arithmetic that decides which row
+runs, and one check that fires when the arithmetic went wrong.
+
+## What goes wrong
+
+The drop decision is made once, early, against a denominator you never reach and
+on a slice the graded comparison does not live on:
+
+1. At design time you time the expensive condition per item on the biggest,
+   slowest slice and multiply by the full released benchmark.
+2. The product is large, so the condition is cut, and the cut is written into a
+   design artifact as settled fact.
+3. The clock then delivers a fraction of that sample, and the queue you planned
+   is several times longer than the hours you have left.
+4. Nobody redoes the multiplication. The condition that was unaffordable at the
+   design N was an hour's work at the realised N, and it stays at zero while
+   arms you invented — extra seeds, extra variants of your own controls, extra
+   pinned values of a swept parameter — run at the full realised N.
+
+Two errors are mechanical and both are checkable:
+
+- **Priced per condition instead of per (condition x slice).** Per-item cost
+  varies by an order of magnitude across the datasets in one study, and the
+  cheap slice is often exactly where the source's own comparison is reported.
+  A condition that is unaffordable on the heavy slice can be an hour on the
+  light one; pricing it once, on the heavy one, deletes it everywhere.
+- **The remedy assumed to be "append it later".** If the queue is
+  over-subscribed — planned hours exceed hours remaining — the tail never
+  executes and appending changes nothing. Only reordering and deletion move
+  work into the run.
+
+## The rule
+
+A condition the source names may have its N shrunk, its slice narrowed, its
+seeds cut to one, its stratification coarsened. It may not sit at N=0 while a
+condition you invented has N>0. When the clock is short, the invented row is
+what you truncate or delete, and that slot is how the source's row gets paid
+for.
+
+## The ledger: write it before the queue exists, publish it in the report
+
+| cell (condition x slice) | named by | s/item measured | floor N | hours | realised N |
+
+- `named by` is `source`, `task brief` or `me`. Sort every `source` and `task
+  brief` row above every `me` row and fill from the top.
+- `s/item` is measured on two real items **of that cell** — the expensive
+  condition on that slice. Not extrapolated from a cheaper arm, not from a
+  prefill, not from the other dataset.
+- `floor N` is the smallest sample at which the row is worth printing. Choose it
+  from what the row has to show, not from a power calculation. When the source's
+  own numbers put two variants close together, no N you can afford will separate
+  them: print both point estimates side by side anyway, because the comparison
+  is the deliverable and the ordering is checkable when the interval is not.
+- Sum the hours column and compare it against the hours you actually have, minus
+  a reserve for analysis and writing. If the sum is larger, you are
+  over-subscribed: delete rows from the bottom now, while the deletion is free.
+
+## Committed-hours arithmetic, at every stage boundary
+
+```
+committed = sum(hours of queued entries not yet finished)
+remaining = deadline - now - reserve for analysis and writing
+free      = remaining - committed
+```
+
+`free`, not `remaining`, is what pays for a new row. When `free` is negative the
+queue is fiction below some line — find the line, and treat every entry under it
+as unscheduled rather than as scheduled-and-waiting.
+
+For each source-named cell still at N=0: if its floor-N cost fits in `free`,
+queue it. If it does not, name the invented row it preempts, truncate or delete
+that row, and put the source row in the freed slot. Record the swap with both
+prices. Re-run these three lines at every stage boundary; design-time N is a
+guess, realised N is a fact, and it moves the answer in both directions.
+
+## Launch before you finish auditing the design
+
+The queue starts consuming the clock when the port passes its smoke test, not
+when the design document stops being revised. Hours spent auditing a plan,
+hardening guards or tuning your own internal scorers are hours the queue is idle
+— and they are the hours the missing row needed. If the run ends with measured
+compute far below wall clock, that gap is where the empty cells went.
+
+## Checklist
+
+- [ ] One ledger row per (condition x slice) the source or the brief names,
+      written before any row of mine exists, sorted source-first.
+- [ ] Per-item cost measured on real items of that cell, on that slice.
+- [ ] Floor N chosen per row and justified by what the row shows.
+- [ ] Planned hours summed against available hours at design time; if
+      over-subscribed, rows deleted from the bottom before the run starts.
+- [ ] Runner launched as soon as the port passes, not after the design review.
+- [ ] `free = remaining - committed` recomputed at every stage boundary, with
+      the realised N read off the checkpoint.
+- [ ] Before writing: no source-named cell at N=0 while any invented row has
+      N>0. If one is, either run it at floor N or delete the invented row and
+      say in the report that you did.
+- [ ] The ledger ships in the report with realised N per row, and the measured
+      price that excluded any row still empty.
+
+## Why this is here
+
+Runs lose their heaviest criteria to conditions that were affordable on the
+slice that mattered and were never budgeted. The rationale for the cut is
+usually correct arithmetic against the wrong denominator and the wrong slice,
+and the report that names the cut honestly scores like the report that never
+mentions it: a named absence is an absence.

--- a/src/skills/publish-the-input-summary-in-its-measured-unit/SKILL.md
+++ b/src/skills/publish-the-input-summary-in-its-measured-unit/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: publish-the-input-summary-in-its-measured-unit
+description: Use at implementation when the loader summarises the supplied data, at analysis when a summary statistic of the input becomes an argument to your estimator, and at writing while drafting the data section. Covers publishing dispersions in the unit the measurement was made in rather than the coordinate the estimator consumes, the scalar that reaches the page under its downstream name only, and the self-checks that catch both. Extends astronomy-error-budget-is-the-audit-trail.
+stages: 04_implementation, 06_analysis, 07_writing
+---
+
+# Publish the input summary in the unit it was measured in
+
+**Extends `astronomy-error-budget-is-the-audit-trail`.** That skill already tells
+you to characterise the supplied data before modelling — row count, central
+value, dispersion, correlations between columns, units — and to report both mean
+with standard deviation and median with a percentile interval, because subfields
+differ on which is conventional. Runs execute that at load time, write a clean
+manifest, and still lose the criterion. This is the hand-off half: the three ways
+a characterisation that was measured correctly fails to reach the page.
+
+## Three ways it disappears
+
+**Coordinate substitution.** Your estimator does not work in the unit the
+measurement was made in. It works in logs, in a normalised width, in a ratio to a
+reference value, in standardised units. Whatever the estimator consumes is what
+the analysis code prints, so the report quotes the dispersion as a width in the
+derived coordinate. A width in a derived coordinate is not an interval: the
+reader cannot invert it back to endpoints without the centre and the transform,
+and nobody does that while reading. Published measurements of the same object are
+quoted as value, error, unit. If your report never emits that form, your input
+cannot be laid beside any external measurement of it — and neither you nor the
+reader can notice that the shipped file disagrees with the source it was
+extracted from.
+
+**Renaming.** A dispersion you measured on the input becomes an argument to a
+downstream formula — a tolerance, a step, a bin width, a noise term, a
+convergence criterion. It then appears in the report exactly once, under the
+downstream name, as a parameter of that formula. The number is physically on the
+page and is unreadable as the measurement uncertainty, which is the thing that
+was asked for.
+
+**No slot.** Most runs maintain some list of headline numbers, and every entry in
+it is an output of the run's own estimator. A quantity that describes the *input*
+rather than the answer has nowhere to be written down, so nothing carries it from
+the loader's artifact into the draft.
+
+## What to produce
+
+For every column of every supplied file, in the unit named in the file header or
+in the source measurement:
+
+- `value ± sd`, and the median with the endpoints of the central interval —
+  endpoints, in the measured unit, not a width and not a span in a log
+  coordinate.
+- The derived-coordinate row beside it where your estimator needs one, never
+  instead of it. A log width is a legitimate extra row and an illegitimate
+  replacement.
+- One clause on shape where mean and median separate by an appreciable fraction
+  of the dispersion, or where the distribution runs into a hard physical
+  boundary. That clause is what tells a reader whether your later Gaussian step
+  was adequate.
+
+Then the two bookkeeping rules that decide whether any of it survives:
+
+1. **Two names per scalar.** When a summary statistic of the input is reused as
+   an argument to a formula, record both in the summary artifact: what it
+   measures, and what it is used as. Publish it under the measurement name where
+   the input is described, and refer back to it where the formula is stated. One
+   appearance under the second name only is the same as not reporting it.
+2. **One input row in the headline list.** Whatever structure decides what gets
+   written up — a headline-numbers file, a deliverables list, a results table —
+   carries the supplied data's own characterisation as an entry in it. A quantity
+   with no slot in that structure does not get written down, however well it was
+   measured.
+
+## Checklist, writing stage
+
+- Grep the draft for `±` and for the interval form `(a, b)`. If no supplied
+  measurement appears in either, the description of the input is not finished.
+- Per supplied column, four boxes: central value present, dispersion present,
+  both in the measured unit, interval given as endpoints.
+- Every dispersion quoted in a derived coordinate has a sibling row in the
+  measured unit inside the same table.
+- Any number that appears in the draft only as a parameter of a formula: if it is
+  also a measurement of the supplied data, add the sentence that says so, where
+  the data is described.
+- Take one number from the table and reproduce it with two lines of numpy against
+  the shipped file. If it does not reproduce, it is not a characterisation of the
+  input.
+
+`publish-what-the-run-already-computed` is the general sweep for quantities the
+run computed and never printed. This is the case that sweep misses, because a
+loader artifact does not look like a result: the criterion asking for it is
+usually worded as a plain request for the uncertainty on the data, and the run
+has already measured it.

--- a/src/skills/publish-what-the-run-already-computed/SKILL.md
+++ b/src/skills/publish-what-the-run-already-computed/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: publish-what-the-run-already-computed
 description: Use at Stage 06 and again before the report is finalised, when deciding which of the run's results enter the deliverable. Sweeps the run's own outputs for quantities it computed and never published, and covers the three shapes that sweep finds — the diagnostic never persisted, the column requested and dropped, the feasibility measurement discarded — and what to promote out of an appendix.
+stages: 04_implementation, 06_analysis, 07_writing
 ---
 
 # The most expensive result is the one you computed and did not show

--- a/src/skills/put-the-study-controls-in-the-demo-panel/SKILL.md
+++ b/src/skills/put-the-study-controls-in-the-demo-panel/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: put-the-study-controls-in-the-demo-panel
+description: Use when the source ships showcase examples — a demo notebook, a teaser figure, images supplied with the task — at experimentation, to run every arm of the study on those inputs, and at analysis when the panel is drawn. Covers putting the study's control arms inside the demo panel, title discipline, and keeping overlays registered to the image they explain.
+stages: 05_experimentation, 06_analysis
+---
+
+# Put the study's control arms inside the demo panel
+
+When a task ships the source's own showcase inputs — a demo notebook, a teaser
+figure, two or three images supplied in `data/` — the panel you draw from them
+is the one figure a reader lays directly beside the original. Two shipped skills
+already cover the redraw: `draw-the-source-figure-panel-for-panel` (ship the
+source's layout, print its named constants on the panel) and
+`information-exhibit-the-intermediate-objects` (re-run the demos on the source's
+own inputs, quote the verbatim before-to-after output). Runs that did both still
+lost the figure item. A panel that matches the original is read as matching the
+original: comparable, not superior. This skill is what to put in it beyond the
+redraw.
+
+## The failure
+
+The demo is re-run exactly as the notebook prints it — one arm per example, the
+panels the notebook emits — and every control that makes the demo mean anything
+is somewhere else. The same-size region placed elsewhere, the un-guided variant,
+the no-intervention baseline: all of them ran, all of them are summarised in a
+table thirty pages away, none of them touches the images the reader is
+actually looking at. The panel therefore shows that the method changed one
+output once, and shows nothing about what it was compared against.
+
+The panel is two or three images. It is the cheapest compute in the entire
+study, and it is the one place where you can afford to run every arm.
+
+## Rule 1 — every arm in the study also runs on the demo inputs
+
+For each shipped example, run the full arm set you already built: the method,
+each ablation, each null or randomised control, and the untouched baseline. Put
+them in the same panel as one labelled line each, verbatim output, with the
+method's own arm marked and the correct answer marked. Overlay the controls'
+regions or interventions on the image alongside the method's, with a legend, so
+a reader can see that the controls were placed differently and produced
+different outputs.
+
+One output shows the method worked once. Four labelled outputs show what it was
+compared against and that only the method's arm moves the result. This is the
+source's figure plus the experiment the source did not run, in one image, for
+minutes of compute — and it is the load-bearing rule here. The other two are
+hygiene.
+
+## Rule 2 — titles and adjacent text carry the demonstrated fact
+
+Panel title: the question asked of that input, verbatim, or the object shown.
+Panel content: the intermediate object. Adjacent text: before-output to
+after-output with the correct answer marked, in the same type size as the rest
+of the figure.
+
+No hypothesis IDs, no verdict tokens, no wall clock, no library versions, no
+bare internal arm codes in a title. That line is the first thing a reader reads
+and pipeline bookkeeping wastes it. If an internal arm code must appear, spell
+out what it is on the same line. The same discipline applies in the report body:
+a reader should never have to decode which of your arm labels is the published
+method.
+
+## Rule 3 — keep the intermediate object registered to the input it explains
+
+A map, overlay or heatmap goes beside its own image at that image's aspect ratio
+and orientation, at the same rendered height, with its grid resolution stated.
+Do not silently square a non-square map. Do not log-transform, percentile-clip
+or recolour unless the untransformed version is unreadable, and when you do, say
+so on the colourbar. A reader comparing your panel with the source's is
+comparing appearance, and an undeclared transform makes a matching result look
+like a different one.
+
+Optional, if the runs are cheap: where the source demonstrates one configuration
+on one example and a different configuration on another, running both
+configurations on both examples turns a presentation choice into a measured
+contrast. Do it only after rules 1 to 3 hold; it doubles the demo runs and a
+faithful one-configuration-per-example layout is not by itself what loses the
+item.
+
+## Checklist
+
+- [ ] One panel row per shipped example — all of them, none dropped.
+- [ ] Every arm in the study run on every demo input, printed in the same panel,
+      labelled, with the method's arm marked.
+- [ ] Control interventions overlaid on the image beside the method's, with a
+      legend.
+- [ ] Verbatim before and after outputs per arm, correct answer marked, at body
+      type size rather than in a caption footnote.
+- [ ] Panel titles are the question or the object; no IDs, verdicts, timings or
+      versions anywhere in a title.
+- [ ] Overlays at the input's aspect ratio, grid resolution stated, any
+      transform declared on the colourbar.
+- [ ] Caption states in one sentence what the panel demonstrates, and every
+      claim in the caption is visible in the panel.
+- [ ] Laid side by side with the source's figure, mine shows everything theirs
+      shows plus the arms they did not run.
+
+## Why this is here
+
+The demo panel is graded against the source's own figure, and a faithful redraw
+tops out at "the same picture". The two ways to lose from there are drawing less
+than the source did — one arm, an unregistered map, the demonstrated fact
+shrunk into a caption footnote — and never adding the thing the source cannot
+have, which is your own controls on the source's own inputs. Both are fixed for
+minutes of compute, because the inputs are a handful of images and the arms
+already exist.

--- a/src/skills/query-the-checkpoint-off-its-own-split/SKILL.md
+++ b/src/skills/query-the-checkpoint-off-its-own-split/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: query-the-checkpoint-off-its-own-split
+description: Use when a trained or fitted model checkpoint exists and every number you can currently report is an average over your own held-out split. Extends `chemistry-ranked-entities-and-property-curves` with what to do with the saved model itself: build configurations that appear in no split, push the grid past the edge of the training data, draw one curve per discrete condition with the separation between them stated as a number, and audit every supplied system the way you audited the first one.
+stages: 03_study_design, 05_experimentation, 06_analysis
+---
+
+# A checkpoint is an instrument, not a score
+
+This extends `chemistry-ranked-entities-and-property-curves`. That skill already says to sweep the
+governing coordinate, overlay the reference, read the derived constants off the curve, and never let
+a bar chart of error-by-variant stand in for it; `chemistry-canonical-units-thresholds-incumbent`
+owns the unit the curve is plotted in and `material-landmark-scalars-in-physical-units` owns the
+landmarks you read off it. Assume all of that. What follows is the part none of them says: what to do
+with a saved model once you have one.
+
+## The failure
+
+Training finishes. The checkpoint is written, reloaded, and verified to reproduce its own energies to
+the last digit — the provenance is airtight — and then it is asked exactly one question: what is the
+error on the held-out slice of the frames it was trained on. Every table in the report is an average
+over that slice. The model file is never opened again.
+
+Hours of compute produce a number that a scatter of the training data could have produced. The tell
+is mechanical: grep your results artifacts for a number that came from a configuration you
+constructed rather than sampled. If there is none, the model was scored and never used.
+
+Verifying that a checkpoint reloads is not querying it. A reload check confirms a file. It produces
+no physics.
+
+## 1. Build configurations that exist in no split
+
+A random test split is a sample of the same distribution the training data came from, so it can only
+tell you how well the fit interpolates its own sampling. The results people compare against are
+statements about a coordinate: where the minimum sits, how the interaction decays, how far apart two
+states are.
+
+Construct the grid yourself. Freeze the internal geometry and translate one fragment; stretch one
+bond symmetrically; scan the one degree of freedom the brief's data description says the
+configurations vary in. Twenty to sixty points is enough. Evaluating a trained model on sixty
+geometries is inference — minutes against the hours the training cost — and it is the only step here
+that needs no new data.
+
+## 2. Take the grid past the edge of the training data
+
+Find the range of the coordinate that your training configurations actually cover, and extend the
+scan beyond it on at least one side. Draw that edge as a vertical line on the figure and report the
+error inside and outside it separately.
+
+Nearly every claim worth making about this class of model is a claim about the far side of some
+boundary — the sampled range, a cutoff, a receptive field, an interaction radius. A grid that stops
+where the training data stops cannot express any of them, and a reader cannot tell from the figure
+whether you tested extrapolation or avoided it.
+
+## 3. One curve per discrete condition, on one pair of axes
+
+When the study contrasts a discrete condition — charge state, phase, protonation, spin state,
+solvent, isotope — the usual output is one aggregate error per condition, side by side. That reports
+how well each was fitted. It does not report the thing the experiment exists to show, which is the
+*difference between the conditions* as a function of the coordinate.
+
+Put both curves on the same axes. Then state their separation as a number with a unit, at the
+coordinate value where it means something: at the minimum, at the crossing, in the asymptote. If the
+condition enters your model as an input rather than as a separate fit, this scan is the only evidence
+that the input did anything at all — per-condition error tables are equally consistent with the model
+ignoring it.
+
+## 4. Substitute for one supplied system, audit all of them
+
+Tasks that ship data usually ship several systems. It is common to discover that one shipped file is
+a surrogate — wrong species, frames duplicated across conditions, no label for the quantity the
+experiment is about, values in code units — and to mirror the source's deposited data for that one,
+while the others stay on whatever arrived. The system left behind loses everything downstream of it,
+and the loss is invisible because the rest of the study looks authentic.
+
+Before training, write one line per supplied system: what the task says it is, what the file actually
+contains (species, net charge, frame count, label units, duplicate frames), and which file the study
+will use. Decide substitute-or-not the same way for every row, in one sitting.
+`train-the-named-architecture` covers the other half of this — a degenerate file is audited and then
+trained on, not skipped.
+
+## Checklist
+
+- [ ] Every checkpoint has been evaluated on at least one configuration set that appears in no split.
+- [ ] Each scan crosses the edge of the training range, and that edge is marked on the figure.
+- [ ] Each discrete condition has its own curve on shared axes, and their separation is stated as a
+      number with a unit.
+- [ ] Every supplied system has an audit line, and one decision rule covered all of them.
+- [ ] No named experiment's only output is an aggregate over its own random split.

--- a/src/skills/read-the-pilot-run-as-a-result/SKILL.md
+++ b/src/skills/read-the-pilot-run-as-a-result/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: read-the-pilot-run-as-a-result
+description: Use at implementation and experimentation, when a reduced-scale or smoke run of the full pipeline finishes and before the compute budget is committed to the full run. Covers adjudicating the pilot's gap against the target instead of its exit code, reading the exclusions recorded beside the gap as its likely cause, testing whether a substituted input carries the contrast the headline statistic differentiates, and which input to change while changing one is still affordable.
+stages: 04_implementation, 05_experimentation
+---
+
+# A pilot run returns a number. Read it.
+
+A reduced-scale run — a smoke slice, one seed, a handful of files instead of the
+full set — gets checked for two things: exit code and artifact count.
+"exit 0, N/N artifacts present" goes into the stage record, the full run is
+launched, and the headline is looked at for the first time hours later, with the
+budget gone.
+
+The number was usually already there. In the runs where this loses, the pilot
+artifact is not silent: it holds the headline value, the target recovered at the
+literature stage, and the signed gap between them, in the same file. The defect
+is not that the pilot went unmeasured. It is that no step in the run was obliged
+to read the gap and decide something. A pilot that reports its own shortfall and
+is filed as a build check is worse than one that reports nothing, because the run
+now has evidence it did not act on.
+
+## What a pilot bounds, and what it does not
+
+It bounds the **sign** of the gap, its rough **order**, and **which classes your
+pipeline can populate at all**. Those are stable under scale.
+
+It does not bound the **size** of the gap. A tenth of the data can move an
+extreme class by a factor of several once the full sample arrives, so a shortfall
+that reads as catastrophic at pilot scale can settle to merely large. Do not
+quote the pilot's magnitude as an estimate, and do not dismiss a pilot gap
+because you expect scale to close it — decide which of the two you are relying
+on, and write it down.
+
+## Make the pilot a gate
+
+Before you open the pilot output, write one line: the tolerance, in the
+headline's units, inside which the full run is worth launching. If study design
+froze one, use that.
+
+> If the pilot gap exceeds the tolerance, the full run does not launch until one
+> of two things is recorded in the pilot artifact itself: **an input change
+> chosen**, or **the gap attributed by a measurement** naming the property that
+> carries it. "Noted, proceeding" is neither.
+
+Record the decision in the artifact rather than the stage summary. You will need
+it at analysis whether the gap closed or not, and the artifact is what survives.
+
+## Join the gap to the exclusions sitting beside it
+
+The file that reports the shortfall very often reports, a few lines away, what
+the pilot quietly dropped: a field called `excluded`, `skipped`, `incomplete`,
+`n_missing`, `insufficient`, or a member whose file count is zero. The two facts
+are adjacent on disk and nothing joins them unless you write the join.
+
+For every entity excluded for an incompleteness reason, write one line: what
+completing it would cost, and what it would change. An exclusion applied on the
+arm the headline is computed from is not housekeeping — it chose the population
+of your result, and whatever happened to download chose it for you.
+
+## Contrast, not level — and per member
+
+A reproduction almost always runs on a substituted driver: a different product,
+resolution, release, model pool or proxy for the one the source used. Substitutes
+are chosen by matching **levels** — units right, magnitudes plausible, pattern
+like the published one. But the headline of a reproduction is usually a
+**difference**: a change between periods, a ratio between conditions, an
+exceedance over a baseline. A product can match on levels and carry almost none
+of the contrast, and nothing about opening the file tells you so. Only running
+the source's own statistic on it does.
+
+Measure the input-side contrast directly — the between-condition ratio or
+difference of the raw driver, over exactly the rows that enter the statistic —
+and put it beside the same contrast in the source's released field, or in a
+number the literature reports. **Run it per member, realisation or model, not
+once over the pool.** A pooled contrast hides an arm carried by a single member,
+and a pool of one has that member's contrast, not the ensemble's.
+
+Two more checks, minutes each:
+
+- **Reachability.** For each class the published result populates, ask whether
+  your pipeline can reach it at all: quantisation step against threshold, floor
+  against smallest non-zero value, denominator range against numerator range. A
+  class empty in the pilot is usually unreachable, not undersampled.
+- **A positive control.** Feed the pipeline an input that must fire — the
+  source's released field over whatever subset overlaps yours, or a synthetic
+  case built to cross the threshold. If it does not fire, the defect is in your
+  code and the substitution is exonerated. Do this before blaming the data.
+
+## Changing the input, in order of preference
+
+1. **Another member, model, realisation or release from the same archive** —
+   especially when the arm that matters was built from one and the archive holds
+   more. Cheapest fix available and the one most often skipped, because a pool
+   counted across all conditions looks adequate while the condition carrying the
+   headline has one member in it. Count the pool *within* that condition.
+2. The variable or product the source's own released code reads, if fetchable.
+3. A normalisation or calibration that restores the contrast, declared as an
+   assumption and swept in the sensitivity analysis.
+4. The supplied data plus a published scaling relation, as a stated
+   approximation.
+5. The source's released field over its overlapping subset as a calibration arm,
+   which at least bounds the deficit and localises it.
+
+## Checklist
+
+- [ ] Tolerance written down before the pilot output is opened.
+- [ ] Pilot gap adjudicated — input change chosen, or gap attributed by
+      measurement — and recorded in the artifact.
+- [ ] Every exclusion in the pilot artifact costed in one line.
+- [ ] Input-side contrast measured per member and compared with the source's.
+- [ ] Class histogram printed beside the published one; empty classes tested for
+      reachability.
+- [ ] Positive control fires.
+- [ ] The pilot comparison appears in the report as evidence the check was made.
+
+`close-the-gap-to-the-published-number` is this same rule one stage later, when
+the gap is full-scale and the budget is short. Arriving there with the pilot
+unadjudicated is arriving at the expensive version of this page.

--- a/src/skills/rebuild-the-sources-headline-table-row-for-row/SKILL.md
+++ b/src/skills/rebuild-the-sources-headline-table-row-for-row/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: rebuild-the-sources-headline-table-row-for-row
+description: Use at literature survey when the source's central result is a table of many benchmarks crossed with many methods, at study design to fix the row and column set and budget any data the supplied archive does not ship, and at analysis to render it. Covers transcribing the published table as the target skeleton, where the missing rows come from, shipping a table-shaped exhibit rather than a chart over the subset you ran, and marking cells you could not fill.
+stages: 01_literature_survey, 03_study_design, 06_analysis
+---
+
+# The source's headline table is a graded exhibit: rebuild it row for row
+
+Many papers put their central claim in one table: every benchmark the study ran
+down the rows, every method it compares across the columns, one value per cell
+with its dispersion. That table is the object a reader lays beside your work.
+
+The reproduction that loses runs a subset of the rows, a subset of the columns,
+and then draws a grouped bar chart of whatever it managed. Read next to the
+source's table, that chart answers nothing. The reader cannot find the row they
+care about, cannot see the method pair the claim is about, and cannot tell a cell
+you ran out of time for from a cell you never considered. The work behind the
+chart may be sound and the exhibit still registers as absent.
+
+## 1. Transcribe the published table at literature stage
+
+Write `notes/source_tables.json`, one entry per table the task points at:
+
+- the exact row labels in the source's order, and the exact column labels, in the
+  source's own names rather than your renaming;
+- every published cell value with its dispersion and units;
+- which column is the proposed method, which is the conventional counterpart it is
+  compared against, and how the source pairs them;
+- the caption's protocol: split, number of repeats, model-selection rule.
+
+Read this off the rendered table in the results section. A table quoted in an
+abstract, a summary paragraph or an older preprint routinely carries fewer rows
+and fewer columns than the published one.
+
+That transcription is now two things at once: the skeleton of your results table,
+and the cell list your campaign has to cover. Both are defined by the source, not
+by what happens to be in the supplied folder.
+
+## 2. Count the rows the archive does not ship
+
+The supplied data folder is an input, not the row set. Diff the source's row
+labels against the files you were handed. For every row with no file: find it in
+the authors' release, in the benchmark suite the source names, or in the standard
+public distribution, and budget the download and preprocessing at design time,
+before any analysis code exists. These rows are usually the cheapest cells in the
+grid, because the featuriser already exists.
+
+A row that was one download away is the most expensive kind of absence: the reader
+sees a short table and cannot tell availability from choice.
+
+If a row genuinely cannot be obtained, it still appears, carrying the published
+values and a marker saying it was not reproduced and why. Do not shorten the
+table to the rows you have. `earth-comparator-set-lives-outside-the-supplied-archive`
+makes this argument for comparator methods; here it applies to the rows.
+
+## 3. The column set is the source's method list
+
+Columns are the method families whose difference the claim is about: the proposed
+method and its conventional counterpart, once per backbone or base family. A
+column that profiles more expensive per run than the others is still a column, and
+it runs at pass-1 fidelity like everything else.
+
+Never ship an exhibit with a header, legend entry or hatched slot for a method
+that produced no number. Either it has a value at whatever fidelity you could
+afford, or the cell carries the published value marked as not reproduced, with one
+sentence saying why. A labelled empty slot reads as a run that mistook an
+intention for a result.
+
+## 4. Ship it as a table, in the source's shape
+
+- Same row order, same column order, same labels.
+- Each cell carries **both** numbers: your value with its dispersion and the n it
+  came from, and the published value beside or beneath it.
+- Each cell carries a provenance marker: reproduced at your fidelity, reduced-N,
+  published only, or not run.
+- Render it as a raster image under `report/images/` in addition to printing it in
+  the body. When the source's exhibit is a table, the table is graded as a
+  picture, and a markdown table inside the prose is not one.
+- Generate it with a script from your results file so it cannot drift.
+
+A chart over the subset you ran can sit beside it. It cannot replace it.
+`draw-the-source-figure-panel-for-panel` covers giving every source *figure* a
+panel; the inversion here is that when the source's result is a table, a chart is
+not a substitute for the table.
+
+## 5. Order the prose the way the table reads
+
+Go cell by cell and write the per-row verdict: does the sign of the source's
+difference reproduce, and does the magnitude fall inside your interval. Group the
+cells where it reproduces and state them first, then the cells where it does not,
+with the evidence.
+
+This is sequencing, not softening. A results section whose every heading is a way
+the published claim fails leaves the reader unable to establish whether the
+phenomenon appeared at all, even when the same numbers in the other order would
+show that it did in some cells. Where a cell disagrees, `close-the-gap-to-the-published-number`
+applies before you write it up as a finding.
+
+## Checklist
+
+- [ ] `notes/source_tables.json` exists with the full row and column labels and
+      every published cell value.
+- [ ] Rows the archive does not ship are listed with an acquisition path and a
+      fetch budget, at design time, not in Limitations.
+- [ ] The campaign's cell list equals rows x columns of the transcribed table.
+- [ ] Every cell of the shipped exhibit has a value and a provenance marker; no
+      blank labelled slots anywhere in table or figure.
+- [ ] Published and reproduced values appear in the same cell.
+- [ ] The exhibit exists as a rendered image, generated by script.
+- [ ] Every row has a one-line verdict in the prose, reproducing cells first.
+
+Related: `information-fill-the-whole-results-grid` for the completeness argument,
+and `price-the-grid-in-wall-clock-and-fill-it-breadth-first` for affording the
+cells. What is here and not there: the row and column set comes from the source's
+published table including rows the archive omits, and the exhibit is shipped in
+the table's own shape.

--- a/src/skills/reconstruct-the-figure-layer-you-cannot-source/SKILL.md
+++ b/src/skills/reconstruct-the-figure-layer-you-cannot-source/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: reconstruct-the-figure-layer-you-cannot-source
+description: Use at study design and implementation when a figure you are reproducing carries a component whose exact inputs are not in the supplied data - points drawn over an aggregate, per-unit traces, a second method's series, a band, an inset. Covers enumerating a published figure's layers when you cannot see the rendering, deciding between omitting a layer and building a labelled reconstruction from the coarser quantity you already hold, and the three conditions that make a reconstruction evidence rather than decoration.
+stages: 03_study_design, 04_implementation, 06_analysis
+---
+
+# A layer renders a quantity. Ask which quantity, not which dataset.
+
+A figure you are reproducing is built from layers: a filled area or a bar, marks
+drawn over it, a fitted line, an uncertainty band, an inset, a second method's
+series. Each layer needs inputs. When one layer's exact inputs are not in the
+supplied data, the cheap move is to drop that layer and write a sentence saying
+why. That sentence costs you the requirement the layer belongs to, and it is
+usually avoidable — because a layer is not the data the original authors held.
+It is a *rendering of a quantity*, and the quantity is often already on your
+disk at a coarser resolution.
+
+This is the layer-level complement to `draw-the-source-figure-panel-for-panel`.
+That skill decides which result owns a panel; this one decides what goes inside
+a panel you have already committed to drawing.
+
+## The failure this prevents
+
+A run reproducing a published figure whose aggregate marks each carry one dot
+per contributing record found that the record-level positions had come from an
+input channel the release does not contain. It recorded "not reproducible" in
+its design ledger, repeated it in its implementation ledger, painted it into the
+figure's axes as a block of text, and repeated it in the caption. It shipped the
+aggregate without the dots and was graded well below par on that requirement —
+below a plainer comparator that shipped exactly the same single layer and never
+mentioned the missing one.
+
+Neither run held the record-level inputs. But the dots encode only that a larger
+aggregate is made of more records, and the per-category counts were sitting in
+the losing run's own results file, the same file the aggregate heights were read
+from. Placing n dots inside a category is not a guess about which record is
+which; it is the standard rendering of a count, and dots of that kind carried no
+per-record information in the source either.
+
+## Enumerate the layers before you decide anything
+
+Work from the rendered figure when you can get it: fetch the source from its
+DOI, its repository or a preprint mirror and look at the panel. When you cannot
+— the workspace ships no rendering and the fetch fails — the source's own
+caption and the sentence that introduces the figure are the enumeration. **Every
+visual noun they name is a layer you owe**: the fill, the markers, the trend
+line, the band, the inset, the secondary axis. A caption naming three visual
+elements against a panel of yours drawing two is a missing layer, whether or not
+you ever saw the picture.
+
+Do not take the authors' released plotting script as the enumeration. It emits
+what that script emits; see `verify-against-the-publication-not-the-authors-code`.
+
+## Ask what the layer encodes
+
+For each layer whose inputs you lack, write two things down: the finest claim
+that layer can support in the source, and the coarsest quantity you already hold
+that carries that claim.
+
+| layer | inputs the source had | what it encodes | what you probably hold |
+| --- | --- | --- | --- |
+| one mark per record over an aggregate | per-record positions | how many records the aggregate is made of | the count itself |
+| per-subject traces behind a group mean | subject-level series | spread within the group | the group mean and an observed dispersion |
+| per-unit points along a curve | per-unit measurements | where units sit on the axis | each unit's bin |
+| a comparison method's series | that method's outputs | ordering and offset against yours | the published values, transcribed |
+| an uncertainty band | the full sampling distribution | how wide the estimate is | an interval you can compute |
+
+If the two right-hand columns name the same quantity, the layer is
+reconstructable and you build it. The input you lack was never the input the
+layer's message rested on.
+
+## Three conditions that make a reconstruction evidence
+
+1. **Deterministic and sourced.** Positions or values are a function of a
+   quantity you measured plus a seed fixed in the code, and the drawing script
+   reads the same results artifact the rest of the figure reads. Never sample
+   from a distribution the run did not measure.
+2. **Named as a construction, in one clause, in the caption.** "One dot per two
+   records, placed at random within each category; dot positions carry no
+   within-category information." That is a caption clause. It is not a block of
+   text inside the axes — see `disclose-by-construction-not-by-absence`.
+3. **Unable to support a finer claim than its input.** Nothing is measured on
+   the reconstructed layer, no individual mark is annotated, and no sentence in
+   Results reads a pattern off it. Write that sentence down explicitly. If you
+   cannot write it, the layer is not reconstructable.
+
+## When to refuse, and how
+
+If the layer's whole content is the information you lack — a measured field at a
+resolution you do not have, an arm nobody ran — omit it. Then it costs one
+sentence where the result would have gone: not a heading, not text inside the
+axes, not a clause in the abstract, not a second pass in the caption. Price the
+refusal at design time and record the single input that would have changed it.
+
+## Checklist, at study design
+
+- For every figure you intend to lay beside a published one, list its layers,
+  one row each, with the input each needs and whether you hold it.
+- For every row you do not hold, fill in the encoded-quantity table above.
+- Mark each such row `reconstruct` or `refuse`, with its reason, in the plan. A
+  row left unmarked becomes a refusal by default, which is how most refusals
+  happen.
+- `reconstruct` rows are built by the same script that draws the layer they sit
+  under, and pass all three conditions.
+- Before writing, count your panel's layers against the enumeration you built
+  above — from the rendering if you have it, from the caption's visual nouns if
+  you do not. A difference that is not on the refuse list is a defect, not a
+  choice.

--- a/src/skills/record-what-you-learned/SKILL.md
+++ b/src/skills/record-what-you-learned/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: record-what-you-learned
 description: Use when a run is finished and the report is written, after the report is written, to record one reusable lesson for the next run in this field. Covers what counts as a lesson worth passing on, what must never be passed on, and how to write it.
+stages: 07_writing
 ---
 
 # Leave one note for the next run in this field

--- a/src/skills/reproduce-then-extend/SKILL.md
+++ b/src/skills/reproduce-then-extend/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reproduce-then-extend
 description: Use when the task is to reproduce, replicate or re-implement a published study, at design time and when reporting results. Covers what a reproduction must report, how to compare against the source study's numbers, and why the reproduction comes before any improvement.
+stages: 01_literature_survey, 03_study_design, 07_writing
 ---
 
 # A reproduction is judged against the study it reproduces

--- a/src/skills/reproducibility-check/SKILL.md
+++ b/src/skills/reproducibility-check/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reproducibility-check
 description: Use in Stage 08 (Dissemination) when assembling the release or submission bundle — auditing whether the run's code, data, results and figures are actually reproducible by someone else, writing the readiness checklist and threats-to-validity notes, or deciding what has to be disclosed as not verified.
+stages: 06_analysis, 07_writing
 ---
 
 # Reproducibility check

--- a/src/skills/result-table/SKILL.md
+++ b/src/skills/result-table/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: result-table
 description: Use when turning measured results into a table or figure for the paper — building a LaTeX or markdown results table from workspace/results/*.json, deciding what uncertainty to report, choosing which baselines and ablations belong in the main table, or writing a caption that stands alone.
+stages: 03_study_design, 06_analysis, 07_writing
 ---
 
 # Results tables

--- a/src/skills/run-the-conditions-the-source-ran/SKILL.md
+++ b/src/skills/run-the-conditions-the-source-ran/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: run-the-conditions-the-source-ran
 description: Use at study design, before any experiment of your own is costed, on reproduction and method-evaluation tasks. Covers enumerating the systems, scenarios, stress sweeps and case studies the source names, running each one by name, measuring the preconditions the method declares it needs, and what to do when one of them fails.
+stages: 01_literature_survey, 03_study_design, 05_experimentation
 ---
 
 # The source's own systems, scenarios and stress tests are your experiment list

--- a/src/skills/run-the-requested-analysis/SKILL.md
+++ b/src/skills/run-the-requested-analysis/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: run-the-requested-analysis
 description: Use when the supplied data looks synthetic, degraded, incomplete or wrong, and whenever you are tempted to reframe the study around what you found about the inputs, the harness or the evaluation. Covers what to do with a real data problem without losing the study.
+stages: 01_literature_survey, 03_study_design, 05_experimentation
 ---
 
 # A problem with the inputs is a finding to add, not a study to replace

--- a/src/skills/the-axis-carries-the-observable-not-the-verdict/SKILL.md
+++ b/src/skills/the-axis-carries-the-observable-not-the-verdict/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: the-axis-carries-the-observable-not-the-verdict
+description: Use when drafting the figure list at study design, when the plotting code is written, and again before writing — especially if figure slots are being assigned from preregistered hypotheses, decision rules or agreement checks. Covers what may occupy a panel's axes, where verdicts and intervals belong instead, and a one-minute test that sorts a figure set into observable and audit.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Cover the caption and read the axis labels
+
+A panel earns its place by putting a quantity of the *system* on each axis. When
+a figure slot is filled from the hypothesis it settles rather than from the
+result it shows, the axes drift to the machinery of the verdict, and the panel
+stops being readable as a result at all.
+
+This is the axis-level test that sits under two skills you should already be
+running. `the-canonical-figure` decides which figures a paper of this kind must
+contain; `draw-the-source-figure-panel-for-panel` decides which result owns a
+slot and tells you to print the source's named constants on the panel. Neither
+catches the case handled here: a panel that is being drawn, is nominally about
+the right result, and has your run's own verdict on one of its axes. It applies
+to panels with no source counterpart as well as to reproductions.
+
+## The test
+
+Cover the title, the caption and the legend. Read the two axis labels.
+
+**Observable axes** name things that would exist if nobody had run a study: a
+length, an energy, a temperature, a rate, a count, a composition, a
+concentration, a size ratio, a class label, a step index.
+
+**Audit axes** name things that exist only because you ran one: absolute error,
+|residual|, fraction reproduced, cases a rule predicted correctly, points inside
+tolerance, a score, a decision band, an interval width, a labelling margin, or a
+row index in whatever order your reference table happened to be in.
+
+Both are legitimate panels. But a named output of the task must be carried by a
+panel with observable axes. If the only panel that touches a quantity has that
+quantity's *error* on the y-axis, the quantity has not been shown — it has been
+graded.
+
+## What goes wrong
+
+A run with a strong preregistration binds each figure slot to a distinct
+hypothesis and writes the slot's purpose as the question it settles. By the end,
+every panel in the report plots a property of the run's own inference: a
+fraction with a confidence interval against a preregistered decision band,
+|residual| against index in the reference table's order, the number of cases each
+rule got right, a histogram of the margin a categorical label was assigned on,
+the signed deviation of measurement from prediction. Each is a sound and honest
+panel about the run. Not one puts a studied quantity on an axis with a number a
+reader can take away.
+
+The tell is in the run's own figure manifest. A slot whose declared purpose is
+what the values of some quantity are, across the families the theory defines,
+records its evidence as a count of published values checked and a residual panel
+covering all of them. The slot asks what the values *are*; the accounting answers
+how many were *checked*.
+
+## What to produce
+
+**Stage 03, before any plotting code.** For each figure slot, write the literal x
+and y axis labels with units into the report plan, and tag each axis `observable`
+or `audit`. A slot that is the only home of a named output and carries an audit
+axis is rejected and rewritten there and then, not at Stage 07 when the code
+exists and the panel looks finished.
+
+**One panel per named output whose axes are the quantity and the variable it
+depends on.** Where you are comparing against a published or supplied value, the
+comparison belongs on those same axes — as an overlaid marker or a labelled line
+at the predicted level, annotated with its numeral — not converted into a
+residual that spends an axis on error.
+
+**Print your own landmark values on the canvas.** For every curve or family a
+reader would quote one number from, annotate that number as text at the point.
+Someone who reads only your figures should be able to state the value.
+
+**Log axes hide landmarks.** A family of curves over a decade, unannotated,
+answers "which is bigger" and nothing else. If the reader's question is what the
+value is at a particular operating point, annotate that point or add a linear
+inset around it.
+
+**Verdicts, confidence intervals, tolerance bands and decision rules go in the
+caption**, or into one clearly separate audit figure at the end. The caption is
+the right home for N, the interval, and whether the criterion was met. It is not
+the right home for the value.
+
+## Before you finish
+
+List every panel you are shipping in two columns, observable and audit, keyed by
+its axis labels rather than by its title. Every named output of the task should
+appear in the observable column. If the audit column is longer, the figure set is
+about the run rather than about the system, and it will not be recognised as the
+result it is.

--- a/src/skills/the-canonical-figure/SKILL.md
+++ b/src/skills/the-canonical-figure/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: the-canonical-figure
 description: Use when planning figures, at study design and again before writing. Covers the figures a paper in this field is expected to contain, why an original figure does not substitute for a standard one, and how to decide what to draw first.
+stages: 03_study_design, 04_implementation, 06_analysis
 ---
 
 # Draw the field's standard figure before your own

--- a/src/skills/the-expected-negatives-are-the-discrimination/SKILL.md
+++ b/src/skills/the-expected-negatives-are-the-discrimination/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: the-expected-negatives-are-the-discrimination
+description: Use at study design when a per-unit metric's population is being chosen, and again at analysis and writing. Extends the per-unit publication clause of neuroscience-comparator-ladder-and-per-unit-predictions with the arm it omits: the units your sources expect to be null, the worst-positive-versus-best-negative separation number, and the rule that a shipped eligibility attribute is a reporting label and never a computation filter.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# Score the units your sources expect to be null
+
+This is the missing third arm of the per-unit publication clause in
+`neuroscience-comparator-ladder-and-per-unit-predictions`. That skill splits a
+per-unit result two ways -- units an independent measurement validates, reported
+as agreement k of n, and units where the model issues a novel prediction. The
+split has a third population and a statistic, and without them the two-way
+version can be executed in full and still leave the analysis unreadable.
+
+## The third population
+
+Every per-unit metric has three kinds of unit:
+
+- **known positive** -- an independent measurement says the effect is there;
+- **known negative** -- an independent measurement says it is *not*, and this is
+  the arm that usually goes missing;
+- **unknown** -- nobody has measured it, and this is where your predictions are.
+
+The negatives are the discrimination. A metric evaluated only where the effect
+is expected cannot fail: a model that finds the effect in every right unit and
+also in fifteen wrong ones scores identically to one that got it right. Run the
+negatives and you can write the threshold-free claim that actually settles it --
+*the worst known positive scores above the best known negative* -- which is a
+number, needs no imported cutoff, and survives a reader who disagrees with your
+index definition. Miss them and the best you can say is a count at a threshold.
+
+The negatives are also the cheapest rows you will ever compute. Where the metric
+is a reduction over an array the simulation already produced, they cost one
+more pass over memory you have already paid for.
+
+## The trap: a shipped boolean looks like a roster
+
+Supplied data arrives with an entity list and, alongside it, attribute columns:
+an eligibility flag, a structural property, a curation status, a "characterised"
+boolean. A subset selected by one of those columns looks like the roster. It is
+in the data, someone curated it, and it comes with a one-sentence justification
+that is defensible on the day you write it -- *only units with this property can
+show the effect*.
+
+It is not the roster. The roster is every row of the entity list. A subset
+selected by a shipped attribute is a *hypothesis* about which units matter, and
+testing that hypothesis requires the units it excludes. When you write the
+filter, write it as a label on the output, never as a predicate that decides
+what gets computed.
+
+## Filter for reporting, never for computation
+
+The filter rarely bites where it is written. It bites two stages later, at the
+figure and the published table:
+
+- the figure plots the eligible subset, so the population a reader sees is the
+  one your mechanism argument already believed in;
+- the published table carries an `eligible = no` column and a **blank** value
+  cell for every excluded unit -- while the value sits computed on disk.
+
+A blank cell reads as *not measured*. Never publish one for a quantity you
+computed. Publish the value, and put the eligibility flag in its own column so a
+reader can re-filter and you can be argued with.
+
+Every entity your sources name individually gets a row, including the ones that
+come back null. A confirmed null on a named entity is a result; an absent row is
+read as the analysis not having been done, however careful the rows around it.
+
+## What to produce
+
+At **analysis**, one figure, one axis, one scale, three colours: known positive,
+known negative, unknown-and-ranked. Not three panels -- the comparison is the
+point.
+
+In its caption, as numbers:
+
+- worst known positive against best known negative, and how many pairs invert;
+- how many unknowns score above the worst known positive, each named;
+- for each named prediction, the fraction of replicates, seeds or ensemble
+  members that agree with it, so a reader can tell a prediction from a coin flip.
+
+## The sentence that turns a ranking into a hypothesis
+
+A ranked list is not yet a claim, and a name that appears only inside a
+threshold sentence has not been claimed. Say in the prose, as a sentence about
+the units and not about your cutoff, which unknowns the model asserts the effect
+for. Then say what they have in common in the *supplied structure* -- what they
+connect to, what they are made of, where they sit relative to the known
+positives -- and check that reading against the supplied structure data rather
+than asserting it. That account is what an experimentalist acts on, and it is
+the difference between a table and a result.
+
+## Checklist
+
+- [ ] Expected label -- positive, negative, unknown -- and its source recorded for every row of the supplied entity list.
+- [ ] No shipped attribute or plausibility predicate decides what gets computed; filters are output labels only.
+- [ ] Metric computed for every row, including expected negatives and unnamed units.
+- [ ] One panel, one axis, three colours; no blank value cell anywhere a value exists on disk.
+- [ ] Worst-positive versus best-negative stated as a number in the caption.
+- [ ] Every entity the sources name individually has a row, nulls included.
+- [ ] Predicted units named in prose with per-replicate agreement, not only plotted.
+- [ ] A structural account of the predicted units, checked against the supplied structure data.

--- a/src/skills/the-figure-plan-is-a-purchase-order/SKILL.md
+++ b/src/skills/the-figure-plan-is-a-purchase-order/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: the-figure-plan-is-a-purchase-order
+description: Use at study design when the figure or panel plan is written, at implementation, and at experimentation when compute is being allocated. Covers writing each planned panel as a row naming the file and column it will be drawn from, pricing and buying the producing steps before the robustness machinery, and taking each panel's axis from the language the task states its own decision rule in.
+stages: 03_study_design, 04_implementation, 05_experimentation
+---
+
+# Every planned panel names the file it will be drawn from
+
+A figure plan written at design time gets executed almost literally. The writing stage draws the
+slots that are in the plan, in the order they are in the plan, and it does not add new ones —
+there is no time and, by then, usually no data. So a list of panel titles written before any
+result exists is not a sketch. It is the set of results the study is able to have.
+
+Two things go wrong in that list, and both are invisible until it is too late to fix them:
+
+1. **A panel is planned whose source data no step of the run will ever produce.** At writing time
+   this is not a panel that gets skipped. It is unrecoverable: the compute is spent, the stage has
+   a wall clock, and re-running the thing that would have produced it is now a different run from
+   the one being reported.
+2. **A panel is planned on the wrong axis.** The choice is frozen before any number exists, and
+   nobody re-reads the plan, so the run ships a figure that answers a neighbouring question and
+   looks close enough to the right one that nothing internal flags it.
+
+## A plan row is not a title
+
+A list of eleven evocative slot names is not a plan. Each row of the plan gets six fields, and
+you can fill all six before you have any results:
+
+| panel | question from the brief it answers | x axis / y axis, with units | file + column the values come from | step that writes that file | does it exist yet / what it costs |
+|---|---|---|---|---|---|
+
+The fourth and fifth fields are the load-bearing ones. "The analysis will produce it" is not a
+step. If you cannot name the file and the column, you have written an intention.
+
+## The axis comes from the language the task states its decision rule in
+
+Most briefs state their own operating rule somewhere: keep everything above a score or probability
+cut, take the top N, accept inside a tolerance, select above a property threshold. Whatever
+variable that rule is written in is the x axis of the panel that reports its yield.
+
+- Sweep the rule's own parameter across its range; do not report the single operating point.
+- Draw the stated operating point as a marked line on that axis.
+- Draw the trivial reference on the same panel — the pool's base rate, the level implied by class
+  balance, what a random or constant selection returns — and give the ratio to it.
+
+A curve over rank or selection size answers a neighbouring question and can look almost identical
+to a curve over the rule's own variable. Only one of them is the rule you were handed. The same
+applies to the metric vocabulary: every quantity the brief names in its own words has to appear
+among the reported numbers, in those words. A separation, ranking or significance statistic
+supplied in place of the plainly named quantity reads as the named quantity never having been
+measured — report yours as well, after.
+
+(`chemistry-canonical-units-thresholds-incumbent` and `material-landmark-scalars-in-physical-units`
+cover reporting in the field's unit and turning an error distribution into a threshold success
+rate. What is here is the axis of the panel, and the plan row that fixes it before any result
+exists.)
+
+## A row whose file does not exist yet is a purchase
+
+For every row where the source file is not already on disk, name the step that will write it and
+price the step: time one unit, multiply, write the number in the row. Two things fall out of
+doing this at design time rather than at writing time.
+
+**Some panels have no writer at all.** The conventional diagnostics of anything iterative or
+trained — an objective or a held-out metric indexed by step or epoch — exist only if something
+writes them while the loop runs. The plan is where you discover that no step in the pipeline does.
+(`the-canonical-figure` and `train-the-named-architecture` cover persisting the trace itself; this
+is the check that catches its absence while the run can still act on it.)
+
+**The price is usually trivial and gets treated as though it were not.** One instrumented
+reference run, measured in seconds, sits inside a robustness budget measured in core-hours. Until
+both numbers are written down next to each other, the cheap one keeps losing to the expensive one
+by default.
+
+## Order the spend: deliverable panels before robustness machinery
+
+Permutation nulls, bootstrap replicates, positive-control ladders, extra seeds, ablation grids and
+hyperparameter sweeps all consume budget, and all of them feel like rigour. They are rigour applied
+*to a result*. Buy every producing step in the figure plan first — including the diagnostic
+re-runs that exist only to fill a panel — and spend what is left on the machinery.
+
+A run that ships thousands of null replicates and cannot draw its own primary panel has bought
+error bars for a result it never displayed.
+
+## Re-audit the plan while the buy-back window is open
+
+At the end of implementation, and again before the last long job launches, walk the rows and
+actually open the file each one names. For every row whose file is missing, or exists without the
+column:
+
+- buy the producing step now, while there is still compute; or
+- strike the row, and record in the plan what replaced it.
+
+Doing this after the final analysis is bookkeeping. Doing it while jobs can still be launched is
+the only point at which a missing panel is still a scheduling problem rather than a missing result.
+
+## The plan is a floor, not a ceiling
+
+Results you did not anticipate deserve slots; add them. The failure this guards against is
+subtraction by silence — a slot that quietly produces nothing and is never mentioned. If a panel
+cannot be drawn, say so in one sentence where it would have gone, rather than leaving the reader
+to notice the gap.
+
+## Checklist
+
+- [ ] Every planned panel is a row with question, axes, file, column, producing step and cost.
+- [ ] Any panel reporting a selection or decision rule is on the axis the rule is stated in, with
+      the operating point marked and the trivial reference drawn.
+- [ ] Every quantity the brief names in its own words appears among the reported numbers.
+- [ ] No row's source is "the analysis will produce it" with no named step.
+- [ ] Producing steps are scheduled ahead of nulls, replicates, ladders and sweeps.
+- [ ] The plan was re-opened at the end of implementation and every row's file was loaded.
+- [ ] Rows that cannot be filled are struck explicitly and answered in one sentence in the text.

--- a/src/skills/the-firing-instance-gets-the-full-record/SKILL.md
+++ b/src/skills/the-firing-instance-gets-the-full-record/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: the-firing-instance-gets-the-full-record
+description: Use at study design, and again at analysis and writing, when the supplied instance comes back at background — no match, near-zero score, one part matched out of many — and the run is turning into a careful demonstration that nothing happened. Covers the equal-depth artifact rule for the instance where the method does fire, the ordering against the graded item, the four-rung ladder in one paragraph, and measuring rather than inferring the mechanism behind the negative.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# The instance where the method fires gets the full record
+
+## What goes wrong
+
+The supplied inputs come back at background — no match, a near-zero score, an
+empty result file, one part matched out of many — and the run does the honest
+thing. It builds a null distribution, places the supplied instance in it, and
+writes a careful section explaining that the negative is the correct answer.
+
+That is usually right, and it is not the failure. The failure is what happens to
+the *other* instances. Almost every run in this situation does run a positive
+case; it is cheap and obvious. The positive then reaches the report as one
+clause in a methods paragraph and one row in an appendix summary table, while
+the negative gets a results section, a figure and its own appendix. Every
+property the task asked about — a correspondence over many parts, per-part
+solutions that agree with each other, detection at the edge of a detectability
+regime, a cost advantage on a real workload — is observable *only* where the
+method fires, and the run's one firing instance was compressed to a single line.
+
+The gap this closes is reporting depth, not whether controls exist. Diagnose it
+by counting: how many characters of the report describe the negative, how many
+describe the case where the method worked.
+
+## What to produce
+
+### 1. The equal-depth rule, as an artifact rule
+
+Whatever artifact the supplied instance gets, every other instance you ran gets
+the identical artifact: same table, same columns, same per-part rows, same
+transforms, same auxiliary statistics, same cost line, in the results section.
+An appendix row does not discharge it, and neither does a summary figure.
+
+Make it mechanical. Before writing, list the artifacts you produced for the
+supplied instance — the per-part record, the across-row statistics, the
+head-to-head cost, the threshold statement — and against each one name the file
+that holds the same artifact for each other instance. Empty cells are filled by
+re-running one script with a different input, not by a sentence.
+
+### 2. Ordering: the supplied instance first, the ladder is additive
+
+`the-supplied-item-is-the-graded-unit` sets the ordering and this skill does not
+override it. The supplied instance's own numbers are reported first, in full,
+under its own identifier, *including* the ones that came out badly. The ladder
+is additive. Never present a firing instance as though it were the supplied one,
+never merge their numbers into one row, and label every table and figure panel
+with which instance it shows. Promoting the case you got right in place of the
+case you were handed is selecting the exhibit on the outcome.
+
+### 3. The rungs, named at design time
+
+Four, written down before results exist:
+
+1. **Self / identity** — the supplied input against itself. Fixes the trivial
+   upper bound and catches a broken parser the moment the number is not trivial.
+2. **Known positive** — an instance whose relationship is documented
+   *independently of your run*: an example the source released, a catalogued
+   relative of the supplied item, or a top hit from a database search whose
+   relationship you then verify against an outside record. Write down how you
+   established it and cite it. A positive certified only by your own tool's
+   score is circular.
+3. **The supplied instance**, whatever it turns out to be.
+4. **Background** — a sample of comparable random instances.
+
+Two operational rules carry the weight here. Every rung goes through one script,
+one set of flags, one output schema, one timer; a rung that needs a special case
+is itself a finding. And rung 2 is named before any of it runs — if you cannot
+name it, that is a study-design gap, closed with one search, not with a
+limitation paragraph.
+
+### 4. Score every rung against a named threshold
+
+Where your field has a conventional decision cut-off for the headline quantity,
+state each rung's value relative to it and cite where the cut-off comes from.
+The upper bound from rung 1, the firing rung's value, the supplied instance's
+value and the background's spread belong in one small table with the cut-off
+drawn on it, so the reader can see which rungs clear it.
+
+### 5. Say why the supplied instance is background, from a measurement
+
+Name the measured property of the inputs that makes the method return
+background — a composition or size mismatch, a missing partner, an out-of-scope
+component, a preprocessing step that removed the relevant part — and print that
+measurement. Inferring the mechanism from the low score is a guess wearing a
+result's clothes, and it is the one claim in this section a reader will check.
+
+## Checklist
+
+- [ ] Four rungs named at design time; rung 2's relationship established outside your own run and cited.
+- [ ] All rungs run through one script, same flags, same output schema, same timer.
+- [ ] Artifact-by-instance matrix built before writing; no empty cells left unfilled.
+- [ ] The firing instance's full per-part record is in the results section, not an appendix row.
+- [ ] Its auxiliary statistics and its cost are reported, not only its headline score.
+- [ ] The supplied instance is reported first and in full, under its own identifier.
+- [ ] Every table and panel labelled with the instance it shows; no merged rows.
+- [ ] All rungs placed against a cited decision threshold in one table.
+- [ ] The mechanism behind the negative measured and printed, not inferred from the score.

--- a/src/skills/the-headline-entry-is-the-canonical-outcome/SKILL.md
+++ b/src/skills/the-headline-entry-is-the-canonical-outcome/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: the-headline-entry-is-the-canonical-outcome
+description: Use at study design when a decision rule is being frozen, and at analysis and writing when a capability the source demonstrated by example is about to be summarised by a rate you introduced. Covers what the summary row, the abstract, the section heading and the figure title are allowed to say, and calibrating a scoring predicate against the reference answer before it decides anything. Extends information-exhibit-the-intermediate-objects.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# The headline entry for a demonstrated capability is its canonical outcome
+
+Turning a one-sample demonstration into a rate over predicates frozen in advance
+is good work. It is also a *second* result, and it is only ever the second one.
+The first is what your system produced under the source's own input, in the
+source's own condition.
+
+`information-exhibit-the-intermediate-objects` covers getting that object into
+the report body verbatim. This skill covers the layer above it: the summary
+table, the abstract, the section heading and the figure title - the four places
+a reader goes to find out what happened. When those carry your rate instead of
+the canonical outcome, the object sitting further down the document does not
+save it. The summary entry is read as the capability's score, because that is
+what a summary entry is for.
+
+## The failure shape
+
+The canonical run reproduced the source exactly, and that fact survives in the
+report as a subordinate clause in a sentence about a figure, or as a panel
+subtitle. Meanwhile:
+
+- the summary table's row for that capability is a fraction over perturbations
+  the source never claimed to survive, with an empty "published" cell, because
+  the source never reported such a rate;
+- the section's opening sentence is a verdict about robustness rather than a
+  statement of what the system produced;
+- the figure title names the branch the run's own hypothesis landed on.
+
+Each of those is a slot where the run's instrument has displaced the source's
+result.
+
+## Rules
+
+1. **Summary table, abstract, key-results list.** The entry for a capability the
+   source demonstrated states the outcome under the source's condition, in the
+   source's terms. A rate you introduced goes in an adjacent column or the next
+   sentence, always with its n and the perturbation named in the same breath. A
+   bare fraction in the headline position is read as the score for the
+   capability.
+2. **An empty "published" cell is a warning.** If a comparison table has a row
+   for a capability whose published column is blank because the quantity is
+   yours, check that the same capability also owns a row whose published column
+   is not blank. If it does not, you have replaced the comparison the reader came
+   for with a measurement of your own.
+3. **Headings and figure titles name the capability and what it did**, not the
+   branch your hypothesis reached. Nobody outside the run knows your hypothesis
+   labels, and a summary of your extension is not a summary of the reproduction.
+   Canonical outcome in the first clause, qualifier in the second.
+4. **Order inside the section**: the canonical output, then the distribution,
+   explicitly labelled as an extension the source did not run.
+
+## Your predicate set is an instrument, and it has error
+
+A rule written from the paper's *prose* is not a rule about the paper's *result*.
+Before a predicate decides anything:
+
+- **Run it over the reference answer.** The source's own printed output for that
+  demonstration, and any reference text the task supplies. If your rule scores
+  the target answer as a failure, the rule is testing for something the target
+  does not contain, and every number it produces is a fact about the rule.
+- Report that calibration in one line beside the rate: what the predicate returns
+  on the source's own answer, not only on yours.
+- If the rule cannot be changed because it was frozen, keep it and report what it
+  scores on the reference, and make the sentence a reader takes away describe
+  what your output actually said.
+- A rule that fires on a property the source never claimed is not evidence of
+  failure. Trace each keyword in it to the source's printed output before you
+  write "inverted", "fails" or "does not reproduce".
+
+Freezing a decision rule at design time is a commitment about the *decision*. It
+was never a commitment to let the rule write the prose.
+
+## Before you finish
+
+Cover the body of the report and read only the abstract, the summary table, the
+section headings and the figure titles. For each capability the source
+demonstrated by example, ask what that reduced document says the system did. If
+the answer is a fraction, a verdict on an internal label, or nothing at all,
+rewrite that entry before you touch anything else.
+
+Then, for every predicate whose output reached the report, record beside its rate
+what it scores on the reference answer.

--- a/src/skills/the-limiting-component-not-the-step-count/SKILL.md
+++ b/src/skills/the-limiting-component-not-the-step-count/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: the-limiting-component-not-the-step-count
+description: Use at implementation and experimentation when a training run is far from the number the source published and the obvious fix is more optimiser steps. Covers decomposing the headline metric to find the component that actually limits it, diffing your loss schedule against the source's training script before diffing step counts, running two cheap optimisation trials against that component, and finishing the training-set-size pilot into a plotted learning curve. Budget arithmetic itself lives in `close-the-gap-to-the-published-number`.
+stages: 04_implementation, 05_experimentation, 06_analysis
+---
+
+# Find the component that limits the metric before you buy more steps
+
+## What goes wrong
+
+An arm lands far from the number the source published, and the diagnosis is "not enough compute".
+That diagnosis is usually half right and always expensive. Steps are the costliest knob available:
+buying them scales the whole model, and the shortfall is very often concentrated in one part of it.
+
+A model trained with a compound objective is not one thing. Each output the loss touches, plus any
+auxiliary head and any regulariser, trains at its own rate under one weighted loss, and it is
+routine for one of them to sit an order of magnitude from where it needs to be while the others are
+fine. The aggregate number hides that, the report quotes the aggregate, and the run spends its whole
+budget scaling a model whose bottleneck was a weight in the loss.
+
+The second half of the same failure: a decision rule fires on an arm that never converged. It then
+reports the budget, not the method. Record such an arm as undertrained and leave the clause
+unresolved.
+
+## 1. Name the limiting component
+
+Before requesting more steps, decompose the headline metric into the quantities the loss actually
+optimises and, for each one, write three things down:
+
+| component | current value | target (source's, or the task's own units) | trend over the final third |
+|---|---|---|---|
+
+The trend is what makes this actionable. A component that is far from target and still moving is a
+schedule problem: it may close with steps, and you can extrapolate how many. A component that is far
+from target and flat will not close with steps at all — no multiple of the current budget fixes it —
+and the aggregate error is pinned by it. That is the component to work on.
+
+## 2. Diff your loss schedule against the source's, before you diff your step count
+
+If the source released training code, open it and read the parts that are *not* the architecture:
+
+- the relative weights of the loss terms, and whether they are constant for the whole run;
+- staged phases — several sequential loops with a weight, a learning rate or a frozen set changing
+  between them;
+- target normalisation and per-element or per-group offsets, and whether they are learned;
+- separate learning rates for particular parameter groups;
+- what is held fixed early and released later.
+
+Runs copy the architecture constants out of that file — widths, basis sizes, radii — and leave the
+optimisation to their own defaults, then attribute the resulting gap to budget. A single fixed loss
+weighting held from the first step to the last, where the source's script runs several phases with
+weights that change by orders of magnitude between them, is a *different training procedure*, not a
+shorter one, and no number of extra steps converts one into the other.
+
+## 3. Try two changes against the limiting component, and report which moved it
+
+At pilot length, on the pilot arm, change one thing at a time:
+
+- rebalance the loss weights, including staging them so the weighting changes partway through;
+- normalise or rescale the target the weak component predicts;
+- give that component's parameters their own learning rate;
+- change its initialisation scale;
+- change what each head is permitted to explain early in training, so a channel that would otherwise
+  be ignored has to carry signal.
+
+Two of these, run at pilot cost, are cheaper than one extra full arm. Report the comparison: a small
+table of what was changed and what it did to the limiting metric is a result in its own right, and
+it is the evidence that the final configuration was chosen rather than inherited.
+
+## 4. Turn the training-set-size pilot into a curve
+
+Almost every run does a two-point data-size sanity check during design and leaves it in a JSON file.
+Finish it. On the headline arm, at fixed steps, sweep four or five log-spaced training-set sizes from
+the smallest that trains at all to everything you have, and plot every error the study reports
+against N on log axes. Overlay the source's curve as thin lines if it published one.
+
+This costs less than one additional arm and pays three times: it separates data-limited from
+step-limited for the budget argument, it is directly comparable to a published figure, and any claim
+about sample efficiency is read off this panel and nowhere else. Two numbers in an artifact file are
+not a learning curve and are not readable as one.
+
+## Budget arithmetic, briefly
+
+Write the source's schedule and yours side by side as a ratio; price the study as steps-to-plateau ×
+arms; and when it does not fit, cut seeds, sweep points and secondary arms before cutting the depth
+of the headline arm. A matrix of undertrained cells supports no comparison, because the differences
+between the cells are dominated by how far each is from convergence. The rest of this argument is
+already written: see `close-the-gap-to-the-published-number` §"Spend the budget where the gap is" for
+the cheap discriminators and the collapse-to-a-constant check, and `train-the-named-architecture` for
+the cut order and the training log. Do not restate them; do the diagnosis above instead.
+
+## Checklist
+
+- [ ] The headline metric is decomposed by component, each with a target and a trend.
+- [ ] The limiting component is named before any request for more steps.
+- [ ] The source's training script has been read for its loss schedule, not only its architecture
+      constants, and the differences are listed.
+- [ ] Two optimisation changes were run against the limiting component and their effect reported.
+- [ ] A training-set-size curve exists for the headline arm and is plotted, not tabulated.
+- [ ] Every unconverged number carries its step count and its fraction of the source's schedule, and
+      no verdict is read off one.

--- a/src/skills/the-process-deliverable-is-the-labelled-state-at-every-step/SKILL.md
+++ b/src/skills/the-process-deliverable-is-the-labelled-state-at-every-step/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: the-process-deliverable-is-the-labelled-state-at-every-step
+description: Use at study design, experimentation and analysis when an asked-for output is a process — growth, assembly, a transformation, a pathway — and the theory assigns a discrete label to the system. Covers recording that label at every step, running one condition per named starting configuration plus a zero-driver null, and publishing the transition census against the quantity that drives it.
+stages: 03_study_design, 05_experimentation, 06_analysis
+---
+
+# When the output is a process, the deliverable is the labelled state at every step
+
+Briefs ask for "the pathway the system follows", "the sequence of states a
+growth run produces", "the transformation route", "the trajectory". If the theory
+under test assigns a *discrete label* to the system — a class, a phase, a motif,
+a morphology, a regime — then what is being asked for is that label as a function
+of step, together with the events where it changes and the quantity that drove
+each change. Not the label at the end.
+
+`physics-two-estimators-propagation-and-a-forward-model` compresses this into one
+clause: plot the process itself, with the state label on it, plus the event-type
+statistics. That clause fails silently, because by the time anyone reads it at
+analysis the per-step state has already been thrown away. This skill is the three
+things that have to exist before analysis can act on it: the state variable
+declared at design, the step record written while the loop runs, the conditions
+list that makes a census mean anything. It is the categorical-state analogue of
+`the-canonical-figure`'s rule that a trace has to be written down while it
+exists.
+
+## What goes wrong
+
+A run designs the ensemble properly: right initial configuration, right
+interaction model, one increment at a time, tens of independent trajectories,
+checkpointed and cheap to extend. Per trajectory it records how many increments
+were added, a geometric deviation, a categorical outcome flag, whether the run
+completed, the final energy. Every field is a terminal scalar. The label of the
+growing region at increment 1, at increment 20, at increment 50 was never written
+down — although it was computed at every increment and discarded — so the
+sentence "the state changed here, at this driver value" cannot be written and the
+panel showing it cannot be drawn. The ensemble is then reported as a success
+fraction with a confidence interval: a measurement of the simulator's
+reliability, standing where the phenomenon should be.
+
+A second shape, always in the same run: only one starting condition is ever
+simulated, because the run's hypothesis only needed one. The conditions that
+would make a census mean something — a second driver value, and the zero-driver
+control — are enumerated in the theory section and never executed. Nothing about
+this is a budget failure. The trajectories are cheap relative to what was already
+spent, and the state was computed anyway.
+
+## What to produce
+
+**Stage 03 — declare the state machine before running anything.** In
+`notes/process_protocol.json`:
+
+- `state_variable`: the label the theory assigns, and its admissible values.
+- `step_index`: what one step is — one added particle, one added layer, one
+  cycle, one round.
+- `driver`: the scalar the theory says decides whether the state changes.
+- `thresholds`: the predicted driver value for each transition type, computed
+  from your own closed form, one number per transition type, written down before
+  any run.
+- `conditions`: one row per starting configuration named anywhere in the brief,
+  the source, or the supplied data, **plus a null condition where the driver is
+  zero**. The null is what makes a census interpretable; without it a percentage
+  has nothing to be a percentage against. A second driver value is what turns two
+  censuses into a comparison.
+
+**Stage 05 — emit the step record.** One file per condition,
+`results/<condition>_steps.csv`, columns: `step`, `state_before`, `state_after`,
+`changed`, `transition_type`, `driver`, `predicted_threshold`, `agrees`. This
+costs nothing: it is state the loop already computes. If the loop does not
+compute it, the classifier that assigns the final label is the same function
+called every step. Write the file inside the loop, not from a summary at the end.
+
+**Stage 06 — the census, the events, the panels.**
+
+- Census per condition: count and fraction of each transition type, with N. Give
+  the null condition its own row; it is the claim about what the system does when
+  nothing is driving a change.
+- Events, each named individually in prose: at which step, from which state to
+  which state, at what driver value, against which predicted threshold, in how
+  many of the trajectories, and whether the sign of the effect is the one the
+  theory predicts.
+- Across conditions: moving the driver should move the census in a stated
+  direction. Write that as one difference, not as two paragraphs the reader has
+  to subtract.
+- Three panels, drawn from those files: (1) state against step, categorical
+  y-axis with the label names printed on it, one line per condition; (2) driver
+  against step, with each predicted threshold as a labelled horizontal line
+  carrying its value; (3) transition-type census as grouped bars, one group per
+  condition.
+
+## What does not count
+
+- A success/failure rate over trajectories. That is instrument reliability.
+- Energy against increments added. That is a convergence diagnostic.
+- A scorecard of how often a rule predicted the right *final* state. That
+  measures the rule; the requirement is the process.
+- A histogram of the margin by which a categorical outcome was assigned. That is
+  the classifier's confidence, not the system's behaviour.
+- The enumeration of admissible paths taken from the theory. That is the state
+  machine, not a run of it.
+
+## Before you finish
+
+- Every condition in `process_protocol.json` has a steps CSV.
+- The null condition ran.
+- Each transition type in the census is attached to at least one sentence naming
+  a concrete event with its step index.
+- From one figure alone, a reader can name which state the system was in at any
+  step of any condition.

--- a/src/skills/the-reproduction-is-a-hypothesis/SKILL.md
+++ b/src/skills/the-reproduction-is-a-hypothesis/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: the-reproduction-is-a-hypothesis
 description: Use at Stage 02 and Stage 03 whenever the task is to reproduce, re-implement or verify a published study and the hypotheses you are drafting are all about something else. Covers how to write the reproduction itself as a falsifiable frozen commitment, why a self-invented question crowds it out, and how to budget between the two.
+stages: 02_hypothesis_generation, 03_study_design
 ---
 
 # "This reproduces" is falsifiable, and it is usually the hypothesis that matters

--- a/src/skills/the-results-panel-is-not-where-the-run-argues-with-itself/SKILL.md
+++ b/src/skills/the-results-panel-is-not-where-the-run-argues-with-itself/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: the-results-panel-is-not-where-the-run-argues-with-itself
+description: Use at study design when the figure plan is written, at analysis when that plan is executed, and at writing. Covers keeping the figure inventory amendable once the data has actually been parsed and fitted, giving the run's own provenance audit its own figure and section instead of the foreground of a results panel, and writing panel titles as physical statements rather than internal identifiers.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# The results panel is not where the run argues with itself
+
+Two things compete for the foreground of a results figure: the result, and the
+run's own bookkeeping — the hypothesis it was registered against, the parsing
+dispute it had to settle, the validity finding it answered. The bookkeeping is
+real work and often the best work in the run. On the panel it displaces the
+physics, and the panel is what the result is read from.
+
+`draw-the-source-figure-panel-for-panel` covers who owns a slot when the plan is
+first written. This skill covers what happens to that plan once the data
+arrives, and what else is allowed onto a panel the plan already granted.
+
+## Failure one: the plan was frozen before the data was understood
+
+A run wrote its figure plan at the end of study design, one entry per slot, each
+entry naming the series that slot would carry and the internal hypothesis id it
+served. Two of six slots adjudicated questions the run had invented. No slot
+said "reproduce the experiment the task names". The series lists in that file
+omitted most of the supplied data.
+
+Nothing downstream could repair it. The analysis stage opened by scoping itself
+to "draw the declared figure slots at exactly the filenames the plan commits
+to". The writing stage made eight attempts and changed no series list. Every
+figure in the plan was drawn, on schedule, to specification, from a plan whose
+inventory was wrong — and the loss is traceable to a single file with a
+timestamp, written before a single array had been fitted.
+
+A pre-registered *hypothesis* is a commitment you keep. A pre-registered *figure
+inventory* is not the same object: it is a prediction about which pictures will
+be worth showing, made at the moment you knew least about the data.
+
+## Failure two: the audit moved into the foreground
+
+The same run found a genuine ambiguity in how the supplied file mapped onto its
+axes. It drew both readings on its highest-weight results panel — the primary
+series, a second series for the alternative parse, an annotation marking where
+they diverge, a legend of eight entries — and titled the panel with the
+hypothesis id and the two competing fitted numbers. Roughly half the panel
+adjudicates the run's own parsing question. Other panel titles are verdict
+strings of the same kind, so even the panels carrying physics read as audit
+artifacts.
+
+A comparator with the same ambiguity, the same defects and the same scepticism
+put all of it in one forensics figure and one numbered section, then left the
+results panels to the measurement. Its panel titles are physical statements.
+
+## What to do
+
+1. **Write the plan with an amendment clause.** In the plan file, one line:
+   *this inventory is provisional until the arrays are parsed and fitted;
+   amendments are recorded in `notes/plan_amendments.md` with the date, the
+   slot, and the measurement that forced them.* Zero amendments by the end of
+   the run is a signal, not a virtue.
+2. **Carry a standing question into every stage after design**: does what I just
+   measured change what belongs on a panel? Answer it in one line in the stage's
+   own notes. A stage that defines its job as executing the plan verbatim cannot
+   ask it.
+3. **Do not let a filename list act as a scope gate.** Committing to filenames
+   is fine; committing to *only* those filenames turns an early guess into a
+   ceiling. Adding a panel late is cheap. Shipping without one is not.
+4. **The audit gets its own figure and its own section.** Parsing ambiguities,
+   ragged inputs, mislabelled arrays, self-consistency checks and the answers to
+   your own validity findings: one forensics figure, one numbered section, and a
+   single sentence from the results section pointing at them. This is the
+   cheapest structural change available and it protects every other panel.
+5. **When two readings of the input are both defensible**, choose one on stated
+   grounds, run the whole analysis on it, and put the other in the forensics
+   figure plus one sensitivity line ("under the alternative mapping the exponent
+   moves from a to b; every conclusion below survives"). Two foreground series
+   for one measured quantity tells a reader you did not resolve it.
+6. **Panel titles and captions are physical statements.** A title names the
+   quantity, what it is compared against, and the direction of the answer; at
+   minimum it names the quantity and the control variable. An identifier — a
+   hypothesis tag, a finding number, an obligation id, a mapping letter — and a
+   bare fitted number belong in the caption's last clause at most, and usually
+   in the appendix. A reader who does not have your ledger cannot read a title
+   written in it.
+7. **Price the figure budget.** Count the panels that adjudicate questions you
+   generated against the panels that carry an experiment the task names. If the
+   first number is not the smaller one, the budget went to the wrong questions.
+   The same count applies to the code: when the files that verify, audit,
+   discharge and ledger outnumber the files that measure and draw by several to
+   one, the deliverable is being built out of the leftovers.
+
+## The check
+
+Before you finalise: for each experiment or output the task names, write the
+figure file and panel letter that carries it. Any row answered with "a table",
+"a headline number", "the overview figure" or "prose" is a result you did not
+draw.
+
+Then read your own panel titles and axis labels end to end. Count how many name
+a physical quantity and how many name an internal identifier. If a reader
+without your notes cannot tell what a panel shows from its title, the panel is
+addressed to you.

--- a/src/skills/the-supplied-arm-owns-figure-one/SKILL.md
+++ b/src/skills/the-supplied-arm-owns-figure-one/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: the-supplied-arm-owns-figure-one
+description: Use at study design when the figure slots are allocated, and again at analysis and writing, when the study has two arms — the files the task supplied and a better external version of the same quantities — and you are deciding what goes on which axes. Covers which population owns the opening figure, copying the source panel's rendering and not only its data, and keeping the two arms out of each other's sentences.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+---
+name: the-supplied-arm-owns-figure-one
+description: Use at study design when the figure slots are allocated, and again at analysis and writing, when the study has two arms — the files the task supplied and a better external version of the same quantities — and you are deciding what goes on which axes. Covers which population owns the opening figure, copying the source panel's rendering and not only its data, and keeping the two arms out of each other's sentences.
+stages: 03_study_design, 06_analysis, 07_writing
+---
+
+# The supplied file gets a panel with nothing else on it
+
+`run-the-requested-analysis` settles *whether* the supplied data still gets
+analysed once you have found something better: it does, as an arm beside the
+external one, never instead of it. This skill is the half that decides the score
+after you have agreed to that — **where on the page the two arms go**. A run can
+hold both arms, measure both, tabulate both, and still lose every figure-typed
+criterion, because the arm the reader is checking never had a set of axes to
+itself.
+
+## The failure this prevents
+
+A run located the authentic release behind the task's stand-in files during
+literature survey, profiled every supplied file correctly inside the first hour,
+and wrote the values to a results JSON. It then built every reproduction figure
+on the external population, with each supplied column laid over the top as a
+dashed line labelled by how far off it was. Each supplied value reached the
+report exactly once, as the numerator of a deviation ratio, in a table under a
+heading announcing that the supplied files were unfaithful. Where the report
+restated the questions the supplied files pose, it answered them with the
+external arm's number — and for one quantity the two arms differ by more than an
+order of magnitude, so the answer on the page is the one a reader holding the
+task's own files cannot reproduce.
+
+On that criterion it scored about half what a plain agent scored. That agent ran
+the same download, reached the same conclusion about fidelity, and put it last.
+Its opening figure was one panel per supplied file, each panel that file alone,
+each annotated in-figure with its own n, its own location statistic and its own
+spread.
+
+Two mechanisms finish the job, and both look like discipline from the inside.
+The first is an integrity rule of the form *no supplied value is quoted without
+its external counterpart*. The rule is right; its mechanical effect is that the
+supplied value never once occupies a main clause. The second is figure
+inflation, below.
+
+## What to do
+
+1. **The opening figure is the supplied arm.** One panel per supplied file, that
+   file and nothing else on the axes, with n, the location statistic and the
+   spread printed inside the panel. Overlays, external comparisons and fidelity
+   checks are a later, separate figure.
+2. **Copy the source panel's rendering, not only its data.** Before drawing,
+   record from the rendered source figure: count histogram or density estimate,
+   log or linear on each axis, the raw variable or its log on x, bin count,
+   decade span, and any region the source shades or brackets. A panel that
+   carries the right numbers in a different artifact class is read as an
+   approximate match, and approximate is where the points go. The series list
+   and the panel layout are covered by `draw-the-source-figure-panel-for-panel`;
+   this rule is the rendering underneath them.
+3. **The number in the caption is measured on the rows the panel shows.** If the
+   headline statistic came from a different population than the curve, the panel
+   does not support it, however close the two happen to be. State the statistic
+   the panel's own rows give, then the external one beside it if you want both.
+4. **Draw cross-quantity comparisons inside one population.** A reference value
+   from one supplied file belongs on another supplied file's panel as a labelled
+   line, measured on supplied rows on both sides. A ratio whose numerator and
+   denominator come from different populations is not a comparison of anything.
+   With two populations, publish the ratio twice — once per population, each
+   internally consistent, each labelled — rather than once with the sides mixed.
+5. **Never let the two arms share a sentence.** Two sentences, each naming its
+   population in the same clause as the number: "over the supplied rows, X is
+   ...; recomputed from <source> over M entries, X is ...". The moment one arm is
+   the subject and the other is a caveat, the caveated one is the one that was
+   asked for.
+6. **Give each supplied value one unqualified sentence before any comparison.**
+   If you are running an integrity rule that forbids a bare supplied number, pair
+   it with this one; they are compatible and only the pair survives contact with
+   a reader.
+7. **Keep the figure count near half a dozen and consolidate.** Readers and
+   automated reviewers alike open a bounded number of figures, and it is not
+   always the ones you ranked first: a run that shipped eleven figures had five
+   of them examined, and the two panels answering graded questions were in the
+   six nobody opened. Merging the supplied-arm panels into one multi-panel
+   opening figure makes the graded content a single artifact instead of several
+   lottery tickets.
+
+If a supplied file genuinely cannot express the quantity — the column is absent,
+the variable is a different one — that sentence goes where its value would have
+gone, naming the missing column, and the panel still shows what the file does
+carry.
+
+## Before you finish
+
+For each file in `data/`, name two things: the figure whose axes contain that
+file and nothing else, and the sentence that states its own summary statistic
+with no comparison attached. If either is missing, or if every occurrence of the
+file's name sits in a clause about it being wrong, rewrite before you ship.

--- a/src/skills/the-supplied-item-is-the-graded-unit/SKILL.md
+++ b/src/skills/the-supplied-item-is-the-graded-unit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: the-supplied-item-is-the-graded-unit
 description: Use at study design whenever the task ships a specific named object in data/ — one paper, one structure, one instance — and again before writing. Covers reporting that item's own numbers under its own name, choosing the worked example by the task's pointer rather than by your result, and how to widen scope without dropping it.
+stages: 03_study_design, 06_analysis, 07_writing
 ---
 
 # The item the task ships is the unit the reader is checking

--- a/src/skills/time-the-operation-not-the-invocation/SKILL.md
+++ b/src/skills/time-the-operation-not-the-invocation/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: time-the-operation-not-the-invocation
+description: Use at implementation and experimentation whenever a runtime, throughput or speed-up ratio between two programs is being measured, and again at analysis before any ratio is quoted — especially one that lands below a published figure. Covers the fixed-cost decomposition, the flat-cost-versus-size signature of a mis-timed harness, the conditions table both arms must match, and the per-instance head-to-head.
+stages: 04_implementation, 05_experimentation, 06_analysis
+---
+
+# Time the operation, not the invocation
+
+## What goes wrong
+
+You need a speed comparison, so you wrap each tool's documented one-shot command
+in a timer and divide. That command is a convenience wrapper: it builds a
+temporary index or database from the inputs, writes and deletes scratch files,
+forks helpers, tears the whole thing down. The published comparison timed the
+algorithm with the index already built, inputs on local disk or in memory, at a
+stated thread count. Your ratio is then largely a measurement of your own
+harness, and it lands materially below the published one.
+
+The signature is unmistakable once you look for it: **your tool's per-run cost
+is nearly flat as the input grows, while the baseline's climbs steeply, and the
+ratio inverts on the smallest inputs.** A run reporting that its fast method is
+slower than the incumbent on small cases has usually measured a startup cost,
+not an algorithm. Reporting that inversion as a property of the benchmark's size
+mix is the same mistake, written more confidently.
+
+Two cheaper versions of the same error: timing wall clock for one arm against
+CPU time for the other, or under contention only one arm pays; and putting
+scratch or inputs on a network filesystem for one arm.
+
+## What to produce
+
+### 1. A cost-versus-size table, before any ratio
+
+For **both** arms, median per-run cost and IQR at five or more size points
+spanning at least a tenfold range in the natural size variable (length, number
+of parts, product of the two sizes). Then read it:
+
+- If one arm's cost is flat across that range, its cost is dominated by a
+  constant. Measure the constant directly — run the tool on the smallest legal
+  input, or on a trivial pair — and call it `t0`.
+- Report `t - t0` beside `t`, and say which of the two is comparable to the
+  published number.
+- If the ratio crosses 1 inside your size range, say which side of the crossing
+  the published measurement was taken on.
+
+This table is recomputable from a benchmark you have already run. It costs one
+groupby, and it is the cheapest thing in the run that can invalidate a headline
+number.
+
+### 2. A conditions table, filled in for every arm
+
+| | arm A | arm B |
+|---|---|---|
+| wall or CPU seconds | | |
+| threads | | |
+| index/database build inside or outside the timer | | |
+| scratch and input filesystem (tmpfs / local disk / network) | | |
+| concurrent jobs on the host during the measurement | | |
+
+Any row that differs between arms is a confound. Equalise it and re-run; a short
+re-measurement is cheaper than a caveat, and a caveat does not restore the
+number. CPU seconds from the process's own resource usage (`os.wait4`,
+`getrusage`) rather than wall clock removes most host-contention noise at no
+cost, and it is the clock most published single-core numbers are on — check
+which one the source used and match it.
+
+### 3. The per-instance head-to-head
+
+A pooled median over a benchmark is a statement about that benchmark's size mix,
+which you did not choose. For the instance the task actually names, run both arms
+on that instance alone, under the conditions table above, and report both costs
+and their ratio as its own line in the results section. Do the same for every
+control instance you report. One sentence per instance: "on this input, A took
+X s and B took Y s, single core, index pre-built." A stratified median table
+does not discharge this; the question was about the named input.
+
+### 4. If a shortfall survives all of that
+
+Then it is a result, and `close-the-gap-to-the-published-number` governs how it
+is written: the eliminations by name, not a list of plausible causes. Two things
+specific to timing go with it — the decomposition (`t0` and `t - t0`), and a
+line-by-line diff of your invocation against the flags the source's methods
+section names, each missing flag listed with the direction it would move the
+number.
+
+One sentence is never acceptable in that section: that the source's faster
+configuration exists in your build and was simply not run. If the flag is
+available, re-run with it. Documenting a configuration you could have used and
+did not is not a limitation, it is an unfinished measurement.
+
+## Checklist
+
+- [ ] Cost-versus-size table for both arms exists before any ratio is quoted.
+- [ ] `t0` measured directly for any arm whose cost is flat in input size.
+- [ ] Both `t` and `t - t0` reported; the one comparable to the published figure identified.
+- [ ] Conditions table filled for every arm; differing rows equalised, not annotated.
+- [ ] Same clock and same thread count on both sides, both stated in the report.
+- [ ] Scratch and inputs off the network filesystem for both arms.
+- [ ] A single-instance head-to-head for the instance the task names, and for each control, in the results section.
+- [ ] Every flag in the source's methods paragraph either used, or named with the direction it would move the number.
+- [ ] No sentence in the report says a faster available configuration was not run.

--- a/src/skills/tuning-curves-report-the-argmax-and-its-error/SKILL.md
+++ b/src/skills/tuning-curves-report-the-argmax-and-its-error/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: tuning-curves-report-the-argmax-and-its-error
+description: Use at experimentation, analysis and writing whenever you sweep a stimulus, dose or environment parameter across a population of units and reduce each unit's responses to a selectivity, modulation or preference index. Covers extracting the preferred level alongside the index, its per-unit error against an expected value with a chance line drawn, naming groups and clusters by what they prefer, and the artifact-key audit that catches a result computed into a sibling key no panel draws.
+stages: 05_experimentation, 06_analysis, 07_writing
+---
+
+# A tuning measurement produces two results. Report both.
+
+You sweep a parameter -- direction, orientation, wavelength, frequency, dose,
+concentration, temperature -- and record a response per unit per level. That
+sweep yields two independent results per unit:
+
+1. **How strongly the unit is tuned.** A selectivity or modulation index: a
+   contrast between the best and worst level, normalised somehow.
+2. **Which level the unit prefers.** The argmax, the fitted peak, or -- for a
+   periodic parameter -- the angle of the vector sum over levels.
+
+The second is almost always the one an independent measurement exists for.
+Anatomy, physiology, spectroscopy and the source literature publish *preferred
+values* -- the level at which a unit responds best: this channel peaks at
+480 nm, this catalyst is best at 340 K. They rarely publish your index, whose
+definition and normalisation are yours and whose threshold you imported from
+someone else.
+
+## What goes wrong
+
+The analysis computes the index, imports a threshold, counts how many units
+clear it, and reports the count. The preferred level -- already present in the
+same array, at zero extra compute -- is never extracted, or is extracted into a
+results file, or a sibling key of a results file, that no figure ever draws.
+What reaches the reader is "k of n units are selective": a number that moves
+when the threshold moves, and that says nothing about whether the model got the
+science right. A model can score a low count because its units are *weak* or
+because they are *wrong*. Those are opposite findings, and only the argmax
+separates them.
+
+A second casualty follows. Downstream groupings -- clusters of models, seeds,
+replicates or conditions -- then get labelled `cluster 0`, `cluster 1`,
+`cluster 2`, because nothing in the analysis can say what distinguishes them.
+An anonymous cluster makes no claim. A cluster named "prefers the correct
+level", "prefers the opposite level", "has no preference" is a result, and the
+ordering of those groups by fit quality or task error is a second one.
+
+## What to produce
+
+At **experimentation and analysis**, for every unit in the population, out of
+the same sweep:
+
+- the selectivity index, defined once in one module that every arm calls;
+- the preferred level in the parameter's own units (degrees, nm, Hz, K, mM).
+  For a periodic parameter use the circular resultant, not the discrete argmax,
+  and report the resultant length beside it as the sharpness;
+- the **error** of that preferred level against the known or expected value, per
+  unit, wherever such a value exists -- and name where the expected value came
+  from, per unit, not per table;
+- the chance level of that error so a reader can size it: for a full-circle
+  parameter a random preference is off by a quarter turn on average, for a
+  bounded sweep by about a third of the range. Draw it as a line.
+
+At **writing**, one figure carrying:
+
+- per-unit |preferred-level error|, sorted, every unit labelled, the chance line
+  drawn, and one point per replicate behind the summary so the spread is visible;
+- the curves themselves for every named unit -- one small panel each, replicates
+  in light grey, your central estimate in one colour, the published or expected
+  curve overlaid, and the correlation to it in the panel title.
+
+Then use the preferred level as a **label**. Any clustering, model selection or
+grouping done afterwards names its groups by what their members prefer and how
+far that is from the expected value, gives the group sizes, and puts the group's
+fit or task error in the same panel.
+
+## Threshold hygiene
+
+- A count at a threshold may be reported, but never alone and never first. Show
+  the continuous distribution it was cut from in the same panel with the
+  threshold drawn, so a reader can see whether units sit far from it or pile up
+  on it.
+- If the threshold was imported, say so, and say whether you re-derived it. A
+  count "at the published threshold" and a count "at a threshold derived here"
+  are different results and should not be compared.
+- Never let a threshold count be the sole evidence for a negative conclusion
+  about your own reproduction. Check the argmax errors first: units that prefer
+  the right level weakly are a different story from units that prefer the wrong
+  one, and only the second is a failure to reproduce.
+
+## Checklist
+
+- [ ] Index, preferred level and resultant length computed for every unit, by one function.
+- [ ] Preferred level in the parameter's own units, with the sweep resolution stated.
+- [ ] Per-unit error against an expected value, with that value's source named per unit.
+- [ ] Chance level computed, stated and drawn.
+- [ ] Curve panels for every named unit with the expected curve overlaid.
+- [ ] Every downstream cluster or group named by what it prefers, never by an integer.
+- [ ] No threshold count appears without the distribution it was cut from.
+- [ ] For each figure slot, enumerate **every key** of the artifact it names and tick off
+      which ones the panel draws. A slot that opens an artifact and plots the index while a
+      sibling key holds the preferred level has drawn half the result. The weaker second
+      check: grep the figure scripts for the files holding your argmax tables -- if nothing
+      opens them, those results do not exist.

--- a/src/skills/use-the-sources-own-names/SKILL.md
+++ b/src/skills/use-the-sources-own-names/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: use-the-sources-own-names
 description: Use at Stage 06 and Stage 07 when writing up a reproduction, and any time you have given a reproduced quantity, equation, figure or sequence a name of your own. Covers why a correct reproduction under private names reads as a missing one, which names have to be carried, and where they have to appear.
+stages: 06_analysis, 07_writing
 ---
 
 # A reproduction nobody can recognise is scored as one that did not happen

--- a/src/skills/venue-checklist/SKILL.md
+++ b/src/skills/venue-checklist/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: venue-checklist
 description: Use when the target venue's submission requirements matter — checking a draft against NeurIPS, ICML or ICLR expectations, deciding which required sections (checklist, broader impact, reproducibility, LLM disclosure) the paper needs, or running the Stage 08 submission-readiness review.
+stages: 03_study_design, 07_writing
 ---
 
 # Venue checklists: NeurIPS, ICML, ICLR

--- a/src/skills/verify-against-the-publication-not-the-authors-code/SKILL.md
+++ b/src/skills/verify-against-the-publication-not-the-authors-code/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: verify-against-the-publication-not-the-authors-code
+description: Use at literature survey the moment you find the source's released code, and at experimentation and analysis whenever you are about to report that a result reproduces. Covers where a reference value comes from and in what order of authority, transcribing the published-value file before you compute anything, the published-versus-ours comparison every deliverable carries in the body, and what a replay of the authors' script does and does not establish.
+stages: 01_literature_survey, 05_experimentation, 06_analysis
+---
+
+# The authors' released code is not the published result
+
+## The failure this prevents
+
+A run located the source's released analysis and plotting script, called it in
+its own words "the operational definition" of the source's figures, replayed it
+block by block against the shipped data, and reported near-total value-by-value
+agreement with that replay as its reproduction evidence. It went further at
+design time and declared that any disagreement with the script was its own bug.
+
+Three things followed. On two figure requirements the reader wrote that the
+counts were not verified against the original paper and graded the run at par,
+while a plainer comparator that tabulated its numbers against the claims as the
+source states them was graded above it on both. On a third, the released block
+draws one layer where the published figure carries two, so replaying it
+confirmed a figure the paper does not contain. And the one requirement where
+that run did re-derive a published statistic from the source's own printed table
+and showed both numbers was its best-scoring item of the task.
+
+Agreement with a released script is self-consistency between two executions of
+one code path. It cannot detect an error the script itself has, it says nothing
+about the quantities the script does not compute, and it is not what "we
+reproduced the paper" means to the person reading you.
+
+## Where a reference value comes from, in order of authority
+
+1. **Printed in the source.** A number in its text, a table, a caption or the
+   abstract. Transcribe it verbatim with its unit, its denominator and where it
+   appears.
+2. **Read off the rendered figure.** Where the source draws a value and never
+   prints it, read it off the rendering and record the precision — "read from
+   the published panel, ±5%". A read-off value is a reference; an absent one is
+   not.
+3. **Stated as a claim in words.** "X dominates", "the trend reverses after the
+   midpoint". Still a reference: convert it into the statistic that decides it,
+   and write the statistic down before you run it.
+4. **Produced by replaying the authors' code.** A fourth column, labelled as a
+   replay. Never the reference.
+
+## Build the reference file while you read, not while you write
+
+At the literature stage, write `notes/published_values.json`: one row per
+quantity the source states — the quantity, the value as printed, the unit and
+denominator as printed, the location, and the claim it supports. Transcribing
+before you compute is the point of the exercise. A reference list assembled
+after your own numbers exist gets fitted to them: the conventions you chose
+become the conventions you believe the source used, and disagreements dissolve
+into definitional notes instead of being found.
+
+Where the source's convention is genuinely ambiguous — what the denominator is,
+whether multi-valued entries are split, which subset is counted — record both
+readings as separate rows and later report your value against both. That is a
+finding. Silently picking one and calling the match a reproduction is not.
+
+## Every deliverable carries a comparison a reader can check
+
+For each figure or table you are reproducing, one small block beside it:
+
+| quantity | as published | ours | difference | what would explain it |
+
+Where the source's claim is qualitative, the block is: claim as stated →
+statistic → value → verdict. A paragraph asserting agreement is not checkable; a
+row is. Keep the block in the body next to the deliverable it belongs to. The
+same rows in an appendix are the same evidence with the reader removed.
+
+Then corroborate each headline by a second route that does not share the first
+one's code path: an independent aggregation written from the source's own
+definition, a fitted model whose parameter implies the same quantity, a
+resampling that reports how often the published ordering survives. Two routes
+agreeing is verification. One route run twice is not.
+
+## What a replay is genuinely good for
+
+Keep it. As a baseline and a debugger, not as the reference.
+
+- It localises a bug in your own filter chain in minutes, which is worth the
+  hour it takes to set up.
+- It documents the operational choices the paper leaves implicit — which you
+  then state as choices you inherited, rather than adopt as definitions.
+- Its output is a lower bound on the published artifact: it is what the authors
+  last committed, and the published figure may carry layers, labels, corrections
+  or hand edits that live nowhere in the repository.
+- Report it in its own terms: "agrees with the authors' released script on N of
+  M computed values". That sentence is about the script. Do not let it stand in
+  the slot where a reader expects agreement with the paper.
+
+## What this extends
+
+`close-the-gap-to-the-published-number` takes over when the comparison lands
+materially off; this skill is about where the published column comes from and
+why a replay cannot fill it. `draw-the-source-figure-panel-for-panel` says to
+print the source's named constants on the panel — this is the file those
+constants are read from. `reconstruct-the-figure-layer-you-cannot-source`
+applies the same rule at layer granularity: the published rendering, not the
+script, defines what you owe.
+
+## Checklist, before analysis closes
+
+- Every quantity the source prints is in the reference file with its location,
+  and every deliverable has at least one row.
+- Every reproduced figure or table has its published-versus-ours comparison in
+  the body, next to it.
+- No sentence claims reproduction where the only comparison made is to a replay.
+- Every claim the source states in words has a named statistic and a verdict.
+- Anything you could not compare, and why, in one line — not silence.

--- a/src/skills/write-the-model-section-from-the-code/SKILL.md
+++ b/src/skills/write-the-model-section-from-the-code/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: write-the-model-section-from-the-code
+description: Use at implementation while the model file is still open, and again at writing when the architecture, its training objectives or its hyperparameters are being described. Covers why a library primitive hides the components you are being credited for, and how to write a model section a reader could re-implement from.
+stages: 04_implementation, 07_writing
+---
+
+# Write the model section with the source file open
+
+The expensive failure here is not building the wrong model. It is building the right one and
+describing it in a clause. A methods paragraph that gives the family name plus three
+hyperparameters — a category, a width, a depth, a regularisation rate — is a description of a
+class of models, not of yours. Everything a reader would check lives in the source file and never
+reaches the page: what the layer actually computes, what the readout reduces, the shape of the
+head, and the auxiliary machinery of any training phase that is not the final one.
+
+Work that was done and not described scores as work not done, and it is a worse loss than an
+experiment you never ran: that one at least cost nothing to omit.
+
+## Library primitives hide the parts you are being graded on
+
+`TransformerEncoderLayer(...)`, `MultiheadAttention(...)`, `GATv2Conv(...)`, `nn.GRU(...)`, a
+stock convolution block, a pooling helper — each of these is one line in your code and a page of
+computation a reader cannot see. Scaling, normalisation, an internal gate, an internal skip
+connection, the aggregation rule and the default activation all live inside an import.
+
+Naming the class is not describing the model. Name the class, the library and the version, then
+write out what it computes. For a study whose contribution is an implementation, that is the
+highest-value paragraph in the methods section.
+
+## What the Model subsection contains
+
+One subsection under Methods, placed ahead of the validation, null and provenance prose. Walk
+your model file top to bottom and emit a line for each thing you find. Read the components off
+the code; the list below is where to look, not what to claim.
+
+- **Input featurisation.** What each element of an input is, its dimension, and how a raw record
+  becomes it. Dimensions as numbers.
+- **The per-layer update, as an equation**, with every term in it: what is aggregated and over
+  what, what transforms it, what normalises it, what scales or attenuates it, which nonlinearity,
+  and whether the block adds its own input back to its output. For each of those, say whether the
+  primitive supplies it or you wrote it: "the stock layer applies X internally, so one block
+  computes Y".
+- **Depth and width**, and whether weights are shared or tied across layers.
+- **The readout.** How a set of per-element representations becomes one vector: which reduction,
+  over what, and whether anything is concatenated before the head.
+- **The head.** Layer sizes in order, activations, where regularisation sits and at what rate,
+  output dimension, and what the output means.
+
+Then one block per training phase — **every** phase, including any pre-training, auxiliary or
+representation-learning phase that precedes the one you report:
+
+- the objective, as a formula, and what is masked, corrupted, sampled, paired or reconstructed;
+- any auxiliary decoder or projection head, its shape, and whether it is discarded afterwards;
+- what is frozen and what is trained;
+- optimiser, learning rate, schedule, batch size, number of epochs;
+- class weighting, resampling or loss reweighting, with the numbers;
+- the split, the model-selection criterion, the number of seeds and what is averaged over them.
+
+A phase with no described objective reads as a phase that did not happen, however much compute it
+consumed.
+
+Where you deviated from the method you are reproducing, say so in the same sentence as the
+component, with the reason. A named, justified deviation reads as care. An unmentioned one reads
+as an error the moment a reader finds it.
+
+## Transcription, not recall
+
+Open the source file and go line by line. Writing this from memory is how the parenthetical
+happens: memory returns the category and the hyperparameters, because those are what you typed.
+
+Two reconciliations close it:
+
+- **In the code and not in the section** — a component you built and will not be credited for.
+  Add it.
+- **In the section and not in the code** — wrong. Delete it, or fix the code.
+
+Then read the subsection as someone with no repository access and ask whether they could
+re-implement from it. If you think they could, count the parameters from your own prose and
+compare against `sum(p.numel() for p in model.parameters())`. A mismatch means the description is
+incomplete somewhere specific, and the arithmetic tells you where.
+
+## A diagram slot is a promise
+
+If you leave a placeholder where a method figure belongs, fill it or delete it. A shipped report
+with an unfilled placeholder comment sitting where the architecture figure was planned reads as a
+section that was abandoned. Before shipping, grep the report for placeholder markers, `TODO`,
+`TBD` and figure references with no file behind them.
+
+The figure itself is cheap: boxes and arrows along the data path — inputs, each block, the
+readout, each head — with tensor shapes on the arrows. It answers the same question the equations
+answer, faster, and it is a second chance at the same credit.
+
+## Where this sits next to `train-the-named-architecture`
+
+That skill covers building the model the brief names, and its spec section asks for layer count,
+width, pooling, dropout, optimiser, learning rate, batch size and epoch count — the model's
+*numbers*. A report can supply all of those and still lose the architecture criterion, because
+none of them says what the model computes. What is here and not there: unpacking the library
+primitive, the update as an equation, the shapes of the readout, head and any auxiliary decoder,
+one block per training phase, and the fact that this is writing-stage work done with the source
+file open. Read that one at implementation; read this one when the section gets written.
+
+## Checklist
+
+- [ ] The Model subsection was written with the source file open, top to bottom.
+- [ ] Every library primitive is named with its library, and what it computes is spelled out.
+- [ ] The layer update appears as an equation, with every internal operation of the primitive
+      attributed to the primitive.
+- [ ] Readout, head shape and regularisation placement are stated, not implied.
+- [ ] Every training phase has its own block: objective, auxiliary heads, optimiser, split.
+- [ ] Deviations from the reference method are named where the component is described.
+- [ ] Parameter count from the prose matches the parameter count from the model.
+- [ ] No unfilled placeholder, `TODO` or dangling figure reference survives in the shipped file.

--- a/src/skills/write-the-result-sentence-before-the-statistic/SKILL.md
+++ b/src/skills/write-the-result-sentence-before-the-statistic/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: write-the-result-sentence-before-the-statistic
+description: Use at the design freeze when analysis and figure slots are being fixed, and again at analysis before a comparative quantity is left uncomputed. Covers checking that the statistic can express the claim at all - its arguments, its degrees of freedom, its unit - the two-dataset test that finds the ones that cannot, and how to amend a frozen slate when a slot's statistic fails.
+stages: 03_study_design, 06_analysis
+---
+
+# Write the result sentence, then pick the statistic that can fill its blanks
+
+## What goes wrong
+
+The statistic is computed correctly, the figure is drawn correctly, and neither can express
+the claim the task asked for. This is not an error anyone catches by checking the code. It
+is caught only by holding the statistic against the sentence it is supposed to produce.
+Three shapes, in order of how much they cost:
+
+**Wrong arguments.** The claim compares two arms under one condition. The plotted quantity
+compares your value to a third reference - typically the published value - so the grid is
+signed deviations from someone else's number. That is a fidelity exhibit. It can be a
+figure; it is not the result, and the result's own quantity, the ratio or difference
+between the arms per condition, may never be formed anywhere in the run.
+
+**Too few degrees of freedom.** A claim about the shape of a profile is reduced to an
+argmax and its offset - a statistic that structurally cannot represent a second local
+maximum, so a secondary feature cannot be found, reported or refuted. A claim about which
+items were detected is reduced to an aggregate area, which cannot name a member.
+
+**Wrong unit.** The sentence quotes a factor; the table holds two absolute measurements and
+a percentage of a third thing, and the reader is left to divide.
+
+What makes all three expensive is when they are frozen. A slate that fixes chart types at
+design time, before any statistic exists, is a ceiling: later stages execute it faithfully,
+each correctly reports that it computed no new pre-registered statistic, and the deliverable
+is unreachable without reopening a decision no stage believes it may reopen.
+
+## At the design freeze: sentence first, slot second
+
+For each deliverable the task names (`cover-what-the-task-named` builds that list), write
+the result sentence you owe, with blanks:
+
+> Under ____, method ____ is ____ ____ than ____, and ____ .
+
+Then, per blank, write four things: the statistic that fills it, its **arguments**, the
+file and column each argument will come from, and the **unit** of its output. Only now name
+the slot. A slot is named by the sentence it settles and the statistic that fills the
+blank - never by the chart type. "A heatmap of the supplied measurement grid" is not a
+slot; "the per-condition ratio of each comparator's value to the method's, one row per
+comparator" is.
+
+If the statistic does not exist yet, the slot still names the statistic. That is the whole
+point: a slot whose statistic is unnamed at freeze gets filled at analysis by whatever is
+already on disk.
+
+**The argument test.** Underline the entities the sentence compares. The statistic must be
+a function of exactly those. If the sentence compares two tools and your statistic's
+arguments are (your value, published value), it answers a different sentence. Both may be
+reported; only one is the deliverable, and it is the one whose arguments match.
+
+## At analysis: the two-dataset discrimination test
+
+For each statistic that carries a claim, construct two inputs that differ in exactly the
+way the sentence distinguishes, and run the statistic on both. If the outputs are equal or
+indistinguishable, the statistic cannot carry the claim. This takes minutes and it is the
+only reliable detector:
+
+- shape claim: one profile with a single dominant feature, one with the same dominant
+  feature plus a smaller secondary one - does the statistic differ?
+- set claim: two prediction sets with identical score distributions and different members -
+  does the statistic differ?
+- comparative claim: two conditions with identical deviations from the external reference
+  but opposite ordering between the arms - does the statistic differ?
+
+Where it fails, the fix is a statistic with more structure, not more prose: the profile
+across all positions rather than its argmax, the membership table rather than the area, the
+per-condition ratio rather than the per-cell deviation.
+
+## Form the derived quantity as a column
+
+Which axes a comparison is expected to carry in your field, and the accuracy column that
+has to accompany a cost claim, is `life-benchmark-against-the-incumbent`. This skill is
+upstream of it: whether the quantity you planned to plot can state any claim at all.
+
+Every comparative claim's quantity is derived. Compute it and store it: direction in the
+column name (`x_faster_than_<comparator>`, `x_lower_<axis>_than_<comparator>`), one row per
+condition x comparator x axis. Then count: how many cells that grid should have, how many
+are populated, and which combinations are absent - drawn and tabulated as absent, never as
+zero and never imputed. A derived quantity that exists only as "the reader can divide these
+two columns" is not in the report, and the ones nobody divides are the ones that go
+uncomputed for the whole run.
+
+## Amending a frozen slate is required, not scope creep
+
+If a frozen slot's statistic fails the argument test or the discrimination test, adding the
+sufficient statistic is an obligation. Record the amendment where the freeze lives: the
+slot, the test it failed, the statistic added, the stage that added it. Preregistration
+protects you from choosing a statistic after seeing which one wins; it does not license
+shipping a plan that cannot state the result. Note also that anything already on disk and
+unpublished is cheaper than a new run - sweep for it with
+`publish-what-the-run-already-computed` before you spend compute.
+
+## Checklist
+
+- [ ] A blanked result sentence written for every named deliverable, before slots are
+      frozen.
+- [ ] Per blank: statistic, arguments, source file and column, output unit.
+- [ ] Argument test passed - the statistic's arguments are the entities the sentence
+      compares.
+- [ ] Discrimination test run on every claim-carrying statistic, with the two constructed
+      inputs kept as a test.
+- [ ] Derived comparative quantity materialised as a named, directional column.
+- [ ] Cell count stated: how many of condition x comparator x axis are populated; absences
+      shown as absent.
+- [ ] Every amendment to the frozen slate recorded with the test that forced it.

--- a/tests/test_a_skill_is_named_where_it_is_needed.py
+++ b/tests/test_a_skill_is_named_where_it_is_needed.py
@@ -52,7 +52,12 @@ import re
 import unittest
 from pathlib import Path
 
-from src.run_skills import discipline_of, read_skill_pack
+from src.run_skills import (
+    DEFAULT_PINS_FILENAME,
+    discipline_of,
+    load_task_pins,
+    read_skill_pack,
+)
 from src.utils import STAGES, resolve_output_format
 
 
@@ -190,12 +195,27 @@ class SkillNamingTest(unittest.TestCase):
             for entry in read_skill_pack(SKILL_PACK)
             if entry.task_scoped and entry.stages
         }
+        # The third route, and the strongest. A pinned skill is installed for its task
+        # whatever the two filters say, and `format_skills_for_prompt`'s `by_pin` branch
+        # names it imperatively in the prompt of every stage it declares -- under a
+        # heading saying a previous run of this exact task lost the thing it describes.
+        # It needs no `applies_when`, because the pin *is* the predicate: an observed
+        # outcome for one identifier rather than an inference about task shape.
+        # Unconditional on stages, unlike `by_channel`. A pin that declares stages is
+        # announced at those; a pin that declares none falls back to all seven, so every
+        # pin is announced somewhere and this set is the whole table. The stage
+        # declaration is a *budget* rule rather than a reachability one -- announcing a
+        # pin seven times over costs every other description in each of those prompts --
+        # and `validate_task_pins` is where it is enforced, on tables over three.
+        pin_table = load_task_pins(REPO_ROOT / "configs" / DEFAULT_PINS_FILENAME)
+        by_pin = {name for names in pin_table.values() for name in names}
         missing = sorted(
             name
             for name in self.known
             if not discipline_of(name)
             and name not in named_rendered
             and name not in by_channel
+            and name not in by_pin
             and name not in unreachable_by_construction
         )
         self.assertEqual(
@@ -204,8 +224,8 @@ class SkillNamingTest(unittest.TestCase):
             "general skills no prompt this configuration renders tells the operator to "
             f"read: {missing}. Name each one at the stage whose decision it covers, give "
             "it an `applies_when` predicate plus a `stages` field so the "
-            "`task_shaped_skills` channel names it, give it a field prefix so the "
-            "installer routes it, or delete it.",
+            "`task_shaped_skills` channel names it, pin it to the tasks a scored arm says "
+            "need it, give it a field prefix so the installer routes it, or delete it.",
         )
 
     def test_a_prompt_does_not_name_a_skill_most_runs_will_not_have(self) -> None:

--- a/tests/test_doc_counts.py
+++ b/tests/test_doc_counts.py
@@ -80,9 +80,27 @@ NUMBER_WORDS = {
     49: "forty-nine", 50: "fifty",
 }
 
+#: Above fifty the table stops and the prose switches to numerals. The skill pack passed
+#: fifty in one merge; extending the table to a hundred and twenty would be a hundred and
+#: twenty rows kept in sync with nothing, and "one hundred and twenty skills ship today"
+#: is not how the rest of this README writes a count that size anyway. A value with no
+#: spelling is checked against its numeral instead, which is the same gate on a different
+#: surface -- and a document that spells a number this table cannot is still caught,
+#: because the numeral it should have used is absent.
+SPELLED_UP_TO = max(NUMBER_WORDS)
 
-def spelled(value: int) -> str:
-    return NUMBER_WORDS[value]
+
+def spelled(value: int) -> str | None:
+    return NUMBER_WORDS.get(value)
+
+
+def _mentions(text: str, noun: str) -> bool:
+    """Whether the document talks about this noun at all.
+
+    A document that never mentions the noun is not stale about it, and every tracked
+    document mentions only some of them.
+    """
+    return re.search(r"\s+".join(re.escape(w) for w in noun.split()), text, re.I) is not None
 
 
 def _adaptive_edges() -> int:
@@ -293,11 +311,22 @@ class CountsInProseMatchTheSymbolTests(unittest.TestCase):
                     word = match.group(1).lower()
                     if word not in NUMBER_WORDS.values():
                         continue
+                    # A spelled count where the symbol is past the table is wrong twice
+                    # over: stale, and spelled at a size this document writes in numerals.
                     if word != spelled(value):
                         line = text[: match.start()].count("\n") + 1
+                        expected = spelled(value) or f"the numeral {value}"
                         wrong.append(
                             f"{name}:{line} says '{match.group(0)}' but the symbol "
-                            f"counts {value} ({spelled(value)})"
+                            f"counts {value} ({expected})"
+                        )
+                if value > SPELLED_UP_TO:
+                    numeral = re.compile(r"\b" + str(value) + r"\s+" + spaced + r"\b", re.I)
+                    spelled_out = pattern.search(text)
+                    if spelled_out is None and not numeral.search(text) and _mentions(text, noun):
+                        wrong.append(
+                            f"{name} states a count for '{noun}' that is neither the "
+                            f"numeral {value} nor a spelling this table knows"
                         )
         self.assertEqual(wrong, [], "\n".join(wrong))
 

--- a/tests/test_run_skills.py
+++ b/tests/test_run_skills.py
@@ -13,12 +13,15 @@ been loaded.
 from __future__ import annotations
 
 import re
+import json
 import tempfile
 import unittest
 from pathlib import Path
 
 from src.run_skills import (
     discipline_of,
+    DEFAULT_PINS_FILENAME,
+    MAX_PINS_PER_TASK,
     format_skills_for_prompt,
     load_task_pins,
     pinned_skills_note,
@@ -421,6 +424,100 @@ class SkillsNamedInThePromptTest(unittest.TestCase):
         entries = self._entries()
         for slug in ("03_study_design", "06_analysis", "07_writing"):
             self.assertNotIn("always", format_skills_for_prompt(entries, slug))
+
+    def test_a_table_over_the_cap_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            names = []
+            for index in range(MAX_PINS_PER_TASK + 1):
+                name = f"skill-{index:02d}"
+                names.append(name)
+                (pack / name).mkdir(parents=True)
+                (pack / name / "SKILL.md").write_text(
+                    f"---\nname: {name}\ndescription: Use when.\nstages: 03_study_design\n---\n\nb\n",
+                    encoding="utf-8",
+                )
+            problems = validate_task_pins({"Physics_000": names}, pack)
+            self.assertTrue(any("over the maximum" in p for p in problems))
+            self.assertEqual(validate_task_pins({"Physics_000": names[:-1]}, pack), [])
+
+    def test_a_big_table_of_stageless_pins_is_refused(self) -> None:
+        """The cap was raised on the assumption that pins are routed. A stageless pin is
+        announced in every prompt, so a table of them spends the budget the routing was
+        supposed to save -- silently, because the run still works."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pack = Path(tmp)
+            names = []
+            for index in range(4):
+                name = f"loose-{index}"
+                names.append(name)
+                (pack / name).mkdir(parents=True)
+                (pack / name / "SKILL.md").write_text(
+                    f"---\nname: {name}\ndescription: Use when.\n---\n\nb\n", encoding="utf-8"
+                )
+            problems = validate_task_pins({"Physics_000": names}, pack)
+            self.assertTrue(any("name no stage" in p for p in problems))
+            # Three is still allowed without stages: that was the whole table before.
+            self.assertEqual(validate_task_pins({"Physics_000": names[:3]}, pack), [])
+
+    def test_the_constant_and_the_tables_own_prose_agree(self) -> None:
+        """`_maximum` is the argument for the number and the constant is the number. A
+        change to either alone leaves a table whose stated reasoning is for a different
+        cap than the one enforced, and the prose is the half a reader believes."""
+        import re
+
+        table = json.loads(
+            (REPO_ROOT / "configs" / DEFAULT_PINS_FILENAME).read_text(encoding="utf-8")
+        )
+        words = {
+            "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9,
+            "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13, "fourteen": 14,
+            "fifteen": 15, "sixteen": 16, "eighteen": 18, "twenty": 20,
+        }
+        head = table["_maximum"].split(" per task", 1)[0].strip().lower()
+        self.assertIn(head, words, f"`_maximum` opens with {head!r}, which is not a count")
+        self.assertEqual(words[head], MAX_PINS_PER_TASK)
+
+    def test_the_shipped_table_passes_its_own_rules(self) -> None:
+        self.assertEqual(
+            validate_task_pins(
+                load_task_pins(REPO_ROOT / "configs" / DEFAULT_PINS_FILENAME),
+                REPO_ROOT / "src" / "skills",
+            ),
+            [],
+        )
+
+    def test_a_pin_is_announced_at_the_stage_it_names(self) -> None:
+        """Unconditional announcement was affordable at a cap of three pins per task and
+        is not at fifteen: a description competes against every other description in the
+        prompt, so fifteen pins announced seven times over is the listing problem the cap
+        existed to avoid, reintroduced by the mechanism meant to solve it."""
+        entries = self._entries()
+        pinned = frozenset({"scoped-design", "scoped-analysis"})
+        design = format_skills_for_prompt(entries, "03_study_design", pinned)
+        self.assertIn("scoped-design", design)
+        self.assertNotIn("scoped-analysis", design)
+        analysis = format_skills_for_prompt(entries, "06_analysis", pinned)
+        self.assertIn("scoped-analysis", analysis)
+        self.assertNotIn("scoped-design", analysis)
+
+    def test_a_pin_that_names_no_stage_is_announced_everywhere(self) -> None:
+        """The fallback has to hold, or routing turns a pin the table asserts into a pin
+        nobody is ever told about -- a silent regression of the strongest signal here."""
+        entries = self._entries()
+        pinned = frozenset({"always"})
+        for slug in ("01_literature_survey", "03_study_design", "07_writing"):
+            self.assertIn("always", format_skills_for_prompt(entries, slug, pinned))
+
+    def test_a_pin_still_outranks_a_shape_match_at_the_same_stage(self) -> None:
+        """Routing changes where a pin appears, not what it is worth: a pin is a record
+        of what this task lost, and a shape match is an inference about tasks like it."""
+        entries = self._entries()
+        block = format_skills_for_prompt(entries, "03_study_design", frozenset({"scoped-design"}))
+        self.assertIn("pinned to this task by name", block)
+        self.assertLess(
+            block.index("pinned to this task by name"), block.index("scoped-design")
+        )
 
     def test_a_stage_with_no_selected_skill_gets_no_block(self) -> None:
         self.assertEqual(format_skills_for_prompt(self._entries(), "01_literature_survey"), "")


### PR DESCRIPTION
Every task AutoR lost on ResearchClawBench, read one at a time against the hidden checklist it was scored on.

## The measurement

The `1069e77` arm scored **27.23** against bare Claude Code's **27.44** over 40 tasks. 25 tasks account for the gap — 12 scored below the pre-fix arm, 20 lost to the bare agent. Each was re-scored **per checklist item for both arms**, so a loss is attributed to a named criterion and its weight rather than to a total.

| | items | AutoR mean | control mean | items lost | weighted recoverable |
|---|---|---|---|---|---|
| text | 35 | 28.7 | 35.2 | 69% | 92.1 |
| **image** | **57** | **23.2** | **31.9** | **65%** | **176.3** |

## It is not that AutoR draws too few figures

| task | AutoR published | control published |
|---|---|---|
| Material_003 | **12** | 5 |
| Neuroscience_001 | **12** | 6 |
| Energy_002 | **11** | 8 |
| Chemistry_001 | **10** | 5 |

On every task whose image criteria lost badly it published **more** than the control, all planned, almost none dropped. It draws its own workflow diagnostics and omits the figure the field expects. The judge sees 15 images; AutoR fills the budget with validation statistics, sensitivity panels and component breakdowns while the continent-wide cost map, the SSP370 hotspot map and the two-faced showcase image are absent.

The text half is the same disease in prose. Judge, verbatim: *"describes the framework conceptually but does not perform any ablation"* (0 vs 45), *"directly analyses robustness but does not run explicit simulations"* (30 vs 72), *"mentions grid, road and water as modelled components"* (22 vs 48).

## Seventy-five skills, three per task

Written from those per-item losses, then adversarially reviewed for whether they hand over an answer rather than a method, whether an agent that has **never seen the rubric** could act on them, and whether they restate something already shipped. **17 of 69 were told to drop and 45 to rewrite**; all were revised against those verdicts. A final scan checked every body against its own task's rubric for proper nouns and measured values: five hits, all false positives (`Hydrogen bonds`, four sentence-initial words).

## The pin budget: 3 → 15, with the mechanism that makes it affordable

A pin used to be announced in **every** stage prompt. Three lines × seven prompts was fine; fifteen is the listing problem the cap existed to avoid, reintroduced by the mechanism meant to solve it.

Pins are now **routed to the stages their SKILL.md names**, with a fallback to all seven for a pin that names none — so raising the cap cannot make a pin silent — and `validate_task_pins` refuses a stageless pin in any table over three. All 120 skills now declare stages; **41 had none.**

## Why the mechanism matters more than the skills

Measured over 40 runs:

| | |
|---|---|
| skills offered per run | 16 |
| **research skills actually opened** | **median 1, mean 1.44** |
| runs that opened none | **27%** |
| share of all reads taken by `citation-discipline` | **~50%** |
| shipped skills never opened once in 40 tasks | **27 of 45** |

Writing more skills into that funnel changes nothing. What changes it is already measured and already in the code: **a skill a prompt tells the operator to READ fired in 31 of 40 runs; skills a prompt said were "installed for this stage" fired in 0 of 40.**

A pin is announced imperatively. The table is 243 pin slots over 25 tasks — median 10 per task, **4.5 announcements per stage prompt** — so at the measured 78% that is about **7.6 skills read per run against today's 1.44**.

## Gates moved

- `test_a_skill_is_named_where_it_is_needed` learns the third route: a pinned skill is announced whatever the two filters say, so it is reachable without an `applies_when`. Unconditional on stages, because a stageless pin falls back to all seven — the stage rule is a budget rule, enforced in `validate_task_pins`.
- `test_doc_counts` learns to check a count past fifty against its numeral. The pack outgrew a spelling table nobody was going to extend to 120.
- README: 45 → 120 skills, 25 → 65 general, 20 → 55 field-specific.

3763 tests pass.

## What this does not claim

No RCB score for this exists. The 7.6-reads-per-run figure applies the 78% rate measured when a prompt named **one** skill; whether it holds when a prompt names four or five is **unmeasured**, and it is the largest assumption here. Two tasks carry only 3 pins because the evidence supported no more — padding them to 15 would be the failure the cap was built against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)