### PR TITLE
The sixty-task trial: the totals are equal and they hide two large effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -996,48 +996,39 @@ is the paired control. `tools/score_fs_run.py` grades an answer against the task
 with the paper's verbatim judge prompt. The dataset is pinned by digest rather than committed,
 and is never downloaded automatically.
 
-**The reference point, measured here.** A bare `claude-opus-4-5` answering directly, no tools,
-one draw per task, all sixty tasks, graded by **gpt-5.1** at high reasoning effort:
+**Where AutoR lands, on all sixty tasks.** Both arms `claude-opus-5[1m]`, identical task
+instruction, browsing denied and witnessed, judged by **gpt-5.1** at one draw per task. Accuracy
+is the benchmark's own metric — the share of tasks scoring at least 7 of 10 rubric points — with
+a refused run scored zero, which is the only framing with no survivorship in it:
 
-| | value |
-|:---|---:|
-| mean rubric points | **4.291 / 10** |
-| across-task sd | 2.795 |
-| pass@≥7 | **13 / 60 = 21.7%** (binomial se 5.3 pp) |
-| chemistry / biology / physics means | 5.044 / 4.801 / 3.028 |
+| arm | overall | physics | chemistry | biology |
+|:---|---:|---:|---:|---:|
+| `direct-opus` — one Claude CLI call | **51.7%** | **30.0%** | 60.0% | **65.0%** |
+| **AutoR** `ideate` — the pipeline | **50.0%** | **15.0%** | **80.0%** | 55.0% |
 
-The paper reports Claude Opus 4.5 at 17.5% over the same sixty tasks at thirty trials each,
-under a **GPT-5** judge that returns 404 on the endpoint available here — and reports the same
-chemistry-then-biology-then-physics ordering. Landing inside one standard error of that figure
-and reproducing its ordering is **corroboration of the scoring path, not comparability of the
-instruments**; judge choice is worth more than the difference being discussed, so no number
-here may be placed beside the paper's table.
+The totals are nearly equal and they hide two large effects in opposite directions: **the pipeline
+gains twenty points of chemistry and loses half of physics.** Over the forty-three tasks where both
+arms produced an answer the paired mean difference is **+0.085 ± 0.233** rubric points — seventeen
+wins, seventeen losses, nine ties, median exactly zero — bought with **4.5× the output tokens and
+5.3× the wall clock**, for an answer a quarter shorter.
 
-**What AutoR costs here.** A three-task calibration — both arms, real operator, `opus`
-answering and reviewing — puts the `ideate` arm at 33 to 77 minutes a task, median 72, at 9 to
-20 backend calls and 154k to 335k output tokens. Sixty tasks by two arms is about a day at a
-concurrency of six, which makes a full paired campaign affordable.
+It also **refused outright on fourteen of sixty tasks**, thirteen because Stage 02 never passed its
+own reviewer, against four for the control that were all the front end's answer timeout rather than
+the benchmark. That is above the plan's 20% publication ceiling, so the trial's own report declines
+to print a difference at all — and the refusal rate, not the difference, is the largest thing this
+benchmark currently says about the pipeline.
 
-**No difference is published from it.** The pipeline arm refused on one of three tasks against
-the plan's 20% ceiling — a run that approved no stage and was refused by two clauses rather than
-being handed a synthesized answer. Refusals are not random across arms, so the survivors are
-biased in the direction that flatters the arm that refused, and the report says so instead of
-averaging them.
+**Not comparable to the paper's table.** The paper grades with GPT-5 over thirty draws; that
+deployment returns 404 here. The anchor that makes the water level readable is a different arm: a
+bare `claude-opus-4-5` through the API scores 21.7% under this judge where the paper puts it at
+**17.5%** under its own — agreement inside one standard error, which is what says the jump to 51.7%
+is the model and the substrate rather than a lenient judge.
 
