### PR TITLE
A run is not dead the instant it starts

### DIFF
--- a/docs/frontierscience.md
+++ b/docs/frontierscience.md
@@ -853,7 +853,12 @@ kill-and-restart wall clock. Four decisions differ from the sibling driver: a li
 run consumes concurrency budget instead of aborting the trial (the lock has already refused a
 second live driver, so a live child is this trial's child); a `launched` run whose pid is gone
 is **abandoned and never resumed**, into a fresh workspace, because adopting a half-finished
-workspace means scoring an answer nobody can say was finished; `fallback` and `incomplete` are
+workspace means scoring an answer nobody can say was finished — but not within
+`FS_LAUNCH_GRACE_SECONDS` (60) of its `launched_at`, because "its pid is gone" is not
+observable the instant a run starts: the state file is written before `Popen` and carries no
+pid at all, and `autor_pids` is a `/proc` walk measured at 33–42 ms on this box. With no grace
+the driver abandoned runs it had launched microseconds earlier and paid for both. A state with
+no `launched_at` gets no grace and behaves as it did before; `fallback` and `incomplete` are
 **refused, not retried**, because the run ran and produced a non-run; and there is no scoring
 action in the loop at all.
 

--- a/src/fs_trial.py
+++ b/src/fs_trial.py
@@ -149,6 +149,32 @@ FS_MAX_ATTEMPTS = 2
 #: catch a hang is short enough to kill a run that was going to finish.
 FS_STALL_SECONDS = 2700
 
+#: How long a ``launched`` run is given to become visible before it may be called dead.
+#:
+#: The liveness test is ``child_pid in autor_pids(...)``, and that set is built by walking
+#: ``/proc`` and substring-matching each command line. Neither end of it is instantaneous.
+#: Measured on this box, over twelve samples on a quiet and a loaded machine, a child took
+#: **33-42 ms** to appear in that set -- and most of it is the ``/proc`` walk itself, not
+#: the child, so the floor rises with the number of processes on the box. Before that, a
+#: perfectly healthy run reads as dead.
+#:
+#: What it cost with no grace at all: ``tools/fs_trial.py`` writes the run's state file
+#: *before* ``Popen``, so there is also a window in which the state says ``launched`` and
+#: carries no ``child_pid`` -- ``int(None or 0)`` is 0, 0 is in no pid set, and the run is
+#: abandoned microseconds after it was started. The replacement gets a fresh workspace and
+#: a fresh attempt while the original child is still executing, so the trial pays twice
+#: and the abandoned attempt's state file stays in its launch shape for ever. In
+#: ``tests/test_fs_trial_driver.py`` the poll interval is overridden to 20 ms -- shorter
+#: than one ``/proc`` scan -- which turned this into an intermittent extra attempt that
+#: failed a different test on about one module run in three.
+#:
+#: Sixty seconds is three orders of magnitude above the measured latency and forty-five
+#: times *below* :data:`FS_STALL_SECONDS`, which is this module's existing statement about
+#: how long a run may be silent before anyone worries. Waiting a minute before declaring a
+#: run that has just started dead is strictly more conservative than the policy already in
+#: force for one that has gone quiet.
+FS_LAUNCH_GRACE_SECONDS = 60
+
 #: Above this share of refused runs in *either* arm, the paired difference is not
 #: published at all -- only the refusal rates are. Refusals are not random with respect
 #: to arm: the pipeline arm can be refused for a stage timeout, an auto-skip or a
@@ -2130,10 +2156,14 @@ def next_actions(
       the same state is the ordinary one after a restart: the lock has already refused a
       second live driver, so a live child is *this* trial's child and the right response
       is to count it and start fewer.
-    * **A ``launched`` run whose pid is gone is abandoned and never resumed.** There is no
-      resume: ``fs_agent.py`` has ``--export-only`` and nothing else, and adopting a
-      half-finished workspace would mean scoring an answer nobody can say was finished.
-      The replacement attempt gets a *fresh* workspace.
+    * **A ``launched`` run whose pid is gone is abandoned and never resumed** -- but not
+      before :data:`FS_LAUNCH_GRACE_SECONDS`. There is no resume: ``fs_agent.py`` has
+      ``--export-only`` and nothing else, and adopting a half-finished workspace would
+      mean scoring an answer nobody can say was finished. The replacement attempt gets a
+      *fresh* workspace. The grace is there because "its pid is gone" is not observable
+      the instant a run starts: the state file is written before ``Popen`` and carries no
+      pid at all, and the pid set is a ``/proc`` walk that takes longer than the child
+      takes to exist. Without it the driver abandoned runs it had just launched.
     * **``fallback`` and ``incomplete`` are refused, not retried.** The run ran and
       produced a non-run. A second draw on the same dice is not what an attempt budget is
       for, and spending it hides the failure behind an eventual success.
@@ -2154,7 +2184,27 @@ def next_actions(
         key = (str(state.get("task_key", "")), str(state.get("arm", "")))
         if state.get("phase") != "launched":
             continue
+        launched_at = state.get("launched_at")
+        dated = isinstance(launched_at, (int, float))
         if int(state.get("child_pid") or 0) in live_pids:
+            live.add(key)
+        elif dated and now - float(launched_at) < FS_LAUNCH_GRACE_SECONDS:
+            # Too young to be called dead: see FS_LAUNCH_GRACE_SECONDS. Counted as live
+            # rather than merely skipped, because the child almost certainly is running
+            # and the concurrency budget below has to see it -- treating it as neither
+            # live nor abandoned would let the loop start one more run than the plan asks
+            # for, every time a launch is polled inside its own first second.
+            #
+            # A state with no `launched_at` gets no grace and behaves exactly as before.
+            # The field has been written by `launch_run` since the driver existed, so the
+            # only states without one are hand-made; failing back to the old behaviour is
+            # the right answer for a record this cannot date.
+            #
+            # `isinstance` and not `or 0.0`: the first draft of this coerced a missing
+            # field to 0.0, which gives an undated record a *sixty-second* grace whenever
+            # `now` is itself near zero -- and `test_a_launched_run_whose_pid_is_gone_is_
+            # abandoned_and_never_resumed` calls this with `now=0.0`. The comment above
+            # was true of the intent and false of the code until that test said so.
             live.add(key)
         else:
             actions.append(

--- a/tests/test_fs_trial.py
+++ b/tests/test_fs_trial.py
@@ -32,6 +32,7 @@ from src.frontierscience import (
     FS_TASK_INSTRUCTION_SHA256,
 )
 from src.fs_trial import (
+    FS_LAUNCH_GRACE_SECONDS,
     FS_ADMISSION_CLAUSES,
     FS_FAKE_FAULTS,
     FS_MAX_REFUSAL_RATE,
@@ -1201,6 +1202,57 @@ class TheStateMachineTests(unittest.TestCase):
         )
         self.assertEqual([action for action in actions if action.kind == "launch"], [])
         self.assertEqual([action.kind for action in actions], ["wait"])
+
+    def test_a_run_launched_a_moment_ago_is_not_abandoned_before_its_pid_can_be_seen(self) -> None:
+        """The liveness test is not observable at the instant a run starts.
+
+        `tools/fs_trial.py` writes the state file *before* `Popen`, so there is a window
+        where the state says `launched` and carries no `child_pid` at all -- and
+        `autor_pids` is a `/proc` walk, measured at 33-42 ms on this box, so even after
+        `Popen` the pid is not in the set yet. With no grace the driver abandoned runs it
+        had started microseconds earlier, gave the replacement a fresh workspace, and paid
+        for both. In `tests/test_fs_trial_driver.py`, whose poll interval is 20 ms --
+        shorter than one `/proc` scan -- that surfaced as an extra attempt failing a
+        different test on about one module run in three.
+        """
+        for label, state in (
+            ("no pid written yet", {"task_key": "fs:000", "arm": CONTROL.label,
+                                    "attempt": 1, "phase": "launched", "launched_at": 100.0}),
+            ("pid written, not yet visible",
+             {**self.launched("fs:000", CONTROL.label, 4242), "launched_at": 100.0}),
+        ):
+            with self.subTest(label):
+                actions = next_actions(self.plan, [state], now=100.0, live_pids=frozenset())
+                self.assertNotIn("abandon", [action.kind for action in actions])
+
+    def test_a_run_in_its_grace_window_consumes_the_budget(self) -> None:
+        """Counted live, not merely skipped.
+
+        Skipping it would leave the budget thinking nothing is running, and the loop would
+        start one more run than the plan asks for every time it polled inside a launch.
+        """
+        states = [
+            {**self.launched("fs:000", CONTROL.label, 4242), "launched_at": 100.0},
+            {**self.launched("fs:000", TREATMENT.label, 4243), "launched_at": 100.0},
+        ]
+        actions = next_actions(self.plan, states, now=100.0, live_pids=frozenset())
+        self.assertEqual([action.kind for action in actions], ["wait"])
+
+    def test_after_the_grace_a_launch_whose_pid_is_gone_is_still_abandoned(self) -> None:
+        """The control on the recovery the grace must not disable."""
+        state = {**self.launched("fs:000", CONTROL.label, 4242), "launched_at": 100.0}
+        actions = next_actions(
+            self.plan, [state], now=100.0 + FS_LAUNCH_GRACE_SECONDS + 1, live_pids=frozenset()
+        )
+        self.assertEqual(actions[0].kind, "abandon")
+
+    def test_a_state_with_no_launch_time_gets_no_grace(self) -> None:
+        """Back-compat control: a record this cannot date behaves exactly as before."""
+        actions = next_actions(
+            self.plan, [self.launched("fs:000", CONTROL.label, 4242)], now=1e9,
+            live_pids=frozenset(),
+        )
+        self.assertEqual(actions[0].kind, "abandon")
 
     def test_a_launched_run_whose_pid_is_gone_is_abandoned_and_never_resumed(self) -> None:
         actions = next_actions(


### PR DESCRIPTION
Found chasing the `test_fs_trial_driver` flake that has been reddening every PR today. The flake
attribution is a hypothesis; **the defect underneath it is proven**.

## The defect

`next_actions` abandons a `launched` run whose `child_pid` is not in `autor_pids(...)`, with no grace
at all. Neither end of that test is observable when a run has just started:

- `tools/fs_trial.py` writes the state file **before** `Popen` and again after it. In between the state
  says `launched` and carries no `child_pid` — `int(None or 0)` is 0, 0 is in no pid set, abandon.
- `autor_pids` walks `/proc` and substring-matches every command line. **Measured here: 33–42 ms** over
  twelve samples on a quiet and a loaded box — and most of it is the walk, not the child, so the floor
  rises with the number of processes on the machine.

A healthy run could therefore be pronounced dead microseconds after launch. The replacement gets a fresh
workspace and a fresh attempt **while the original child is still executing**: the trial pays twice, and
the abandoned attempt's state file stays in its launch shape for ever.

Probed directly on the pure function, before the fix:

```
just launched, no pid yet              -> ['abandon', 'launch']
just launched, pid not yet visible     -> ['abandon', 'launch']
pid visible in live_pids               -> ['launch']
```

## The fix

`FS_LAUNCH_GRACE_SECONDS = 60`. Three orders of magnitude above the measured latency, and **forty-five
times below `FS_STALL_SECONDS`** — this module's existing statement about how long a run may be silent
before anyone worries. Waiting a minute before declaring a just-started run dead is strictly more
conservative than the policy already in force for one that has gone quiet.

A run inside its grace is counted **live**, not skipped: skipping it would let the loop start one more
run than the plan asks for every time it polled inside a launch.

## What is proven, and what is not

**Proven.** Four new tests drive `next_actions` directly. Three go red with the grace branch removed;
two controls stay green either way — an undated record gets no grace, and a dead launch past the grace
is still abandoned, so the recovery this must not disable is held.

**Not proven — the attribution.** `tests/test_fs_trial_driver.py` fails about one module run in three
under load, on a different test each time, and **never in isolation** (6/6 clean alone, 6/6 clean alone
under load). One captured failure had attempt 1's state stuck in launch shape with an `ok` attempt 2
beside it, which is exactly this signature, and that module overrides the poll interval to 20 ms —
shorter than one `/proc` scan. But **eight loaded module runs with the fix and eight without both came
back clean**, so my load model does not reproduce the flake and that comparison has no power. Whether
this removes the flake is unverified. CI is the next reading.

## One correction inside the change

The comment claiming an undated record gets no grace was false when first written: `float(None or 0.0)`
is 0.0, and `now - 0.0 < 60` holds whenever `now` is near zero — which is exactly how the existing
`test_a_launched_run_whose_pid_is_gone_is_abandoned_and_never_resumed` calls it. That test went red
immediately. The code now tests for the field rather than coercing it.

Full suite: 3820 tests, OK (skipped=1), `umask 022`, `TMPDIR=/tmp`. `docs/frontierscience.md` records the
grace beside the abandon policy it qualifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)