### PR TITLE
A fresh session is not a continuation, and a retry should not have to fetch its own goal

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -403,7 +403,13 @@ is used:
 
 A separate mechanism handles a **resume failure**: if the backend reports that
 a session ID no longer exists, the operator detects it from the error text and
-falls back to a fresh session rather than failing the stage.
+falls back to a fresh session rather than failing the stage. It writes a
+`<slug>_attempt_NN_restart.prompt.md` beside the original rather than replaying it:
+the continuation prompt speaks about the *work* -- there is a draft and the job is
+to improve it, which is true on both paths -- and the restart file adds the one
+sentence only the operator can say, that the earlier turns are gone. The original
+is left untouched, because `prompt_cache/` is the record of what actually ran and
+overwriting it would make the resumed attempt and its restart indistinguishable.
 
 After `MAX_STAGE_ATTEMPTS` (5, `src/utils.py`) AutoR stops and offers you
 skip, roll back, or abort. Under `--full-auto` the stage is auto-skipped

--- a/docs/iclr/round-loop-and-stage-graph.md
+++ b/docs/iclr/round-loop-and-stage-graph.md
@@ -501,10 +501,21 @@ not adopt the general framing of "add a *what this stage has established* block"
 duplicates the handoff context and the channel set already in the prompt, and this repository
 has already paid for sending memory and handoff together.
 
-**(1) and (2) are fixed** (#256). The parity test that came with the first is the general
+**All three are fixed** — (1) and (2) in #256, (3) here. The parity test that came with the first is the general
 form: the two builders take five of the same optional content parameters, each gets a
 sentinel, and both prompts must carry all five — a parameter one builder accepts and
-drops is the same defect under another name. (3) stands.
+drops is the same defect under another name.
+
+For (3): the goal is inlined on the retry path rather than pointed at, bounded by
+`MAX_RETRY_GOAL_CHARS` — measured at a 13.6 KB median and a 16.7 KB maximum over 197
+archived prompts, so the ceiling clips nothing the archive contains. Approved memory
+stays a pointer, and that is the trade rather than an omission: its p90 over the same
+archive is 132 KB. The false premise is gone by moving the claim to whoever can make it.
+The prompt now speaks about the *work* — there is a draft and the job is to improve it,
+which is true on both paths — and the operator writes a `_restart.prompt.md` carrying the
+one sentence only it can say, that the earlier turns are gone. Whether a session was
+resumed is a fact about the invocation, and `build_continuation_prompt` is written before
+anyone asks the CLI for one.
 
 *Class: two live defects plus one false premise. Effort: small.*
 

--- a/src/operator.py
+++ b/src/operator.py
@@ -147,8 +147,34 @@ class ClaudeOperator:
             and self._looks_like_resume_failure(stdout_text, stderr_text)
         ):
             fallback_session_id = str(uuid.uuid4())
+            # A different file, carrying one sentence the original cannot: the earlier
+            # turns are gone.
+            #
+            # Whether a stage's conversation is in context is a fact about the
+            # invocation, and this is the only place that knows it -- `build_continuation_prompt`
+            # is written before anyone asks the CLI to resume, and it used to assert the
+            # continuation outright. Replaying it here handed a brand-new, empty session
+            # a document telling it that it was mid-conversation. The prompt now speaks
+            # about the work and this speaks about the session, so neither has to guess
+            # at the other's half.
+            #
+            # Written beside the original rather than over it: `prompt_cache/` is the
+            # audit trail of what actually ran, and overwriting the file would leave the
+            # resumed attempt and its restart indistinguishable in it.
+            fallback_prompt_path = prompt_path.with_name(
+                prompt_path.name.replace(".prompt.md", "_restart.prompt.md")
+            )
+            write_text(
+                fallback_prompt_path,
+                read_text(prompt_path)
+                + "\n\n# The Earlier Turns Of This Conversation Are Gone\n\n"
+                "This stage's session could not be resumed, so this is a new one and "
+                "nothing before this message is in context. Everything the sections above "
+                "point at is still on disk and still correct; read what you need rather "
+                "than relying on having seen it.\n",
+            )
             fallback_command, fallback_cwd, fallback_stdin_text = self._prepare_invocation(
-                prompt_path,
+                fallback_prompt_path,
                 fallback_session_id,
                 paths=paths,
                 resume=False,
@@ -163,7 +189,7 @@ class ClaudeOperator:
                         "previous_session_id": session_id,
                         "fallback_session_id": fallback_session_id,
                         "command": fallback_command,
-                        "prompt_path": str(prompt_path),
+                        "prompt_path": str(fallback_prompt_path),
                     }
                 },
             )