-The two pairs are worth stating as two observations: `fs:010` **2.500 against 9.375**, `fs:043`
-4.000 against 4.000. The pipeline arm did not win a task — it lost one by twenty times the
-judge's sampling noise and drew the other, at 7.4× and 5.6× the wall clock. Two pairs is two
-pairs, but it points the same way as ResearchClawBench, where AutoR also lands below the bare
-CLI it can be configured to run on top of.
-
-The first pass of that calibration lost two of three single-call runs to the Claude CLI's own
-300 s stream idle timeout, firing while the model was still thinking. `CLAUDE_STREAM_IDLE_TIMEOUT_MS`
-is the knob — not the `BYTE_`-prefixed one, which changed nothing — and 1,800,000 is the ceiling
-it clamps to. Raise both before any campaign: the failure exits cleanly, leaves a file behind,
-and fires on thinking time, so what it removes is the hard questions.
-
-The full table, why each arm refused, the ten admission clauses and the judge's measured noise
-are in [docs/frontierscience.md](docs/frontierscience.md).
+The full record — the three framings and why they disagree about the sign, the per-task movements,
+both kinds of refusal, and the three-task calibration this overturns — is in
+[docs/frontierscience-results.md](docs/frontierscience-results.md); the adapter, the prompt
+contract and the ten admission clauses are in
+[docs/frontierscience.md](docs/frontierscience.md).
 
 ### FIRE-Bench
 
@@ -1208,6 +1199,7 @@ below is the detail behind it.
 | [ResearchClawBench Landscape](docs/researchclawbench-landscape.md) | How EvoScientist, ARIS Codex and MIRA actually score on the benchmark, which reported numbers reproduce, and the baseline any result must be quoted against. |
 | [AIRS-Bench](docs/airsbench.md) | The fourth benchmark: twenty ML research tasks scored by a deterministic metric over `submission.csv`. The adapter, the arm harness, three defects running it surfaced in the benchmark itself, and what AutoR scores. |
 | [FrontierScience-Research](docs/frontierscience.md) | The second benchmark: sixty written science questions graded against a rubric by a judge model. The two profiles, the prompt contract, the judge's measured noise, the paired trial, and the two numbers that are not measured. |
+| [FrontierScience Results](docs/frontierscience-results.md) | The sixty-task paired trial: the pipeline against one bare model call, accuracy by subject, what it cost, both kinds of refusal, and the calibration it overturns. |
 | [Architecture](docs/architecture.md) | Layers, the module map, the stage walk, prompt assembly by typed channel, recovery, extension points. |
 | [Development](docs/development.md) | Dev setup, tests, CI, conventions, and recipes for adding a stage, venue, or backend. |
 | [Troubleshooting](docs/troubleshooting.md) | Symptom-to-fix for the errors AutoR actually raises. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ detail behind it.
 | Look up a command-line flag | [CLI Reference](cli-reference.md) |
 | Run AutoR unattended, or benchmark it on ResearchClawBench | [ResearchClawBench](researchclawbench.md) |
 | Answer and score a written science exam question | [FrontierScience-Research](frontierscience.md) |
+| See what AutoR scores on that benchmark | [FrontierScience results](frontierscience-results.md) |
 | Rediscover a published finding by running experiments, under a one-hour clock | [FIRE-Bench](firebench.md) |
 | Understand what a run leaves on disk | [Run Artifacts](run-artifacts.md) |
 | Know exactly what a stage must produce to be accepted | [Stage Contract](stage-contract.md) |
@@ -80,6 +81,10 @@ detail behind it.
 
 ### Internals
 
+- **[frontierscience-results.md](frontierscience-results.md)** — the experiment
+  record for that benchmark: a sixty-task paired trial of the pipeline against one
+  bare model call, its accuracy by subject, what it cost, the two kinds of refusal
+  it produced, and the earlier claims on this branch that it overturns.
 - **[self-improvement.md](self-improvement.md)** — the stage graph and its
   guards, routing, the rigour rubric and the champion ratchet, the cross-run
   archive and its comparability basis, paired trials — and the constraints that

