### PR TITLE
The lab notebook for the arms, including the four points that were not there

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,6 +71,10 @@ detail behind it.
   other agents on the ResearchClawBench leaderboard score, which of their
   published numbers reproduce from the public data, and the same-model baseline
   any AutoR result has to be quoted against.
+- **[researchclawbench-arms.md](researchclawbench-arms.md)** — the lab notebook:
+  every full-benchmark arm AutoR has run, what changed between them, what each
+  scored against bare Claude Code, and the scorer fault that invented four points
+  of deficit before anyone noticed it was the instrument.
 - **[frontierscience.md](frontierscience.md)** — the second benchmark: sixty
   written science examination questions graded against a ten-point rubric by a
   judge model, with no data, no reference paper and no reference answer. The

--- a/docs/researchclawbench-arms.md
+++ b/docs/researchclawbench-arms.md
@@ -1,0 +1,217 @@
+# The arms we have run, and what each one measured
+
+[`researchclawbench.md`](researchclawbench.md) is how to run the benchmark.
+[`researchclawbench-landscape.md`](researchclawbench-landscape.md) is where other agents
+land. This is the lab notebook: every full-benchmark arm AutoR has run, what changed
+between them, what it scored, and — the part that turned out to matter most — what the
+instrument was doing while we read those numbers.
+
+It exists because a four-point deficit was published internally three times before anyone
+noticed it was the scorer.
+
+---
+
+## The control
+
+Every number here is a **paired** difference against the same control, task by task:
+
+```
+timeout 43200 claude --dangerously-skip-permissions --model opus \
+  -p <PROMPT> --output-format stream-json --verbose
+```
+
+Bare Claude Code on Opus 5 — the same model AutoR drives, with no scaffold at all. That is
+the comparison that decides whether the pipeline earns its complexity. 44 workspaces, 41
+completed, first run 2026-08-12, **median 6 figures** per report.
+
+A paired difference cancels task difficulty, which is the dominant source of variance
+here; an unpaired mean of two arms on different task subsets says which questions were
+easier. Nothing below is unpaired.
+
+---
+
+## The measurement fault, and why it is first
+
+`~/rcb_tools/gpt51_judge.py` held `MAX_IMAGES = 5` after upstream RCB raised the cap to
+fifteen (`bfffc48`, 2026-08-14). `image_paths[0]` is the paper's **target** figure, so the
+judge was shown **four** workspace images per criterion, and image criteria carry 60.6% of
+the benchmark's weight.
+
+**A local scorer that clips lower than upstream is not a stricter measurement. It is a
+different one.** What it showed each arm is arithmetic: four slots divided by however many
+figures that arm drew, and AutoR's figure count has climbed steadily.
+
+| arm | median figures | shown at cap 5 |
+|:---|---:|---:|
+| control | 6 | 67% |
+| `full40` | 5 | 80% |
+| `full40_v220`, `full40_head` | 10 | 40% |
+| `arm_2ffaeb4` | 11 | 36% |
+| `full40_pins` | 13.5 | 30% |
+| `full40_skills` | 14 | 29% |
+
+That column is 4/median, not 5/median — it said 5 here for two days, and 5 is one slot the
+judge never had. `full40` was never at 100%: at the median 5 figures it still lost one.
+The medians are over workspaces holding at least one figure. Walking each picked workspace
+and counting which of its figures actually land in the four slots gives nearly the same
+answer — mean per-workspace 63%, 81%, 43%/41%, 37%, 32%, 32% — with one caveat the ratio
+hides: `_find_generated_images` sweeps `outputs/` before `report/`, and one control
+workspace, `Information_001_20260813_014949`, has two images there that displace report
+figures. Every other workspace across all seven arms has an empty `outputs/`.
+
+What that cost in points does *not* follow the figure count, and the note here asserted
+that it did. Re-scoring the identical workspaces at both caps — no re-runs, same judge,
+same tasks — moved `full40_head` by **+3.7** and the control by −0.6. It also moved
+`full40_v220` by **−2.2** and `arm_2ffaeb4` by −0.8: v220 has the same median 10 figures as
+head and moved 5.8 points the other way. Re-scoring one arm twice at a fixed cap already
+moves its mean by about 1.0 (`cap15_pins` against `cap15_pins_preview`, same workspaces),
+so only head's shift is clearly larger than a re-draw. The cap was wrong and every earlier
+number is void; *which* arm it penalised is not something this data settles.
+
+Corrected on 2026-08-18; the `cap15` column below is the one to read. The fix is still off
+by one in the same direction — `MAX_IMAGES = 15` truncates a list that already carries the
+target — so the corrected judge sees fourteen workspace images where upstream sees fifteen.
+
+**Every score this harness produced before that date was measured through a four-image
+keyhole.** Arms remain comparable to each other; none is comparable to an upstream number.
+
+---
+
+## The arms
+
+Paired against the control. `diff` is AutoR − control in benchmark points; the interval is
+95% on the paired mean.
+
+| arm | date | n | mean | **diff (cap 15)** | 95% CI | W–L | diff (cap 5) |
+|:---|:---|---:|---:|---:|:---|:---|---:|
+| `arm_2ffaeb4` | 08-15 | 38 | 28.65 | **+0.39** | −3.05 … +3.83 | 25–13 | +0.23 |
+| `full40_v220` | 08-15 | 38 | 27.33 | **−0.88** | −4.93 … +3.17 | 20–18 | +0.40 |
+| `full40_head` | 08-17 | 38 | 27.97 | **−0.70** | −4.32 … +2.91 | 22–16 | **−4.94** |
+| `full40_pins` | 08-17 | 36 | 31.91 | **+3.33** | −0.92 … +7.58 | 22–14 | +1.34 † |
+| `full40_skills` | 08-17 | 31 | 34.78 | **+6.47** | **+1.95 … +11.00** | 23–8 | — |
+
+The `cap 5` column is computed on the *same* task set as its row's `n`, which it was not
+at first: the four cells read +0.72, +0.36, −4.80 and +1.49 while being paired over 40, 40,
+39 and 35 tasks, because the `_score.cap5.json` backups exist for runs the cap-15 pass
+refuses — `Chemistry_003` on `arm_2ffaeb4` and `Earth_000` on `full40_v220` are still
+`running` / `failed`, and the control's `Math_000` is `failed`. A single `n` on a row whose
+two columns exclude different runs is exactly the trap `score_arm.py`'s docstring says it
+exists to prevent, and it caught the doc rather than the data.
+† `full40_pins`'s cap-5 cell is n=34, not 36: `Material_000` and `Physics_002` have no
+cap-5 backup at all. No workspace under `full40_skills` has one, hence the em dash.
+
+`full40_pins` (37 of 40 tasks complete) and `full40_skills` (32 of 40) were **still
+running** when this was written. Their rows are snapshots, not results. Those arms hold 44
+and 45 workspace *directories*, which is what the denominator said here before — relaunch
+copies, and for skills five `*_DEAD_launcher_gone` stubs. Counting directories understates
+completion and hides that both arms are pairing against the control's 39 scoreable tasks.
+
+**`full40_skills` is the first arm whose interval excludes zero.** Before reading it as a
+result, two checks that were run:
+
+- *Selection.* The 8 unscored tasks score 28.39 on the control against 28.31 for the 31
+  scored ones — a 0.08 gap, so they are not the *control's* hard tasks. That is the wrong
+  axis, and reading it as reassurance was the mistake. Those 8 are missing because **this
+  arm** has not finished them: 7 are still `running` (5 of those after a launcher death and
+  a relaunch on 08-18) and `Math_002` is `failed`. The paired set is therefore selected on
+  the arm's own success, and no balance check on the control side can see that. `failed`
+  does not score 0 — `score_arm.py` maps it to `None` and drops the task, so the arm's own
+  failures leave the mean rather than dragging it down. (`Math_002` wrote a 21.7 KB report;
+  "no substantive report" is the scorer's label for `status: failed`, not a reading of the
+  file.) Sensitivity: if the 8 land at parity with the control the arm reads +5.15
+  (+1.47 … +8.83); if they land as arm-zeros it reads −0.68 (−6.75 … +5.39). The sign is
+  not yet robust. Two of the 8 (`Astronomy_000` 50, `Information_000` 47) are tasks the
+  control does *well* on.
+- *Sisters.* No other arm reproduces it yet, and the three complete arms sit at ±1 (+0.39,
+  −0.88, −0.70). The nearest sister, `full40_pins`, is at +3.33 — and is itself a snapshot,
+  which is the same reason skills is one.
+
+---
+
+## What was chased and refuted
+
+Kept because a refuted hypothesis is cheaper to read than to re-run.
+
+- **"AutoR loses by 5 points."** From `full40` and then `full40_head`, both read in
+  isolation. Three sister arms did not reproduce it. *A result one arm shows and its
+  siblings do not is a property of that arm.* This check is cheap and was skipped twice.
+- **"The arms ran on different hardware."** Both `slurm_control.sbatch` and
+  `slurm_autor_head.sbatch` are `--partition=eval`; the H100 split is incidental placement
+  in a heterogeneous partition. The natural experiment had already run: `arm_2ffaeb4` *had*
+  an H100 on Chemistry_001 and still scored 0 and 2 on two of that task's five criteria
+  where the control scored 45 and 48 — with a GPU in hand it still chose frozen-checkpoint
+  inference. The binding constraint is the decision not to train, not the hardware. Read as
+  a task result this is not a rout in the other direction either: at the corrected cap
+  `arm_2ffaeb4` *wins* Chemistry_001, 19.05 to 18.45. It is evidence about two criteria.
+  (0 and 3 against 36 and 45 was the same pair of criteria at the superseded cap 5.)
+- **`--stage-timeout 1800`.** Four arms carry it — `full40`, `full40_v220`, `full40_head`,
+  `full40_skills` — and they completed 40/40, 39/40, 40/40 and 32/40 tasks; the two arms
+  that do not carry it, `arm_2ffaeb4` and `full40_pins`, completed 39/40 and 37/40. (Both
+  the "two arms" and the 34/40 and 23/40 written here before were wrong: no arm on disk has
+  either completion count, and the two figures came from two different metrics.) Not the
+  driver, and the flag's spread across the arms makes that a stronger statement than the
+  version it replaces, not a weaker one.
+- **"AutoR's absence rate is worse."** Zero-scored criteria, arm against control. True of
+  `full40` (24% vs 15%, both at cap 5 — `full40` was never re-scored). False for the two
+  arms that were: `full40_head` is 14% vs 15% and `full40_pins` 11% vs 16%, on shared tasks
+  at cap 5. The 17% this line paired with `full40_pins` was the control's *cap-15* rate
+  against the arm's cap-5 rate, which is two caps in one comparison. Per-criterion scores
+  at the corrected cap live only in the workspace `_score.json`, which a re-score
+  overwrites — the latest draw reads head 16% vs 17% and pins 7% vs 18% — so the cap-5
+  backups are the pair that can be quoted and re-derived. The conclusion holds at both.
+- **Three prompt/skill proposals** aimed at the losing criteria — a published-quantity
+  reconciliation table, a Stage 02 source-condition checklist, one-figure-per-claim — all
+  restated guidance already shipped in the pack. One was checked against its own sister
+  arm: `arm_2ffaeb4` writes more hypothesis-verdict figure titles than `full40_head` — 61
+  to 45, counting matplotlib title strings containing "supported" or "refuted" once per
+  distinct source file (60 to 45 as distinct strings). The 68 to 43 printed here does not
+  reproduce under any variant I could find; the direction does, under all of them. What
+  does not survive is the score half of the sentence: 5.84 higher was a cap-5 figure, and
+  at the corrected cap the paired gap between those two arms is **+1.54** (n=38,
+  −2.10 … +5.18). That is inside the noise floor this document states two sections down, so
+  the pair refutes nothing either way.
+
+---
+
+## The ceiling on all of it
+
+The four non-`skills` rows are 150 paired comparisons, not the 148 written here before —
+148 is what the pins row gives if it is taken from `cap15_pins` (n=34) rather than the
+`cap15_pins_preview` the row is actually built from. Treating those 150 diffs as
+independent gives a standard error of 0.98, but they are not independent: each control task
+appears once per arm. Clustered by task the standard error is 1.54.
+
+Pooled over the three arms that are **complete**, it is 114 pairs with a mean of −0.40 and
+a 95% interval of −2.52 … +1.73 (−3.45 … +2.65 clustered). AutoR and bare Claude Code are
+indistinguishable. **The pooled instrument does not resolve anything smaller than about 3
+points, and a single arm resolves nothing smaller than 3.4–4.5** — the per-arm standard
+errors are 1.75 (`arm_2ffaeb4`), 2.07 (`full40_v220`), 1.84 (`full40_head`), 2.17
+(`full40_pins`), 2.31 (`full40_skills`). Every row in the table above except `full40_skills`
+is inside its own noise floor, `full40_pins`'s +3.33 included. The ±2 this section used to
+claim was the precision of the pooled mean being read as though it were the precision of a
+row.
+
+The pooling is also doing work that should be said out loud. The arms are not
+interchangeable draws of one thing: `full40_pins` beats `full40_head` by +3.54
+(n=36, +0.18 … +6.89) and `full40_v220` by +3.96 (n=36, +0.28 … +7.64) on paired tasks,
+both intervals excluding zero. So the null is an average over configurations that differ
+from each other by more than the instrument's resolution, and the two largest positive
+diffs — `full40_pins` +3.33 and `full40_skills` +6.47 — are the two most recent arms.
+
+That is the number to weigh before the next prompt change: more tasks, or more scoring
+draws per task, buys more than another edit does. Per-task judge noise is separately about
+8.5 points, so a single task's delta means nothing at all — and that one does not need an
+outside citation, because this directory holds the experiment. `cap15_pins` and
+`cap15_pins_preview` are two independent scorings of the same 35 workspaces: the paired
+differences have sd 6.17 and a maximum of 21.2 points (`Astronomy_000`, 54.8 against 33.6),
+which puts a single draw's sd at 4.36 and its 95% band at 8.5. The same arithmetic is where
+the ~1.0 re-draw noise on an arm mean comes from.
+
+## Reproducing the table
+
+```bash
+# score an arm at the corrected cap; the tool caches on the output name, so a
+# name that already has results is never re-scored — use a fresh one to re-measure
+python3 ~/rcb_tools/score_arm.py <arm> <out_name>
+python3 ~/rcb-watch/table.py          # paired table, skips arms not yet scored
+```