--- a/src/utils.py
+++ b/src/utils.py
@@ -1158,11 +1158,11 @@ def build_prompt(
             "2. The final approved stage file will be promoted separately by the workflow manager after validation.\n"
             "3. Do not write half-finished, in-progress, placeholder, outline-only, or pending content to the stage output file.\n"
             "4. If you need scratch work, drafts, notes, or temporary checkpoints, write them under the workspace directories instead of the stage output file.\n"
-            "5. Only write or overwrite the stage output file once you are ready to produce a complete stage summary for the current attempt.\n"
-            "6. If any tool, search, or subtask fails, still finish the stage by writing the best complete summary you can, clearly marking limitations in prose rather than leaving placeholders.\n"
-            "7. Read the stage output file back before finishing and verify every required heading is present and fully filled.\n"
-            "8. Do not leave placeholder text such as [In progress], [Pending], [TODO], [TBD], or similar unfinished in the final file.\n"
-            "9. Never leave the stage without a valid stage summary markdown file at the temporary output path."
+            "6. Only write or overwrite the stage output file once you are ready to produce a complete stage summary for the current attempt.\n"
+            "7. If any tool, search, or subtask fails, still finish the stage by writing the best complete summary you can, clearly marking limitations in prose rather than leaving placeholders.\n"
+            "8. Read the stage output file back before finishing and verify every required heading is present and fully filled.\n"
+            "9. Do not leave placeholder text such as [In progress], [Pending], [TODO], [TBD], or similar unfinished in the final file.\n"
+            "10. Never leave the stage without a valid stage summary markdown file at the temporary output path."
         ),
         "# Original User Request",
         user_request.strip(),