--- a/docs/frontierscience-results.md
+++ b/docs/frontierscience-results.md
@@ -1,0 +1,236 @@
+# What AutoR scores on FrontierScience-Research
+
+A sixty-task paired trial, run 2026-08-17 to 2026-08-18. This page is the experiment record:
+what was run, what it cost, what it scored, and which of the earlier claims on this branch it
+overturns. [frontierscience.md](frontierscience.md) is the other half — how the benchmark is wired
+and how to run it.
+
+> **Not comparable to the paper's table.** Every score here was produced by **`gpt-5.1`** at high
+> reasoning effort against the paper's verbatim Appendix B prompt, at **one draw per task**. The
+> paper grades with GPT-5 and averages thirty draws; that deployment returns 404 on the endpoint
+> available here. Judge choice alone has been measured to move a total by about sixteen points on
+> the sibling benchmark. A number from this page may not be placed beside the paper's 25.2 / 19.4 /
+> 17.5 without this paragraph.
+
+---
+
+## The two arms
+
+Both arms answer the same sixty questions with the same model, the same verbatim task instruction,
+and browsing denied. They differ in one thing: whether AutoR is between the question and the answer.
+
+| | `direct-opus` | `58e8491-autor-ideate` |
+|:---|:---|:---|
+| what it is | one Claude CLI call | AutoR entered at Stage 02 and stopped there, five-lens ideation panel on, answer synthesized from the approved stage |
+| model | `claude-opus-5[1m]` | `claude-opus-5[1m]`, reviewing with the same |
+| task instruction | identical, frozen in the plan digest | identical |
+| browsing | denied, and witnessed at zero | denied on **all seven model seats**, each witnessed |
+
+Plan digest `0b46222767267097`, frozen before the first launch. The treatment arm ran from a
+worktree pinned at the commit its label names.
+
+**`--model opus` resolves to `claude-opus-5[1m]` on this box**, so the control arm is bare Claude
+Code with Opus 5 and one turn. It is *not* the same instrument as the same model called through the
+Anthropic API: on one question the CLI arm wrote 43,075 characters and scored 9.375 where an API
+call wrote 5,822 and scored 5.75. Only the CLI arm is the paired control.
+
+---
+
+## Accuracy
+
+The benchmark's own metric: the share of tasks scoring at least 7 of 10 rubric points.
+
+**All sixty tasks, a refused run scored 0.** No selection of any kind — every task counts, and an
+arm that produced no answer is scored the way the benchmark would score one.
+
+| arm | overall | physics | chemistry | biology |
+|:---|---:|---:|---:|---:|
+| Opus 4.5, API *(reference)* | 21.7% ± 5.3 | 10.0% | 30.0% | 25.0% |
+| **`direct-opus`** | **51.7% ± 6.5** | **30.0%** | 60.0% | **65.0%** |
+| **`58e8491-autor-ideate`** | **50.0% ± 6.5** | **15.0%** | **80.0%** | 55.0% |
+
+**The forty-three complete pairs**, where both arms produced an answer. Same population for both
+arms, so like for like — but that population is the subset on which the pipeline converged, which
+flatters it by an unknown amount.
+
+| arm | overall | physics | chemistry | biology |
+|:---|---:|---:|---:|---:|
+| `direct-opus` | 60.5% ± 7.5 | 36.4% | 68.8% | 68.8% |
+| `58e8491-autor-ideate` | 67.4% ± 7.1 | 27.3% | **93.8%** | 68.8% |
+
+The two framings disagree about the sign, and that disagreement is the first result: a reader who
+is handed one number has been handed a choice somebody else made. A third framing — admitted runs
+only, different populations per arm — puts the pipeline further ahead still, at 65.2% against
+55.4%, and is the least defensible of the three.
+
+The reference row is a different model on a different substrate and is here for one reason: the
+paper reports Claude Opus 4.5 at **17.5%** under a GPT-5 judge, and this harness puts it at 21.7%
+under gpt-5.1 — agreement inside one standard error. That anchor is what says the jump to 51.7% is
+the model and the substrate rather than a lenient judge.
+
+### The subject interaction is the finding
+
+The overall numbers are nearly identical, 51.7% against 50.0%, and they hide two large effects
+pointing in opposite directions.
+
+| subject | accuracy | mean rubric points |
+|:---|:---|---:|
+| chemistry | 60.0% → **80.0%** | **+0.799** |
+| physics | 30.0% → **15.0%** | −0.464 |
+| biology | 65.0% → 55.0% | −0.253 |
+
+Over the complete pairs the chemistry effect is larger still: 68.8% → **93.8%**, fifteen of sixteen.
+The pipeline roughly halves physics and clearly gains chemistry, and the two nearly cancel in the
+total. Reporting only the total would have hidden both.
+
+Per-task, the largest movements in each direction:
+
+| | task | direct → ideate | |
+|:---|:---|:---|---:|
+| gains | `fs:020` chemistry | 6.000 → 10.000 | +4.000 |
+| | `fs:022` chemistry | 6.500 → 10.000 | +3.500 |
+| | `fs:034` chemistry, `fs:047` biology, `fs:052` biology | | +2.500 |
+| losses | `fs:044` biology | **10.000 → 6.000** | −4.000 |
+| | `fs:009` physics | 4.000 → 1.000 | −3.000 |
+| | `fs:054` biology | 3.000 → 1.000 | −2.000 |
+
+`fs:044` is the sharpest artifact in the trial: ten rubric items, every one of the form *give the
+point if the answer states X*, where X is a named protein — ACLY, PANK2, PANK4, Akt. The control
+scored a perfect ten. The pipeline's answer is only 18% shorter, so this is not compression; it
+names the graded entities roughly a third as often (ACLY 42 mentions against 11, PANK2 24 against
+12, PANK4 26 against 14). What the pipeline spent its length on was not the thing being scored.
+
+---
+
+## What the pipeline costs
+
+Over the runs that produced an answer:
+
+| | `direct-opus` | `58e8491-autor-ideate` | ratio |
+|:---|---:|---:|---:|
+| wall clock, median | 607 s | 3,916 s | 6.5× |
+| wall clock, range | 7 – 1,800 s | 1,797 – 14,816 s | |
+| wall clock, whole arm | 13.1 h | **70.0 h** | 5.3× |
+| backend calls, median | 1 | 9 | 9× |
+| output tokens, median | 44,707 | 288,947 | 6.5× |
+| output tokens, whole arm | 3.16 M | **14.08 M** | 4.5× |
+| answer length, median | 67,558 chars | 50,399 chars | 0.75× |
+
+**The pipeline spends four and a half times the tokens and five times the wall clock to produce an
+answer a quarter shorter, for a paired mean difference of +0.085 ± 0.233 over forty-three pairs.**
+It wins seventeen, loses seventeen, ties nine. The median difference is exactly zero.
+
+At forty-three pairs and a difference standard deviation of 1.531, the minimum effect detectable at
+80% power is **0.654 points** — above the 0.5 declared as the minimum effect of interest, so this
+trial is slightly underpowered for the effect it set out to find. The observed effect is 0.085,
+which is well below both. This is not an effect the sample failed to resolve; it is an absence.
+
+---
+
+## Refusals, which are two different things
+
+| arm | refused | rate |
+|:---|---:|---:|
+| `direct-opus` | 4 / 60 | 6.7% |
+| `58e8491-autor-ideate` | **14 / 60** | **23.3%** |
+
+**The control's four refusals were not the benchmark and not AutoR.** All four hit the front end's
+thirty-minute answer timeout. Two of them (`fs:008`, `fs:011`) were still writing when it fired, at
+363,301 and 310,293 characters, over the length ceiling. The other two (`fs:019`, `fs:026`) were cut
+off before a result event was ever written, so the transcript witness came back all-null and the
+admission clauses refused them — correctly, because a `browsing_tool_calls == 0` clause must refuse
+a run with no evidence rather than admit it as a zero. Those two exited the front end with code 0
+and were caught by the trial's gate rather than the run's, which is the second gate doing the job
+the first cannot.
+
+This is an artifact of the harness, and it is not neutral: the runs it removed are the ones where
+the model wrote longest, and length correlates with score on this rubric. It biases the control
+*downward*.
+
+**The pipeline's fourteen refusals are the pipeline.** Thirteen are one shape: Stage 02 was never
+approved within its two attempts, so the synthesizer refused to write an answer from zero approved
+summaries rather than quietly asking the model the original question again — which would have
+produced a plausible document, a `synthesized` source and an exit code of 0. `answer_not_fallback`
+and `pipeline_completed` both named each one. **Roughly a quarter of pipeline runs cannot get a
+single stage past its own reviewer.** That costs a whole task, not a point, and it is the largest
+single lever on this benchmark.
+
+---
+
+## The trial withheld its own headline, and that was right
+
+`max_refusal_rate_for_publication` is 0.20. The pipeline arm refused 23.3%, so the report declines
+to publish the paired difference at all, and prints the refusal rates as the trial's result. The
+rule was written before there was anything to apply it to; this is the first time it has fired.
+
+The reasoning is in the report and it holds: refusals are not random with respect to arm. A pipeline
+arm can be refused for a stage timeout, an auto-skipped stage or a synthesized answer; a single-call
+arm structurally cannot be refused for any of the three. The surviving pairs are the tasks the
+pipeline found easy.
+
+The numbers above are published here anyway, in three framings side by side, precisely so that no
+single one of them can be mistaken for *the* result. The one the evidence supports as a headline is
+the all-sixty framing with a refusal scored zero, because it is the only one with no survivorship in
+it — and it is also the one least flattering to the pipeline.
+
+---
+
+## Corrections to earlier claims on this branch
+
+**A three-task calibration is not a result, and this trial is the demonstration.** The calibration
+landed in an earlier change reporting `fs:010` at 2.500 for the pipeline against 9.375 for the
+control, a 6.875-point loss, described as pointing the same way as the sibling benchmark. In the
+full trial, the same task under the same configuration:
+
+| `fs:010` | calibration | full trial | swing |
+|:---|---:|---:|---:|
+| `direct-opus` | 9.375 | 8.875 | −0.500 |
+| `58e8491-autor-ideate` | **2.500** | **8.750** | **+6.250** |
+
+The pipeline arm's run-to-run swing on one task is at least 6.25 points — larger than any effect
+this trial measured. That single pair was noise, and the conclusion drawn from it was wrong. Two
+pairs cannot carry a direction; forty-three say the effect is +0.085.
+
+**The headline metric was wrong too.** This work initially reported mean rubric points and treated
+pass-at-seven as a footnote, on the grounds that pass rates would be near zero. That was true of the
+water level it was decided at — gpt-5.1 answering its own exam scores 2 to 3 points — and false of
+the arms actually run, which pass half the time. Accuracy is the benchmark's own metric and is the
+headline here.
+
+---
+
+## What would refute this
+
+The next trial has to be able to. The baseline it must beat or fail against is the all-sixty
+framing above: **physics 15.0%, chemistry 80.0%, biology 55.0%, overall 50.0%, fourteen refusals, a
+paired mean of +0.085 over 43 pairs.**
+
+Three things would move it and are worth separating:
+
+1. **The refusals.** Thirteen tasks where Stage 02 never passed its reviewer. Recovering them is
+   worth up to thirteen tasks of accuracy, far more than any per-answer improvement measured here.
+2. **Physics and biology.** The mechanism is under diagnosis; the artifacts are all retained.
+3. **The control's own ceiling.** Raising the front end's answer timeout above thirty minutes would
+   return the control's four refusals, and they are its longest and probably strongest answers. Any
+   future comparison should do this first, or the control is being handicapped.
+
+---
+
+## Provenance
+
+| | |
+|:---|:---|
+| state directory | `/rmeng_data/robtang/fs-trial-full60/` — `plan.json`, `runs/`, `scores/`, `judge-raw/`, `workspaces/`, `report.md` |
+| plan digest | `0b46222767267097`, frozen before the first launch |
+| dataset | `research_test.jsonl`, sha256 `96c0434a…`, 60 rows, checked on every load |
+| task instruction | sha256 `cae42a4c…`, byte-identical in both arms |
+| judge | `gpt-5.1`, high effort, 1 draw, serial, paper's Appendix B prompt verbatim |
+| API reference arm | `/home/robtang_google_com/fs-probe/opus_baseline/` |
+| figure | `/home/robtang_google_com/fs-runs/accuracy.html`, data derived by `chartdata.py` |
+
+Two notes for whoever runs the next one. The Claude CLI kills a stream after 300 s of silence and
+the variable that governs it is `CLAUDE_STREAM_IDLE_TIMEOUT_MS`, not the `BYTE_`-prefixed one that
+looks like it should; 1,800,000 is the ceiling it clamps to, and a larger value is silently reduced.
+And the report's INTERIM banner fires whenever the pair count is below the planned task count, which
+cannot distinguish a trial that has not finished from one that finished with refusals — here it
+reads "43 of 60 pairs" over a completed trial.

