### PR TITLE
Seven skills for the benchmark where the record is worth nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ naming them.
 | Required stage-summary headings | `REQUIRED_STAGE_HEADINGS` | 7 |
 | Rubric criteria (weighted, backend-free) | `CRITERIA`, [src/rubric.py](src/rubric.py) | 10 |
 | Flags on `main.py` / `rcb_agent.py` | `parse_args` | 61 / 37 |
-| Python modules / lines / tests | the tree | 254 / 137 k / 4040 |
+| Python modules / lines / tests | the tree | 254 / 137 k / 4048 |
 
-`python -m unittest discover -s tests -p "test_*.py"` runs **4040 tests in ~430 s across 143 test
+`python -m unittest discover -s tests -p "test_*.py"` runs **4048 tests in ~440 s across 143 test
 modules**, with no third-party dependency.
 
 ## Quick start
@@ -642,7 +642,7 @@ Alongside the prompt, AutoR installs an agent skill pack from [src/skills/](src/
 `runs/<run_id>/.claude/skills/` — the operator's working directory — so the agent can *pull*
 long-form craft guidance when it needs it. A skill costs nothing in the prompts that do not use it.
 
-161 skills ship today: 72 general ones and 89 field-specific ones. Forty of them were written in one pass against the twelve tasks that trailed a bare-Claude-Code control under a single judge — three or four per task, each selected by a phrase in that task's brief and in no other of the forty, and every one of the forty pinned. Most of them were written against a scored arm's per-criterion losses on the
+168 skills ship today: 79 general ones and 89 field-specific ones. Forty of them were written in one pass against the twelve tasks that trailed a bare-Claude-Code control under a single judge — three or four per task, each selected by a phrase in that task's brief and in no other of the forty, and every one of the forty pinned. Most of them were written against a scored arm's per-criterion losses on the
 twenty-five ResearchClawBench tasks that lost, at least three per task. **A run is not offered all of
 them.** Two filters narrow the pack, and a skill has to survive both:
 
@@ -650,10 +650,13 @@ them.** Two filters narrow the pack, and a skill has to survive both:
    become two. A materials run does not benefit from being offered advice about observational
    astronomy, it just has one more description to read past.
 2. **Shape.** A skill may carry an `applies_when` regex, matched against this run's own research
-   brief and data manifest. Forty-four skills are scoped this way today; measured over the forty
+   brief and data manifest. 51 skills are scoped this way today; measured over the forty
    ResearchClawBench briefs they select between 1 and 7 tasks each — forty of the
-   forty-four select exactly one — eighteen tasks receive none of them, and no task receives
-   more than six. `tools/skill_selectivity.py` prints the selection set
+   forty-four RCB-shaped ones select exactly one — eighteen tasks receive none of them, and no task
+   receives more than six. The seven added for AIRS-Bench are scoped on a different corpus and
+   select 19 of its 20 briefs and **none** of the forty ResearchClawBench ones; the twentieth is a
+   brief whose whole task paragraph is one sentence that never says what the deliverable is, so no
+   predicate over task shape can reach it and its pin does instead. `tools/skill_selectivity.py` prints the selection set
    for a corpus and `--expect` turns it into an assertion, because a predicate is a claim about a
    kind of research problem and it should be checkable.
 
@@ -665,10 +668,13 @@ the same tasks today and generalise to nothing.
    that are installed for it whatever the two filters say. A pin is not an inference about a kind of
    task — it is a record that this exact identifier already ran, already scored, and lost criteria
    whose subject is those skills, so it is the one routing input that cannot be derived from the
-   task statement and does not generalise past the name it carries. Twenty-seven ResearchClawBench tasks
-   are pinned today, 280 pins between them, at most fifteen on any one task; twenty of the 280
-   are skills the two filters would have withheld, in each case a field skill whose content
-   applies outside its own field. **A run that matches an entry writes `skill_pins` into its `run_config.json` and a
+   task statement and does not generalise past the name it carries. Forty-seven tasks are pinned
+   today — twenty-seven from ResearchClawBench and all twenty of AIRS-Bench — 420 pins between
+   them, at most fifteen on any one task; twenty of them are skills the two filters would have
+   withheld, in each case a field skill whose content applies outside its own field. The two
+   benchmarks' pins are derived differently and the file says so: RCB's from per-criterion losses,
+   AIRS-Bench's from a mechanism that is arm-wide because that benchmark has no criteria — 43% of
+   the median run's tool calls landed after its predictions file stopped changing. **A run that matches an entry writes `skill_pins` into its `run_config.json` and a
    `skills pinned_by_task_id` line into its log**, because a pinned arm and an unpinned arm are two
    configurations and a score from one is not a score from the other.
 

--- a/configs/task_skill_pins.json
+++ b/configs/task_skill_pins.json
@@ -453,5 +453,363 @@
     "math-a-proposer-that-learned-nothing-is-the-control",
     "math-an-unused-hypothesis-is-a-stronger-theorem",
     "math-rebuild-the-generator-the-system-learned-from"
-  ]
+  ],
+  "_airs_provenance": "The twenty AIRS-Bench task ids below are pinned from the scored 19-task arm at b11af48 (/rmeng_data/robtang/airs-runs/exp2, one seed, opus both arms, 4 h cap, CPU-only slurm array), reported in the benchmark's own units by tools/airs_report.py: bare Claude Code 0.894 mean / 0.932 median normalized against AutoR 0.834 / 0.844, bare winning 16 of 19 with a 100% valid submission rate against AutoR's 94.7%. Unlike the ResearchClawBench pins above, these are NOT derived from per-criterion losses -- AIRS-Bench has no criteria, only a metric over submission.csv -- so they are derived from the mechanism instead, and the mechanism is arm-wide rather than per-task. Three measurements carry it. (1) The median run spent 43% of its tool calls AFTER the last time it changed the predictions file, and 93 minutes of a 240-minute budget; per-task shares are in _airs_rationale. (2) All 19 runs hit the cap and none finished the walk: six never left Stage 01. (3) On two molecular-property tasks the Stage 01 survey recorded the published ladder (0.021-0.029) or resolved the DOIs of the graph networks that produce it, and the run shipped a gradient-boosted tree at 0.11; the control arm, which did no survey, wrote a graph network and won. Because the mechanism is arm-wide, every task that ran gets the same seven, ordered by when they bite. TimeSeriesForecastingRideshareMAE is pinned unmeasured -- its dataset cannot be staged under any `datasets` version, so it has never run here; it is included so that the pin table covers the benchmark rather than covering the subset that happened to work.",
+  "CodeGenerationAPPSPassAt5": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "CodeRetrievalCodeXGlueMRR": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "CoreferenceResolutionSuperGLUEWSCAccuracy": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "CoreferenceResolutionWinograndeAccuracy": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "CvMolecularPropertyPredictionQm9MeanAbsoluteError": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "GMolecularPropertyPredictionQm9MeanAbsoluteError": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "GraphRegressionZincMae": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "MathQuestionAnsweringSVAMPAccuracy": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "QuestionAnsweringDuoRCAccuracy": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "QuestionAnsweringEli5RougeL": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "QuestionAnsweringFinqaAccuracy": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "R2AbsMolecularPropertyPredictionQm9MeanAbsoluteError": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "ReadingComprehensionSquadExactMatch": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "SentimentAnalysisYelpReviewFullAccuracy": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "TextualClassificationSickAccuracy": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "TextualSimilaritySickSpearmanCorrelation": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "TimeSeriesForecastingKaggleWebTrafficMASE": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "TimeSeriesForecastingSolarWeeklyMAE": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "U0MolecularPropertyPredictionQm9MeanAbsoluteError": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "TimeSeriesForecastingRideshareMAE": [
+    "a-scoreable-file-in-the-first-hour",
+    "the-row-count-comes-from-the-split-not-the-brief",
+    "assume-this-stage-is-the-last-one-you-get",
+    "the-submission-is-the-only-artifact-that-scores",
+    "your-survey-already-named-the-method-that-hits-the-number",
+    "a-model-you-can-audit-is-not-a-model-that-scores",
+    "the-audit-trail-is-not-the-deliverable-here"
+  ],
+  "_airs_rationale": {
+    "CodeGenerationAPPSPassAt5": {
+      "pins": 7,
+      "autor": 7.371,
+      "control": 14.153,
+      "net": -6.781,
+      "final_stage_reached": "03",
+      "pct_calls_after_deliverable_froze": 55,
+      "note": "lost to the control"
+    },
+    "CodeRetrievalCodeXGlueMRR": {
+      "pins": 7,
+      "autor": 0.808,
+      "control": 0.817,
+      "net": -0.009,
+      "final_stage_reached": "04",
+      "pct_calls_after_deliverable_froze": 46,
+      "note": "lost to the control"
+    },
+    "CoreferenceResolutionSuperGLUEWSCAccuracy": {
+      "pins": 7,
+      "autor": 0.407,
+      "control": 0.526,
+      "net": -0.12,
+      "final_stage_reached": "06",
+      "pct_calls_after_deliverable_froze": 17,
+      "note": "lost to the control"
+    },
+    "CoreferenceResolutionWinograndeAccuracy": {
+      "pins": 7,
+      "autor": 0.873,
+      "control": 0.845,
+      "net": 0.028,
+      "final_stage_reached": "03",
+      "pct_calls_after_deliverable_froze": 5,
+      "note": "won by AutoR; pinned anyway because the arm-wide mechanism applies and this run still hit the cap"
+    },
+    "CvMolecularPropertyPredictionQm9MeanAbsoluteError": {
+      "pins": 7,
+      "autor": 0.808,
+      "control": 0.956,
+      "net": -0.148,
+      "final_stage_reached": "01",
+      "pct_calls_after_deliverable_froze": 8,
+      "note": "lost to the control"
+    },
+    "GMolecularPropertyPredictionQm9MeanAbsoluteError": {
+      "pins": 7,
+      "autor": 0.828,
+      "control": 0.932,
+      "net": -0.104,
+      "final_stage_reached": "01",
+      "pct_calls_after_deliverable_froze": 12,
+      "note": "lost to the control"
+    },
+    "GraphRegressionZincMae": {
+      "pins": 7,
+      "autor": 0.861,
+      "control": 0.868,
+      "net": -0.007,
+      "final_stage_reached": "04",
+      "pct_calls_after_deliverable_froze": 48,
+      "note": "lost to the control"
+    },
+    "MathQuestionAnsweringSVAMPAccuracy": {
+      "pins": 7,
+      "autor": 0.902,
+      "control": 0.887,
+      "net": 0.015,
+      "final_stage_reached": "03",
+      "pct_calls_after_deliverable_froze": 62,
+      "note": "won by AutoR; pinned anyway because the arm-wide mechanism applies and this run still hit the cap"
+    },
+    "QuestionAnsweringDuoRCAccuracy": {
+      "pins": 7,
+      "autor": 0.639,
+      "control": 0.743,
+      "net": -0.105,
+      "final_stage_reached": "02",
+      "pct_calls_after_deliverable_froze": 65,
+      "note": "lost to the control"
+    },
+    "QuestionAnsweringEli5RougeL": {
+      "pins": 7,
+      "autor": 0.606,
+      "control": 0.678,
+      "net": -0.072,
+      "final_stage_reached": "01",
+      "pct_calls_after_deliverable_froze": 15,
+      "note": "lost to the control"
+    },
+    "QuestionAnsweringFinqaAccuracy": {
+      "pins": 7,
+      "autor": 0.0,
+      "control": 0.291,
+      "net": -0.291,
+      "final_stage_reached": "01",
+      "pct_calls_after_deliverable_froze": 57,
+      "note": "no valid submission: 1137 rows where the split has 1147"
+    },
+    "R2AbsMolecularPropertyPredictionQm9MeanAbsoluteError": {
+      "pins": 7,
+      "autor": 0.759,
+      "control": 0.956,
+      "net": -0.197,
+      "final_stage_reached": "04",
+      "pct_calls_after_deliverable_froze": 69,
+      "note": "lost to the control"
+    },
+    "ReadingComprehensionSquadExactMatch": {
+      "pins": 7,
+      "autor": 1.141,
+      "control": 1.134,
+      "net": 0.007,
+      "final_stage_reached": "01",
+      "pct_calls_after_deliverable_froze": 43,
+      "note": "won by AutoR; pinned anyway because the arm-wide mechanism applies and this run still hit the cap"
+    },
+    "SentimentAnalysisYelpReviewFullAccuracy": {
+      "pins": 7,
+      "autor": 0.597,
+      "control": 0.636,
+      "net": -0.039,
+      "final_stage_reached": "01",
+      "pct_calls_after_deliverable_froze": 31,
+      "note": "lost to the control"
+    },
+    "TextualClassificationSickAccuracy": {
+      "pins": 7,
+      "autor": 1.099,
+      "control": 1.15,
+      "net": -0.051,
+      "final_stage_reached": "03",
+      "pct_calls_after_deliverable_froze": 13,
+      "note": "lost to the control"
+    },
+    "TextualSimilaritySickSpearmanCorrelation": {
+      "pins": 7,
+      "autor": 1.104,
+      "control": 1.173,
+      "net": -0.069,
+      "final_stage_reached": "04",
+      "pct_calls_after_deliverable_froze": 60,
+      "note": "lost to the control"
+    },
+    "TimeSeriesForecastingKaggleWebTrafficMASE": {
+      "pins": 7,
+      "autor": 0.986,
+      "control": 0.988,
+      "net": -0.001,
+      "final_stage_reached": "03",
+      "pct_calls_after_deliverable_froze": 19,
+      "note": "lost to the control"
+    },
+    "TimeSeriesForecastingSolarWeeklyMAE": {
+      "pins": 7,
+      "autor": 0.908,
+      "control": 0.945,
+      "net": -0.037,
+      "final_stage_reached": "02",
+      "pct_calls_after_deliverable_froze": 70,
+      "note": "lost to the control"
+    },
+    "U0MolecularPropertyPredictionQm9MeanAbsoluteError": {
+      "pins": 7,
+      "autor": 0.844,
+      "control": 0.955,
+      "net": -0.111,
+      "final_stage_reached": "02",
+      "pct_calls_after_deliverable_froze": 8,
+      "note": "lost to the control"
+    },
+    "TimeSeriesForecastingRideshareMAE": {
+      "pins": 7,
+      "note": "never run here; its dataset cannot be staged"
+    }
+  }
 }

