### PR TITLE
Report the three numbers FIRE-Bench reports, and report them from one draw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,19 +1036,38 @@ the agent writes, decomposed into atomic claims and matched against the authors'
 deadline, in one agentic call instead of a stage walk.
 
 **Measured here, six tasks, one run each, `opus` executing and reviewing, every arm on the
-benchmark's own 3600 s clock, three judge draws per log, medians:**
+benchmark's own 3600 s clock. Each cell is the median judge draw of three — one draw, so
+its three numbers are consistent with each other; arms are the mean ± sd across tasks,
+which is the shape [FIRE-Bench's own Table 3](https://github.com/maitrix-org/FIRE-Bench)
+reports:**
 
-| task | AutoR pipeline | AutoR direct | stock Claude Code |
-|:---|---:|---:|---:|
-| `cot_in_planning` | **100.0** | 70.6 | no conclusion |
-| `premise_order_effects` | 0.0 | **80.0** | no conclusion |
-| `prompt_formatting_sensitivity` | 40.0 | **71.8** | no conclusion |
-| `lifebench_length_following` | 0.0 | **42.9** | no conclusion |
-| `persona_reasoning_biases` | 0.0 | **20.0** | 15.4 |
-| `mcq_selection_bias` | 41.2 | **50.0** | 30.3 |
-| **scoreable runs** | 6 / 6 | 6 / 6 | **2 / 6** |
-| **median F1** | 20.0 | **60.3** | 22.9 |
-| **median wall clock** | 52 min | **11 min** | 61 min (killed) |
+| task | AutoR pipeline | | | AutoR direct | | | stock Claude Code | | |
+|:---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| | P | R | F1 | P | R | F1 | P | R | F1 |
+| `cot_in_planning` | 62.5 | 100.0 | **76.9** | 60.0 | 66.7 | 63.2 | — | — | *no conclusion* |
+| `premise_order_effects` | 0.0 | 0.0 | 0.0 | 80.0 | 80.0 | **80.0** | — | — | *no conclusion* |
+| `prompt_formatting_sensitivity` | 50.0 | 33.3 | 40.0 | 75.0 | 66.7 | **70.6** | — | — | *no conclusion* |
+| `lifebench_length_following` | 0.0 | 0.0 | 0.0 | 46.2 | 40.0 | **42.9** | — | — | *no conclusion* |
+| `persona_reasoning_biases` | 0.0 | 0.0 | 0.0 | 28.6 | 50.0 | **36.4** | 11.1 | 50.0 | 18.2 |
+| `mcq_selection_bias` | 30.0 | 50.0 | 37.5 | 75.0 | 66.7 | **70.6** | 25.0 | 83.3 | 38.5 |
+
+| arm | scoreable | Prec. | Recall | F1 | median wall clock |
+|:---|---:|---:|---:|---:|---:|
+| AutoR pipeline | 6 / 6 | 23.8 ± 28.0 | 30.6 ± 40.0 | 25.7 ± 31.5 | 52 min |
+| AutoR direct | 6 / 6 | **60.8 ± 20.1** | **61.7 ± 14.3** | **60.6 ± 17.2** | **11 min** |
+| stock Claude Code | **2 / 6** | 18.1 ± 9.8 | 66.7 ± 23.5 | 28.4 ± 14.4 | 61 min, killed |
+| *stock, counting an unscoreable run as 0* | 6 / 6 | 6.0 ± 10.3 | 22.2 ± 36.0 | 9.4 ± 16.0 | |
+
+The stock arm's two rows are both reported because neither is obviously the right one and
+the choice moves its F1 from 28.4 to 9.4. Which is comparable to a published table depends
+on how that table handled a run that produced nothing, and FIRE-Bench's paper does not say.
+
+**How much of this is the judge.** These six logs were scored twice, with nothing changing
+but the judge's sampling. The arm means moved by 4 to 5 F1 points — pipeline 30.2 → 25.7,
+direct 55.9 → 60.6, stock 22.9 → 28.4 — and one *task* moved by 13.7 (`cot_in_planning`,
+pipeline arm, 100.0 → 76.9). The ordering of the arms did not move. Treat the ordering as
+the result and the individual numbers as one draw of a noisy instrument; on a single
+unchanged log the measured range is 43 F1 points.
 
 **Three things this says, in decreasing order of how much the sample supports them.**
 
@@ -1062,7 +1081,8 @@ artifact read, and says to write it early and rewrite it, plus a watcher that re
 scored line every time the file on disk improves.
 
 **2. Under this clock, the pipeline loses to one call of the same model on the same
-contract.** Direct wins 5 of 6 tasks, median **+25.9 F1**. Every pipeline run hit the reserve
+contract.** Direct wins 5 of 6 tasks, median **+34.8 F1**, and it wins on precision and
+recall alike rather than by trading one for the other. Every pipeline run hit the reserve
 boundary at 52 minutes having approved one to three of its four stages; the direct arm
 finished in a median of 11. This is the same direction as
 [ResearchClawBench](#researchclawbench) and [FrontierScience](#frontierscience-research), and
@@ -1076,7 +1096,7 @@ control at 0.15 accuracy confirming the task was real, and concluded that premis
 every ordering — at ceiling — and it said so. It scored **0.0**, because the reference
 conclusion says premise order matters. The direct arm, on the same task in a fifth of the
 time, ran a pilot, saw the ceiling, generated a harder pool with chains up to sixteen steps,
-found the effect at sign-test p = 0.0001, and scored **80.0**. The lesson is about
+found the effect at sign-test p = 0.0001, and scored **80.0 / 80.0 / 80.0**. The lesson is about
 *iteration*, not about honesty: what the pipeline lacked was a second pass at its own
 instance difficulty, and its budget went to preregistration, a reproduction table and a gate
 ledger instead.

--- a/docs/firebench.md
+++ b/docs/firebench.md
@@ -224,6 +224,27 @@ Only `overall_metrics` (precision, recall, F1) is meaningful: `eval.py` requests
 eleven metrics while hardcoding `retrieved_context: []`, so the eight retriever and
 generator metrics are empty-input fallbacks that read like measurements.
 
+### Report all three, and report them from one draw
+
+FIRE-Bench's own Table 3 is precision, recall and F1 side by side, and there is a reason
+to keep all three: a run can lose on precision by saying more than was asked, or on recall
+by answering a narrower question, and an F1 column cannot tell those apart. On the six-task
+matrix measured here the stock arm's recall (66.7) is the highest of any arm while its
+precision (18.1) is the lowest — it answered the right question at enormous length, and F1
+alone would have read as "it did badly".
+
+**The three numbers in a row have to come from one draw.** Taking the median of each metric
+independently is arithmetically fine and produces rows that describe no run that happened:
+measured on two real cells, `P = 53.8, R = 50.0, F1 = 41.2`, whose harmonic mean is 51.8.
+`score_fire_run.py` writes `median_draw` — the draw whose F1 is the median — and that is the
+row; the per-metric medians and ranges stay beside it because each metric's spread is worth
+reporting, and laying three of *those* out as a row is the thing that is forbidden.
+
+Across tasks, each metric is averaged independently, which is what the paper does: its own
+52.1 and 48.3 give a harmonic mean of 50.1, not the 46.7 it prints, because a macro-average
+of per-task F1 is not the F1 of the macro-averaged precision and recall. That is correct at
+the arm level and wrong one level down.
+
 ### Making the shipped scorer run at all
 
 Two things, neither of them optional, both outside this repository:

--- a/tests/test_firebench_adapter.py
+++ b/tests/test_firebench_adapter.py
@@ -554,6 +554,65 @@ class ArtifactVisibilityTests(unittest.TestCase):
             self.assertEqual(mirror_run_artifacts(workspace, None), {"code": 0, "outputs": 0})
 
 
+class ReportedRowTests(unittest.TestCase):
+    """FIRE-Bench reports three numbers, and they have to come from one draw.
+
+    Table 3 of the paper is precision, recall and F1 side by side; a report that prints
+    only F1 drops the two columns that say *how* a score was reached -- a run can lose on
+    precision by saying more than was asked, or on recall by answering a narrower
+    question, and F1 alone cannot tell those apart.
+
+    And the three have to be one draw. Taking the median of each metric independently is
+    arithmetically fine and produces rows that describe no run that happened: measured on
+    two real cells, ``P = 53.8, R = 50.0, F1 = 41.2``, whose harmonic mean is 51.8.
+    """
+
+    #: The tool under test is stdlib-only and lives in ``tools/``, which is not a package.
+    @staticmethod
+    def _median_draw(draws):
+        import importlib.util
+
+        path = Path(__file__).resolve().parent.parent / "tools" / "score_fire_run.py"
+        spec = importlib.util.spec_from_file_location("_score_fire_run", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module.median_draw(draws)
+
+    @staticmethod
+    def _draw(precision, recall, f1):
+        return {"status": "scored", "overall_metrics": {"precision": precision, "recall": recall, "f1": f1}}
+
+    def test_the_row_is_one_draw_and_its_f1_is_its_own_harmonic_mean(self) -> None:
+        row = self._median_draw([
+            self._draw(27.3, 50.0, 35.3),
+            self._draw(53.8, 33.3, 41.2),
+            self._draw(55.6, 50.0, 52.6),
+        ])
+        self.assertEqual(row, {"precision": 53.8, "recall": 33.3, "f1": 41.2})
+        harmonic = 2 * row["precision"] * row["recall"] / (row["precision"] + row["recall"])
+        self.assertAlmostEqual(harmonic, row["f1"], delta=0.2)
+
+    def test_independent_medians_would_not_have_been_coherent(self) -> None:
+        """The negative control: the exact three draws that produced the bad row."""
+        import statistics
+
+        draws = [(27.3, 50.0, 35.3), (53.8, 33.3, 41.2), (55.6, 50.0, 52.6)]
+        p = statistics.median(d[0] for d in draws)
+        r = statistics.median(d[1] for d in draws)
+        f1 = statistics.median(d[2] for d in draws)
+        self.assertNotAlmostEqual(2 * p * r / (p + r), f1, delta=0.2)
+
+    def test_a_draw_that_failed_is_not_eligible_to_be_the_row(self) -> None:
+        row = self._median_draw([
+            {"status": "error", "overall_metrics": {}},
+            self._draw(80.0, 80.0, 80.0),
+        ])
+        self.assertEqual(row["f1"], 80.0)
+
+    def test_no_scored_draw_is_no_row_rather_than_a_zero(self) -> None:
+        self.assertIsNone(self._median_draw([{"status": "no_conclusion"}]))
+
+
 class WorkspaceNameTests(unittest.TestCase):
     def test_a_task_id_with_underscores_survives_the_round_trip(self) -> None:
         """``to_cot_or_not_to_cot`` is a real task id. A single-underscore scheme loses it."""

--- a/tools/fire_trial.py
+++ b/tools/fire_trial.py
@@ -99,6 +99,24 @@ def cell_dir(plan: dict, cell: dict) -> Path:
     return Path(plan["runs_root"]) / cell["id"]
 
 
+def autor_root(plan: dict) -> Path:
+    """The checkout to run the adapter and the scorer from.
+
+    The plan records the checkout it was written in, because a trial has to be able to
+    say which tree produced its runs. But a plan outlives that tree: this one was written
+    in a worktree that was removed after the branch merged, and every later
+    ``fire_trial.py score`` then invoked a path that no longer existed -- which python
+    reports as exit code 2, the same code argparse uses for a bad flag, so it read as a
+    tool bug rather than a missing file. Fall back to the checkout this file is in, and
+    say so.
+    """
+    recorded = Path(plan.get("autor_root", ""))
+    if recorded.is_dir() and (recorded / "fire_agent.py").is_file():
+        return recorded
+    print(f"[note] recorded autor_root {recorded} is gone; using {REPO_ROOT}", flush=True)
+    return REPO_ROOT
+
+
 def launch(plan: dict, cell: dict) -> dict:
     root = cell_dir(plan, cell)
     root.mkdir(parents=True, exist_ok=True)
@@ -116,7 +134,7 @@ def launch(plan: dict, cell: dict) -> dict:
     if arm["kind"] == "autor":
         command = [
             sys.executable,
-            str(Path(plan["autor_root"]) / "fire_agent.py"),
+            str(autor_root(plan) / "fire_agent.py"),
             "--bench-root", plan["bench_root"],
             "--task", cell["task"],
             "--profile", arm["profile"],
@@ -265,7 +283,7 @@ def _score_cell(plan: dict, cell: dict, scorer: Path, draws: int) -> str:
 
 def do_score(args: argparse.Namespace) -> int:
     plan = json.loads(Path(args.plan).expanduser().read_text(encoding="utf-8"))
-    scorer = Path(plan["autor_root"]) / "tools" / "score_fire_run.py"
+    scorer = autor_root(plan) / "tools" / "score_fire_run.py"
     cells = [
         cell for cell in plan["cells"]
         if (cell_dir(plan, cell) / "run.json").is_file()
@@ -286,11 +304,29 @@ def do_score(args: argparse.Namespace) -> int:
     return 0
 
 
-def _median_f1(summary: dict, metric: str = "f1") -> float | None:
-    block = summary.get(metric)
-    if isinstance(block, dict) and block.get("median") is not None:
-        return float(block["median"])
-    return None
+#: The three numbers FIRE-Bench reports, in the order its own Table 3 prints them.
+METRICS = ("precision", "recall", "f1")
+
+
+def _row(summary: dict) -> dict | None:
+    """The cell's (precision, recall, F1), from one draw.
+
+    ``median_draw`` is written by ``tools/score_fire_run.py`` and is the draw whose F1 is
+    the median. The fallback reads the per-metric medians, which is what the first
+    version of this file did for every cell -- and which produced rows whose F1 was not
+    the harmonic mean of their own precision and recall, because the three medians came
+    from three different draws. It is kept only so that a summary written before that
+    field existed still reports something, and it is marked when used.
+    """
+    row = summary.get("median_draw")
+    if isinstance(row, dict) and row.get("f1") is not None:
+        return {**row, "coherent": True}
+    legacy = {}
+    for metric in METRICS:
+        block = summary.get(metric)
+        if isinstance(block, dict) and block.get("median") is not None:
+            legacy[metric] = float(block["median"])
+    return {**legacy, "coherent": False} if "f1" in legacy else None
 
 
 def do_report(args: argparse.Namespace) -> int:
@@ -309,8 +345,13 @@ def do_report(args: argparse.Namespace) -> int:
             summary = json.loads(summary_path.read_text(encoding="utf-8"))
             entry["scored"] = summary.get("scored", 0)
             entry["not_scored"] = summary.get("not_scored", {})
-            for metric in ("precision", "recall", "f1"):
-                entry[metric] = _median_f1(summary, metric)
+            row = _row(summary)
+            for metric in METRICS:
+                entry[metric] = row.get(metric) if row else None
+            # None when there is no row at all -- an unscoreable run and an incoherent
+            # one are different facts and a boolean cannot hold both.
+            entry["coherent_row"] = None if row is None else bool(row.get("coherent"))
+            entry["f1_spread"] = (summary.get("f1") or {}).get("values")
             entry["conclusion"] = summary.get("conclusion")
         table[(cell["task"], cell["arm"])] = entry
 
@@ -318,18 +359,51 @@ def do_report(args: argparse.Namespace) -> int:
                               "per_task": {}, "per_arm": {}, "paired": {}}
     for task in plan["tasks"]:
         report["per_task"][task] = {arm: table.get((task, arm), {}) for arm in plan["arms"]}
+    # All three metrics, mean and sd across tasks, which is the shape FIRE-Bench's own
+    # Table 3 reports (`52.1±26.1  48.3±24.8  46.7±23.4` for its best row). Reporting F1
+    # alone was the first version and it drops two of the three columns the benchmark is
+    # defined by -- and the two it drops are the ones that say *how* a score was reached:
+    # a run can lose on precision by saying more than was asked, or on recall by
+    # answering a narrower question, and an F1 column cannot tell those apart.
+    #
+    # Each metric is averaged over tasks independently, which is what the paper does:
+    # its own 52.1 and 48.3 give a harmonic mean of 50.1, not the 46.7 it prints, because
+    # a macro-average of per-task F1 is not the F1 of the macro-averaged P and R. That is
+    # correct at this level and wrong one level down, which is why the per-cell row comes
+    # from a single draw.
     for arm in plan["arms"]:
-        values = [table.get((task, arm), {}).get("f1") for task in plan["tasks"]]
-        got = [v for v in values if v is not None]
-        report["per_arm"][arm] = {
-            "tasks": len(plan["tasks"]),
-            "scored_tasks": len(got),
-            "f1_median": round(statistics.median(got), 2) if got else None,
-            "f1_mean": round(statistics.mean(got), 2) if got else None,
-            "f1_sd": round(statistics.stdev(got), 2) if len(got) > 1 else None,
-            "f1_values": got,
-            "unscored_tasks": [t for t, v in zip(plan["tasks"], values) if v is None],
+        per_task = {
+            metric: [table.get((task, arm), {}).get(metric) for task in plan["tasks"]]
+            for metric in METRICS
         }
+        got = {metric: [v for v in values if v is not None] for metric, values in per_task.items()}
+        entry: dict[str, Any] = {
+            "tasks": len(plan["tasks"]),
+            "scored_tasks": len(got["f1"]),
+            "unscored_tasks": [
+                task for task, value in zip(plan["tasks"], per_task["f1"]) if value is None
+            ],
+        }
+        for metric in METRICS:
+            values = got[metric]
+            entry[metric] = {
+                "mean": round(statistics.mean(values), 1) if values else None,
+                "sd": round(statistics.stdev(values), 1) if len(values) > 1 else None,
+                "median": round(statistics.median(values), 1) if values else None,
+                "values": values,
+            }
+            # The same three, with an unscoreable run counted as a zero. Both are
+            # reported because neither is obviously right and the choice moves the
+            # answer: on the measured six-task matrix the stock arm's F1 is 22.9
+            # excluding its four unscoreable runs and 7.6 counting them, and which one is
+            # comparable to a published table depends on how that table handled a run
+            # that produced nothing -- which its paper does not say.
+            padded = values + [0.0] * (len(plan["tasks"]) - len(values))
+            entry[metric]["mean_unscoreable_as_zero"] = round(statistics.mean(padded), 1) if padded else None
+            entry[metric]["sd_unscoreable_as_zero"] = (
+                round(statistics.stdev(padded), 1) if len(padded) > 1 else None
+            )
+        report["per_arm"][arm] = entry
     if len(plan["arms"]) >= 2:
         base = plan["arms"][-1]
         for arm in plan["arms"][:-1]:
@@ -338,6 +412,7 @@ def do_report(args: argparse.Namespace) -> int:
                 for task in plan["tasks"]
                 if table.get((task, arm)) and table.get((task, base))
             ]
+            report["paired"].setdefault("_metric", "f1")
             complete = [(t, a, b) for t, a, b in pairs if a is not None and b is not None]
             deltas = [a - b for _, a, b in complete]
             report["paired"][f"{arm} - {base}"] = {
@@ -351,6 +426,18 @@ def do_report(args: argparse.Namespace) -> int:
             }
     out = Path(args.out).expanduser() if args.out else Path(plan["runs_root"]) / "report.json"
     write_json(out, report)
+    print(f"{'arm':18s} {'n':>4s}   {'Prec.':>13s} {'Recall':>13s} {'F1':>13s}")
+    for arm in plan["arms"]:
+        entry = report["per_arm"][arm]
+        cells = []
+        for metric in METRICS:
+            block = entry[metric]
+            cells.append(
+                f"{block['mean']:6.1f}±{block['sd'] if block['sd'] is not None else 0.0:4.1f}"
+                if block["mean"] is not None else f"{'--':>11s}"
+            )
+        print(f"{arm:18s} {entry['scored_tasks']:2d}/{entry['tasks']:<2d}   " + " ".join(cells))
+    print()
     print(json.dumps({"per_arm": report["per_arm"], "paired": report["paired"]}, indent=2))
     print(f"[written] {out}")
     return 0

--- a/tools/score_fire_run.py
+++ b/tools/score_fire_run.py
@@ -26,6 +26,13 @@ under it, one draw per subprocess. One draw per process rather than a loop insid
 deliberate: ``refchecker`` retries a 4xx forever with a ten-second sleep and no
 traceback, so a hung draw has to be killable without losing the draws already finished.
 
+**The reportable row is ``median_draw``, not the three per-metric medians.** FIRE-Bench
+reports precision, recall and F1 together, and those three numbers have to come from one
+draw or the row describes no run that happened -- ``F1 = 2PR/(P+R)`` fails on it, and the
+reader cannot tell that from an arithmetic error. The per-metric medians and ranges are
+kept beside it because each metric's spread is worth reporting; laying three of them out
+as a row is what is forbidden.
+
 **A draw that did not produce a number is not a zero.** ``no_conclusion``,
 ``judge_failed`` and ``error`` draws are counted and named in the summary, and excluded
 from the statistics -- the failure mode this guards against is the one that scored a
@@ -109,12 +116,43 @@ def one_draw(
     return {"status": "error", "note": "driver wrote no readable result"}
 
 
+def median_draw(draws: list[dict]) -> dict | None:
+    """The one draw whose F1 is the median, as a coherent (precision, recall, F1) triple.
+
+    **A row has to come from one draw.** Taking the median of each metric independently
+    is what this function replaced, and it produces rows that cannot be true together:
+    measured on two real cells, ``P = 53.8, R = 50.0, F1 = 41.2`` -- whose harmonic mean
+    is 51.8, not 41.2 -- because the three medians came from three different draws.
+    Nothing in the arithmetic is wrong; the row simply describes no run that happened,
+    and a reader who checks it against F1 = 2PR/(P+R) finds an error that is not there.
+
+    The per-metric medians stay in the summary beside this, because the spread of each
+    metric is a real thing to report. What may not be done is to lay three of them out
+    as a row.
+    """
+    scored = [
+        d for d in draws
+        if d.get("status") == "scored" and (d.get("overall_metrics") or {}).get("f1") is not None
+    ]
+    if not scored:
+        return None
+    scored.sort(key=lambda d: float(d["overall_metrics"]["f1"]))
+    chosen = scored[len(scored) // 2]["overall_metrics"]
+    return {
+        "precision": round(float(chosen.get("precision", 0.0)), 2),
+        "recall": round(float(chosen.get("recall", 0.0)), 2),
+        "f1": round(float(chosen.get("f1", 0.0)), 2),
+    }
+
+
 def summarise(draws: list[dict]) -> dict:
     scored = [d for d in draws if d.get("status") == "scored" and d.get("overall_metrics")]
     summary: dict = {
         "draws": len(draws),
         "scored": len(scored),
         "not_scored": {},
+        # The row. Everything below it is per-metric spread, which is not a row.
+        "median_draw": median_draw(draws),
     }
     for draw in draws:
         if draw.get("status") != "scored":
@@ -207,7 +245,8 @@ def main(argv: list[str] | None = None) -> int:
     summary_path = out_dir / "summary.json"
     summary_path.write_text(json.dumps(summary, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     print(json.dumps({k: v for k, v in summary.items()
-                      if k in {"task", "draws", "scored", "not_scored", "precision", "recall", "f1"}},
+                      if k in {"task", "draws", "scored", "not_scored", "median_draw",
+                               "precision", "recall", "f1"}},
                      indent=2))
     print(f"[written] {summary_path}")
     return 0 if summary["scored"] else 1


### PR DESCRIPTION
Follow-up to #272. Two defects in how that PR presented its own results. Neither changes a
run; both change what a reader is told about one.

## 1. Two of the three columns were missing

FIRE-Bench's Table 3 is **precision, recall and F1** side by side.
`tools/fire_trial.py report` collected all three per cell and aggregated only F1, so #272's
table printed one column of three.

The two that were dropped are the ones that say *how* a score was reached: a run can lose on
precision by saying more than was asked, or on recall by answering a narrower question, and
F1 cannot tell those apart. On the measured matrix that is not hypothetical — the stock arm
has the **highest recall of any arm (66.7) and the lowest precision (18.1)**, which is a
specific and legible failure (it answered the right question at enormous length) that
"F1 28.4" hides completely.

## 2. The three medians did not come from the same draw

Each cell is scored three times because the judge is noisy, and the summary took the median
of each metric independently. That is arithmetically fine and produces rows that describe no
run that happened. Measured, on two real cells:

```
P = 53.8   R = 50.0   F1 = 41.2      # harmonic mean of 53.8 and 50.0 is 51.8
```

A reader who checks the row against `F1 = 2PR/(P+R)` finds an error that is not there.

`score_fire_run.py` now writes `median_draw` — the draw whose F1 is the median, one run,
internally consistent — and that is the row. The per-metric medians and ranges stay beside
it, because each metric's spread is worth reporting; what is forbidden is laying three of
*those* out as a row.

Across tasks each metric is still averaged independently, which is what the paper does and
is correct at that level: its own 52.1 and 48.3 give a harmonic mean of 50.1, not the 46.7
it prints, because a macro-average of per-task F1 is not the F1 of the macro-averaged P and R.

## The corrected table

Six tasks, one run each, `opus`, every arm on the benchmark's own 3600 s clock. Cells are
the median judge draw of three; arms are mean ± sd across tasks, in the paper's format.

| arm | scoreable | Prec. | Recall | F1 | median wall clock |
|:---|---:|---:|---:|---:|---:|
| AutoR pipeline | 6 / 6 | 23.8 ± 28.0 | 30.6 ± 40.0 | 25.7 ± 31.5 | 52 min |
| AutoR direct | 6 / 6 | **60.8 ± 20.1** | **61.7 ± 14.3** | **60.6 ± 17.2** | **11 min** |
| stock Claude Code | **2 / 6** | 18.1 ± 9.8 | 66.7 ± 23.5 | 28.4 ± 14.4 | 61 min, killed |
| *stock, unscoreable counted as 0* | 6 / 6 | 6.0 ± 10.3 | 22.2 ± 36.0 | 9.4 ± 16.0 | |

Both stock rows are reported because neither is obviously right and the choice moves its F1
from 28.4 to 9.4; which one is comparable to a published table depends on how that table
handled a run that produced nothing, and the paper does not say.

The conclusions of #272 are unchanged: direct beats pipeline 5 of 6 (median **+34.8 F1**,
and on precision and recall alike rather than by trading one for the other), and four of six
stock runs produced nothing scoreable.

## The re-score is itself a measurement

Picking up the coherent row meant re-scoring all eighteen cells. With nothing changing but
the judge's sampling, arm means moved 4–5 F1 points — pipeline 30.2 → 25.7, direct
55.9 → 60.6, stock 22.9 → 28.4 — and one task moved 13.7. **The ordering of the arms did not
move**, which is the part worth reporting. On a single unchanged log the measured range is
43 F1 points.

## One more, found while re-scoring

`fire_trial.py` invoked the checkout recorded in the plan, and a plan outlives the worktree
it was written in. The removed worktree made every `score` call exit 2 — the same code
argparse uses for a bad flag, so it read as a tool bug rather than a missing file. It now
falls back to the checkout it is running from, and says so.

## Checks

`python3 -m unittest discover -s tests` — **3882 tests, OK, 1 skipped**. Four new, including
the negative control that the three independent medians of those exact draws are *not*
coherent — without it the coherence test cannot distinguish a working rule from three draws
that happened to agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)