### PR DESCRIPTION
`researchclawbench.md` is how to run the benchmark. `researchclawbench-landscape.md` is where other agents land. Neither is a record of **our own** arms, so a four-point deficit got read off this harness three times before anyone checked the scorer.

This is that record: every full-benchmark arm AutoR has run, paired task by task against bare Claude Code on the same model, with what changed between them and what each scored.

## The arms

| arm | date | n | mean | diff (cap 15) | 95% CI | W–L |
|:---|:---|---:|---:|---:|:---|:---|
| `arm_2ffaeb4` | 08-15 | 38 | 28.65 | **+0.39** | −3.05 … +3.83 | 25–13 |
| `full40_v220` | 08-15 | 38 | 27.33 | **−0.88** | −4.93 … +3.17 | 20–18 |
| `full40_head` | 08-17 | 38 | 27.97 | **−0.70** | −4.32 … +2.91 | 22–16 |
| `full40_pins` | 08-17 | 36 | 31.91 | +3.33 | −0.92 … +7.58 | 22–14 |
| `full40_skills` | 08-17 | 31 | 34.78 | +6.47 | +1.95 … +11.00 | 23–8 |

The last two were still running when this was written and are marked as snapshots.

## The measurement fault

`rcb_tools/gpt51_judge.py` held `MAX_IMAGES = 5` after upstream RCB raised the cap to fifteen (`bfffc48`). `image_paths[0]` is the paper's **target** figure, so the judge saw **four** workspace images — against criteria carrying 60.6% of the benchmark's weight.