--- a/docs/airsbench.md
+++ b/docs/airsbench.md
@@ -454,6 +454,75 @@ same cap.
 
 <!-- results:end -->
 
+## Why the scaffold loses here, and the seven skills written from it
+
+The result is that the bare CLI wins 16 of 19. The question worth answering is *how*, since
+AutoR is the same model with more machinery. Four measurements over the nineteen AutoR run
+trees answer it, and none of them is "the agent was worse at machine learning".
+
+**1. It does more work, not less.** AutoR made a median of **313 tool calls** per task
+against the bare arm's **86**, and **63** of them touched `submission.csv` against the bare
+arm's **8**. Whatever is going wrong, it is not idleness or timidity.
+
+**2. Nearly half of that work lands after the deliverable stops changing.** Median **43%**
+of AutoR's tool calls came after the last write to `submission.csv`; on seven of nineteen
+tasks it was over half, and on the worst — `R2Abs…Qm9` — it was **294 of 427**. The median
+gap between the last write and the end of the run was **93 minutes of a 240-minute budget**.
+The bare arm's median gap was **2 minutes**. Read the calls in that window and they are
+recognisable: resolving DOIs for two architectures the run had decided not to build,
+rewiring claims to sources, "an independent verifier for every stage number", "a full
+integrity sweep of all artifacts", four calls removing a parenthesised backtick from a notes
+file. Competent work, on a benchmark that reads one CSV.
+
+**3. Every run hit the cap and none finished the walk.** Six of nineteen never left Stage
+01; four of those spent 13–22 attempts on it. So the pipeline's later stages — the ones
+designed to run the experiments and improve the result — mostly never executed, and the
+scored file is whatever an early stage produced in passing.
+
+**4. The survey found the answer and the implementation did not hear it.** On
+`Cv…Qm9` the Stage 01 survey recorded the published ladder for that target and metric —
+**0.021 to 0.029** — and the run shipped **0.11**, five times off a number in its own notes.
+On `R2Abs…Qm9` it resolved the DOIs of two graph-network architectures, cited them
+correctly, and shipped a gradient-boosted tree on hand-built features, beside scripts named
+`audit_train_test_alignment.py`, `audit_units_and_temperature.py` and
+`emit_demand_coverage.py`. The bare arm, which did no survey at all, wrote `schnet.py`,
+`graphs.py` and `finetune.py`, and won all three QM9 tasks by 0.11 to 0.20.
+
+Taken together the failure is not one of capability but of **allocation and closure**: the
+scaffold's gates are the loudest signal in the run, so effort flows to them; and the
+findings that would redirect the modelling arrive as documents rather than as instructions.
+
+### The skills
+
+Seven skills are written from those four measurements, each scoped by `applies_when:
+predictions will be scored` — a claim about task shape that selects **19 of the 20
+AIRS-Bench briefs and 0 of the 40 ResearchClawBench ones** — and pinned to all twenty task
+identifiers in [configs/task_skill_pins.json](../configs/task_skill_pins.json).
+
+| skill | the measurement behind it | stages |
+|:---|:---|:---|
+| [`a-scoreable-file-in-the-first-hour`](../src/skills/a-scoreable-file-in-the-first-hour/SKILL.md) | 19/19 hit the cap; one shipped no valid file at all | 01–04 |
+| [`the-row-count-comes-from-the-split-not-the-brief`](../src/skills/the-row-count-comes-from-the-split-not-the-brief/SKILL.md) | 1,137 rows where the split has 1,147; and a task whose own brief states the wrong shape | 03–05 |
+| [`assume-this-stage-is-the-last-one-you-get`](../src/skills/assume-this-stage-is-the-last-one-you-get/SKILL.md) | six of nineteen never left Stage 01; none finished the walk | 01–04 |
+| [`the-submission-is-the-only-artifact-that-scores`](../src/skills/the-submission-is-the-only-artifact-that-scores/SKILL.md) | 43% of calls, 93 minutes, after the file stopped changing | 01–06 |
+| [`your-survey-already-named-the-method-that-hits-the-number`](../src/skills/your-survey-already-named-the-method-that-hits-the-number/SKILL.md) | ladder recorded at 0.021–0.029, shipped 0.11 | 01–04 |
+| [`a-model-you-can-audit-is-not-a-model-that-scores`](../src/skills/a-model-you-can-audit-is-not-a-model-that-scores/SKILL.md) | gradient-boosted tree against the control's graph network | 03–05 |
+| [`the-audit-trail-is-not-the-deliverable-here`](../src/skills/the-audit-trail-is-not-the-deliverable-here/SKILL.md) | 294 of 427 calls on the record, on the worst-affected task | 01–06 |
+
+**They are weighted at the early stages on purpose.** A skill named only at Stage 05 would
+be unreachable on this benchmark: over a forty-task arm, stages 05, 06 and 07 accounted for
+five `Skill` launches between them, and here most runs never reach 05 at all.
+
+**Pinned, not merely installed, for the same reason.** Measured over that arm, a skill a
+prompt names imperatively fired in 31 of 40 runs; a skill that was only installed fired in
+almost none, with the pack drawing 78 launches in 789 hours of agent time. A skill nobody
+opens is indistinguishable from a skill nobody wrote.
+
+**None of this is measured yet.** The seven are a hypothesis about a measured failure, not a
+result: no arm has been run with them. The honest test is a re-run of the same nineteen
+tasks under the same cap with the pins on, against these numbers as the control — and until
+that exists, this section describes a diagnosis and a prescription, not an improvement.
+
 ## What is not measured
 
 - **This is not a leaderboard number and cannot be placed beside one.** The published table