@@ -1206,6 +1206,17 @@ def build_prompt(
     return "\n\n".join(sections).strip() + "\n"
 
 
+#: How much of the goal a retry carries. Measured over 197 archived stage prompts, the
+#: `# Original User Request` block has a median of 13.6 KB and a maximum of 16.7 KB, so
+#: this clips nothing the archive contains -- it is a ceiling against a pathological task
+#: statement, the same shape as `Channel.max_chars`. One block of that size against a
+#: prompt whose median is 144 KB is the cheapest thing in it, and it is the one thing a
+#: long-horizon harness must not lose: losing the goal after a context refresh is the
+#: first failure `docs/iclr/round-loop-and-stage-graph.md` records the other harness
+#: designing against.
+MAX_RETRY_GOAL_CHARS = 24_000
+
+
 def build_continuation_prompt(
     stage: StageSpec,
     stage_template: str,
@@ -1222,10 +1233,19 @@ def build_continuation_prompt(
     current_final = paths.stage_file(stage)
 
     sections = [
-        "# Continue Existing Stage Conversation",
+        "# Continue Existing Stage Work",
         (
-            f"You are continuing {stage.stage_title} in the same AutoR conversation for this stage. "
-            "This is an incremental improvement pass inside the current stage, not a fresh restart."
+            # About the *work*, not about the conversation. This block used to say "you
+            # are continuing in the same AutoR conversation for this stage", which the
+            # manager is not in a position to promise: whether the earlier turns are in
+            # context is a fact about the invocation, and only the operator knows it.
+            # `ClaudeOperator._run_real` falls back to a fresh session when a resume is
+            # refused and replays this same file, so on exactly that path the sentence
+            # was false -- an empty session told it had a history. The operator now says
+            # what it alone knows, and this says what is true on both paths: there is a
+            # draft on disk and the job is to improve it.
+            f"You are continuing work on {stage.stage_title}. This is an incremental "
+            "improvement pass on an existing draft, not a fresh start on the stage."
         ),
         "# Stage Instructions",
         stage_template.strip(),
@@ -1240,15 +1260,15 @@ def build_continuation_prompt(
         (
             f"1. Read the current draft at `{current_draft.resolve()}` if it exists.\n"
             f"2. Read the last promoted stage summary at `{current_final.resolve()}` if it exists.\n"
-            f"3. Read approved memory from `{paths.memory.resolve()}` and the original user goal from `{paths.user_input.resolve()}` if needed.\n"
+            f"3. Read approved memory from `{paths.memory.resolve()}` if you need what earlier stages settled.\n"
             f"4. Read prior handoff summaries under `{paths.handoff_dir.resolve()}` when they exist.\n"
-            f"4. Treat workspace artifacts already under `{paths.workspace_root.resolve()}` as part of the current stage context and reuse them.\n"
-            "5. Preserve all valid work already completed in this stage unless the new feedback requires changing it.\n"
-            "6. Fill the missing pieces, fix weak points, and update the stage summary instead of throwing away correct work.\n"
-            "7. Overwrite only the draft stage output path once you are ready to produce the updated complete summary.\n"
-            "8. Do not leave placeholder text such as [In progress], [Pending], [TODO], [TBD], or similar unfinished markers.\n"
-            "9. If the existing stage work is partially correct, keep the correct parts and extend them rather than replacing them blindly.\n"
-            "10. **Revision Delta**: Because this is a refinement pass, you MUST insert a `## Revision Delta` section "
+            f"5. Treat workspace artifacts already under `{paths.workspace_root.resolve()}` as part of the current stage context and reuse them.\n"
+            "6. Preserve all valid work already completed in this stage unless the new feedback requires changing it.\n"
+            "7. Fill the missing pieces, fix weak points, and update the stage summary instead of throwing away correct work.\n"
+            "8. Overwrite only the draft stage output path once you are ready to produce the updated complete summary.\n"
+            "9. Do not leave placeholder text such as [In progress], [Pending], [TODO], [TBD], or similar unfinished markers.\n"
+            "10. If the existing stage work is partially correct, keep the correct parts and extend them rather than replacing them blindly.\n"
+            "11. **Revision Delta**: Because this is a refinement pass, you MUST insert a `## Revision Delta` section "
             "immediately after the top-level `# Stage ...` heading and before `## Objective`. "
             "This section must contain a concise bullet-point summary of what you changed in this attempt compared to the previous version. Include:\n"
             "   - Which sections were modified and how\n"
@@ -1261,6 +1281,16 @@ def build_continuation_prompt(
         sections.extend(["# Web Search Capability", web_search_context.strip()])
     # A contract that only appears on the first attempt is one every retry can forget.
     from .deliverables import format_deliverables_for_prompt
+
+    # Inlined, not pointed at. This block used to say "read the original user goal from
+    # <path> if needed" -- an agent-pull with an opt-out, for the one input the whole
+    # stage is judged against. Approved memory stays a pointer beside it and that is
+    # deliberate: its p90 over the same archive is 132 KB against the goal's 16.7 KB
+    # maximum, and re-sending it on every retry is the duplication `build_prompt` already
+    # withholds the handoff to avoid.
+    _goal = truncate_text(read_text(paths.user_input), max_chars=MAX_RETRY_GOAL_CHARS)
+    if _goal:
+        sections.extend(["# Original User Request", _goal])
 
     _deliverables = format_deliverables_for_prompt(task_statement(read_text(paths.user_input)))
     if _deliverables:

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -304,3 +304,80 @@ class TestRunStageMaxAttempts(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheGoalSurvivesARetryTest(unittest.TestCase):
+    """The one input the whole stage is judged against was an agent-pull with an opt-out.
+
+    `build_continuation_prompt` said "read the original user goal from <path> if needed".
+    Approved memory stays a pointer beside it on purpose -- p90 132 KB over 197 archived
+    prompts, against the goal's 16.7 KB maximum -- but the goal itself is the cheapest
+    block in the prompt and the first thing a long-horizon harness must not lose.
+    """
+
+    def _paths(self, tmp: str, goal: str):
+        from src.utils import build_run_paths, ensure_run_layout, write_text
+
+        paths = build_run_paths(Path(tmp) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, goal)
+        return paths
+
+    def test_the_goal_is_in_the_retry_prompt(self) -> None:
+        from src.utils import STAGES, build_continuation_prompt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp, "Derive the coupling limit and report it in GeV^-1.")
+            prompt = build_continuation_prompt(
+                STAGES[2], "template", paths, handoff_context="", revision_feedback=None
+            )
+            self.assertIn("# Original User Request", prompt)
+            self.assertIn("Derive the coupling limit", prompt)
+
+    def test_memory_is_still_a_pointer(self) -> None:
+        """The control on the trade: inlining the goal is not inlining everything."""
+        from src.utils import STAGES, build_continuation_prompt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp, "goal")
+            prompt = build_continuation_prompt(
+                STAGES[2], "template", paths, handoff_context="", revision_feedback=None
+            )
+            self.assertIn("Read approved memory from", prompt)
+
+    def test_a_pathological_goal_is_clipped_to_the_declared_budget(self) -> None:
+        from src.utils import MAX_RETRY_GOAL_CHARS, STAGES, build_continuation_prompt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp, "g" * (MAX_RETRY_GOAL_CHARS * 2))
+            prompt = build_continuation_prompt(
+                STAGES[2], "template", paths, handoff_context="", revision_feedback=None
+            )
+            self.assertLess(prompt.count("g"), MAX_RETRY_GOAL_CHARS + 100)
+
+    def test_the_premise_no_longer_claims_a_conversation(self) -> None:
+        """Only the operator knows whether the earlier turns are in context."""
+        from src.utils import STAGES, build_continuation_prompt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp, "goal")
+            prompt = build_continuation_prompt(
+                STAGES[2], "template", paths, handoff_context="", revision_feedback=None
+            )
+            self.assertNotIn("same AutoR conversation", prompt)
+            self.assertIn("existing draft", prompt)
+
+    def test_the_discipline_list_numbers_each_item_once(self) -> None:
+        """It had two items numbered 4, which is how a list nobody counts reads."""
+        import re
+
+        from src.utils import STAGES, build_continuation_prompt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = self._paths(tmp, "goal")
+            prompt = build_continuation_prompt(
+                STAGES[2], "template", paths, handoff_context="", revision_feedback=None
+            )
+            block = prompt.split("# Continuation Discipline", 1)[1].split("\n# ", 1)[0]
+            numbers = [int(m.group(1)) for m in re.finditer(r"^(\d+)\. ", block, re.M)]
+            self.assertEqual(numbers, list(range(1, len(numbers) + 1)))

--- a/tests/test_operator_recovery.py
+++ b/tests/test_operator_recovery.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from src.operator import ClaudeOperator
 from src.utils import (
     STAGES,
+    read_text,
     build_run_paths,
     ensure_run_layout,
     initialize_memory,
@@ -260,6 +261,71 @@ class OperatorRecoveryTests(unittest.TestCase):
             )
 
             self.assertIsNone(resolved)
+
+
+class AFreshSessionIsNotAContinuationTests(unittest.TestCase):
+    """The resume fallback used to replay a document that asserted a history it had lost.
+
+    `build_continuation_prompt` opens by telling the agent it is continuing this stage's
+    conversation. When a resume is refused the operator starts a *new* session and, until
+    now, sent it that same file -- so an empty session was told it was mid-conversation,
+    on exactly the path where that is false.
+
+    Whether the earlier turns are in context is a fact about the invocation, and this is
+    the only place that knows it. The prompt now speaks about the work; this speaks about
+    the session.
+    """
+
+    def _run_with_a_refused_resume(self, tmp_dir: str):
+        paths = build_run_paths(Path(tmp_dir) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "Resume refused")
+        initialize_memory(paths, "Resume refused")
+        operator = ClaudeOperator(fake_mode=False, output_stream=io.StringIO())
+        stage = STAGES[0]
+        sent: list[str] = []
+
+        def fake_stream(*args, **kwargs):
+            command = kwargs["command"]
+            sent.append(read_text(Path(command[command.index("-p") + 1].lstrip("@"))))
+            if len(sent) == 1:
+                return (1, "", "No conversation found with session id abc", None,
+                        {"raw_line_count": 0, "non_json_line_count": 0, "malformed_json_count": 0})
+            write_text(paths.stage_tmp_file(stage), "# Stage 01: Literature Survey\n")
+            return (0, "done", "", None,
+                    {"raw_line_count": 1, "non_json_line_count": 0, "malformed_json_count": 0})
+
+        with patch("src.operator.shutil.which", return_value="/usr/bin/claude"), patch.object(
+            operator, "_run_streaming_command", side_effect=fake_stream
+        ):
+            operator._run_real(
+                stage, "You are continuing work on Stage 01.", paths,
+                attempt_no=1, continue_session=True,
+            )
+        return paths, stage, sent
+
+    def test_the_restart_is_told_its_history_is_gone(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _paths, _stage, sent = self._run_with_a_refused_resume(tmp_dir)
+            self.assertEqual(len(sent), 2, "the fallback ran")
+            self.assertNotIn("Earlier Turns Of This Conversation Are Gone", sent[0])
+            self.assertIn("Earlier Turns Of This Conversation Are Gone", sent[1])
+
+    def test_the_restart_keeps_everything_the_original_said(self) -> None:
+        """It is an addition, not a replacement: the work premise is still true."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _paths, _stage, sent = self._run_with_a_refused_resume(tmp_dir)
+            self.assertIn(sent[0].strip(), sent[1])
+
+    def test_the_original_prompt_file_is_left_alone(self) -> None:
+        """`prompt_cache/` is the record of what actually ran. Overwriting the file would
+        leave the resumed attempt and its restart indistinguishable in it."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            paths, stage, _sent = self._run_with_a_refused_resume(tmp_dir)
+            original = paths.prompt_cache_dir / f"{stage.slug}_attempt_01.prompt.md"
+            restart = paths.prompt_cache_dir / f"{stage.slug}_attempt_01_restart.prompt.md"
+            self.assertTrue(original.is_file() and restart.is_file())
+            self.assertNotIn("Are Gone", read_text(original))
 
 
 class SecondEntryToAStageTests(unittest.TestCase):


### PR DESCRIPTION
The last of §4.7, and with it the last open item on [#254](https://github.com/tangxiangru/AutoR/pull/254)'s list.

## The prompt asserted a fact it was written too early to know

`build_continuation_prompt` opened with:

> You are continuing *&lt;stage&gt;* in the same AutoR conversation for this stage.

Whether the earlier turns are in context is a fact about the **invocation**, and the prompt is built
before anyone asks the CLI to resume. `ClaudeOperator._run_real` falls back to a fresh session when a
resume is refused — and replayed that same file. On exactly that path a brand-new, empty session was
handed a document telling it that it was mid-conversation.

Fixed by moving each claim to whoever can make it:

- the **prompt** now speaks about the *work* — there is a draft on disk and the job is to improve it,
  which is true on both paths;
- the **operator** writes `<slug>_attempt_NN_restart.prompt.md` carrying the sentence only it knows:
  the earlier turns are gone, read what you need rather than relying on having seen it.

Written *beside* the original rather than over it — `prompt_cache/` is the record of what actually ran,
and overwriting would leave the resumed attempt and its restart indistinguishable in it.

## The goal was an agent-pull with an opt-out

Discipline item 3 read *"read approved memory from &lt;path&gt; and the original user goal from
&lt;path&gt; **if needed**"* — for the one input the whole stage is judged against.

Inlined now, bounded by `MAX_RETRY_GOAL_CHARS`. Measured: over 197 archived stage prompts the goal block
has a **median of 13.6 KB and a maximum of 16.7 KB**, so the ceiling clips nothing the archive contains
and exists for a pathological task statement — the same shape as the `Channel.max_chars` that landed in
[#279](https://github.com/tangxiangru/AutoR/pull/279).

**Approved memory stays a pointer**, and that is the trade rather than an omission: its p90 over the same
archive is **132 KB** against the goal's 16.7 KB maximum, and re-sending it on every retry is the
duplication `build_prompt` already withholds the handoff to avoid.

## And the list had two items numbered 4

Renumbered, with a test that reads the numbers off the rendered block rather than trusting them.

## Tests

Nine. The restart file carries the sentence and the original does not; the restart is an addition rather
than a replacement; the original file is left alone; the goal is present; memory is still a pointer; a
pathological goal is clipped; the premise no longer claims a conversation; the numbering is a run of
consecutive integers. Pointing the fallback back at the original prompt file turns the first red.

Full suite: 4030 tests, OK (skipped=4), `umask 022`, `TMPDIR=/tmp`.

Docs: `architecture.md` describes the restart file beside the resume-failure mechanism it belongs to;
`docs/iclr/round-loop-and-stage-graph.md` §4.7 now reads *all three are fixed*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)