### PR TITLE
Search on gemini-3.7-flash, and the measurement that says the control needs one too

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -896,7 +896,7 @@ Those four options are the whole flag surface.
 | Flag | Default | Description |
 | --- | --- | --- |
 | `--json` | off | Emit `{query, model, backend, answer, grounded, citable_source_count, results[]}` instead of markdown, each result being `{title, url, citable, supported_claims[]}`. |
-| `--model MODEL` | `gemini-2.5-flash` (API key) / `gemini-3.6-flash` (Vertex) | Overridable with `AUTOR_WEB_SEARCH_MODEL` or `GEMINI_MODEL`. |
+| `--model MODEL` | `gemini-2.5-flash` (API key) / `gemini-3.7-flash` (Vertex) | Overridable with `AUTOR_WEB_SEARCH_MODEL` or `GEMINI_MODEL`. |
 | `--max-results N` | `10` | Maximum number of grounded sources to report. |
 | `--no-resolve-urls` | off | Leave Vertex grounding redirects unresolved. Faster, but the source URLs are opaque stubs that cannot be cited. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -330,7 +330,7 @@ AutoR reads very few environment variables of its own.
 | --- | --- | --- |
 | `GOOGLE_API_KEY` | `src/web_search.py` | Gemini key for all three Gemini paths: `--research-diagram`, `--web-search gemini`, and `--cross-review`. `resolve_gemini_api_key` is the single resolver; `src/diagram_gen.py` delegates to it so the features cannot drift apart. |
 | `GEMINI_API_KEY` | `src/web_search.py` | Same, checked second. |
-| `AUTOR_WEB_SEARCH_MODEL` | `src/web_search.py` | Model for Gemini-backed web search. Defaults to `gemini-2.5-flash` on the Gemini API and `gemini-3.6-flash` on Vertex AI. |
+| `AUTOR_WEB_SEARCH_MODEL` | `src/web_search.py` | Model for Gemini-backed web search. Defaults to `gemini-2.5-flash` on the Gemini API and `gemini-3.7-flash` on Vertex AI. |
 | `GEMINI_MODEL` | `src/web_search.py` | Same, checked second. |
 | `AUTOR_WEB_SEARCH_BACKEND` | `src/web_search.py` | Force `vertex` or `api_key` instead of auto-detecting. |
 | `AUTOR_VERTEX_PROJECT` | `src/web_search.py` | Vertex AI project for web search. Falls back to `GOOGLE_CLOUD_PROJECT`, then `ANTHROPIC_VERTEX_PROJECT_ID`. |

--- a/docs/researchclawbench.md
+++ b/docs/researchclawbench.md
@@ -332,7 +332,7 @@ python3 tools/web_search.py "diffusion model scaling laws" --json --max-results 
 | Auth | Application Default Credentials | API key |
 | Project | `AUTOR_VERTEX_PROJECT`, `GOOGLE_CLOUD_PROJECT`, or `ANTHROPIC_VERTEX_PROJECT_ID` | — |
 | Location | `AUTOR_VERTEX_LOCATION`, `GOOGLE_CLOUD_LOCATION`, default `global` | — |
-| Default model | `gemini-3.6-flash` | `gemini-2.5-flash` |
+| Default model | `gemini-3.7-flash` | `gemini-2.5-flash` |
 
 An explicit API key wins over Vertex, because setting one is deliberate whereas the Vertex
 project is often inherited from the host's Claude Code configuration. Force the choice with
@@ -395,7 +395,7 @@ that every citation must come from a URL the tool actually returned. `auto` degr
 native rather than advertising a tool that would fail on first use.
 
 The search model defaults per backend — `gemini-2.5-flash` on the Developer API,
-`gemini-3.6-flash` on Vertex, as in the table above — and `resolve_search_model` lets an
+`gemini-3.7-flash` on Vertex, as in the table above — and `resolve_search_model` lets an
 explicit `--model` win over `AUTOR_WEB_SEARCH_MODEL` or `GEMINI_MODEL`, which in turn win over
 both defaults.
 

--- a/src/web_search.py
+++ b/src/web_search.py
@@ -33,7 +33,7 @@ from urllib.parse import urlsplit
 DEFAULT_SEARCH_MODEL = "gemini-2.5-flash"
 
 #: Vertex AI serves a different model catalogue than the Gemini Developer API.
-DEFAULT_VERTEX_SEARCH_MODEL = "gemini-3.6-flash"
+DEFAULT_VERTEX_SEARCH_MODEL = "gemini-3.7-flash"
 DEFAULT_VERTEX_LOCATION = "global"
 
 DEFAULT_MAX_RESULTS = 10


### PR DESCRIPTION
One default and its four documented copies. `gemini-3.7-flash` answers on Vertex here
(`3.7-pro` and a bare `3.7` are both 404 on this project), so it replaces `gemini-3.6-flash`
as the Vertex default; the Gemini-API default is untouched.

## Why this was being looked at

A fairness check on the benchmark comparison, and it found the comparison backwards.

AutoR runs with `--web-search gemini` and the bare-Claude-Code control runs with nothing,
which reads like the control being handicapped — until you look at what either arm actually
got. In the control's `_agent_output.jsonl` for Astronomy_000 there is exactly one
`WebSearch` call and it came back:

    API Error: 400 Organization Policy constraint
    constraints/vertexai.allowedPartnerModelFeatures violated

Reproduced by hand against the same CLI on this box: the tool is offered and the call is
refused. That is a GCP project policy, not a flag, which is what `src/web_search.py`'s
opening paragraph has said all along — the built-in is disabled on Vertex and this module
exists to replace it.

So over the 40 scored tasks the control had **no working search at all** while AutoR made 21
successful `web_search` calls. The published gap — AutoR 28.77 against the control's 31.43,
-2.65, 15-25 — was measured across a capability difference in AutoR's favour, and AutoR
still lost. The number is not too harsh; it is too kind.

Fixing that is a re-run rather than a code change, and it is running: the control now gets
the same `web_search` tool over MCP, on the same model, verified against the real binary
before launch. This commit is the part of it that belongs in the repo.

Testing: the 180 web-search tests pass, and the doc-count gate holds the four copies to the
symbol.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