--- a/src/skills/a-model-you-can-audit-is-not-a-model-that-scores/SKILL.md
+++ b/src/skills/a-model-you-can-audit-is-not-a-model-that-scores/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: a-model-you-can-audit-is-not-a-model-that-scores
+description: Use at study design and implementation when choosing between a method you can validate quickly and a stronger one you are not sure you can afford. Covers pricing the expensive method with a measurement instead of an impression, the go/no-go that has to be written before the clock is spent, and why the safe choice is only safe on the axes nobody is grading.
+applies_when: predictions will be scored
+stages: 03_study_design, 04_implementation, 05_experimentation
+---
+
+# The auditable method wins the argument and loses the score
+
+Given a fixed clock and a scored predictions file, there is a recurring choice
+between two methods:
+
+- one you can build in twenty minutes, cross-validate cleanly, explain fully, and
+  defend against every question a reviewer asks;
+- one the field actually uses to get the published number, which needs an hour of
+  setup you have not done, has failure modes you cannot fully enumerate, and might
+  not finish.
+
+Every incentive inside a rigour-checking pipeline points at the first. The gates
+reward an auditable choice. The reviewer is easier to satisfy. The write-up is
+cleaner. And on a benchmark that grades predictions, none of that is measured.
+
+Measured on a scored arm: the pipeline shipped a gradient-boosted tree on hand-built
+features, with a set of scripts beside it named for what they audited — the
+train/test alignment, the units, the row alignment, the submission state. The
+control arm, on the same task with the same clock, wrote a graph network. The
+control won by a fifth of the normalized range.
+
+## Price it; do not judge it
+
+The decision is not "is the expensive method better" — you already know it is. It
+is "does it fit". That is a measurement, and it takes ten minutes:
+
+1. **Run one unit of it.** One epoch on 1% of the data, or one forward pass on one
+   batch, timed. Not an estimate from experience; the actual wall clock on this
+   machine, which is the only one whose speed matters.
+2. **Extrapolate to the full fit.** Epochs × data multiple × the unit. Add 50% for
+   the things a first run does not do.
+3. **Compare against the clock you have left**, minus a reserve for writing and
+   checking the submission.
+4. **Write the go/no-go down with both numbers in it.** Two lines is enough:
+   "one epoch on 1% took 42 s → full fit ≈ 70 min; 150 min remain after reserve;
+   go."
+
+Step 4 is what makes this different from deciding by feel. A run that has written
+the estimate can revisit it when the clock moves; a run that has only an
+impression will re-litigate the same choice three times and act on none of them.
+
+## Make the expensive method safe rather than avoiding it
+
+Most of what makes the strong method feel unaffordable is recoverable:
+
+- **Checkpoint every epoch and write a submission from the best checkpoint so far.**
+  Then a training run that is killed by the clock has still contributed, and the
+  downside of trying is bounded by the time, not by the outcome.
+- **Start it in the background and keep the foreground on the cheap method.** The
+  two do not compete for your attention, only for CPU, and the cheap one is
+  already your floor.
+- **Fix the seed and the split before the first fit**, so a later comparison
+  between the two methods is a comparison and not a coincidence.
+
+With those three, "try the strong method" costs you the wall clock and nothing
+else. Without them it risks the deliverable, which is what makes the conservative
+choice feel correct.
+
+## The tell
+
+You are on the wrong side of this when your validation number has stopped moving
+and your file count has not. Four more feature-engineering scripts against a
+plateau is the shape of a run that has decided, without saying so, that the method
+is fixed. If the method is fixed and the number is short of the ladder, the run
+has already ended; the remaining hours are spent on the record.