--- a/docs/frontierscience.md
+++ b/docs/frontierscience.md
@@ -511,102 +511,32 @@ standard error of it *and* reproduce its subject ordering by accident.
 
 ---
 
-## What AutoR actually costs here, and what it scored
+## What AutoR scores here
 
-The two rows this page carried as UNMEASURED were filled on 2026-08-17 by a three-task
-calibration: `fs:010`, `fs:024` and `fs:043`, one per subject, both arms, real operator, `opus`
-answering and reviewing, `--stage-timeout 3600 --max-attempts 2 --max-auto-skips 0`, judged by
-`gpt-5.1`. It is the first real AutoR run of this benchmark that has ever happened.
+A sixty-task paired trial finished on 2026-08-18 and is written up in full in
+[frontierscience-results.md](frontierscience-results.md) — the arms, the accuracy by subject, the
+cost, both kinds of refusal, and the earlier claims on this branch that it overturns. The headline,
+under a `gpt-5.1` judge at one draw per task, scoring a refused run as zero:
 
-It took two passes, and the reason is worth stating before the numbers: the first pass lost two
-of three `direct` runs to a timeout in the Claude CLI that has nothing to do with this benchmark
-or with AutoR. The table below is the second pass, with that timeout raised. The first pass is
-kept in the section after it, because a refusal that turned out to be an artifact of the harness
-is exactly the kind of thing a later reader needs to be able to tell apart from a refusal that
-was real.
+| arm | overall | physics | chemistry | biology |
+|:---|---:|---:|---:|---:|
+| `direct-opus` — one Claude CLI call | **51.7%** | **30.0%** | 60.0% | **65.0%** |
+| `58e8491-autor-ideate` — the pipeline | **50.0%** | **15.0%** | **80.0%** | 55.0% |
 