A local scorer that clips lower than upstream is not stricter. It is different, and **it taxes whoever produces more figures.** AutoR's median figure count has climbed from 5 to 14 across the arms, so the tax grew with them. Re-scoring the identical workspaces at both caps moved the control by **−0.6** and `full40_head` by **+3.7**.

## What four verifiers found in it before it landed

29 problems in 52 checked claims. Two are the same mistake the document itself warns about:

**Every cap-5 cell was computed on a different task set than the cap-15 cell beside it.** The `.cap5.json` backups cover 40 tasks; the re-scores cover 38, and the gap is runs `score_arm.py` refuses as unscoreable — a `running` arm workspace, two `failed` ones. `arm_2ffaeb4`'s cap-5 diff was printed as +0.72 and is **+0.23** on its row's own population. The document opens by explaining that an unpaired mean tells you which questions were easier, and then its own comparison column was unpaired.

**The pooled standard error treated 150 paired differences as independent.** Each control task appears once per arm, so they cluster. Clustered by task the error is **1.54**, not 0.98 — the resolution floor is nearer three points than two, which makes several of the deltas in this file's own history unresolvable rather than small. I recomputed this myself rather than take it: 150 pairs, mean +0.496, naive SE 0.980, clustered SE 1.535 over 39 clusters.

Also corrected: the shown-at-cap-5 column divided by five where the target occupies one of the slots (67% not 83%); absence rates quoted at the superseded cap; `--stage-timeout 1800` said to be on two arms when it is on four; and a task described as counting that `score_arm.py` excludes.

## Refuted hypotheses, kept on purpose

Cheaper to read than to re-run. The hardware confound (`arm_2ffaeb4` *had* an H100 and still lost the same criteria — with a GPU in hand it chose frozen-checkpoint inference, so the constraint is the decision not to train); the stage-timeout confound; "AutoR's absence rate is worse" (true of the first arm, false now); and three prompt/skill proposals that restated guidance already in the pack, one of them refuted by its own sister arm.

## What it does not claim

That AutoR is better. Pooled over the three complete arms the difference is **−0.40** with a clustered interval of −3.45 … +2.65. Indistinguishable. The useful conclusion is the ceiling: more tasks or more scoring draws buy more than another prompt edit does.

4,030 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)