--- a/src/skills/a-scoreable-file-in-the-first-hour/SKILL.md
+++ b/src/skills/a-scoreable-file-in-the-first-hour/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: a-scoreable-file-in-the-first-hour
+description: Use at the first stage of a run whose deliverable is a predictions file, and again at every stage when one still does not exist. Covers why a trivial submission written early dominates a good one written late, what the first version should contain, and how to improve it in place without ever leaving it invalid.
+applies_when: predictions will be scored
+stages: 01_literature_survey, 02_hypothesis_generation, 03_study_design, 04_implementation
+---
+
+# Write a scoreable file before you write anything else
+
+A predictions file that does not exist scores nothing. Not a low score — no score,
+and on a benchmark that reports *valid submission rate* as a headline metric
+beside the score, a missing file costs you on two axes at once.
+
+So the first version is not a milestone to work toward. It is a thing to get out
+of the way in the first hour, from whatever you can compute immediately, and then
+improve in place for the rest of the run.
+
+## Why this is not the obvious advice
+
+The instinct is that a trivial submission is embarrassing and that a real one is
+close, so it is better to wait. Two measurements say otherwise.
+
+Every run of a scored arm on this benchmark hit its wall clock — nineteen of
+nineteen — and none of them finished the pipeline they had planned. Six never got
+past the first stage. Whatever a run intends to do at stage five, it should assume
+it will not get there.
+
+And a run on that arm shipped **1,137 rows where the split has 1,147** and scored
+nothing at all on a task it had otherwise solved, because the file was written
+once, late, and never re-checked.
+
+## The first version
+
+Build it from the training labels alone, with no model:
+
+| task shape | first submission |
+|---|---|
+| regression | the training mean, or the per-group mean if a grouping column is obvious |
+| classification | the majority class, or the class prior |
+| ranking / retrieval | the identity ordering, or a length or frequency heuristic |
+| generation scored by overlap | the most common training answer, or the input echoed |
+| forecasting | the last observed value, or the seasonal naive |
+
+Each of these is ten minutes of work and each is a real floor. Several of them
+are not far off what a tuned model gets on a hard task, which is itself worth
+knowing before you spend three hours on the model.
+
+Then, in the same hour, write the check that keeps it valid — see
+`the-row-count-comes-from-the-split-not-the-brief`.
+
+## Improve in place, never in a branch
+
+Every later model writes to the same path, and only after it has beaten the
+current file on a validation split you built. The sequence for every improvement
+is the same four steps:
+
+1. score the candidate on your held-out split
+2. compare against the score of what is currently in the file
+3. if it wins, write it and record both numbers
+4. re-run the shape check
+
+Step 2 requires you to have kept the current file's validation score. Keep it in a
+one-line file next to the submission; a number you have to recompute is a number
+you will skip recomputing.
+
+**Never move the file aside while you work.** The most expensive version of this
+mistake is a run that deletes a valid submission to write a better one, then runs
+out of clock in between.
+
+## What to do with the rest of the hour
+
+Once the file exists and the check passes, you have bought the right to be
+ambitious for the remaining three hours, because the downside is now bounded by a
+number you have already banked rather than by zero.