-| task | arm | wall | backend calls | output tokens | answer chars | source | points |
-| --- | --- | ---: | ---: | ---: | ---: | --- | ---: |
-| `fs:010` | `direct` | 266 s | 1 | 23,719 | 43,075 | `agent` | **9.375** |
-| `fs:010` | `ideate` | 1,962 s | 9 | 153,848 | 3,731 | `synthesized` | **2.500** |
-| `fs:024` | `direct` | 842 s | 1 | 63,370 | 122,933 | `agent` | **8.000** |
-| `fs:024` | `ideate` | 4,597 s | 16 | 335,157 | 236 | `fallback` | refused |
-| `fs:043` | `direct` | 769 s | 1 | 54,368 | 121,923 | `agent` | **4.000** |
-| `fs:043` | `ideate` | 4,333 s | 20 | 307,352 | 70,606 | `synthesized` | **4.000** |
+The totals are nearly equal and they hide two large effects in opposite directions: the pipeline
+gains chemistry and roughly halves physics. It costs 4.5× the output tokens and 5.3× the wall clock
+to do it, and over the forty-three tasks where both arms produced an answer the paired mean
+difference is **+0.085 ± 0.233** — seventeen wins, seventeen losses, nine ties.
 
-**The `ideate` arm costs 33 to 77 minutes a task**, median 72 minutes, at 9 to 20 backend calls
-and 154,000 to 335,000 output tokens. The `direct` arm costs 4 to 14 minutes, median 13, at one
-call. Sixty tasks by two arms at a concurrency of six is therefore about a day of wall clock plus
-2.4 hours of judging, which makes a full paired campaign affordable — and is the fact the
-sixty-task plan could not be frozen without.
+It also refused outright on **fourteen of sixty** tasks, thirteen of them because Stage 02 never
+passed its own reviewer, which is above the plan's 20% publication ceiling and is why the trial's
+own report declines to print a difference at all. That refusal rate, not the difference, is the
+largest thing this benchmark currently has to say about the pipeline.
 
