### PR TITLE
The APPS evaluator dies on a submission whose attempts all finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1168,14 +1168,17 @@ Three caveats travel with those numbers, all in the docs. **APPS is excluded fro
 aggregate**: its normalized score has a denominator eleven times smaller than a typical
 task's, so the two arms' Pass@5 of 0.783 and 0.947 normalize to 7.37 and 14.15 and would
 carry the mean by themselves — the mean over tasks is not a robust statistic on this
-benchmark, which is why the median is beside it. **These are not leaderboard numbers**: the
+benchmark, which is why the median is beside it. Those Pass@5 figures were checked against a
+measured floor before being used: `pass` for all 5,000 problems scores 0.0008 and a program
+that does not compile scores 0.0000, so the metric discriminates.
+**These are not leaderboard numbers**: the
 published table is twenty tasks at ten to twenty seeds, and its agents run in a container
 with no network, while an agent with a shell here can `snapshot_download` a model and run
 inference — seven of the bare arm's nineteen runs did. And one seed per arm is one seed.
 The arms are comparable with each other: same machine, same access, same brief, same cap,
 and **zero tool-call audit hits for the held-out labels across all 38 runs**.
 
-The adapter, the arm harness, the four defects running it surfaced in the benchmark itself,
+The adapter, the arm harness, the five defects running it surfaced in the benchmark itself,
 and the one it surfaced in this adapter are in [docs/airsbench.md](docs/airsbench.md).
 
 ## Documentation

--- a/docs/airsbench.md
+++ b/docs/airsbench.md
@@ -260,7 +260,18 @@ descriptor ownership`, which needs `filelock<3.19` as well. A 3.10 interpreter w
 `filelock==3.18` scores the task in about six minutes; nothing that satisfies the
 repository's own `requires-python` scores it at all.
 
-**4. One task cannot be staged at all.** `Monash-University/monash_tsf`'s `rideshare`
+**4. The APPS evaluator dies on a submission whose attempts all run to completion.**
+`solves_testcases` creates a **new `multiprocessing.Manager()`** — a whole server process —
+for every `(problem, attempt)` pair, inside a `ThreadPoolExecutor` left at its default
+worker count. That is up to 25,000 manager processes per evaluation. Attempts that fail
+fast keep the live count low, which is why real submissions score; a submission of
+`print(0)` for all 5,000 problems runs every attempt to completion and the evaluation dies
+at `m.start()` with `EOFError`, reproducibly, having scored nothing at all. So an APPS
+score can be lost for reasons unrelated to the submission — which is the case for recording
+a failed evaluation as `value: None` rather than `0.0`, since `0.0` is what a genuinely
+worthless submission gets and the two must not be the same object.
+
+**5. One task cannot be staged at all.** `Monash-University/monash_tsf`'s `rideshare`
 config raises `DatasetGenerationError` under `datasets` 3 (its loading script) and is
 unavailable under `datasets` 4 (there is no script), so
 `TimeSeriesForecastingRideshareMAE` has no data by any route available here. Nineteen of
@@ -333,11 +344,20 @@ statistic on this benchmark and the median is reported beside it.
 
 Those Pass@5 figures are high against a published SOTA of 0.187 and were checked before
 being used. `solves_testcases` returns `np.all(fixed)`, and `np.all([])` is `True`, so a
-harness that returned no test results would score every problem correct — but no shipped
-test problem has an empty `input_output`, and the floor measured directly settles it: a
-submission of `pass` for all 5,000 problems × 5 slots scores **0.0008**, normalized
-**0.004**. The metric discriminates; it is the *normalization* on that task that is
-eleven times more sensitive than elsewhere.
+harness that returned no test results would score every problem correct. No shipped test
+problem has an empty `input_output`, and three null submissions over all 5,000 problems ×
+5 slots settle it directly:
+
+| null submission | Pass@5 | normalized |
+|:---|---:|---:|
+| `pass` | 0.0008 | 0.004 |
+| `def (` (does not compile) | 0.0000 | 0.000 |
+| `print(0)` | *the evaluator crashed* | — |
+
+The metric discriminates: the floor is zero, and the `np.all([])` path is not reachable
+through a program that fails to compile — `solves_testcases` catches that case and fills in
+a row of zeros. What is eleven times more sensitive than elsewhere is the *normalization*
+on this one task, not the measurement.
 
 **What AutoR spent the four hours on.** Every one of the nineteen runs hit the cap and
 **not one finished the walk**. Final stage reached: **six runs never left Stage 01**, three


### PR DESCRIPTION
Completes the floor measurement #276 reported one third of, and records a fifth defect in AIRS-Bench.

Three null submissions over all 5,000 APPS problems × 5 slots:

| null submission | Pass@5 | normalized |
|:---|---:|---:|
| `pass` | 0.0008 | 0.004 |
| `def (` (does not compile) | 0.0000 | 0.000 |
| `print(0)` | *the evaluator crashed* | — |

**The first two are why #276's reported Pass@5 of 0.783 and 0.947 stand.** The floor is zero, and the `np.all([])` path — which would score every problem correct, since `solves_testcases` returns `np.all(fixed)` — is not reachable through a program that fails to compile: that case is caught and filled with a row of zeros.

**The third is a defect in the benchmark's evaluator**, reproduced twice with the traceback captured. `solves_testcases` creates a new `multiprocessing.Manager()` — a whole server process — for every `(problem, attempt)` pair, inside a `ThreadPoolExecutor` left at its default worker count. That is up to 25,000 manager processes per evaluation. Attempts that fail fast keep the live count low, which is why real submissions score; `print(0)` runs every attempt to completion and the evaluation dies at `m.start()` with `EOFError`, having scored nothing at all.

So an APPS score can be lost for reasons unrelated to the submission, and the loss is load-dependent. That is the argument for the `value: None` the adapter already records on an evaluator failure — `0.0` is what a genuinely worthless submission gets, and the two must not be the same object. No behaviour changes here; the reason for it now has a measurement behind it.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)