--- a/src/skills/assume-this-stage-is-the-last-one-you-get/SKILL.md
+++ b/src/skills/assume-this-stage-is-the-last-one-you-get/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: assume-this-stage-is-the-last-one-you-get
+description: Use at the first three stages of a run under a hard wall clock, when the plan defers the modelling to a later stage. Covers the measured probability that the later stages never execute, why deferring to the stage designed for the work is the most expensive available choice, and what each early stage should leave behind if it turns out to be the last one to run.
+applies_when: predictions will be scored
+stages: 01_literature_survey, 02_hypothesis_generation, 03_study_design, 04_implementation
+---
+
+# Plan as if the experimentation stage will not happen, because usually it does not
+
+The pipeline has a stage for running experiments and a stage for analysing them.
+On a wall-clocked run they are frequently theoretical.
+
+Measured over a nineteen-task scored arm, with a four-hour cap per task:
+
+| final stage the run reached | runs |
+|---|---|
+| 01 literature survey | 6 |
+| 02 hypothesis generation | 3 |
+| 03 study design | 5 |
+| 04 implementation | 4 |
+| 06 analysis | 1 |
+
+**Nineteen of nineteen hit the cap. None finished the walk.** Six never left the
+first stage; four of those six spent between 13 and 22 attempts on it. So the
+predictions file that got scored was, on most tasks, whatever an early stage
+happened to produce on the way past.
+
+That is the environment. Planning as though stage five will arrive is planning
+for a stage that arrives about one time in twenty.
+
+## What follows
+
+**Do the modelling in the stage you are in.** Not because the stage boundaries are
+wrong, but because a plan whose payoff is two stages away has a low probability of
+being executed, and a marginally worse model built now has a probability of one.
+
+Concretely, at each early stage:
+
+- **01, literature survey.** Alongside the sources, run the data loader, print the
+  shapes, and write the trivial baseline submission. The survey is better for it —
+  you now know what the columns actually contain — and if the run ends here, it
+  ends with a valid file.
+- **02, hypotheses.** Every hypothesis you register should be one you could test
+  with a script you could write this hour. A hypothesis whose test needs
+  infrastructure you have not built is a hypothesis that will be adjudicated by
+  the clock.
+- **03, study design.** Design the experiment you will run *first*, not the full
+  grid. Then run it. A designed-and-unrun grid scores the same as no grid.
+- **04, implementation.** The thing you implement should end by writing a
+  submission, every time. "Implemented, not yet run" is the most common way this
+  arm ended.
+
+## Leave the run resumable at every boundary
+
+Because you do not know which stage is the last one, each should leave the next
+one able to start in five minutes rather than thirty:
+
+- the current submission, valid
+- its validation score, in a file, next to it
+- the single script that regenerates it end to end
+- one line saying what the next thing to try is
+
+That is a smaller handoff than the pipeline's own artifacts and it is the one that
+determines whether the following stage does research or does reconstruction.
+
+## The stage budget is not yours to spend evenly
+
+If the cap is four hours and there are six stages, the arithmetic that gives each
+stage forty minutes is wrong, because the last three stages have a low chance of
+running at all. Weight the front: the first two stages should end with a model, and
+the later ones should improve it if they arrive. A run that is refused at stage one
+three times has spent its budget on the stage with the least leverage over the
+score.