-### No paired difference is published from this, and the harness is the reason
-
-The `ideate` arm refused on one of three tasks against a `max_refusal_rate_for_publication` of
-0.20. One refusal in three is 33%, so the report withholds the difference and so does this page.
-Refusals are not distributed at random across arms — the surviving pairs are the ones where the
-pipeline happened to converge — so a mean over them is biased by an amount nobody can estimate,
-and the bias runs in the direction that flatters the arm that refused.
-
-What can be said is the two pairs, as two observations rather than as a mean:
-
-| task | `direct` | `ideate` | difference |
-| --- | ---: | ---: | ---: |
-| `fs:010` | 9.375 | 2.500 | **−6.875** |
-| `fs:043` | 4.000 | 4.000 | 0.000 |
-
-The pipeline arm did not win a task. It lost one by twenty times the judge's sampling noise and
-drew the other, at 7.4 and 5.6 times the wall clock. Two pairs is two pairs — but it points the
-same way as the sibling benchmark, where AutoR also lands below the bare CLI it can be configured
-to run on top of, and the mechanism is legible: this rubric awards points for enumerated
-specifics, the `direct` arm wrote 43,000 to 123,000 characters of them, and the synthesizer
-compresses to between 236 and 70,606.
-
-### The first pass, and the timeout that produced it
-
-In the first pass the `direct` arm refused on two of three tasks and the numbers above for those
-two were `609 s / 2 calls / 0 output tokens / 198 characters / fallback`. Every one of those
-refusals was the Claude CLI's own `API Error: Stream idle timeout - no chunks received`, firing
-at almost exactly 302 s while the model was still thinking and had emitted nothing. Six of seven
-`direct` attempts died that way; `fs:024` reproduced it four times across two runs at two
-different concurrency levels, so it is not a load artifact; and the one that survived, `fs:010`,
-finished its call in 264 s — just under.
-
-**The knob is `CLAUDE_STREAM_IDLE_TIMEOUT_MS`, and the obvious guess is wrong.** Raising only
-`CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS` changed nothing and the next run failed again at 302.2 s;
-the function behind that error floors the *un-prefixed* variable at 300,000 ms. Both were then
-set to 1,800,000, which is the ceiling the CLI clamps to — a larger value is silently reduced,
-which is the worst kind of configuration, one that reads as set and is not. The two tasks that
-had failed four times between them then succeeded on the first attempt, and nothing else changed.
-
-Neither variable is reachable from `fs_agent.py`; both belong in the environment of whatever
-launches it, and raising them is the first thing to do before a campaign. The failure mode is
-worth remembering on its own: the process exits, a file exists, and only the metadata says the
-file is a placeholder — and because it fires on thinking time, what it removes is the hard
-questions, so a mean over the survivors reads high.
-
-### The refusal that was real
-
-**The `ideate` arm's refusal is the one this integration was designed for.** `fs:024` spent 76
-minutes and 16 backend calls, approved no stage, and came out with `pipeline_completed: false`,
-`stages_approved: []` and a `fallback` answer of 236 characters. The synthesizer refused to write
-an answer from zero approved stages rather than quietly asking the model the original question
-again — which would have produced a plausible document, a `synthesized` source and an exit code
-of 0. Two clauses named it, `answer_not_fallback` and `pipeline_completed`, and the exit code was
-1. On the sibling benchmark the same shape of run wrote `status: "completed"` thirty-nine times
-out of forty.
-
-Three further things the calibration confirmed in a real run rather than a fake one: the
-no-browsing protocol held on **all seven model seats** of the `ideate` arm, each carrying the
-denied-tool list and each witnessed at `browsing_tool_calls: 0`; the walk approved exactly
-`["02_hypothesis_generation"]` and auto-skipped nothing; and the `direct` arm through the CLI
-writes a far longer answer than the same model called through the API — 43,075 characters against
-5,822 on the same question — which is most of why it scored 9.375 where the API baseline scored
-5.75. The two things called `direct` are not the same instrument, and only the CLI one is the
-paired control.
-
-Artifacts: `fs-runs/fs0NN_{direct,ideate}/` with `_meta.json`, `answer.md` and the run tree, and
-`fs-runs/fs0NN_*.score.json` beside them.
+The three-task calibration that preceded the trial is kept in the results page rather than here,
+because what it mainly demonstrates is that three tasks cannot carry a direction: on one of them the
+pipeline swung 6.25 points between the calibration and the full trial under an unchanged
+configuration.
 
 ### Reproducing it
 
