### PR TITLE
Tell the router what this node already cost, and refuse to spend a revisit on it

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1073,9 +1073,13 @@ them — the ratchet polishes every stage towards 1.000 and 71% of routing decis
 against a stage reporting exactly that, with the rubric's "where the points are" list empty. The
 grounds were on disk and unread: 30% of hypotheses came back `inconclusive` or `not_tested` and 84%
 of runs held at least one, and the prompt's own worked example of a good reason is "H2 is
-inconclusive because only one seed was run". `unfinished_business` now puts the unsettled verdicts
-and the open obligations in front of the router, and a saturated total is labelled as the ceiling it
-is rather than left to read as a verdict on the research. Whether that moves the departure rate is
+inconclusive because only one seed was run". `unfinished_business` now puts the unsettled verdicts,
+the open obligations and **what this node has already charged** in front of the router, and a
+saturated total is labelled as the ceiling it is rather than left to read as a verdict on the
+research. The last of those is the cost ledger's first reader outside its own tests: the router was
+shown `Visits to <node>: N of M` and the backward moves already taken, and neither says what those
+visits were *spent on* — a node that refused eleven attempts against one wall is a different
+proposition from one that refused eleven against eleven different objections. Whether that moves the departure rate is
 unmeasured — it changes what the router is shown, not what it is told to choose, and a prompt that
 instructed it to depart more often would be obeyed on the runs that had nothing to go back for.
 

--- a/docs/iclr/round-loop-and-stage-graph.md
+++ b/docs/iclr/round-loop-and-stage-graph.md
@@ -395,6 +395,29 @@ figure to `describe_budget_for_prompt`. Do not add a `prior_refusals` doer chann
 also that `Visit.refusal` already exists with a different meaning — why the router's answer
 was not used — so the new field needs a different name.
 
+**Landed as the router's fact, and refused as the supervisor's rule.**
+
+`src.router.unfinished_business` now names what a node has already charged across its
+closed visits and whether that spend went against one wall or many — `prior_digests` in
+`src.stage_cost`, beside the ledger it reads. That is the closed rows' first reader
+outside their own tests.
+
+Feeding those digests to `RunSupervisor`'s repeat rule, which is what this section
+originally proposed, was implemented and then **reverted**: it ends a revisit at its first
+repeated attempt, and two tests already in the tree are this repository's decision the
+other way — `test_a_second_visit_to_an_exhausted_stage_still_buys_attempts` and
+`test_a_revisit_gets_the_whole_ceiling_and_not_one_attempt`, whose docstring says in as
+many words that one attempt is a revisit that cannot work. Both went red on the
+concatenation. `TheRepeatRuleDeliberatelyStopsAtTheVisitBoundaryTests` is the note that
+stops the idea coming back.
+
+Blast radius of the version that was reverted, replayed over
+`tools/supervisor_threshold_replay.py`'s `MEASURED_RUNS` before the two tests spoke: 0 of
+22 visits change verdict, because only two of twenty stages in that population were
+visited more than once and neither repeated a digest. Worth recording as a caution: the
+replay said the change was free, and the suite said it was wrong. A population that
+contains no instance of the case cannot price it.
+
 *Class: a ledger nobody reads. Effort: small.*
 
 ### 4.7 Retry state the harness owns, not state the provider owns

--- a/src/router.py
+++ b/src/router.py
@@ -58,6 +58,8 @@ from pathlib import Path
 from typing import Any
 
 from .approval_agent import extract_json_payload
+from .stage_cost import prior_digests, read_stage_cost_ledger
+from .supervisor import charged_attempts, longest_unchanged_run
 from .obligations import load_ledger
 from .preregistration import load_hypothesis_outcomes
 from .rubric import StageScore, format_score_for_prompt