--- a/src/skills/the-audit-trail-is-not-the-deliverable-here/SKILL.md
+++ b/src/skills/the-audit-trail-is-not-the-deliverable-here/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: the-audit-trail-is-not-the-deliverable-here
+description: Use at every stage of a run graded on a predictions file, whenever a gate is asking for manifests, claims, sources, coverage or provenance. Covers producing each artifact once at the size the gate accepts, the difference between satisfying a gate and elaborating one, and the specific elaborations that have eaten whole runs.
+applies_when: predictions will be scored
+stages: 01_literature_survey, 02_hypothesis_generation, 03_study_design, 04_implementation, 05_experimentation, 06_analysis
+---
+
+# Satisfy the gate. Do not develop a relationship with it
+
+This pipeline asks every stage for machine-readable evidence: sources and claims
+that cross-reference, a hypothesis manifest with decision rules, a report plan, an
+experiment manifest, coverage entries, provenance. Those gates exist for good
+reasons and they are not optional — a refused stage costs more clock than the
+artifact would have.
+
+They are also, on a task graded by a metric over a predictions file, worth exactly
+zero. The correct relationship is: produce each one once, at the size that passes,
+and return to the model.
+
+## What over-service looks like
+
+These are real, from a scored arm, and each was a defensible act:
+
+- Resolving the DOIs for two architectures the run had already decided not to
+  build, then rewiring its claims to cite them.
+- Building "an independent verifier for every stage number" — a second
+  implementation of the pipeline's own checking, written in the last hour.
+- A "full integrity sweep of all artifacts", twice.
+- Four calls locating and removing a parenthesised backtick from a notes file.
+- Forty-one appends to a claims ledger on a task whose score is a mean absolute
+  error.
+
+On the worst-affected task, 294 of 427 tool calls were of this kind and they all
+came after the predictions file had stopped changing. The run was not idle and it
+was not careless. It was doing the wrong job carefully.
+
+## The test before you write
+
+Before any call that touches a manifest, a claim, a source or a coverage entry,
+answer one question:
+
+> Is a gate currently refusing me, or blocking the stage I am trying to leave?
+
+- **Yes** → write the minimum that clears it. One entry, one claim, one path.
+- **No** → this call is optional, and the deliverable is older than it was.
+
+There is no third answer. "It would be more complete" and "the record should
+reflect what I found" are both descriptions of a document nobody scores.
+
+## Write it once, at gate size
+
+A useful default for each artifact class:
+
+| artifact | what clears the gate |
+|---|---|
+| sources / claims | the sources you actually used, each cited by one claim that needs it |
+| hypothesis manifest | one hypothesis per thing you will actually measure, each with its decision rule |
+| report plan | the figures you will really produce, named, each against a claim |
+| experiment manifest | the runs you really executed, with their numbers |
+| coverage | one entry per demand in the task statement, quoting it verbatim |
+
+In every row, the sizing word is *actually*. An artifact describing work you did
+not do is both more expensive and more likely to be refused, because the validator
+checks that the paths resolve and the numbers appear in a results file.
+
+## The one exception worth making
+
+Recording a **measured number** is never over-service, even when no gate is asking:
+the validation score of the model currently in the submission, the wall clock a
+fit took, the row count you checked. Those are inputs to the next decision about
+the deliverable. The distinction is not "artifact versus model" — it is whether
+the thing you are writing will change what you do next.

--- a/src/skills/the-row-count-comes-from-the-split-not-the-brief/SKILL.md
+++ b/src/skills/the-row-count-comes-from-the-split-not-the-brief/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: the-row-count-comes-from-the-split-not-the-brief
+description: Use at implementation and experimentation, and again before any stage that writes the predictions file, whenever the task statement states a submission shape. Covers why the stated shape is a claim rather than a measurement, the one line that settles it, and the invariant to attach to every write.
+applies_when: predictions will be scored
+stages: 03_study_design, 04_implementation, 05_experimentation
+---
+
+# The brief states the shape. The split decides it. They disagree
+
+An evaluator that reads your predictions with `read_csv(header=0)` and compares
+the row count against its own labels refuses a mismatch outright. There is no
+partial credit for 99% of the rows, and the refusal looks identical to having
+produced nothing.
+
+So the row count is not a detail to get right at the end. It is an invariant to
+attach to the file the first time you write it.
+
+## Both numbers are in front of you and one of them is wrong
+
+The task statement tells you the shape. It is derived from the benchmark's own
+metadata, and on at least one shipped task both are wrong: the description says
+the submission should be of shape `(1531, 1)`, the metadata says `shape: [1531]`,
+and the data the task hands you is a **1,267**-row split — which is what its
+evaluator counts. An agent that believes the description scores zero on a task it
+solved.
+
+The prepared split is not a hint you are not entitled to. It is one line inside
+the directory you were given:
+
+```python
+from datasets import load_from_disk
+n = len(load_from_disk('./data/test'))
+```
+
+**That number wins over every statement of it, including the task's own.** When
+they disagree, note the disagreement and use the split.
+
+## Make it an invariant, not a step
+
+A check you run once is a check you ran before the last three edits. Put it in a
+function the writer calls, so an invalid file cannot be left on disk:
+
+```python
+def write_submission(values, path='submission.csv', header='prediction'):
+    n = len(load_from_disk('./data/test'))
+    values = list(values)
+    assert len(values) == n, f'{len(values)} predictions, split has {n}'
+    ...  # write only after the assertion
+```
+
+Failing the write is the point. A run that raises here has a valid file from ten
+minutes ago; a run that writes anyway has nothing.
+
+## The four ways the count drifts
+
+Each of these has produced a refused submission, and none of them looks like a bug
+at the moment it happens:
+
+- **A filter that was meant for training.** Dropping malformed or out-of-range
+  rows is correct on the training split and fatal on the test split.
+- **A groupby or a merge that loses a key.** Any row whose key is absent from the
+  right-hand table disappears silently. Merge with an explicit `how='left'` and
+  assert the length afterwards.
+- **A batched inference loop that drops the last partial batch.** `drop_last=True`
+  is a training default and it silently truncates predictions.
+- **A dedupe.** The test split is allowed to contain duplicate inputs and it
+  expects one prediction for each occurrence, in order.
+
+Order matters as much as count and is not checked by the row assertion. If any
+step of your pipeline sorts, shuffles or groups, carry the original index through
+it and restore that order before writing.
+
+## Before the run ends
+
+Read the file back the way the evaluator does — not the way you wrote it — and
+check the count, the header, and that nothing is null or infinite:
+
+```python
+import pandas as pd
+df = pd.read_csv('submission.csv', header=0)
+preds = df.values.squeeze()
+assert preds.shape[0] == len(load_from_disk('./data/test'))
+assert pd.notna(df.values).all()
+```
+
+Round-tripping through the reader catches the class of failure that inspecting
+your in-memory array cannot: a quoting problem, a stray index column, a header
+you wrote twice.

