### PR TITLE
A channel declares what it may spend, and the run records what it spent

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -332,6 +332,24 @@ delivery rules therefore sit inside `build_prompt` instead of next to a
 sending both put ~350 words of verbatim duplicate into every prompt from Stage
 04 on.
 
+Every channel declares what it may spend. `Channel.max_chars` is enforced in
+`_render`, which clips the body to the budget and says in the block how many
+characters it dropped — a silent truncation would leave the model unable to tell a
+channel that had little to say from one whose tail was taken. A channel that
+declares no budget must be named in `UNBOUNDED_BY_CONSTRUCTION` with the structure
+that bounds it, and `information_flow` raises at import on one that is neither, the
+way `Edge.__post_init__` refuses an unregistered guard. The numbers come from
+rendering every channel against 40 archived run roots; each ceiling sits above the
+observed maximum, because a budget here is a guard against the tail rather than a
+squeeze on what runs today.
+
+`_record_inbound_channels` writes the per-channel character count and its budget
+into the run log beside the keys, and marks a channel that reached its ceiling. The
+keys alone said *which* information arrived and nothing about *how much*, and the
+number worth knowing — a Stage 07 prompt has a median of 277 KB over 197 archived
+prompts and a maximum of 1.79 MB — could only be recovered by measuring
+`prompt_cache/` from outside.
+
 The result is written to `prompt_cache/<slug>_attempt_NN.prompt.md` and passed
 to the CLI **by reference** (`-p @<path>`). Two consequences worth knowing:
 the prompt cache is load-bearing during a run rather than a log, and every

--- a/docs/iclr/round-loop-and-stage-graph.md
+++ b/docs/iclr/round-loop-and-stage-graph.md
@@ -326,6 +326,33 @@ an inline marker in the prompt string), and any blanket swap of tail-drop for he
 since two callers already implement the head-drop variant deliberately and one argues for
 tail-drop on a goal.
 
+**Landed, the structural half and the telemetry.** `Channel` now carries `max_chars`,
+`_render` enforces it and names the dropped characters in the block, and a channel that
+declares no budget has to be in `UNBOUNDED_BY_CONSTRUCTION` with the structure that
+bounds it — checked at import, raising, the way `Edge.__post_init__` refuses an
+unregistered guard, so the rule is the program's and not only a test's. The sizes reach
+the run log per channel, with a mark on any channel at its ceiling.
+
+The ceilings are measured rather than picked: every channel was rendered against 40
+archived run roots, and each budget sits above that channel's observed maximum
+(`hypotheses` 27,713 → 40,000; `decision_ledger` 15,087 → 24,000; and so on). Ten of the
+twenty channels rendered anything on those runs; the other ten carry a stated guess from
+the shape of what the builder emits, and the docstring says which are which. A budget
+here is a guard against the tail, not a squeeze on today's content — clipping what runs
+now would be a behaviour change with an unmeasured cost.
+
+Measured while doing it, and worth recording because it is the number the whole section
+is about: over 197 archived stage prompts, `# Stage Instructions` (the rendered channel
+set) has a median of 25.6 KB and a p90 of 78.6 KB, `# Approved Memory` a p90 of 132 KB
+and a maximum of 177 KB, `# Stage Handoff Context` a p90 of 99 KB. The prompt they sit in
+runs from a median of 21 KB at Stage 01 to 277 KB at Stage 07, with a maximum of 1.79 MB.
+
+**Still open:** approved memory and the handoff context are not channels — they are
+arguments to `build_prompt` — so neither is covered by this, and they are two of the
+three biggest blocks. The repair prompt still inlines whole stdout, stderr, prompt, draft
+and promoted file. Those are behaviour changes on the largest blocks in the prompt and
+want the telemetry that just landed to price them.
+
 *Class: design gap plus missing telemetry. Effort: medium.*
 
 ### 4.5 The contract is back-checked every round; ours is checked once, at the end

--- a/src/information_flow.py
+++ b/src/information_flow.py
@@ -105,6 +105,25 @@ class Channel:
     #: Why these consumers and not others. Read by the test that guards the
     #: topology, so a narrowing has to be argued for rather than just made.
     rationale: str = ""
