### PR TITLE
Whether the run answered the question is not a question about the output format

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,7 +40,8 @@ correctly — and then runs the validity-chain validators that ask whether a
 `validate_validity_response` and `validate_round_decision`, plus the three
 report-plan validators (`validate_report_plan`, `validate_report_plan_sources`,
 `validate_report_plan_coverage`) and the task-deliverables gate
-(`validate_deliverables_coverage`). Counting the two Stage 07 format branches,
+(`validate_deliverables_coverage`, which is the one Stage 07 gate outside both
+format branches). Counting the two Stage 07 format branches,
 eighteen `validate_*` functions are reachable from it; the full table, with the
 condition each one refuses on, is in the
 [README](../README.md#the-stage-contract-and-what-gets-validated). The code
@@ -166,7 +167,7 @@ touching a verdict — see **[framework.md](framework.md)**.
 | [`src/hypothesis_manifest.py`](../src/hypothesis_manifest.py) | Parses Stage 02's typed `T*`/`H*`/`C*` identifiers into `hypothesis_manifest.json` — the input the `has_hypotheses` guard reads. |
 | [`src/writing_manifest.py`](../src/writing_manifest.py) | Stage 07 support: writing manifest, figure/result scanning, layout review generation and validation. |
 | [`src/report_plan.py`](../src/report_plan.py) | The report contract. `PlannedFigure`, `HeadlineNumber`, `TaskOutput`, `ReportPlan`. The run commits at Stage 03 to which figures the report will carry and which claim each supports; `stamp_report_plan` writes `declared_at` and a digest to `runs/<id>/report_plan_stamp.json` — outside `workspace/`, so the agent cannot backdate its own declaration. Three validators hang off it: shape at Stage 03, every `source_artifact` resolving to a non-empty file at 06, and every non-dropped slot published *and* referenced at 07 in markdown mode. |
-| [`src/deliverables.py`](../src/deliverables.py) | The task-deliverables contract — the only gate that asks whether the run answered *what it was asked*. `demanding_sentences()` parses the user's own task statement for a fixed list of demand verbs; `validate_deliverables_coverage` requires every `task_quote` to be a verbatim span of `user_input.txt`, every addressed entry to name a `where` that appears in `report.md`, and every demanding sentence to be covered by content-word overlap. `format_deliverables_for_prompt` injects a `# What the Task Asks For` block into every stage prompt. |
+| [`src/deliverables.py`](../src/deliverables.py) | The task-deliverables contract — the only gate that asks whether the run answered *what it was asked*. `demanding_sentences()` parses the user's own task statement for a fixed list of demand verbs; `validate_deliverables_coverage` requires every `task_quote` to be a verbatim span of `user_input.txt`, every addressed entry to name a `where` that appears in the run's deliverable — `report.md`, or the `.tex` sources under `workspace/writing/` when the run targets latex, and every demanding sentence to be covered by content-word overlap. `format_deliverables_for_prompt` injects a `# What the Task Asks For` block into every stage prompt. |
 
 ### Improvement
 

--- a/docs/iclr/round-loop-and-stage-graph.md
+++ b/docs/iclr/round-loop-and-stage-graph.md
@@ -330,8 +330,23 @@ the plan still covers every demanding sentence. The stage that discovers a deman
 meet at design time can still route backwards; the one that discovers it at Stage 07 cannot
 afford to.
 
-*Class: a check placed at the wrong end of the run. Effort: small for the branch, medium for
-the channel.*
+**The first move landed**; the second has not. `validate_deliverables_coverage` now runs
+at `stage.number >= 7` whatever the output format, and its locator half reads the run's
+actual deliverable — `report.md`, or the `.tex` sources under `workspace/writing/` — so
+it no longer degrades to a skip with no counter when there is no markdown report.
+
+Blast radius, measured before landing: **335 archived run configs, every one of them
+`markdown`**. So no archived run changes verdict, which is the honest figure and cuts
+both ways — the gap never cost an observed run, and the fix has never been exercised by
+one either. It is a correctness change about coupling, not a bug with a measured price.
+
+What is still terminal is the *timing*: the check runs once, at Stage 07, and the second
+move above — an earlier writer for the coverage artifact and a reviewer axis over it — is
+what would let a run discover at design time that it is not going to answer half the
+brief.
+
+*Class: a check placed at the wrong end of the run. Effort: small for the branch (done),
+medium for the channel.*
 
 ### 4.6 Carried refusal evidence — the machine-read half only
 

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -965,8 +965,8 @@ of the rows are directory-level counts, and the rest check named files.
   `build_log.txt` and `layout_review.json` in latex mode;
   `citation_verification.json` and `self_review.json` in both. Do not read that
   as the whole set — further per-file gates hang off the same Stage 07 branches
-  (`claim_provenance.json` in both formats, `deliverables_coverage.json` in
-  markdown), and the `stage.number >= 7` branches of `validate_stage_artifacts`
+  (`claim_provenance.json` and `deliverables_coverage.json` in both formats), and
+  the `stage.number >= 7` branches of `validate_stage_artifacts`
   are where the current list lives. Freshness is narrower still: at Stage 07
   itself the files named in that branch's `stage7_required_files`, plus the PDF
   and the section sources in latex mode, must be newer than the stage's start

--- a/docs/stage-contract.md
+++ b/docs/stage-contract.md
@@ -182,11 +182,11 @@ before the branch:
 | From stage | Requirement | Checked by |
 | --- | --- | --- |
 | **07+** | Every claim in `workspace/artifacts/claim_provenance.json` is `confirmatory` on a `supported` hypothesis or labelled `exploratory`, and cites a file that exists. | `validate_claim_provenance` |
+| **07+** | `workspace/artifacts/deliverables_coverage.json` accounts for what the task statement demanded (see [the deliverables contract](#the-deliverables-contract)). Format-independent: whether the run answered the question it was given is not a question about how the answer was typeset. | `validate_deliverables_coverage` |
 
 Everything else at Stage 07 depends on the run's `output_format`, and **the two
-branches share very little**. In particular `validate_markdown_report`,
-`validate_report_plan_coverage` and `validate_deliverables_coverage` do **not**
-run on the latex branch.
+branches share very little**. In particular `validate_markdown_report` and
+`validate_report_plan_coverage` do **not** run on the latex branch.
 
 **`markdown` (the default):**
 
@@ -199,7 +199,6 @@ run on the latex branch.
 | **07+** | Every image reference resolves to a file that exists under `workspace/report/`. | `validate_markdown_report` |
 | **07+** | Every referenced image is renderable: `.png .jpg .jpeg .gif .webp` (`RENDERABLE_IMAGE_SUFFIXES`). | `validate_markdown_report` |
 | **07+** | The count of **published, renderable images under `workspace/report/images/`** is at least this run's figure floor and at most `MAX_REPORT_FIGURES` (5). | `validate_markdown_report` |
-| **07+** | `workspace/artifacts/deliverables_coverage.json` accounts for what the task statement demanded (see [the deliverables contract](#the-deliverables-contract)). | `validate_deliverables_coverage` |
 | **07+** | `workspace/artifacts/citation_verification.json`, structurally valid. | `validate_citation_verification` |
 | **07+** | `workspace/artifacts/self_review.json`. | — |
 | **07+** | `workspace/artifacts/report_review.json`, structurally valid. | `validate_report_review` |

--- a/src/deliverables.py
+++ b/src/deliverables.py
@@ -215,6 +215,39 @@ def load_coverage(paths: RunPaths) -> Any:
         return "invalid"
 
 
+def _deliverable_text(paths: RunPaths) -> tuple[str, str]:
+    """The document a `where` has to point into, whichever format the run targets.
+
+    This used to read ``paths.report_file`` alone, which is `workspace/report/report.md`
+    and nothing else. A latex run has no such file, so the locator check fell through the
+    ``elif report_text and ...`` guard and asserted nothing -- a skip with no counter,
+    inside the one gate that asks whether the run answered the question it was given.
+
+    The other three halves of this validator -- the quote is verbatim, every demanding
+    sentence is accounted for, an unmet demand states why -- never depended on the
+    format. Only this one did, and only because the deliverable was named rather than
+    resolved.
+
+    Returns the document's name as well as its text, so a refusal says which document it
+    looked in rather than always saying `report.md`.
+
+    Still fail-open when neither exists: a stage that has written no deliverable yet is
+    caught by the gates that check for one, and making this the second refusal for one
+    condition would be two gates over one fact.
+    """
+
+    if paths.report_file.exists():
+        return paths.report_file.name, _normalize(read_text(paths.report_file)).lower()
+    sources = sorted(
+        path for path in paths.writing_dir.rglob("*.tex") if path.is_file()
+    ) if paths.writing_dir.exists() else []
+    if sources:
+        joined = "\n".join(read_text(path) for path in sources)
+        name = "main.tex" if len(sources) == 1 else f"the {len(sources)} .tex sources under workspace/writing"
+        return name, _normalize(joined).lower()
+    return "", ""
+
+
 def validate_deliverables_coverage(paths: RunPaths, task_statement: str) -> list[str]:
     """Check that the report answers what the task statement asked for."""
     problems: list[str] = []
@@ -229,7 +262,7 @@ def validate_deliverables_coverage(paths: RunPaths, task_statement: str) -> list
         return [f"{COVERAGE_FILENAME} must contain a non-empty 'deliverables' list."]
 
     normalized_task = _normalize(task_statement).lower()
-    report_text = _normalize(read_text(paths.report_file)).lower() if paths.report_file.exists() else ""
+    deliverable_name, deliverable_text = _deliverable_text(paths)
 
     quotes: list[str] = []
     declined: list[str] = []
@@ -268,10 +301,10 @@ def validate_deliverables_coverage(paths: RunPaths, task_statement: str) -> list
                 problems.append(
                     f"{COVERAGE_FILENAME} entry {index} is marked addressed but does not say where."
                 )
-            elif report_text and not _locator_appears(where, report_text):
+            elif deliverable_text and not _locator_appears(where, deliverable_text):
                 problems.append(
                     f"{COVERAGE_FILENAME} entry {index} points at {where[:60]!r}, which does not "
-                    "appear in report.md."
+                    f"appear in {deliverable_name}."
                 )
         elif not _normalize(str(entry.get("reason") or "")):
             problems.append(

--- a/src/operator.py
+++ b/src/operator.py
@@ -1037,9 +1037,18 @@ Original stderr:
                     "priority_fixes": ["Replace this placeholder with a real report review."],
                 },
             )
-            # A coverage record the real gate accepts, saying plainly that it is fake.
-            # It quotes the task statement verbatim rather than inventing a requirement,
+        if stage.number >= 7:
+            # A coverage record the real gate accepts, saying plainly that it is fake. It
+            # quotes the task statement verbatim rather than inventing a requirement,
             # because that is exactly the rule a real run is held to.
+            #
+            # Outside the markdown branch, like the gate that reads it. Both had the same
+            # coupling and for the same reason -- the record arrived while markdown was
+            # the only format anyone ran -- so a latex run wrote no coverage record and
+            # was never asked for one. Moving only the gate turned the latex end-to-end
+            # pipeline red at Stage 07, which is `test_no_stage_needed_a_retry` doing the
+            # job its comment claims: noticing an artifact gate fake mode was never
+            # taught to satisfy.
             from .deliverables import COVERAGE_FILENAME, demanding_sentences
 
             _statement = task_statement(read_text(paths.user_input))
@@ -1058,7 +1067,6 @@ Original stderr:
             ]
             _write_json(paths.artifacts_dir / COVERAGE_FILENAME, {"deliverables": _entries})
 
-        if stage.number >= 7:
             venue = selected_venue_key(paths)
             _write(
                 paths.writing_dir / "main.tex",

--- a/src/utils.py
+++ b/src/utils.py
@@ -1843,6 +1843,25 @@ def validate_stage_artifacts(
         for problem in validate_claim_provenance(paths):
             problems.append(f"{stage.stage_title} {problem}")
 
+    # Rigour about the wrong question still fails the task. Everything in the
+    # markdown block below measures how well the report was made; this measures whether
+    # it answered what was asked, which is not a question about the output format.
+    #
+    # It sat inside that block until now, so a latex run was never asked whether it
+    # covered the brief. The condition predates the module: it arrived with the change
+    # that made markdown the default report format, and the coverage check was appended
+    # inside it. Blast radius of moving it out, measured over 335 archived run configs:
+    # every one of them is `markdown`, so no archived run changes verdict. That is the
+    # honest figure and it cuts both ways -- the gap has never cost an observed run, and
+    # the fix has never been exercised by one either.
+    if stage.number >= 7:
+        from .deliverables import validate_deliverables_coverage
+
+        problems.extend(
+            f"{stage.stage_title}: {problem}"
+            for problem in validate_deliverables_coverage(paths, task_statement(read_text(paths.user_input)))
+        )
+
     if stage.number >= 7 and selected_output_format(paths) == "markdown":
         from .report_plan import validate_report_plan_coverage
 
@@ -1857,15 +1876,6 @@ def validate_stage_artifacts(
             )
         )
 
-        # Rigour about the wrong question still fails the task. Everything above this
-        # measures how well the report was made; this measures whether it answered what
-        # was asked.
-        from .deliverables import validate_deliverables_coverage
-
-        problems.extend(
-            f"{stage.stage_title}: {problem}"
-            for problem in validate_deliverables_coverage(paths, task_statement(read_text(paths.user_input)))
-        )
 
         if not (paths.artifacts_dir / "citation_verification.json").exists():
             problems.append(

--- a/tests/test_task_deliverables_contract.py
+++ b/tests/test_task_deliverables_contract.py
@@ -432,6 +432,83 @@ class TheStageGateCallsItTest(unittest.TestCase):
         self.assertNotIn(COVERAGE_FILENAME, problems)
 
 
+class CoverageIsNotAMarkdownQuestionTest(unittest.TestCase):
+    """The gate that asks whether the run answered the brief, asked of a latex run too.
+
+    It sat inside `if stage.number >= 7 and selected_output_format(paths) == "markdown"`.
+    That condition arrived with the change making markdown the default report format and
+    the coverage check was appended inside it, so a latex run was never asked whether it
+    covered the task. Measured over 335 archived run configs every one is `markdown`, so
+    no archived run changes verdict -- which is also why nothing noticed.
+
+    Two halves, and both need holding: the gate has to *run* for a latex stage, and the
+    locator check inside it has to have a document to read, or it degrades to a skip with
+    no counter.
+    """
+
+    def _paths(self, output_format: str):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, TASK)
+        write_text(paths.run_config, json.dumps({"output_format": output_format}))
+        return paths
+
+    def _cover(self, paths, **entry):
+        write_text(paths.artifacts_dir / COVERAGE_FILENAME,
+                   json.dumps({"deliverables": [{"task_quote": MASS_QUOTE, **entry}]}))
+
+    def test_a_latex_stage_is_asked_for_the_coverage_artifact(self) -> None:
+        from src.utils import validate_stage_artifacts
+
+        paths = self._paths("latex")
+        write_text(paths.writing_dir / "main.tex", r"\section{Coupling Limits}")
+        problems = " ".join(validate_stage_artifacts(STAGES[6], paths))
+        self.assertIn(COVERAGE_FILENAME, problems)
+
+    def test_a_markdown_stage_is_still_asked(self) -> None:
+        """Control: the move must not take the check off the format that had it."""
+        from src.utils import validate_stage_artifacts
+
+        paths = self._paths("markdown")
+        write_text(paths.report_file, "# Report\n")
+        problems = " ".join(validate_stage_artifacts(STAGES[6], paths))
+        self.assertIn(COVERAGE_FILENAME, problems)
+
+    def test_a_locator_is_checked_against_the_tex_sources(self) -> None:
+        paths = self._paths("latex")
+        write_text(paths.writing_dir / "main.tex", r"\section{Coupling Limits}" + "\ntext\n")
+        self._cover(paths, addressed=True, where="Coupling Limits")
+        self.assertEqual(validate_deliverables_coverage(paths, TASK), [])
+
+    def test_a_locator_that_points_nowhere_in_the_tex_is_refused(self) -> None:
+        """The half that used to fall through: no report.md, so no check at all."""
+        paths = self._paths("latex")
+        write_text(paths.writing_dir / "main.tex", r"\section{Mass Limits}" + "\ntext\n")
+        self._cover(paths, addressed=True, where="Coupling Limits")
+        problems = " ".join(validate_deliverables_coverage(paths, TASK))
+        self.assertIn("does not appear in", problems)
+        self.assertIn("main.tex", problems)
+
+    def test_sections_under_writing_are_read_too(self) -> None:
+        paths = self._paths("latex")
+        write_text(paths.writing_dir / "main.tex", r"\input{sections/results}")
+        write_text(paths.writing_dir / "sections" / "results.tex", r"\subsection{Coupling Limits}")
+        self._cover(paths, addressed=True, where="Coupling Limits")
+        self.assertEqual(validate_deliverables_coverage(paths, TASK), [])
+
+    def test_with_no_deliverable_at_all_the_locator_still_fails_open(self) -> None:
+        """A stage that has written nothing is caught by the gates that check for one.
+
+        Two refusals for one condition is one too many, and the second is the one nobody
+        maintains.
+        """
+        paths = self._paths("latex")
+        self._cover(paths, addressed=True, where="Coupling Limits")
+        self.assertEqual(validate_deliverables_coverage(paths, TASK), [])
+
+
 class RefinementTurnsKeepTheContractTest(unittest.TestCase):
     """A contract that only appears on the first attempt is one every retry can forget.
 

--- a/tests/test_writing_pipeline.py
+++ b/tests/test_writing_pipeline.py
@@ -100,6 +100,19 @@ class WritingPipelineTests(unittest.TestCase):
             paths.artifacts_dir / "self_review.json",
             json.dumps({"overall_score": 8.0, "final_verdict": "ready", "rounds": 1}),
         )
+        # The deliverables contract is a Stage 07 gate in both formats now, not only in
+        # markdown -- whether the run answered the question it was given is not a
+        # question about how the answer was typeset. The fixture states what a valid
+        # latex Stage 07 looks like, so it has to carry one.
+        from src.deliverables import COVERAGE_FILENAME
+
+        write_text(
+            paths.artifacts_dir / COVERAGE_FILENAME,
+            json.dumps({"deliverables": [
+                {"task_quote": "Test writing pipeline", "addressed": False,
+                 "reason": "the fixture builds a manuscript shape, not research"},
+            ]}),
+        )
         generate_layout_review(paths)
 
     def test_stage07_validation_passes_with_expected_outputs(self) -> None:


### PR DESCRIPTION
§4.5 of [#254](https://github.com/tangxiangru/AutoR/pull/254)'s list, and the smallest of the four
still open.

## The coupling

`validate_deliverables_coverage` is the only gate that asks the prior question — *did the run answer
what it was asked* — and it ran only on markdown runs. It sat under
`stage.number >= 7 and selected_output_format(paths) == "markdown"`, a condition that arrived with the
change making markdown the default report format; the deliverables module came later and was appended
inside it. Meanwhile `format_deliverables_for_prompt` reaches **every** stage in **both** formats, so a
latex run was told to write `deliverables_coverage.json` and never asked for it.

## The locator half was a silent skip

It read `paths.report_file` — `workspace/report/report.md` and nothing else — behind
`elif report_text and not _locator_appears(...)`. No markdown report ⇒ empty string ⇒ the branch falls
through and asserts nothing, inside the gate that exists to notice omissions.

`_deliverable_text` now **resolves** the deliverable instead of naming it: the markdown report, else the
`.tex` sources under `workspace/writing/`, else nothing. The refusal names the document it actually read.
Still fails open when neither exists — a stage that wrote no deliverable is already refused by the gates
that check for one, and two refusals for one condition is one too many.

## Blast radius, and where my measurement was wrong

Before landing I measured **335 archived run configs, every one `markdown`** → no archived run changes
verdict. I reported that figure.

The suite then found what the archive could not: `FakePipelineLatexEndToEndTest` went red at Stage 07,
because **the fake operator wrote its coverage record inside a markdown-only branch too**. Two encodings
of one coupling, and the archive contained no instance of either. `test_no_stage_needed_a_retry` is doing
exactly what its comment claims — noticing an artifact gate fake mode was never taught to satisfy.

So the fake operator's record moves out of its branch as well, and the latex Stage 07 fixture in
`test_writing_pipeline` now carries a coverage artifact, because that is part of what a valid latex
Stage 07 looks like.

## Tests

Six, in `CoverageIsNotAMarkdownQuestionTest`. **Two go red without the change**:

- `test_a_latex_stage_is_asked_for_the_coverage_artifact` — the gate did not run
- `test_a_locator_that_points_nowhere_in_the_tex_is_refused` — the locator was never checked

Four are controls: markdown is still gated, `sections/*.tex` under `writing/` are read, a valid latex
locator passes, and no deliverable at all still fails open.

Full suite: 3813 tests, OK (skipped=1), `umask 022`, `TMPDIR=/tmp`.

## Docs

- `stage-contract.md` — the row moves out of the markdown table into the format-independent one, and the
  sentence that named this validator as latex-exempt is corrected.
- `architecture.md` — the `where` no longer "appears in `report.md`"; it appears in the run's deliverable.
- `run-artifacts.md` — stops listing `deliverables_coverage.json` as markdown-only.
- `docs/iclr/round-loop-and-stage-graph.md` §4.5 — records the half that landed, the half that did not
  (the coverage artifact still has no earlier writer and no reviewer axis, so the check is still terminal),
  and both blast-radius figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)