@@ -643,8 +573,13 @@ Stage 02 is a run that produced nothing while reporting that it finished.
 ### The cost, and the neighbour it used to be estimated from
 
 Judging: at a mean of 72.9 s per serial call, sixty tasks by two arms at one draw each is about
-2.4 hours. Answering, now that the calibration has run: the `ideate` arm's median is 72 minutes
-a task over three tasks, so the same sixty by two arms is roughly a day at a concurrency of six.
+2.4 hours. Answering, now that the sixty-task trial has run and the three-task calibration it
+replaced is superseded: the `ideate` arm's median is **3,916 s** a task and its range is 1,797 to
+14,816, so its whole arm cost **70.0 h** of run time and 14.08 M output tokens. The `direct` arm's
+median is **607 s**, its whole arm 13.1 h and 3.16 M tokens. At a concurrency of ten the pair took
+about nine hours of wall clock. The calibration's estimate — a 72-minute median from three tasks —
+survived contact with sixty, but its range did not: three tasks spanned two to one and sixty span
+eight to one.
 
 Before that measurement existed this section reasoned from a neighbour, and the neighbour was
 wrong by an order of magnitude in the direction that matters. Thirty-nine real


### PR DESCRIPTION
The FrontierScience integration shipped with a three-task calibration and a warning that three tasks
could not carry a direction. Sixty tasks have now run, both arms, and the warning was right.