+    #: The most characters this channel's body may spend in a stage prompt.
+    #:
+    #: A budget was a per-builder convention before this field existed:
+    #: ``withdrawal_ledger`` caps itself at five records, ``settled_reasoning`` at four
+    #: cruxes and six hundred characters a field, ``artifact_index`` at five entries a
+    #: category -- and each of those arguments lives inside the builder that makes it,
+    #: so a channel added without one is unbounded and nothing says so. ``_render``
+    #: enforces this, which is what turns the convention into a rule.
+    #:
+    #: ``None`` means the channel is structurally bounded by what it renders and needs
+    #: no ceiling. That is a claim, and ``test_information_flow`` makes it a checked one:
+    #: every channel either declares a budget or is named in ``UNBOUNDED_BY_CONSTRUCTION``
+    #: with the reason it cannot grow, so the exemption list cannot grow by assertion.
+    #:
+    #: What the numbers are measured against: over 197 archived stage prompts the whole
+    #: rendered channel set -- everything under ``# Stage Instructions`` after the static
+    #: template -- has a median of 25.6 KB and a p90 of 78.6 KB, and the prompt it sits
+    #: in runs to a median of 277 KB by Stage 07 with a maximum of 1.79 MB.
+    max_chars: int | None = None
 
     def serves(self, stage: StageSpec) -> bool:
         return stage.slug in self.consumed_by
@@ -122,9 +141,33 @@ class ChannelContext:
 
 
 def _render(block: str | None, channel: Channel) -> str:
+    """The channel's block, clipped to what it declared it may spend.
+
+    The clip keeps the head and says how much it dropped, in the prompt itself. A silent
+    truncation is the worst of the three available behaviours: the model cannot tell a
+    channel that had little to say from one whose tail was taken, and neither can a
+    reader of ``prompt_cache/``. Keeping the head rather than the tail because these
+    blocks are written most-important-first -- a rendered ledger leads with what is open,
+    a findings list with what was raised -- and two callers elsewhere that need the tail
+    (``approval_agent`` and ``review_panel``, reading a verdict at the end of a
+    transcript) implement their own head-drop for that reason. The direction is a
+    per-reader decision and this is the readers' side of it.
+
+    The heading and preface are outside the budget. They are the harness's own words
+    about how to read the block, they are a fixed cost per channel, and clipping them
+    would remove the instruction before the thing it describes.
+    """
+
     body = (block or "").strip()
     if not body:
         return ""
+    if channel.max_chars is not None and len(body) > channel.max_chars:
+        dropped = len(body) - channel.max_chars
+        body = (
+            body[: channel.max_chars].rstrip()
+            + f"\n\n_[{dropped} character(s) dropped: this channel's budget is "
+            f"{channel.max_chars}.]_"
+        )
     parts = [channel.heading, ""]
     if channel.preface:
         parts.extend([channel.preface.strip(), ""])
