### PR TITLE
The four-point deficit was the instrument, not the scaffold

### DIFF
--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -120,8 +120,10 @@ is exactly 50/50). Every number in this section is re-derivable from
 the `type: image` entries per task for the criterion counts. They move when the task set
 does, and they were last measured on 2026-08-10 against the 40 shipped tasks.
 
-The judge is **not** shown five images chosen for the item. `evaluation/score.py` collects
-one set per *workspace* and hands the first five of that same set to every image criterion:
+The judge is **not** shown images chosen for the item. `evaluation/score.py` collects
+one set per *workspace* and hands the first *N* of that same set to every image criterion.
+**`N` was five until upstream `bfffc48` (2026-08-14) raised it to fifteen**, which is why
+`MAX_REPORT_FIGURES` is 15 and no longer 5:
 
 ```python
 generated_images = _find_generated_images(workspace)               # once, per workspace
@@ -130,7 +132,7 @@ for search_dir in [workspace / "outputs", workspace / "report"]:   # outputs fir
     for ext in IMAGE_EXTENSIONS:
         images.extend(search_dir.rglob(f"*{ext}"))                 # filesystem order
 ...
-for img in generated_images[:5]:                                   # per item, the same five
+for img in generated_images[:15]:                                  # per item, the same set
 ```
 
 Four consequences drive the export, and the plan the run writes at Stage 03:
@@ -1001,11 +1003,27 @@ A clause that has stopped firing because an internal artifact was renamed looks 
 like a clause never violated, and the gate does not fail loudly when that happens — it
 stops refusing.
 
-### What no clause can bound: which five images
+### What no clause can bound: which images
 
 `no_images_under_outputs` bounds where the judge's images come from. It cannot bound how
-many there were: the scorer shows the first five of one `rglob` list against *every*
-image criterion, and image criteria are 60.6% of the benchmark's weight. Four figures all
+many there were: the scorer shows the first `MAX_REPORT_FIGURES` of one `rglob` list
+against *every* image criterion, and image criteria are 60.6% of the benchmark's weight.
+
+**A local scorer that clips lower than upstream is not a stricter measurement, it is a
+different one, and it is not neutral between arms.** Ours held `MAX_IMAGES = 5` after
+upstream moved to fifteen. Re-scoring the identical workspaces with the two caps, changing
+nothing else:
+
+| | cap 5 | cap 15 |
+|:---|---:|---:|
+| bare Claude Code (7 figures median) | 29.19 | 28.67 |
+| AutoR (10 figures median) | 24.26 | **27.97** |
+| paired difference | **-4.94** | **-0.70** |
+| AutoR wins - losses | 12-25 | 22-16 |
+
+The clip cost the arm that produced more figures roughly four times what it cost the arm
+that produced fewer, because it hid half of one and a quarter of the other. A four-point
+deficit that three sister arms did not reproduce was the instrument. Four figures all
 shown and twelve figures of which an arbitrary five were shown are different evidence,
 and the score file was already recording which images went in — the trial simply threw
 it away, so two arms shown different figures produced an identical `env_digest` and the


### PR DESCRIPTION
AutoR measured **4.94 points below bare Claude Code** over 39 paired tasks. Three sister arms did not reproduce it (`arm_2ffaeb4` +0.72, `full40_v220` +0.36, `full40_pins` +0.68) — which is the signal that an *arm* is being measured, not a scaffold.

## What it was

Our local judge wrapper held `MAX_IMAGES = 5` after upstream raised the cap to fifteen (`RCB bfffc48`, 2026-08-14):

```python
# rcb_tools/gpt51_judge.py:35,118        # RCB/evaluation/score.py:163
MAX_IMAGES = 5                           for img in generated_images[:15]:
for path in (image_paths or [])[:MAX_IMAGES]:
```

`image_paths[0]` is the paper's **target** figure, so the judge saw **four** workspace images.

That is not a stricter measurement. It is a different one, **and it is not neutral between arms**:

| | figures shipped (median) | shown at cap 5 | shown at cap 15 |
|:---|---:|---:|---:|
| bare Claude Code | 6.8 | 4.95 (**73%**) | 100% |
| AutoR | 10.3 | 5.00 (**49%**) | 100% |

The arm that produced more figures paid roughly four times as much.

## Re-scoring the identical workspaces

No re-runs. Same artifacts, same judge, same tasks — only the cap changed:

| | cap 5 | cap 15 |
|:---|---:|---:|
| bare Claude Code | 29.19 | 28.67 |
| AutoR | 24.26 | **27.97** |
| **paired difference** | **−4.94** | **−0.70** |
| 95% CI | −8.44 .. −1.43 | −4.32 .. +2.91 |
| AutoR wins–losses | 12–25 | **22–16** |

**The deficit was the instrument.** At the upstream cap all four arms agree: AutoR ties bare Claude Code.

## What this PR changes

`MAX_REPORT_FIGURES` is already 15 — the code was right. The **documentation** was not. Four passages still described a five-image window as the benchmark's behaviour, including the section a reader consults to decide how many figures a run should publish, and a code block quoting `generated_images[:5]` that no longer exists upstream.

The measured table goes in the doc rather than only in this message, because the next person to read a four-point deficit off this harness should learn in the same paragraph that **the instrument has done this once already**.

The wrapper itself lives in `~/rcb_tools/`, outside this repo; it has been corrected to 15 there.

## What this does not claim

That AutoR is *better*. −0.70 with a CI spanning −4.32 to +2.91 is a tie, and the honest reading of all four arms together is a tie. It also does not revalidate any number published before this: **every score this harness has produced was measured through the four-image keyhole**, and arms are only comparable to each other, not to anything scored upstream.

Three findings from the same investigation are deliberately *not* here, because adversarial review killed them: a hardware confound (the GPU arm lost the same criteria by the same margin — `arm_2ffaeb4` had an H100 on Chemistry_001 and still scored 0 and 3 against the control's 36 and 45), a stage-timeout confound (both 1800 s arms, one at 34/40 completion and one at 23/40), and three prompt/skill proposals that turned out to restate guidance already shipped in the pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)