--- a/src/skills/the-submission-is-the-only-artifact-that-scores/SKILL.md
+++ b/src/skills/the-submission-is-the-only-artifact-that-scores/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: the-submission-is-the-only-artifact-that-scores
+description: Use at every stage of a run whose deliverable is a predictions file scored by a fixed metric, and especially when a stage has been running for a while without changing that file. Covers how to tell work that moves the score from work that moves the record, the one measurement that separates them, and what to do when the deliverable has stopped moving.
+applies_when: predictions will be scored
+stages: 01_literature_survey, 02_hypothesis_generation, 03_study_design, 04_implementation, 05_experimentation, 06_analysis
+---
+
+# One file is scored. Everything else you produce is overhead you chose
+
+On this kind of task the grader opens exactly one artifact: the predictions file.
+No report, no figure, no manifest, no claim, no source entry, and no coverage
+table is read by anything that produces a number. That is unusual — most of what
+this pipeline is built for is graded on the write-up — and it inverts the normal
+allocation of effort.
+
+It is easy to agree with that in principle and violate it for four hours.
+
+## The measurement that catches you
+
+Over nineteen tasks of a scored arm, the median run spent **43% of its tool calls
+after the last time it changed the predictions file**, and the median gap between
+that last change and the end of the run was **93 minutes of a 240-minute budget**.
+On the worst task, 294 of 427 calls came after the deliverable stopped moving:
+resolving DOIs for two architectures the run had decided not to build, rewiring
+claims to sources, running "a full integrity sweep of all artifacts", and fixing a
+stray backtick in a document. Every one of those calls was competent work. None of
+it could change the score.
+
+The control arm — the same model, same brief, same clock, no pipeline — went two
+minutes between its last submission write and the end of its run, and beat this
+arm on 16 of 19 tasks.
+
+## The rule
+
+**Keep the age of the deliverable in front of you, and treat it as the run's
+health metric.**
+
+```bash
+# how long since the graded artifact last changed
+echo "$(( ($(date +%s) - $(stat -c %Y submission.csv)) / 60 )) min"
+```
+
+Run it at every stage boundary and after every long-running command. Read the
+number as follows:
+
+| age of the submission | what it means |
+|---|---|
+| under 20 min | you are working on the deliverable |
+| 20–45 min | you are between attempts; know what the next write will be |
+| over 45 min | you are working on the record; stop and say why that is right |
+| over 90 min with budget left | the run has changed jobs without deciding to |
+
+The last row is not a warning to note in a summary. It is an instruction to go
+back to the model.
+
+## What still gets produced
+
+This is not licence to skip the stage artifacts. The gates are real, a stage that
+does not produce them is refused, and a refused stage costs more budget than the
+artifact did. Produce them — at the size the gate accepts, once, and then leave
+them alone. The failure mode is not writing them; it is *returning* to them.
+
+Two symptoms that you have returned:
+
+- You are editing a file you already wrote to make it read better. Prose quality
+  is worth zero here and the gate does not measure it.
+- You are adding evidence for a claim about work you have already finished. The
+  claim was accepted when you made it.
+
+## When the deliverable genuinely cannot move
+
+Sometimes it cannot: a training run is in flight, or the next idea needs data you
+are still building. That is a legitimate reason for the age to climb, and the
+thing to do is make it explicit rather than let it drift:
+
+1. Write down what the next write to the file will be and what has to finish first.
+2. Put the long job in the background and keep the foreground on something that
+   changes the file — a second model, a blend, a better validation split.
+3. If nothing can change the file for the next hour, the honest move is to spend
+   that hour on the cheapest thing that might: another method, not another audit.
+
+A run that ends with three hours of impeccable bookkeeping and a submission it
+wrote in its first hour has produced one hour of research and called it four.

--- a/src/skills/your-survey-already-named-the-method-that-hits-the-number/SKILL.md
+++ b/src/skills/your-survey-already-named-the-method-that-hits-the-number/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: your-survey-already-named-the-method-that-hits-the-number
+description: Use at the end of the literature survey and at the start of study design and implementation, when a published number exists for the dataset and metric you were handed and your own measured number is well short of it. Covers extracting the method family rather than the citation, the ladder that says how far off you are, and the refusal to let the survey's finding stop at the write-up.
+applies_when: predictions will be scored
+stages: 01_literature_survey, 02_hypothesis_generation, 03_study_design, 04_implementation
+---
+
+# The survey found the answer. Check that the implementation heard it
+
+A literature survey on a task like this produces two things. One is a set of
+sources and claims the pipeline's gates will ask for. The other is a fact worth
+more than all of them: **which family of method produces the numbers the field
+reports on this exact dataset and metric.**
+
+The second is the reason to do the survey at all, and it is the one that reliably
+fails to arrive at the model.
+
+## How the failure looks from inside
+
+It does not look like ignorance. It looks like this, measured on a scored arm:
+
+- On a molecular-property task, the survey recorded the published ladder for the
+  target and metric: **0.021 to 0.029**. The run then built features by hand,
+  fitted a gradient-boosted tree, and shipped **0.11** — five times off a number
+  it had written down in its first stage.
+- On a second task from the same dataset, the run resolved the DOIs for two graph
+  network architectures, cited them correctly, and shipped a gradient-boosted
+  tree.
+- The control arm, which did no survey at all, wrote a graph network and beat both.
+
+Nothing in those runs was dishonest and nothing was refused by a gate. The survey
+did its job; the finding just never became an instruction.
+
+## Make the survey produce an instruction
+
+Before the survey stage closes, write down four things — not as prose, as a note
+you will re-read at implementation:
+
+1. **The ladder.** The three or four best published numbers for *this dataset and
+   this metric*, each with the method family that produced it. Not "the paper is
+   good"; the number.
+2. **The family**, at the level of a thing you could build: a graph network over
+   the molecular graph, a fine-tuned sentence encoder, a gradient-boosted tree on
+   engineered features, a retrieval-plus-rerank stack, a seasonal-naive baseline
+   with a learned residual.
+3. **The floor.** What the simplest defensible method gets. Often in the same
+   papers, in their own baseline table.
+4. **The gap you are accepting** if you build something other than (2), stated as
+   a ratio against (1).
+
+Point 4 is the one that does the work, because it forces the comparison to be
+made rather than avoided.
+
+## The rule at implementation
+
+**When your measured validation number is more than about twice the published
+ladder away from it, the method is the defect, not the tuning.**
+
+Tuning a family that is a factor of five off will not close a factor of five. The
+options at that point are to change family or to write down, with a cost estimate
+rather than an impression, why you cannot afford to — see
+`a-model-you-can-audit-is-not-a-model-that-scores` for how to price that decision.
+
+What is not an option is to keep tuning and let the survey's own ladder sit
+unmentioned in the notes. If your run holds a number the field beats by 5x and
+your remaining plan is a hyperparameter sweep, the plan is wrong.
+
+## When the ladder is out of reach
+
+It often is: the published number may come from a model pre-trained on more data
+than you were given, or from days of compute. That is a real finding and it should
+be stated with the ratio attached. State it in the terms the ladder is in — "the
+published 0.021 comes from a graph network trained for N GPU-hours; the budget
+here is four CPU-hours, and the best I can reach in that is X" — and then spend
+what is left going after X rather than polishing something well below it.