Both arms `claude-opus-5[1m]`, identical task instruction frozen in the plan digest, browsing denied
and witnessed on all seven model seats, judged by `gpt-5.1` at one draw per task. Accuracy — the
benchmark's own metric, the share of tasks at ≥ 7 of 10 rubric points — over all sixty tasks with a
refused run scored zero:

| arm | overall | physics | chemistry | biology |
|:---|---:|---:|---:|---:|
| `direct-opus` — one Claude CLI call | **51.7%** | **30.0%** | 60.0% | **65.0%** |
| `58e8491-autor-ideate` — the pipeline | **50.0%** | **15.0%** | **80.0%** | 55.0% |

**The totals are within noise of each other and they hide the result.** The pipeline gains twenty
points of chemistry and loses half of physics; over the complete pairs the chemistry effect is
larger still, 68.8% → 93.8%. Reporting only the total would have hidden both.

Over the 43 tasks where both arms produced an answer the paired mean difference is **+0.085 ±
0.233** rubric points — 17 wins, 17 losses, 9 ties, median exactly zero — bought with **4.5× the
output tokens and 5.3× the wall clock**, for an answer a quarter shorter. At that sample and a
difference sd of 1.531 the minimum detectable effect is 0.654, above the 0.5 declared as the minimum
of interest, so the trial is slightly underpowered for the effect it set out to find. The observed
effect is 0.085, well below both: not an effect the sample failed to resolve, an absence.

## Fourteen refusals, and only one kind is AutoR's

| arm | refused | why |
|:---|---:|:---|
| `direct-opus` | 4 / 60 | all four the front end's 30-minute answer timeout, not the benchmark |
| `58e8491-autor-ideate` | **14 / 60** | thirteen because **Stage 02 never passed its own reviewer** |

Above the plan's 20% ceiling, so the trial's own report declines to publish a difference at all —
the first time that rule has fired since it was written. Roughly a quarter of pipeline runs cannot
get a single stage approved, which costs a whole task rather than a point and is the largest lever
this benchmark currently offers.

The control's four are not neutral either: two were still writing at 363k and 310k characters when
the timeout fired, and length correlates with score here, so the harness removed the control's
longest answers and biased it *downward*.

## Three framings, printed side by side because they disagree about the sign

complete pairs **+0.085**, all-sixty-with-zeros **−0.733**, admitted-only **+0.488**. A reader handed
one of them has been handed a choice somebody else made. The all-sixty framing is the headline
because it is the only one with no survivorship in it — and it is also the least flattering to the
pipeline.

## Two earlier claims on this branch are withdrawn

**The calibration's headline was noise.** `#263` reported `fs:010` at 2.500 against 9.375 and read
the 6.875-point loss as pointing the same way as ResearchClawBench. The full trial re-ran that task
under an unchanged configuration:

| `fs:010` | calibration | full trial | swing |
|:---|---:|---:|---:|
| `direct-opus` | 9.375 | 8.875 | −0.500 |
| pipeline | **2.500** | **8.750** | **+6.250** |

The pipeline arm's run-to-run swing on one task is larger than any effect this trial measured.

**And the headline metric was wrong.** This work reported mean rubric points and treated
pass-at-seven as a footnote because pass rates would be near zero. That was true of the water level
it was decided at — gpt-5.1 answering its own exam scores 2 to 3 points — and false of the arms
actually run, which pass half the time. Accuracy is the benchmark's own metric and is the headline
now, reported in its shape: overall and by subject, with binomial error.

## What is here

`docs/frontierscience-results.md` is new — the full experiment record, including the per-task
movements, the `fs:044` artifact (ten rubric items each of the form *give the point if the answer
states X*, where the control scored a perfect 10 and the pipeline 6 while naming the graded entities
a third as often), the cost table, and what would refute all of it. `docs/frontierscience.md` loses
the superseded calibration section and gains a pointer; its cost section is re-anchored on sixty
tasks rather than three. README, `docs/README.md` and the documentation table follow.

Docs only — no source change. Suite `Ran 4030 tests`, `OK (skipped=4)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)