@@ -137,14 +180,26 @@ def inbound_channels(stage: StageSpec, channels: tuple[Channel, ...]) -> list[Ch
 
 
 def render_inbound(
-    context: ChannelContext, channels: tuple[Channel, ...]
+    context: ChannelContext,
+    channels: tuple[Channel, ...],
+    sizes: "list[tuple[str, int, int | None]] | None" = None,
 ) -> tuple[str, list[str]]:
     """Compose this stage's inbound context. Returns the text and the keys used.
 
     The key list is the point of the return tuple: it is what lets a run record
     which information actually reached a stage, which is the input attribution
     needs.
+
+    *sizes* is a sink -- ``(key, characters, budget)`` appended per delivered channel --
+    and not a third element of the tuple, in the shape ``CostTally`` and ``CustodyWatch``
+    already have. It is a sink for a harder reason than theirs, though: **a builder may
+    write.** ``_artifact_index`` calls ``write_artifact_index`` and ``_experiment_manifest``
+    rewrites the manifest with a fresh timestamp -- which is the very drift
+    ``docs/iclr/composable-stage-graphs.md`` excludes from the committed view by name. A
+    second pass to measure what the first pass rendered would run those writes twice per
+    prompt. The measurement has to come off the same render as the text.
     """
+
     blocks: list[str] = []
     delivered: list[str] = []
     for channel in inbound_channels(context.stage, channels):
@@ -152,6 +207,8 @@ def render_inbound(
         if rendered:
             blocks.append(rendered)
             delivered.append(channel.key)
+            if sizes is not None:
+                sizes.append((channel.key, len(rendered), channel.max_chars))
     return ("\n\n".join(blocks), delivered)
 
 
@@ -387,6 +444,36 @@ def _task_shaped_skills(context: ChannelContext) -> str:
     return format_skills_for_prompt(list(entries), context.stage.slug, frozenset(pinned))
 
 
+#: Channels that declare no budget, and the reason each cannot grow.
+#:
+#: The list is the point. `Channel.max_chars` defaulting to ``None`` would otherwise make
+#: "unbounded" the thing that happens when nobody thought about it, which is how a
+#: convention decays -- so a channel is either given a ceiling or named here with the
+#: structure that bounds it, and ``test_information_flow`` fails on a channel that is
+#: neither. An exemption list that cannot grow by assertion is the same device
+#: ``docs/iclr/composable-stage-graphs.md`` uses for the channel excluded from the
+#: committed view.
+UNBOUNDED_BY_CONSTRUCTION: dict[str, str] = {
+    "run_configuration": (
+        "a fixed block from the venue registry and the run config; measured at 508-522 "
+        "characters over 320 renders, and it has no input that grows"
+    ),
+    "report_contract": (
+        "static prose conditioned on the output format, with the figure ceiling read from "
+        "MAX_REPORT_FIGURES; 934 characters on every one of 120 renders"
+    ),
+    "settled_reasoning": (
+        "the builder is the ceiling: MAX_CRUXES=4, MAX_REJECTED=5 and MAX_FIELD_CHARS=600, "
+        "argued in its own module docstring"
+    ),
+    "withdrawal_history": (
+        "PROMPT_WITHDRAWAL_LIMIT=5 records, with the same argument this field generalises "
+        "-- 'an unbounded block would grow until it crowded out the work the stage is "
+        "being asked to do'"
+    ),
+}
+
+
 CHANNELS: tuple[Channel, ...] = (
     Channel(
         key="run_configuration",
@@ -413,6 +500,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="artifact_index",
+        max_chars=6_000,
         heading="## Structured Artifact Index",
         produced_by=None,
         consumed_by=frozenset(
@@ -433,6 +521,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="experiment_manifest",
+        max_chars=6_000,
         heading="## Experiment Bundle Manifest",
         produced_by="05_experimentation",
         consumed_by=frozenset(
@@ -443,6 +532,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="intake_resources",
+        max_chars=4_000,
         heading="## Pre-Loaded Resources (already in workspace)",
         produced_by=None,
         consumed_by=frozenset({"00_intake", "01_literature_survey"}),
@@ -454,6 +544,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="project_context",
+        max_chars=24_000,
         heading="# Existing Project Repository (from the project bootstrap)",
         produced_by=None,
         consumed_by=_from("01_literature_survey"),
@@ -491,6 +582,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="idea_pool",
+        max_chars=24_000,
         heading="## Candidate Hypothesis Pool",
         produced_by=None,
         consumed_by=frozenset({"02_hypothesis_generation"}),
@@ -499,6 +591,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="writing_manifest",
+        max_chars=8_000,
         heading="## Writing Manifest",
         produced_by=None,
         consumed_by=frozenset({"07_writing"}),
@@ -507,6 +600,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="researcher_profile",
+        max_chars=12_000,
         heading="# Researcher Profile (from paper corpus bootstrap)",
         produced_by=None,
         consumed_by=frozenset(
@@ -520,6 +614,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="decision_ledger",
+        max_chars=24_000,
         heading="# Decision Ledger (from prior stages)",
         produced_by="01_literature_survey",
         consumed_by=_from("02_hypothesis_generation"),
@@ -533,6 +628,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="hypotheses",
+        max_chars=40_000,
         heading="# Hypothesis Context (from Stage 02)",
         produced_by="02_hypothesis_generation",
         consumed_by=frozenset({"03_study_design", "04_implementation"}),
@@ -552,6 +648,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="preregistration",
+        max_chars=40_000,
         heading="# Preregistered Hypotheses (frozen — not editable)",
         produced_by="04_implementation",
         consumed_by=_from("05_experimentation"),
@@ -560,6 +657,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="experimental_protocol",
+        max_chars=12_000,
         heading="# Experimental Protocol (declared at Stage 03)",
         produced_by="03_study_design",
         consumed_by=frozenset(
@@ -618,6 +716,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="report_plan",
+        max_chars=30_000,
         heading="# Report Plan (declared at Stage 03)",
         produced_by="03_study_design",
         consumed_by=frozenset(
@@ -655,6 +754,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="research_rounds",
+        max_chars=24_000,
         heading="# Earlier Research Rounds",
         produced_by="06_analysis",
         consumed_by=frozenset(
@@ -675,6 +775,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="validity_findings",
+        max_chars=24_000,
         heading="# Adversarial Validity Findings (each must be answered)",
         produced_by="05_experimentation",
         consumed_by=frozenset({"06_analysis", "07_writing"}),
@@ -683,6 +784,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="hypothesis_verdicts",
+        max_chars=24_000,
         heading="# Hypothesis Verdicts",
         produced_by="06_analysis",
         consumed_by=frozenset({"07_writing", "08_dissemination"}),
@@ -714,6 +816,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="task_shaped_skills",
+        max_chars=12_000,
         heading="## Skills Selected For This Task",
         produced_by=None,
         consumed_by=frozenset(ALL_STAGES),
@@ -729,3 +832,41 @@ CHANNELS: tuple[Channel, ...] = (
         ),
     ),
 )
+
+
+def _every_channel_declares_what_it_may_spend() -> None:
+    """Refuse a channel that neither declares a budget nor says why it cannot grow.
+
+    At import, and raising, for the reason :meth:`Edge.__post_init__` refuses an
+    unregistered guard: the alternative fails open. ``max_chars`` defaults to ``None``,
+    so an author who does not think about it gets "unbounded" -- which is how the
+    per-builder convention this field replaces decayed in the first place.
+
+    Safe to raise here because the population is source, not run data. This can only
+    fail while someone is editing this file, never on a user's run, so it is not the
+    kind of precondition ``docs/iclr/composable-stage-graphs.md`` warns about.
+    """
+
+    undeclared = sorted(
+        channel.key
+        for channel in CHANNELS
+        if channel.max_chars is None and channel.key not in UNBOUNDED_BY_CONSTRUCTION
+    )
+    if undeclared:
+        raise ValueError(
+            "These channels declare no `max_chars` and give no reason they cannot grow: "
+            + ", ".join(undeclared)
+            + ". Give each one a budget, or name it in UNBOUNDED_BY_CONSTRUCTION with "
+            "the structure that bounds it."
+        )
+    stale = sorted(set(UNBOUNDED_BY_CONSTRUCTION) - {channel.key for channel in CHANNELS})
+    if stale:
+        raise ValueError(
+            "UNBOUNDED_BY_CONSTRUCTION names channels that no longer exist: "
+            + ", ".join(stale)
+            + ". A reason nobody can reach is a reason nobody will notice has stopped "
+            "applying."
+        )
+
+
+_every_channel_declares_what_it_may_spend()

--- a/src/manager.py
+++ b/src/manager.py
@@ -3429,13 +3429,15 @@ class ResearchManager:
         # instead of every block being gated on a stage-number threshold. The
         # delivered keys are recorded so a run can say what information actually
         # reached a stage — which is what attribution needs.
+        channel_sizes: list[tuple[str, int, int | None]] = []
         inbound, delivered = render_inbound(
             ChannelContext(paths=paths, stage=stage, attempt_no=attempt_no, manager=self),
             CHANNELS,
+            channel_sizes,
         )
         if inbound:
             stage_template = stage_template.rstrip() + "\n\n" + inbound + "\n"
-        self._record_inbound_channels(paths, stage, delivered)
+        self._record_inbound_channels(paths, stage, delivered, channel_sizes)
 
         routine = self.effort_plan.is_routine(stage)
         if self.effort_plan.enabled:
@@ -5070,7 +5072,11 @@ class ResearchManager:
             )
 
     def _record_inbound_channels(
-        self, paths: RunPaths, stage: StageSpec, delivered: list[str]
+        self,
+        paths: RunPaths,
+        stage: StageSpec,
+        delivered: list[str],
+        sizes: "list[tuple[str, int, int | None]] | None" = None,
     ) -> None:
         """Write down what information reached this stage.
 
@@ -5079,13 +5085,32 @@ class ResearchManager:
         get from "this edge helped" to "this information helped". This is the
         cheapest possible version of that record: the channel keys, per stage,
         in the run log.
+
+        And what each one spent. The keys alone answered *which* information reached a
+        stage and nothing about *how much*, so the one number every reader of this run
+        actually wanted -- a Stage 07 prompt has a median of 277 KB over 197 archived
+        prompts and a maximum of 1.79 MB -- could only be recovered by measuring
+        ``prompt_cache/`` from outside. A channel at its declared budget is marked, so a
+        ceiling that has started biting is legible here rather than inferable from a
+        clip marker buried in the prompt.
         """
+        measured = dict((key, (chars, budget)) for key, chars, budget in (sizes or []))
+        lines = []
+        for key in delivered:
+            chars, budget = measured.get(key, (0, None))
+            share = f"{chars} chars"
+            if budget is not None:
+                share += f" of {budget}"
+                if chars >= budget:
+                    share += " (AT BUDGET -- clipped)"
+            lines.append(f"- {key}: {share}")
         append_log_entry(
             paths.logs,
             f"{stage.slug} inbound_channels",
             (
-                f"{len(delivered)} information channels delivered.\n"
-                + ("\n".join(f"- {key}" for key in delivered) or "- none")
+                f"{len(delivered)} information channels delivered, "
+                f"{sum(chars for chars, _ in measured.values())} characters in total.\n"
+                + ("\n".join(lines) or "- none")
             ),
         )
 

--- a/tests/test_information_flow.py
+++ b/tests/test_information_flow.py
@@ -14,14 +14,17 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 
 from src.run_skills import read_skill_pack
 from src.information_flow import (
     ALL_STAGES,
     CHANNELS,
+    UNBOUNDED_BY_CONSTRUCTION,
     Channel,
     ChannelContext,
+    _render,
     dependency_edges,
     inbound_channels,
     render_inbound,
@@ -86,6 +89,126 @@ class TopologyTest(unittest.TestCase):
         edges = dependency_edges(CHANNELS)
         self.assertGreater(len(edges), 20)
         self.assertIn(("04_implementation", "06_analysis", "preregistration"), edges)
+
+
+class EveryChannelDeclaresWhatItMaySpendTest(unittest.TestCase):
+    """A budget was a per-builder convention, and a convention has no floor.
+
+    Three channels capped themselves and argued for it in their own module docstrings --
+    `withdrawal_ledger`'s five records, `settled_reasoning`'s four cruxes and six hundred
+    characters a field, `artifact_index`'s five entries a category. Each argument lived
+    inside the builder that made it, so a channel added without one was unbounded and
+    nothing anywhere said so. `Channel.max_chars` is the rule; this is what stops the
+    exemption from being the easy answer.
+    """
+
+    def test_a_channel_declares_a_budget_or_says_why_it_cannot_grow(self) -> None:
+        undeclared = [
+            channel.key
+            for channel in CHANNELS
+            if channel.max_chars is None and channel.key not in UNBOUNDED_BY_CONSTRUCTION
+        ]
+        self.assertEqual(
+            undeclared, [],
+            "give it a max_chars, or name it in UNBOUNDED_BY_CONSTRUCTION with the "
+            "structure that bounds it",
+        )
+
+    def test_the_exemption_list_names_no_channel_that_is_gone(self) -> None:
+        """The other direction: a reason for a channel that no longer exists is a reason
+        nobody will notice has stopped applying."""
+        live = {channel.key for channel in CHANNELS}
+        self.assertEqual([key for key in UNBOUNDED_BY_CONSTRUCTION if key not in live], [])
+
+    def test_every_exemption_carries_a_reason_long_enough_to_be_one(self) -> None:
+        short = [
+            key for key, reason in UNBOUNDED_BY_CONSTRUCTION.items() if len(reason.strip()) < 40
+        ]
+        self.assertEqual(short, [], "a reason too short to check is not a reason")
+
+    def test_the_rule_is_the_programs_and_not_only_this_files(self) -> None:
+        """It raises at import, like `Edge.__post_init__` on an unregistered guard.
+
+        A rule that lives only in a test is a rule that passes for anyone who does not
+        run it. The population here is source rather than run data, so raising can only
+        happen while someone is editing the channel table.
+        """
+        from src.information_flow import _every_channel_declares_what_it_may_spend
+
+        with patch("src.information_flow.CHANNELS", (
+            Channel(key="nameless", heading="## X", produced_by=None,
+                    consumed_by=frozenset(), build=lambda _ctx: "x"),
+        )):
+            with self.assertRaises(ValueError) as caught:
+                _every_channel_declares_what_it_may_spend()
+        self.assertIn("nameless", str(caught.exception))
+
+    def test_a_reason_for_a_channel_that_is_gone_also_raises(self) -> None:
+        from src.information_flow import _every_channel_declares_what_it_may_spend
+
+        stale = dict(UNBOUNDED_BY_CONSTRUCTION)
+        stale["retired"] = "a reason long enough to look like a real one, and stale"
+        with patch("src.information_flow.UNBOUNDED_BY_CONSTRUCTION", stale):
+            with self.assertRaises(ValueError) as caught:
+                _every_channel_declares_what_it_may_spend()
+        self.assertIn("retired", str(caught.exception))
+
+    def test_a_declared_budget_is_a_positive_number(self) -> None:
+        self.assertEqual(
+            [c.key for c in CHANNELS if c.max_chars is not None and c.max_chars <= 0], []
+        )
+
+
+class TheBudgetIsEnforcedAndSaysWhatItDroppedTest(unittest.TestCase):
+    """A silent truncation is the worst of the three available behaviours.
+
+    The model cannot tell a channel that had little to say from one whose tail was taken,
+    and neither can a reader of `prompt_cache/`.
+    """
+
+    def _channel(self, budget: int | None, body: str) -> Channel:
+        return Channel(
+            key="probe", heading="## Probe", produced_by=None,
+            consumed_by=frozenset({STAGES[0].slug}), build=lambda _ctx: body,
+            max_chars=budget,
+        )
+
+    def _render_probe(self, budget: int | None, body: str) -> str:
+        return _render(body, self._channel(budget, body))
+
+    def test_a_block_inside_its_budget_is_untouched(self) -> None:
+        rendered = self._render_probe(100, "short")
+        self.assertIn("short", rendered)
+        self.assertNotIn("dropped", rendered)
+
+    def test_a_block_over_budget_is_clipped_and_says_by_how_much(self) -> None:
+        rendered = self._render_probe(50, "x" * 200)
+        self.assertIn("150 character(s) dropped", rendered)
+        self.assertIn("budget is 50", rendered)
+
+    def test_the_head_is_what_survives(self) -> None:
+        """These blocks lead with what is open. Two callers elsewhere keep the tail
+        instead, reading a verdict at the end of a transcript, and implement their own
+        head-drop for that reason -- the direction is the reader's decision."""
+        rendered = self._render_probe(10, "HEADHEADHEADtailtail")
+        self.assertIn("HEADHEADHE", rendered)
+        self.assertNotIn("tailtail", rendered)
+
+    def test_no_budget_means_no_clip(self) -> None:
+        """The control on the exemption: a channel on the list is genuinely not clipped."""
+        rendered = self._render_probe(None, "y" * 5000)
+        self.assertNotIn("dropped", rendered)
+        self.assertIn("y" * 5000, rendered)
+
+    def test_the_heading_and_preface_are_outside_the_budget(self) -> None:
+        channel = Channel(
+            key="probe", heading="## Probe", produced_by=None,
+            consumed_by=frozenset({STAGES[0].slug}), build=lambda _ctx: "z" * 100,
+            preface="Read this first.", max_chars=10,
+        )
+        rendered = _render("z" * 100, channel)
+        self.assertIn("## Probe", rendered)
+        self.assertIn("Read this first.", rendered)
 
 
 class HypothesisDuplicationTest(unittest.TestCase):


### PR DESCRIPTION
§4.4 of [#254](https://github.com/tangxiangru/AutoR/pull/254)'s list — the structural half and the
telemetry. The two biggest blocks are named as still open rather than quietly skipped.

## The gap

A budget was a per-builder convention. `withdrawal_ledger` caps itself at five records, `settled_reasoning`
at four cruxes and 600 characters a field, `artifact_index` at five entries a category — and every one of
those arguments lives *inside the builder that makes it*, so a channel added without one is unbounded and
nothing anywhere says so. `Channel` had no budget field; `_render` concatenated whatever came back.

## What landed

**`Channel.max_chars`, enforced in `_render`.** The clip names the dropped characters inside the block — a
silent truncation leaves the model unable to tell a channel that had little to say from one whose tail was
taken. The head survives: these blocks lead with what is open, and the two callers that need the tail
(`approval_agent`, `review_panel`, reading a verdict at the end of a transcript) already implement their
own head-drop for that reason.

**Declare or explain, checked by the program.** A channel with no budget must be named in
`UNBOUNDED_BY_CONSTRUCTION` with the structure that bounds it, and `information_flow` **raises at import**
on one that is neither — the way `Edge.__post_init__` refuses an unregistered guard. The population is
source, not run data, so it can only fire while someone is editing the channel table.

**The ceilings are measured.** Every channel rendered against 40 archived run roots; each budget sits
*above* that channel's observed maximum:

| channel | observed max | budget |
| --- | --- | --- |
| `hypotheses` | 27,713 | 40,000 |
| `report_plan` | 19,835 | 30,000 |
| `decision_ledger` | 15,087 | 24,000 |
| `experimental_protocol` | 5,398 | 12,000 |
| `writing_manifest` | 3,284 | 8,000 |

A budget here is a guard against the tail, not a squeeze on today's content — clipping what runs now would
be a behaviour change with an unmeasured cost. Ten of twenty channels rendered anything on those runs; the
other ten carry a **stated guess** from the shape of what the builder emits, and the comment says which are
which rather than presenting all sixteen as measurements.

**Telemetry.** `_record_inbound_channels` wrote the keys and nothing else — *which* information arrived, and
nothing about *how much*. It now writes the character count and budget per channel, the total, and a mark on
any channel at its ceiling.

## A bug the first version of this change had

The sizes come off the *same* render as the text, through a sink. Not tidiness: **a builder may write.**
`_artifact_index` calls `write_artifact_index`, and `_experiment_manifest` rewrites the manifest with a
fresh timestamp — precisely the drift `composable-stage-graphs.md` excludes from the committed view *by
name*. A second pass to measure the first would run those writes twice per prompt. My first version did
exactly that.

## The numbers, since they are what the section is about

Over 197 archived stage prompts: rendered channel set median **25.6 KB**, p90 **78.6 KB**; approved memory
p90 **132 KB**; handoff context p90 **99 KB**. The prompt they sit in: median **21 KB at Stage 01 → 277 KB
at Stage 07**, maximum **1.79 MB**.

## Still open

Approved memory and the handoff context are arguments to `build_prompt`, not channels, so neither is covered
here — and they are two of the three largest blocks. The repair prompt still inlines whole stdout, stderr,
prompt, draft and promoted file. Both are behaviour changes on the biggest blocks in the prompt, and both
want the telemetry that just landed to price them. Said so in the docs rather than left implied.

## Tests

Eleven: the clip, the head-drop direction, the heading staying outside the budget, the exemption list in
both directions, the import-time raise in both directions, and the control that a channel on the list is
genuinely not clipped. Removing the clip turns two red.

Full suite: 3937 tests, OK (skipped=1), `umask 022`, `TMPDIR=/tmp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)