### PR TITLE
58% of what every run was held to was the harness talking about itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ Alongside the prompt, AutoR installs an agent skill pack from [src/skills/](src/
 `runs/<run_id>/.claude/skills/` — the operator's working directory — so the agent can *pull*
 long-form craft guidance when it needs it. A skill costs nothing in the prompts that do not use it.
 
-120 skills ship today: 65 general ones and 55 field-specific ones. Seventy-five of them were written against a scored arm's per-criterion losses on the
+121 skills ship today: 66 general ones and 55 field-specific ones. Seventy-five of them were written against a scored arm's per-criterion losses on the
 twenty-five ResearchClawBench tasks that lost, three per task. **A run is not offered all of
 them.** Two filters narrow the pack, and a skill has to survive both:
 

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -66,6 +66,7 @@ from src.rigor import resolve as resolve_rigor  # noqa: E402
 from src.utils import (  # noqa: E402
     BENCHMARK_MIN_REPORT_FIGURES,
     DEFAULT_OUTPUT_FORMAT,
+    MAX_STAGE_ATTEMPTS,
     DEFAULT_VENUE,
     OUTPUT_FORMAT_CLI_CHOICES,
     WEB_SEARCH_MODE_CHOICES,
@@ -86,9 +87,16 @@ from src.web_search import (  # noqa: E402
 #: puts a timeout on the agent subprocess — so a stage is only ever cut short by this value.
 #: Clipping it buys nothing back except a thinner report.
 DEFAULT_STAGE_TIMEOUT = 14400
-#: More retries than the interactive default: every retry re-runs the stage with its
-#: validation errors attached, and an exhausted stage is auto-skipped, which costs real score.
-DEFAULT_MAX_ATTEMPTS = 8
+#: No limit, matching ``main.py``. The comment this replaces argued that eight is "more
+#: retries than the interactive default" — and it was, until the interactive default became
+#: *none*. The benchmark path kept the old ceiling, so the change that removed the budget
+#: landed on the entry point nobody benchmarks and missed the one that produces every score.
+#:
+#: What that cost is measured. Of the six tasks where AutoR lost most heavily to bare Claude
+#: Code, **all six auto-skipped two or three stages** after "bounded retries were exhausted",
+#: and Stage 03 was skipped in five of the six. An exhausted stage is not a slow stage; it is
+#: a stage that never happened, and the report is then written standing on nothing.
+DEFAULT_MAX_ATTEMPTS = MAX_STAGE_ATTEMPTS
 #: The benchmark scores report/report.md, which Stage 07 writes. Everything after it is
 #: wall-clock spent on artifacts the judge never opens.
 DEFAULT_FINAL_STAGE = "07_writing"
@@ -295,8 +303,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=DEFAULT_MAX_ATTEMPTS,
         help="Attempts allowed per stage before it is auto-skipped. Each retry re-runs the "
-             f"stage with the previous attempt's validation errors attached. Defaults to "
-             f"{DEFAULT_MAX_ATTEMPTS}.",
+             "stage with the previous attempt's validation errors attached. **Omitted, the "
+             "default, means no limit**, the same as main.py: exhausting the budget does not "
+             "stop the run, it skips the stage and writes a report standing on nothing.",
     )
     parser.add_argument(
         "--max-operator-calls-per-stage",

--- a/src/prompts/03_study_design.md
+++ b/src/prompts/03_study_design.md
@@ -2,7 +2,9 @@ You are the person who will run this design yourself next week, on the compute a
 machine, in the time this run has left. A design whose cost is never stated is a wish list, and
 Stage 05 will report your omission as its own blocker.
 
-Before you cost anything, read `cover-what-the-task-named`, and on a reproduction also
+Before you list a single deliverable, read `a-deliverable-is-not-an-instruction`: the sheet you
+were handed is two documents, and only one of them is the task. Then read
+`cover-what-the-task-named`, and on a reproduction also
 `run-the-conditions-the-source-ran`: the source's named systems, scenarios, stress sweeps and worked
 examples are experiment rows in this plan, and a named method may not enter the cut order — cut your
 extension, the extra seeds, the second substrate, and run the paper's method at reduced scale

--- a/src/rcb.py
+++ b/src/rcb.py
@@ -272,6 +272,53 @@ def ensure_workspace_layout(workspace: Path) -> None:
         (workspace / name).mkdir(parents=True, exist_ok=True)
 
 
+#: The heading ResearchClawBench's own template puts above the research question.
+#: Everything under it is the task; everything outside it is how to operate the harness.
+_TASK_HEADING = re.compile(r"^##\s+Research Task\s*$", re.M)
+_NEXT_HEADING = re.compile(r"^##\s+\S", re.M)
+
+
+def fence_research_task(instructions: str) -> str:
+    """Put the task fence around the research question, not the whole instruction sheet.
+
+    :func:`src.utils.task_statement` reads what is inside the fence, and every
+    deliverable the coverage gate holds a run to comes from there. Fencing the whole
+    ``INSTRUCTIONS.md`` therefore hands the gate the *harness's operating instructions*
+    as research deliverables. Measured over the 40 shipped tasks,
+    ``demanding_sentences`` returns **337 demands on the full sheet and 142 on the
+    research task alone — 58% of what every run was held to was boilerplate** — and the
+    same five phantoms appear in all forty:
+
+        Read & Understand -- Study the related work and data to build domain context.
+        Code & Execute -- Implement the analysis, generate figures, and iterate ...
+        Analyze & Report -- Interpret the results and produce a publication-quality ...
+        Your primary goal is to complete the research task and produce a ... report.md
+        Figures are mandatory -- generate plots and save to report/images/ ...
+
+    3.5 demands per task after narrowing is the right order of magnitude too: the
+    shipped checklists carry three to five criteria each.
+
+    The agent still reads the whole sheet — only the *fence* moves, so the extractors
+    see the question while the prompt keeps the workspace rules. When the heading is
+    absent, which is any goal a human typed, the whole thing is fenced exactly as
+    before: narrowing a goal that is already only a question would delete it.
+    """
+    text = instructions.strip()
+    match = _TASK_HEADING.search(text)
+    if match is None:
+        return f"{TASK_BEGIN_MARKER}\n{text}\n{TASK_END_MARKER}"
+    start = match.end()
+    nxt = _NEXT_HEADING.search(text, start)
+    end = nxt.start() if nxt else len(text)
+    task = text[start:end].strip()
+    if not task:
+        return f"{TASK_BEGIN_MARKER}\n{text}\n{TASK_END_MARKER}"
+    head = text[: match.start()].rstrip()
+    tail = text[end:].lstrip()
+    parts = [head, match.group(0), f"{TASK_BEGIN_MARKER}\n{task}\n{TASK_END_MARKER}", tail]
+    return "\n\n".join(part for part in parts if part).strip()
+
+
 def build_benchmark_goal(
     workspace: Path,
     instructions: str,
@@ -391,7 +438,7 @@ def build_benchmark_goal(
                 "Make the best judgement you can from the data and keep going."
             ),
             "## Research Task",
-            f"{TASK_BEGIN_MARKER}\n{instructions.strip()}\n{TASK_END_MARKER}",
+            fence_research_task(instructions),
             "## Benchmark Workspace Contract",
             (
                 f"The benchmark workspace is `{resolved}`. It is separate from the AutoR run tree "

--- a/src/skills/a-deliverable-is-not-an-instruction/SKILL.md
+++ b/src/skills/a-deliverable-is-not-an-instruction/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: a-deliverable-is-not-an-instruction
+description: Use at study design when listing the task's deliverables into report_plan.json, and again before writing when checking coverage. Covers how to tell a research deliverable from the harness's own operating instructions, why a padded list is worse than a short one, and what to write when a deliverable is genuinely out of reach.
+stages: 03_study_design, 07_writing
+---
+
+# The sheet you were handed is two documents. Only one of them is the task.
+
+A task statement that arrives through a harness is rarely only the task. Around
+the research question sits a second document: how to operate, where to write
+files, what not to do, what counts as finished. Both are addressed to you, both
+are written in the imperative, and one of them is not a deliverable.
+
+Enumerate the wrong one and the study is planned against phantoms.
+
+## The failure this prevents
+
+Measured on a forty-task benchmark arm: the deliverable list drawn off the whole
+instruction sheet held **337 requirements; the research questions alone held 142**.
+Fifty-eight per cent of what every run was planning against was the harness talking
+about itself, and the same five phantoms appeared in all forty runs:
+
+> Read & Understand — Study the related work and data to build domain context.
+> Code & Execute — Implement the analysis, generate figures, and iterate…
+> Analyze & Report — Interpret the results and produce a publication-quality report.
+> Your primary goal is to … produce a high-quality `report/report.md`.
+> Figures are mandatory — generate plots and save to `report/images/`.
+
+Every one is a true instruction. Not one is a finding. A plan that answers
+"Read & Understand" with `figure:2` has spent a figure slot on the fact that
+reading happened.
+
+The damage is not only wasted slots. A plan is checked for a *covering* answer to
+each listed deliverable, so a list of seventeen forces seventeen answers out of a
+study that has four results — and the entries that cannot be answered honestly get
+answered emptily. An empty entry fails the gate, the stage is sent back, and a
+stage sent back often enough is a stage that never happens.
+
+## The test
+
+For each imperative sentence, ask: **would the answer to this appear in the
+published paper?**
+
+| Sentence | In the paper? | Deliverable |
+|:---|:---|:---|
+| "derive upper limits on the coupling strength" | yes, a number with an interval | **yes** |
+| "compare against the incumbent method" | yes, a table | **yes** |
+| "report the distribution across all seven datasets" | yes, a figure | **yes** |
+| "study the related work to build context" | no — everyone does this | no |
+| "save all figures as PNG" | no — that is file format | no |
+| "install python packages as needed" | no | no |
+| "produce a high-quality report" | no — that is the container | no |
+
+The distinction is not importance. Saving figures as PNG matters enormously; it is
+just not a finding. Obey those instructions — they are how the work gets delivered
+— and keep them out of the list of things the work *found*.
+
+A second cue: a deliverable is task-specific. If the sentence would read identically
+in a task about superconductors and a task about cloud seeding, it came from the
+template, not from the study.
+
+## Sizing the list
+
+Three to six deliverables is the normal shape of a research task. If your list has
+grown past ten, you are almost certainly enumerating the template. Re-read it and
+cut, rather than inventing an answer for each.
+
+Two entries that look like two deliverables are often one: "derive limits on masses
+**and** coupling strengths" is two, because either can be present without the other;
+"produce reproducible tables **and** figure-level evidence" is one result delivered
+two ways. Split on *what could be missing independently*, not on the conjunction.
+
+## When one is genuinely out of reach
+
+Say so in the entry rather than leaving it blank or inventing a cover. Name the
+deliverable, say exactly what is missing — the data was not supplied, the reference
+implementation is not public, the compute is not there — and say what you did
+instead.
+
+**A blank entry is the worst of the three options.** It fails the plan gate, which
+costs the stage; and if it survives, it claims coverage that does not exist. An
+honest "not reachable, because X" costs nothing and is a sentence the report can
+reuse in its limitations.
+
+## Before you leave study design
+
+- Every entry names something that would appear in a published paper.
+- No entry would read identically in a task from another field.
+- No entry is blank.
+- The count is in single digits, and each one is answered by a figure, a number,
+  or a named section — not by "prose" used as a placeholder.

--- a/tests/test_fence_research_task.py
+++ b/tests/test_fence_research_task.py
@@ -1,0 +1,191 @@
+"""The fence decides what the run thinks it was asked for.
+
+``src.utils.task_statement`` reads what is inside the task fence, and every deliverable
+the coverage gate holds a run to comes from there. Fencing the whole ``INSTRUCTIONS.md``
+handed the gate the benchmark harness's *operating instructions* as research deliverables.
+
+Measured over the 40 shipped tasks: ``demanding_sentences`` returned **337 demands on the
+full sheet and 142 on the research task alone**. The same five phantoms appeared in all
+forty runs, and "Read & Understand -- Study the related work" was one of them.
+
+The cost was not abstract. Of the six tasks where AutoR lost most heavily to bare Claude
+Code, every one auto-skipped two or three stages, and the single most common validation
+error across them -- 24 occurrences -- was Stage 03's plan gate refusing an entry that
+"states nothing": a deliverable list padded to cover phantoms, with the unanswerable
+entries left blank.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.deliverables import demanding_sentences
+from src.rcb import fence_research_task
+from src.utils import TASK_BEGIN_MARKER, TASK_END_MARKER, task_statement
+
+# The shape of ResearchClawBench's INSTRUCTIONS.md, trimmed to the sections that matter.
+SHEET = """## Role
+
+You are an autonomous scientific research agent.
+
+1. **Read & Understand** - Study the related work and data to build domain context.
+2. **Code & Execute** - Implement the analysis, generate figures, and iterate.
+
+---
+
+## Research Task
+
+### Task Description
+The goal is to derive statistically rigorous upper limits on ULB masses and
+self-interaction coupling strengths, and to compare them against the incumbent bound.
+
+### Available Data Files
+- **samples.dat**: Contains the posterior distribution samples for the black hole.
+
+---
+
+## Execution Protocol
+
+Your primary goal is to complete the research task and produce a high-quality report.
+
+## Workspace
+
+- **Figures are mandatory** - generate plots and save them to `report/images/`.
+"""
+
+
+class FenceNarrowingTest(unittest.TestCase):
+    def _fenced(self, text: str = SHEET) -> str:
+        return fence_research_task(text)
+
+    def test_the_research_task_is_what_ends_up_inside_the_fence(self) -> None:
+        inner = task_statement(self._fenced())
+        self.assertIn("upper limits on ULB masses", inner)
+        self.assertIn("samples.dat", inner)
+
+    def test_the_harness_boilerplate_is_outside_the_fence(self) -> None:
+        inner = task_statement(self._fenced())
+        for phantom in ("Read & Understand", "Code & Execute", "Figures are mandatory",
+                        "produce a high-quality report", "autonomous scientific research agent"):
+            self.assertNotIn(phantom, inner, f"{phantom!r} is an instruction, not a deliverable")
+
+    def test_the_agent_still_reads_the_whole_sheet(self) -> None:
+        # Only the fence moves. Losing the workspace rules would trade one failure for
+        # a worse one: figures written somewhere the judge never looks.
+        fenced = self._fenced()
+        for kept in ("## Role", "## Execution Protocol", "## Workspace",
+                     "Figures are mandatory", "Read & Understand"):
+            self.assertIn(kept, fenced)
+
+    def test_the_demand_count_drops_to_the_research_task(self) -> None:
+        before = demanding_sentences(SHEET)
+        after = demanding_sentences(task_statement(self._fenced()))
+        self.assertLess(len(after), len(before))
+        self.assertTrue(any("upper limits" in s for s in after))
+        self.assertFalse(any("Study the related work" in s for s in after))
+
+    def test_a_goal_a_human_typed_is_fenced_whole(self) -> None:
+        # No `## Research Task` heading. Narrowing here would delete the question.
+        goal = "Work out whether regularizer choice changes which variables look predictive."
+        inner = task_statement(fence_research_task(goal))
+        self.assertEqual(inner, goal)
+
+    def test_an_empty_research_task_section_falls_back_to_the_whole_sheet(self) -> None:
+        # A heading with nothing under it must not fence emptiness: the run would then
+        # believe it had been asked for nothing at all.
+        sheet = "## Role\n\nBe an agent.\n\n## Research Task\n\n## Workspace\n\nWrite here.\n"
+        inner = task_statement(fence_research_task(sheet))
+        self.assertIn("Be an agent", inner)
+
+    def test_the_fence_is_well_formed_and_appears_once(self) -> None:
+        fenced = self._fenced()
+        self.assertEqual(fenced.count(TASK_BEGIN_MARKER), 1)
+        self.assertEqual(fenced.count(TASK_END_MARKER), 1)
+        self.assertLess(fenced.index(TASK_BEGIN_MARKER), fenced.index(TASK_END_MARKER))
+
+    def test_a_research_task_running_to_the_end_of_the_sheet_still_closes(self) -> None:
+        sheet = "## Role\n\nBe an agent.\n\n## Research Task\n\nDerive the bound.\n"
+        inner = task_statement(fence_research_task(sheet))
+        self.assertEqual(inner, "Derive the bound.")
+
+    def test_the_heading_itself_stays_readable_outside_the_fence(self) -> None:
+        # The agent should still see what the section is called.
+        self.assertIn("## Research Task", self._fenced())
+
+
+class BuiltGoalTest(unittest.TestCase):
+    """The producer, not the helper.
+
+    Every test above calls ``fence_research_task`` directly, which leaves
+    ``build_benchmark_goal`` free to go on fencing the whole sheet -- the actual defect.
+    Reverting the call site killed no test until this class existed.
+    """
+
+    def _goal(self, sheet: str = SHEET) -> str:
+        import tempfile
+        from pathlib import Path
+
+        from src.rcb import build_benchmark_goal
+
+        with tempfile.TemporaryDirectory() as tmp:
+            return build_benchmark_goal(Path(tmp), sheet)
+
+    def test_the_built_goal_fences_only_the_research_task(self) -> None:
+        inner = task_statement(self._goal())
+        self.assertIn("upper limits on ULB masses", inner)
+        self.assertNotIn("Read & Understand", inner)
+        self.assertNotIn("Figures are mandatory", inner)
+
+    def test_the_built_goal_still_carries_the_whole_sheet_for_the_agent(self) -> None:
+        goal = self._goal()
+        self.assertIn("Read & Understand", goal)
+        self.assertIn("## Execution Protocol", goal)
+
+    def test_autors_own_contract_never_leaks_into_the_task(self) -> None:
+        """The property the fence exists for, held at the producer.
+
+        Without it the fallbacks are untestable in isolation: an empty fence makes
+        ``extract_fenced_task`` return None and ``task_statement`` hand back the whole
+        goal -- AutoR's grading contract and workspace rules included, which is the
+        phantom-deliverable bug the fence was introduced to fix.
+        """
+        inner = task_statement(self._goal())
+        for wrapper in ("Benchmark Run: ResearchClawBench", "Benchmark Workspace Contract",
+                        "How This Report Is Graded"):
+            self.assertNotIn(wrapper, inner)
+
+    def test_a_sheet_whose_research_task_section_is_empty_does_not_leak_the_contract(self) -> None:
+        sheet = "## Role\n\nBe an agent.\n\n## Research Task\n\n## Workspace\n\nWrite here.\n"
+        inner = task_statement(self._goal(sheet))
+        self.assertIn("Be an agent", inner)
+        self.assertNotIn("How This Report Is Graded", inner)
+
+    def test_a_human_goal_through_the_producer_keeps_its_question(self) -> None:
+        inner = task_statement(self._goal("Does regularizer choice change which variables look predictive?"))
+        self.assertIn("regularizer choice", inner)
+        self.assertNotIn("Benchmark Workspace Contract", inner)
+
+
+class BenchmarkEntryPointTest(unittest.TestCase):
+    def test_the_benchmark_path_has_the_same_retry_budget_as_main(self) -> None:
+        """The divergence that turned recoverable stages into skipped ones.
+
+        ``main.py`` removed the attempt ceiling; ``rcb_agent.py`` kept eight, and
+        ``rcb_agent.py`` is the entry point that produces every benchmark score. All six
+        of the worst-losing tasks auto-skipped stages "after bounded retries were
+        exhausted".
+        """
+        import rcb_agent
+
+        from src.utils import MAX_STAGE_ATTEMPTS
+
+        self.assertEqual(rcb_agent.DEFAULT_MAX_ATTEMPTS, MAX_STAGE_ATTEMPTS)
+
+    def test_the_benchmark_path_does_not_reintroduce_a_number(self) -> None:
+        import rcb_agent
+
+        self.assertIsNone(rcb_agent.DEFAULT_MAX_ATTEMPTS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rcb_adapter.py
+++ b/tests/test_rcb_adapter.py
@@ -95,8 +95,22 @@ class BenchmarkGoalTest(unittest.TestCase):
                 self.assertIn(question, goal_excerpt(goal, budget), f"lost at {budget} chars")
 
     def test_the_fenced_task_round_trips_out_of_the_goal(self) -> None:
+        """The fence carries the research task, not the whole instruction sheet.
+
+        This used to assert the sheet round-tripped whole, which is what handed the
+        coverage gate `## Role` as a deliverable. Over the 40 shipped tasks that was
+        58% of every run's requirement list.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             task = "## Role\n\nAnalyst.\n\n## Research Task\n\nFit the exclusion curve."
+            goal = build_benchmark_goal(Path(tmp).resolve(), task)
+            self.assertEqual(extract_fenced_task(goal), "Fit the exclusion curve.")
+            # The agent still reads the part that is not fenced.
+            self.assertIn("Analyst.", goal)
+
+    def test_a_sheet_with_no_research_task_heading_round_trips_whole(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            task = "Fit the exclusion curve and report the bound."
             goal = build_benchmark_goal(Path(tmp).resolve(), task)
             self.assertEqual(extract_fenced_task(goal), task)
 


### PR DESCRIPTION
Chased from the score down, not from the code up.

## The measurement that started it

Over **34 paired tasks**, same judge both sides, AutoR against bare Claude Code (Opus 5):

```
mean paired difference  -5.14      median -4.62      sd 11.31
AutoR wins 11, loses 23              95% CI  -8.94 .. -1.34
```

Six tasks lost by 17–30 points. **All six auto-skipped two or three stages** after *"bounded retries were exhausted"*. Stage 03 was skipped in five of the six, and one validation error accounts for **24 of the refusals**:

```
Stage 03: Study Design report_plan.json task output N states nothing.
```

## Cause 1 — the fence was around the wrong document

`src.utils.task_statement` reads what is inside the task fence, and **every deliverable the coverage gate holds a run to comes from there.** `build_benchmark_goal` fenced the whole `INSTRUCTIONS.md`, so the gate received the benchmark harness's *operating instructions* as research deliverables.

Measured over the 40 shipped tasks:

| | demands |
|:---|---:|
| fencing the whole sheet | **337** |
| fencing the research task | **142** |

**58% of what every run was planning against was boilerplate**, and the same five phantoms appear in all forty:

> Read & Understand — Study the related work and data to build domain context.
> Code & Execute — Implement the analysis, generate figures, and iterate…
> Analyze & Report — Interpret the results and produce a publication-quality report.
> Your primary goal is to … produce a high-quality `report/report.md`.
> Figures are mandatory — generate plots and save to `report/images/`.

Every one is a true instruction. Not one is a finding. 3.5 demands per task after narrowing is also the right order of magnitude — the shipped checklists carry three to five criteria each.

The downstream damage is visible in the artifacts: **674 `task_outputs` across the 40 plans, 17 per task**, of which 13 had an empty `stated` — which is exactly what "states nothing" refuses. A list padded to cover phantoms gets the unanswerable entries left blank.

The fence now wraps the `## Research Task` section. **The agent still reads the whole sheet — only the fence moves**, so the extractors see the question while the prompt keeps the workspace rules. A goal with no such heading, which is any goal a human typed, is fenced whole exactly as before: narrowing a goal that is already only a question would delete it.

## Cause 2 — the benchmark entry point kept a budget `main.py` had removed

```python
# rcb_agent.py
DEFAULT_MAX_ATTEMPTS = 8      # main.py's default is None
```

The change that removed the attempt ceiling landed on the entry point nobody benchmarks and missed the one that produces every score. The comment defending the 8 said it was *"more retries than the interactive default"* — and it was, until the interactive default became none.

**An exhausted stage is not a slow stage; it is a stage that never happened**, and the report is then written standing on nothing.

## The judgement half is a skill

No code fix can tell a research deliverable from an operating instruction in a sheet nobody has seen yet. `a-deliverable-is-not-an-instruction` covers the test (*would the answer appear in the published paper?*), why a padded list is worse than a short one, how to split a conjunction on what could be missing independently, and what to write when a deliverable is genuinely out of reach — a blank entry being the worst of the three options.

It is **named in the Stage 03 prompt**, because `test_every_general_skill_is_named_by_a_prompt_that_runs` encodes a measured fact: 13 of 34 skills never launched across 40 runs, and a general skill competing on description alone is not enough.

## Verification

3,807 tests, 16 new.

| Mutant | Killed |
|:---|:---|
| call site back to fencing the whole sheet *(the defect)* | 1 |
| no-heading fallback removed — a human goal gets deleted | 1 |
| empty-section fallback removed — AutoR's own contract leaks in | 1 |
| fence runs to end of sheet instead of the next heading | 2 |
| the rest of the sheet dropped — agent loses the workspace rules | 2 |
| benchmark path back to 8 attempts | 2 |

Two of those first **survived**. Every test called `fence_research_task` directly, which left `build_benchmark_goal` — the actual producer, and the actual defect — free to go on fencing the whole sheet. Same gap as [#199](https://github.com/tangxiangru/AutoR/pull/199): *the predicate was covered, the caller was not.* `BuiltGoalTest` closes it.

One existing test changed rather than being worked around: `test_the_fenced_task_round_trips_out_of_the_goal` asserted the sheet round-tripped **whole**, which is the behaviour that handed the gate `## Role` as a deliverable. It now pins the correct contract, plus a second case for the no-heading path.

## What this does not claim

No score. It removes a measured cause of a measured loss; whether it closes the 5.14-point gap is a question for the next paired arm. The honest read of that arm is still bounded by the per-task judge noise of ~8.5 points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)