@@ -717,6 +719,44 @@ def unfinished_business(paths: RunPaths, stage: StageSpec) -> str:
             lines.append(
                 f"- `{obligation.obligation_id}` (raised at {obligation.origin_stage}, "
                 f"deferred {obligation.deferrals}x): {truncate_text(obligation.text, max_chars=400)}"
+            )
+        lines.append("")
+
+    # What this node has already cost, and whether it cost it against one wall.
+    #
+    # The router is shown `Visits to <node>: N of M` and the backward moves already taken,
+    # and neither says what those visits were *spent on*. The cost ledger has carried the
+    # answer per visit since it existed -- `attempt_digests`, and the repeat structure over
+    # them -- and had no reader outside its own tests. A node that has refused eleven
+    # attempts across two visits, the last four of them for the same reason, is a
+    # different proposition from one that has refused eleven for eleven different reasons,
+    # and the move out of here is the decision that difference is about.
+    #
+    # A fact, not advice, like everything else in this block: it says what was spent and
+    # whether it repeated, and nothing about where to go. It is also deliberately not a
+    # rule -- ending a visit on a cross-visit repeat was tried in `RunSupervisor` and
+    # refused, because a revisit is entitled to its own attempts
+    # (`test_a_revisit_gets_the_whole_ceiling_and_not_one_attempt`).
+    rows = read_stage_cost_ledger(paths)
+    spent_here = [row for row in rows if str(row.get("stage") or "") == stage.slug]
+    charged = sum(charged_attempts(row) for row in spent_here)
+    if spent_here and charged:
+        digests = prior_digests(rows, stage.slug)
+        repeat = longest_unchanged_run(digests)
+        lines += [
+            f"**This stage has already charged {charged} attempt(s) over "
+            f"{len(spent_here)} closed visit(s).**",
+            "",
+        ]
+        if repeat > 1:
+            lines.append(
+                f"- {repeat} of them in a row failed for the same recorded reason, so that "
+                "much of the spend bought no change."
+            )
+        elif digests:
+            lines.append(
+                f"- {len(digests)} recorded failure(s), no two of them consecutive "
+                "repeats: the spend was against different objections each time."
             )
         lines.append("")
 

--- a/src/stage_cost.py
+++ b/src/stage_cost.py
@@ -708,6 +708,37 @@ def stage_cost_ledger_path(paths: RunPaths) -> Path:
     return paths.stage_cost_ledger
 
 
+def prior_digests(rows: Sequence[Mapping[str, Any]], stage_slug: str) -> list[str]:
+    """What earlier visits to *stage_slug* were spent on, oldest first.
+
+    :meth:`StageCostMeter.attempt_digests` answers this for the visit in progress and
+    stops at its own boundary, so nothing in the tree could say that a stage had already
+    been fought over, with the same objection, before the walk came back to it. The rows
+    have carried the answer since this module existed and had no reader outside the
+    tests.
+
+    Not for the supervisor's repeat rule. Feeding it these ends a revisit at its first
+    repeated attempt, and this repository has already decided the other way --
+    ``test_a_revisit_gets_the_whole_ceiling_and_not_one_attempt`` says in as many words
+    that one attempt is a revisit that cannot work. The reader is
+    :func:`src.router.unfinished_business`, which puts the fact in front of the party
+    choosing the next move instead of spending the visit on it.
+
+    The rows come off :func:`read_stage_cost_ledger`, which is written in the ``finally``
+    of a stage visit, so the open visit is never in here.
+    """
+
+    found: list[str] = []
+    for row in rows:
+        if str(row.get("stage") or "") != stage_slug:
+            continue
+        entries = row.get("attempt_digests")
+        if isinstance(entries, Sequence) and not isinstance(entries, (str, bytes)):
+            found.extend([str(e.get("digest") or "") for e in entries
+                         if isinstance(e, Mapping) and e.get("digest")])
+    return found
+
+
 def read_stage_cost_ledger(paths: RunPaths) -> list[dict[str, Any]]:
     """The rows written so far, oldest first. ``[]`` when there is nothing readable.
 

--- a/src/supervisor.py
+++ b/src/supervisor.py
@@ -846,6 +846,15 @@ class RunSupervisor:
         deliverable_number: int,
         per_stage_ceiling: int | None,
     ) -> Intervention:
+        # The open visit only, deliberately. Concatenating the closed rows' digests here
+        # was tried and is refused: it ends a revisit at its first repeated attempt, and
+        # `test_a_revisit_gets_the_whole_ceiling_and_not_one_attempt` and
+        # `test_a_second_visit_to_an_exhausted_stage_still_buys_attempts` are this
+        # repository's decision that a revisit is entitled to its own attempts even when
+        # it meets the objection that ended the last one. "One attempt is a revisit that
+        # cannot work." What the closed rows are read for instead is
+        # `src.router.unfinished_business`, which puts the repeat in front of the router
+        # as a fact rather than spending the visit on it.
         digests = countable_digests(meter.attempt_digests()) if meter is not None else []
         live_charged = max(meter.attempts - meter.polish_rounds, 0) if meter is not None else 0
         ceiling = self.attempt_ceiling(stage_slug, per_stage_ceiling)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -661,6 +661,54 @@ class UnfinishedBusinessTests(unittest.TestCase):
             json.dumps({"version": 1, "obligations": list(obligations)}),
         )
 
+    def _closed_visit(self, slug: str, digests: list[str]) -> None:
+        from src.stage_cost import StageCostMeter, append_stage_cost_row
+        from src.utils import STAGES as _STAGES
+
+        stage = next(item for item in _STAGES if item.slug == slug)
+        meter = StageCostMeter(stage)
+        for index, digest in enumerate(digests, start=1):
+            meter.note_attempt()
+            meter.note_failure(index, "validators_refused", digest)
+        append_stage_cost_row(self.paths, meter.close())
+
+    def test_what_this_node_already_charged_is_named(self) -> None:
+        """The cost ledger's first reader outside its own tests.
+
+        The router is shown `Visits to <node>: N of M` and the backward moves already
+        taken, and neither says what those visits were spent on. A node that refused four
+        attempts against one wall is a different proposition from one that refused four
+        against four different objections, and the move out of here is the decision that
+        difference is about.
+        """
+        self._closed_visit(STAGE_06.slug, ["a", "a", "a"])
+        text = unfinished_business(self.paths, STAGE_06)
+        self.assertIn("already charged 3 attempt(s) over 1 closed visit(s)", text)
+        self.assertIn("3 of them in a row failed for the same recorded reason", text)
+
+    def test_distinct_failures_are_reported_as_distinct(self) -> None:
+        """The other half of the same fact, and the reason it is worth printing at all."""
+        self._closed_visit(STAGE_06.slug, ["a", "b", "c"])
+        text = unfinished_business(self.paths, STAGE_06)
+        self.assertIn("no two of them consecutive repeats", text)
+        self.assertNotIn("in a row", text)
+
+    def test_it_spans_visits(self) -> None:
+        """Two visits, one wall. This is the case the supervisor's rule cannot see."""
+        self._closed_visit(STAGE_06.slug, ["a", "a"])
+        self._closed_visit(STAGE_06.slug, ["a"])
+        text = unfinished_business(self.paths, STAGE_06)
+        self.assertIn("over 2 closed visit(s)", text)
+        self.assertIn("3 of them in a row", text)
+
+    def test_another_stages_spend_is_not_reported_here(self) -> None:
+        self._closed_visit("04_implementation", ["a", "a", "a"])
+        self.assertNotIn("already charged", unfinished_business(self.paths, STAGE_06))
+
+    def test_a_node_that_has_never_closed_a_visit_says_nothing(self) -> None:
+        """Silence is the point, as it is for every other block here."""
+        self.assertEqual(unfinished_business(self.paths, STAGE_06), "")
+
     def test_an_inconclusive_hypothesis_is_named(self) -> None:
         self.outcomes("supported", "inconclusive", "refuted")
         text = unfinished_business(self.paths, STAGE_06)