--- a/tests/test_every_skill_can_be_loaded.py
+++ b/tests/test_every_skill_can_be_loaded.py
@@ -35,10 +35,32 @@ from src.run_skills import read_skill_pack, select_run_skills
 REPO = Path(__file__).resolve().parent.parent
 BENCH = Path("/home/robtang_google_com/RCB/tasks")
 
+_AIRS = (
+    "Written for AIRS-Bench, whose deliverable is a predictions file scored by a fixed "
+    "metric -- a shape none of the forty ResearchClawBench briefs has, since every one of "
+    "those is graded on a report. Reachability was checked on the corpus it was written "
+    "from rather than asserted: `tools/skill_selectivity.py --briefs <airs>/tasks/rad` "
+    "selects 19 of the 20 AIRS briefs and 0 of the 40 RCB ones. The twentieth, "
+    "CodeRetrievalCodeXGlueMRR, has a task paragraph of one sentence that never says what "
+    "the deliverable is, so no predicate over task shape can reach it; all twenty are "
+    "pinned by identifier, which is what reaches that one. The AIRS briefs are not vendored "
+    "here -- they are CC-BY-NC benchmark content and this repository is proprietary -- so "
+    "this corpus cannot check them and says so instead of loosening the predicate until "
+    "something in the wrong corpus matches."
+)
+
 #: Skills that no benchmark brief selects, and the reason that is correct. A skill written
 #: for a research shape the forty tasks do not contain belongs here rather than in a regex
 #: loosened until something matches.
-UNREACHABLE_ON_PURPOSE: dict[str, str] = {}
+UNREACHABLE_ON_PURPOSE: dict[str, str] = {
+    "a-model-you-can-audit-is-not-a-model-that-scores": _AIRS,
+    "a-scoreable-file-in-the-first-hour": _AIRS,
+    "assume-this-stage-is-the-last-one-you-get": _AIRS,
+    "the-audit-trail-is-not-the-deliverable-here": _AIRS,
+    "the-row-count-comes-from-the-split-not-the-brief": _AIRS,
+    "the-submission-is-the-only-artifact-that-scores": _AIRS,
+    "your-survey-already-named-the-method-that-hits-the-number": _AIRS,
+}
 
 
 def briefs() -> dict[str, str]:


### PR DESCRIPTION
On AIRS-Bench the bare CLI beats AutoR on 16 of 19 tasks. This is the diagnosis of *how*, and seven skills written from it.

## Four measurements over the nineteen AutoR run trees

**1. AutoR does more work, not less.** 313 tool calls median against the control's 86; 63 touching `submission.csv` against 8. Not idleness, not timidity.

**2. 43% of that work lands after the deliverable stops changing** — median, seven tasks over half, worst case **294 of 427 calls**. Median **93 minutes of a 240-minute budget** between the last write to `submission.csv` and the end of the run; the control's median gap was **2 minutes**. The calls in that window: resolving DOIs for two architectures the run had decided not to build, rewiring claims to sources, building "an independent verifier for every stage number", "a full integrity sweep of all artifacts", four calls removing a parenthesised backtick from a notes file.

**3. Every run hit the cap and none finished the walk.** Six of nineteen never left Stage 01, four of those at 13–22 attempts. The scored file is usually whatever an early stage produced in passing.

**4. The survey found the answer and the implementation did not hear it.** On `Cv…Qm9`, Stage 01 recorded the published ladder for that target and metric — **0.021 to 0.029** — and the run shipped **0.11**. On `R2Abs…Qm9` it resolved the DOIs of two graph networks, cited them correctly, and shipped a gradient-boosted tree, beside `audit_train_test_alignment.py` and `emit_demand_coverage.py`. The control, which did no survey at all, wrote `schnet.py` and won all three QM9 tasks by 0.11–0.20.

The failure is **allocation and closure**, not capability: the gates are the loudest signal in the run, so effort flows to them, and findings arrive as documents rather than as instructions.

## The seven

| skill | measurement behind it | stages |
|:---|:---|:---|
| `a-scoreable-file-in-the-first-hour` | 19/19 hit the cap; one shipped no valid file | 01–04 |
| `the-row-count-comes-from-the-split-not-the-brief` | 1,137 rows where the split has 1,147 | 03–05 |
| `assume-this-stage-is-the-last-one-you-get` | six never left Stage 01; none finished the walk | 01–04 |
| `the-submission-is-the-only-artifact-that-scores` | 43% of calls, 93 min, after the file froze | 01–06 |
| `your-survey-already-named-the-method-that-hits-the-number` | ladder recorded 0.021–0.029, shipped 0.11 | 01–04 |
| `a-model-you-can-audit-is-not-a-model-that-scores` | boosted tree against the control's graph network | 03–05 |
| `the-audit-trail-is-not-the-deliverable-here` | 294 of 427 calls on the record | 01–06 |

## Routing is the other half

`applies_when: predictions will be scored` is a claim about task shape, checked rather than asserted: `tools/skill_selectivity.py` selects **19 of 20 AIRS briefs and 0 of the 40 ResearchClawBench ones**. The twentieth has a task paragraph of one sentence that never says what the deliverable is, so no shape predicate can reach it — its pin does.

**All twenty task ids are pinned**, because the arm data says installation is not routing: a skill a prompt names imperatively fired in **31 of 40** runs; a merely installed one fired in almost none, with the pack drawing 78 launches in 789 hours. And they are **weighted at stages 01–04** because a skill named only at Stage 05 is unreachable here — stages 05/06/07 managed five launches across forty runs, and on this benchmark most runs never reach 05.

They are added to `UNREACHABLE_ON_PURPOSE` in `test_every_skill_can_be_loaded` rather than made to match something. That gate's corpus is the forty RCB briefs, every one graded on a report; loosening a predicate until it matches the wrong corpus is the exact failure the gate exists to catch. The exemption names the command and its numbers.

## What this is not

**None of it is measured.** Seven skills are a hypothesis about a measured failure, not an improvement. The honest test is a re-run of the same nineteen tasks under the same cap with the pins on, against these numbers as the control. It has not been run, and the docs say so in those words.

Full suite green: 4048 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)