### PR TITLE
Say what the walk actually did at the end of it

### DIFF
--- a/docs/iclr/round-loop-and-stage-graph.md
+++ b/docs/iclr/round-loop-and-stage-graph.md
@@ -252,6 +252,24 @@ obligation src/stage_graph.py` returns nothing; obligations reach prompts, and `
 increments a counter with no ceiling and no reader that can refuse. An obligation that can
 be deferred indefinitely with no reader is a debt with no creditor.
 
+**Landed, as the sentence rather than the status.** `_complete_run` now calls
+`_completion_sentence`, which reads two harness-written records the close had never
+consulted — the manifest's own `skipped` flag and the obligation ledger — and says what
+it finds. A run with neither says exactly what it said before, so a clean run's closing
+line is unchanged; the sentence only moves where it would have been false.
+
+That also gives the obligation ledger its first reader that can act on it. `note_deferrals`
+incremented a counter with no ceiling and nothing downstream ever asked what was still
+open; now the run cannot close claiming everything was approved while a debt a reviewer
+attached is outstanding.
+
+**The fourth `run_status` value was considered and refused.** The walk did complete; what
+was false was the prose. A new status would have to be taught to six places in
+`src/frontend/static/app.js` that test `=== "completed"` for settledness, plus
+`humanStatus` and a CSS class — a wide change across a surface this suite does not cover,
+for a defect entirely in a sentence. The RCB adapter is unaffected either way: its
+`status` is derived from whether the report is substantive, not from the manifest.
+
 *Class: a record that overstates. Effort: small.*
 
 ### 4.4 A channel with no declared budget

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -208,7 +208,12 @@ what rollback rewrites. Written by [`src/manifest.py`](../src/manifest.py).
 }
 ```
 
-**`run_status`** — one of `pending`, `running`, `human_review`, `completed`,
+**`run_status`** — unchanged when a walk reaches the terminal with gaps: the walk did
+complete, and what a skipped stage or an open obligation changes is the `run_complete`
+log entry and the closing line, which `ResearchManager._completion_sentence` derives from
+the manifest's `skipped` flags and the obligation ledger rather than asserting. A clean
+run still reads *"All stages approved."*; a run that auto-skipped its writing stage now
+names it instead. One of `pending`, `running`, `human_review`, `completed`,
 `failed`, `cancelled`, `halted`, `abandoned`.
 
 The last two are the ones worth knowing about, because both are stops that are

--- a/src/manager.py
+++ b/src/manager.py
@@ -17,6 +17,7 @@ from .bootstrap import (
 from .approval_agent import AutomatedReviewer, ReviewDecision
 from .cross_reviewer import GeminiCrossReviewer
 from .obligations import (
+    OPEN as OBLIGATION_OPEN,
     discharge_obligations,
     format_for_stage_prompt,
     ledger_summary,
@@ -940,10 +941,27 @@ class ResearchManager:
             )
             return True
 
+        # Derived, not asserted. "All stages approved." was written on every walk that
+        # reached the terminal, and `settled` is `approved or skipped` -- so a run whose
+        # writing stage exhausted its attempts and was auto-skipped closed by saying every
+        # stage had been approved. Roughly two in five archived runs contain an auto-skip,
+        # so this was not a rare wrong sentence.
+        #
+        # The gaps come from records the harness already keeps and the agent cannot write:
+        # the manifest's own `skipped` flag, and the obligation ledger, which until now had
+        # no reader that could act on it at all -- `note_deferrals` incremented a counter
+        # with no ceiling and nothing downstream ever asked what was still open.
+        #
+        # `run_status` deliberately stays `completed`. The walk did complete; what was
+        # false was the sentence. A fourth status value would have to be taught to six
+        # places in `src/frontend/static/app.js` that test `=== "completed"` for
+        # settledness, plus `humanStatus` and its CSS class, none of which this suite
+        # covers -- a wide untested change for a defect that is entirely in the prose.
+        closing = self._completion_sentence(paths)
         append_log_entry(
             paths.logs,
             "run_complete",
-            "All stages approved." + (f"\nRoute: {route}" if route else ""),
+            closing + (f"\nRoute: {route}" if route else ""),
         )
         update_manifest_run_status(
             paths,
@@ -955,12 +973,43 @@ class ResearchManager:
         if route and self.stage_graph.name != "linear":
             self.ui.show_status(f"Route taken: {route}", level="info")
         self._report_optional_machinery(paths)
-        # The disclosure rides on this line rather than beside it, because "All stages
-        # approved" is the sentence it qualifies.
+        # The disclosure rides on this line rather than beside it, because the completion
+        # sentence is what it qualifies.
         self._print(
-            "All stages approved. Run complete." + (f"\n{disclosure}" if disclosure else "")
+            f"{closing} Run complete." + (f"\n{disclosure}" if disclosure else "")
         )
         return True
+
+    def _completion_sentence(self, paths: RunPaths) -> str:
+        """What the run may honestly say about itself at the terminal.
+
+        Two records, both harness-written, both already on disk, neither previously read
+        at the close: which stages were promoted without being accepted, and which debts a
+        reviewer attached and nobody discharged. A run with neither says exactly what it
+        said before, so a clean run's closing line is unchanged and the tests that pin it
+        keep passing -- which is the point. The sentence only moves when it would have
+        been false.
+        """
+
+        skipped = [entry.slug for entry in ensure_run_manifest(paths).stages if entry.skipped]
+        open_debts = [
+            obligation.obligation_id
+            for obligation in load_ledger(paths).obligations
+            if obligation.status == OBLIGATION_OPEN
+        ]
+        if not skipped and not open_debts:
+            return "All stages approved."
+
+        parts = []
+        if skipped:
+            parts.append(
+                f"{len(skipped)} stage(s) promoted without being accepted: " + ", ".join(skipped)
+            )
+        if open_debts:
+            parts.append(
+                f"{len(open_debts)} obligation(s) still open: " + ", ".join(sorted(open_debts))
+            )
+        return "The walk reached the end with gaps. " + "; ".join(parts) + "."
 
     def _record_block_census(self, paths: RunPaths, state: "GraphState | None") -> None:
         """Write down which edges this walk was offered and what shut the rest.

--- a/tests/test_validity_completion.py
+++ b/tests/test_validity_completion.py
@@ -395,3 +395,94 @@ class TheGateIsNotWhereThisLivesTest(CompletionTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheClosingSentenceIsDerivedTest(unittest.TestCase):
+    """"All stages approved." was written on every walk that reached the terminal.
+
+    `settled` is `approved or skipped`, so a run whose writing stage exhausted its
+    attempts and was auto-skipped reached the end and closed by saying every stage had
+    been approved. About two in five archived runs contain an auto-skip, so this was not
+    a rare wrong sentence -- and the obligation ledger, which records what a reviewer said
+    a later stage still owed, had no reader at the close at all.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.paths = build_run_paths(Path(self._tmp.name) / "run")
+        ensure_run_layout(self.paths)
+        write_text(self.paths.user_input, "goal")
+        from src.manifest import ensure_run_manifest
+
+        ensure_run_manifest(self.paths)
+        self.manager = ResearchManager(
+            project_root=Path(__file__).resolve().parent.parent,
+            runs_dir=Path(self._tmp.name) / "runs",
+            operator=None,
+            ui=TerminalUI(output_stream=io.StringIO(), interactive=False),
+        )
+
+    def _sentence(self) -> str:
+        return self.manager._completion_sentence(self.paths)
+
+    def test_a_clean_run_says_exactly_what_it_said_before(self) -> None:
+        """The control. The sentence only moves where it would have been false."""
+        self.assertEqual(self._sentence(), "All stages approved.")
+
+    def test_a_skipped_stage_is_named_rather_than_called_approved(self) -> None:
+        from src.manifest import mark_stage_skipped_manifest
+        from src.utils import STAGES
+
+        mark_stage_skipped_manifest(self.paths, STAGES[6], 5, [], kind="auto",
+                                    reason="attempts exhausted")
+        sentence = self._sentence()
+        self.assertNotIn("All stages approved", sentence)
+        self.assertIn("07_writing", sentence)
+        self.assertIn("without being accepted", sentence)
+
+    def test_an_open_obligation_is_named(self) -> None:
+        """The ledger's first reader at the close: `note_deferrals` counted, nobody asked."""
+        from src.obligations import record_obligations
+        from src.utils import STAGES
+
+        record_obligations(
+            self.paths, stage=STAGES[0],
+            entries=["State a power analysis and justify the sample size before running anything."],
+        )
+        sentence = self._sentence()
+        self.assertIn("obligation(s) still open", sentence)
+        self.assertNotIn("All stages approved", sentence)
+
+    def test_a_discharged_obligation_does_not_count(self) -> None:
+        from src.obligations import discharge_obligations, record_obligations
+        from src.utils import STAGES
+
+        added = record_obligations(
+            self.paths, stage=STAGES[0],
+            entries=["State a power analysis and justify the sample size before running anything."],
+        )
+        discharge_obligations(self.paths, stage=STAGES[2],
+                              obligation_ids=[added[0].obligation_id])
+        self.assertEqual(self._sentence(), "All stages approved.")
+
+    def test_the_sentence_reaches_the_log_and_the_closing_line(self) -> None:
+        """Wiring, not just the helper. A sentence nothing prints is not a correction.
+
+        `_completion_sentence` is private, so `test_declared_symbols_are_wired` would not
+        notice if `_complete_run` stopped calling it -- and the whole defect was a closing
+        line nobody had re-derived.
+        """
+        from src.manifest import mark_stage_skipped_manifest
+        from src.utils import STAGES, read_text as _read
+
+        mark_stage_skipped_manifest(self.paths, STAGES[6], 5, [], kind="auto",
+                                    reason="attempts exhausted")
+        stream = io.StringIO()
+        self.manager.ui = TerminalUI(output_stream=stream, interactive=False)
+        self.manager._complete_run(self.paths)
+
+        logged = _read(self.paths.logs)
+        self.assertIn("07_writing", logged)
+        self.assertIn("without being accepted", logged)
+        self.assertNotIn("All stages approved", logged)


### PR DESCRIPTION
§4.3 of [#254](https://github.com/tangxiangru/AutoR/pull/254)'s list.

## The false sentence

`_complete_run` wrote **"All stages approved."** on every walk that reached the terminal. `settled` is
`approved or skipped`, so a run whose writing stage exhausted its attempts and was auto-skipped got
there, took that branch, and closed by saying every stage had been approved.

Not a rare case: `docs/iclr/composable-stage-graphs.md` measured **53 of 135 archived manifests** with at
least one auto-skip, and **34 of those 53 advanced past** the skipped stage rather than stopping.

## The fix

`_completion_sentence` derives the line from two harness-written records the close had never read — the
manifest's own `skipped` flag and the obligation ledger. A run with neither says *exactly* what it said
before; the control test pins that, and it is the point. **The sentence only moves where it would have
been false.**

```
All stages approved.
The walk reached the end with gaps. 1 stage(s) promoted without being accepted: 07_writing.
```

## This is the obligation ledger's first reader that can act on it

`note_deferrals` incremented a counter with no ceiling; `format_for_review_prompt` put open debts in
front of an LLM; and **no deterministic decider anywhere read the file** (`grep obligation
src/stage_graph.py` still returns nothing). A run can no longer close claiming everything was approved
while a debt a reviewer attached is outstanding.

## A fourth `run_status` was considered and refused

The walk *did* complete; what was false was the prose. A new status value would have to be taught to six
places in `src/frontend/static/app.js` that test `=== "completed"` for settledness, plus `humanStatus`
and a CSS class — none of which this suite covers. A wide untested change for a defect entirely in a
sentence.

The RCB adapter is unaffected either way, which I checked before deciding: `RunExport.status` is derived
from whether the report is substantive, not from the manifest, so the benchmark exit code never depended
on this.

## Tests

Five. Four hold the sentence (clean run unchanged; a skipped stage is named; an open obligation is named;
a discharged one does not count) and one holds the **wiring** — `_completion_sentence` is private, so
`test_declared_symbols_are_wired` would not notice `_complete_run` dropping the call, and a closing line
nobody re-derives is the entire defect. Rewiring `closing` back to the literal turns that one red.

Full suite: 3818 tests, OK (skipped=1), `umask 022`, `TMPDIR=/tmp`.

## Docs

`docs/iclr/round-loop-and-stage-graph.md` §4.3 records what landed and the refused alternative;
`docs/run-artifacts.md` notes that `run_status` is deliberately unchanged and where the gaps show up
instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)