--- a/tests/test_run_supervisor.py
+++ b/tests/test_run_supervisor.py
@@ -64,6 +64,7 @@ from unittest.mock import MagicMock
 from src.stage_cost import (
     OUTCOME_APPROVED,
     OUTCOME_AUTO_SKIPPED,
+    OUTCOME_ROLLED_BACK,
     REVIEWER_REFUSED,
     StageCostMeter,
     append_stage_cost_row,
@@ -513,6 +514,62 @@ class UnchangingFailureTests(unittest.TestCase):
             meter.note_polish_round(number)
         digests = [entry["digest"] for entry in meter.attempt_digests()]
         self.assertTrue(unchanging_failure(digests))
+
+
+class TheRepeatRuleDeliberatelyStopsAtTheVisitBoundaryTests(unittest.TestCase):
+    """Concatenating the closed rows' digests here was tried, and is refused.
+
+    The gap is real: `StageCostMeter.attempt_digests` stops at its own visit, so the rule
+    cannot see that the walk already fought this node over the same objection, and
+    `longest_unchanged_run`'s own docstring says it is "here for the closed rows" that no
+    caller passed it.
+
+    Acting on it here is what is refused. Feeding the prior visits in ends a revisit at
+    its first repeated attempt, and two tests in this file are this repository's decision
+    the other way -- `test_a_second_visit_to_an_exhausted_stage_still_buys_attempts` and
+    `test_a_revisit_gets_the_whole_ceiling_and_not_one_attempt`, whose docstring says one
+    attempt is a revisit that cannot work. Both go red on the concatenation; they are the
+    measurement, and this class is the note that stops the idea coming back.
+
+    The closed rows do get a reader: `src.router.unfinished_business` puts the repeat in
+    front of the party choosing the next move, where it costs no attempt.
+    """
+
+    def _closed_visit_refusing(self, paths, slug: str, digest: str, times: int) -> None:
+        stage = next(item for item in STAGES if item.slug == slug)
+        meter = StageCostMeter(stage)
+        for index in range(times):
+            meter.note_attempt()
+            meter.note_failure(index + 1, "validators_refused", digest)
+        meter.note_outcome(OUTCOME_ROLLED_BACK)
+        append_stage_cost_row(paths, meter.close())
+
+    def test_a_revisit_is_not_ended_by_what_the_last_visit_kept_hitting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            self._closed_visit_refusing(
+                paths, "03_study_design", "same", STOP_AFTER_IDENTICAL_FAILURES + 2
+            )
+            stage = next(item for item in STAGES if item.slug == "03_study_design")
+            meter = StageCostMeter(stage)
+            meter.note_attempt()
+            meter.note_failure(1, "validators_refused", "same")
+            ruling = rule_on(a_supervisor(), paths, "03_study_design", meter=meter, attempt=2)
+            self.assertFalse(ruling.ends_the_visit)
+
+    def test_the_open_visit_reaching_the_threshold_still_ends_it(self) -> None:
+        """The control: stopping at the boundary is not the same as not stopping."""
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = fresh_paths(tmp)
+            stage = next(item for item in STAGES if item.slug == "03_study_design")
+            meter = StageCostMeter(stage)
+            for index in range(STOP_AFTER_IDENTICAL_FAILURES):
+                meter.note_attempt()
+                meter.note_failure(index + 1, "validators_refused", "same")
+            ruling = rule_on(a_supervisor(), paths, "03_study_design", meter=meter,
+                             attempt=STOP_AFTER_IDENTICAL_FAILURES + 1)
+            self.assertTrue(ruling.ends_the_visit)
+            self.assertEqual(ruling.rule, UNCHANGING_FAILURE)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
§4.6 of [#254](https://github.com/tangxiangru/AutoR/pull/254)'s list — and it landed as roughly the
opposite of what that section proposed, because two tests already in the tree said so.

## The gap

The per-stage cost ledger records what every attempt of every visit was spent on — `attempt_digests`,
and the repeat structure over them — and **nothing outside its own tests read a closed row**.
`longest_unchanged_run`'s docstring has said since it was written that it is *"here for the closed
rows, whose `attempt_digests` come back off disk as dictionaries"*, and no caller ever passed it any.

## What landed

`router.unfinished_business` now names what a node has already charged across its closed visits, and
whether that spend went against one wall or many:

```
**This stage has already charged 11 attempt(s) over 2 closed visit(s).**

- 4 of them in a row failed for the same recorded reason, so that much of the spend bought no change.
```

The router is shown `Visits to <node>: N of M` and the backward moves already taken, and neither says
what those visits were *spent on*. A node that refused eleven attempts against one recorded reason is a
different proposition from one that refused eleven against eleven, and the move out of it is the
decision that difference is about. A fact, not advice, like everything else in that block.

## What was refused, and by what

This started as the change §4.6 actually proposed: concatenate the closed rows' digests into
`RunSupervisor`'s `unchanging_failure`, so the repeat rule could see across the edge the graph exists
to take. I implemented it. **Two tests already in the tree went red:**

- `test_a_second_visit_to_an_exhausted_stage_still_buys_attempts`
- `test_a_revisit_gets_the_whole_ceiling_and_not_one_attempt` — *"one attempt is a revisit that cannot
  work"*

Ending a revisit at its first repeated attempt is exactly the starvation that class was built to
prevent. The rule stays at the visit boundary, and `TheRepeatRuleDeliberatelyStopsAtTheVisitBoundaryTests`
records why so the idea does not come back.

## A caution worth keeping

Before those tests spoke, I replayed the reverted version over `tools/supervisor_threshold_replay.py`'s
pinned `MEASURED_RUNS`: **0 of 22 visits change verdict** — only two of twenty stages in that population
were visited more than once, and neither repeated a digest.

So the replay said the change was free, and the suite said it was wrong. A population containing no
instance of the case cannot price it, and *"the blast radius is zero"* is not *"the change is right"*.
Both halves are in the docs.

## Tests

Seven. Three hold the router block and go red without it; two are controls on it (another stage's spend
is not reported here; a node with no closed visit says nothing); two hold the refusal (a revisit is not
ended by what the last visit kept hitting, and the control that an open visit reaching the threshold
still ends).

Full suite: 3885 tests, OK (skipped=1), `umask 022`, `TMPDIR=/tmp`.

Docs: `framework.md` adds the new fact to what `unfinished_business` puts in front of the router;
`docs/iclr/round-loop-and-stage-graph.md` §4.6 records what landed, what was refused, and the caution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)