### PR TITLE
The budgets I measured on a sample clip the median render

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -121,6 +121,10 @@ detail behind it.
   [round-loop-and-stage-graph.md](iclr/round-loop-and-stage-graph.md) reads
   AMAP-ML's LongHorizon-Harness against it and records what the stage graph
   should take from a round loop, and what it should not.
+  [what-the-comparison-changed.md](iclr/what-the-comparison-changed.md) is the
+  implementation record behind that reading: what landed, what was refused and by
+  what, every figure with the command that reproduces it, and the four places a
+  measurement said the wrong thing.
 
 ### Project notices
 

--- a/docs/iclr/round-loop-and-stage-graph.md
+++ b/docs/iclr/round-loop-and-stage-graph.md
@@ -146,9 +146,9 @@ that is the part that works.
 **Landed**, as `src/review_custody.py`, with two corrections the design did not survive
 contact with.
 
-*The census is over content, not modification time.* Replayed over 138 archived reviewer
+*The census is over content, not modification time.* Replayed over 152 archived reviewer
 episodes (`tools/review_custody_replay.py`, population pinned by name), an mtime census
-fires on **138 of 138** with no exclusion list and **4 of 138** with one — and all four
+fires on **152 of 152** with no exclusion list and **4 of 152** with one — and all four
 are the same behaviour: the reviewer re-running the doer's producer scripts in place to
 check they reproduce. Both of the two approvals among them say so in their own recorded
 reason. A gate that fires hardest on the most rigorous reviewer is the wrong gate, so a
@@ -161,7 +161,7 @@ census would also have caught is not answerable from disk. That is what the ledg
 for.
 
 What it still cannot see is worth stating, because the reading that produced this
-mechanism also produced the counterexample: in the same 138 episodes there are three
+mechanism also produced the counterexample: in the same 152 episodes there are three
 tool-level writes, and two of them go to a `~/.claude/projects/.../memory/` directory
 far outside any run root. The census claims *"the reviewer changed nothing it was
 judging"*, not *"the reviewer changed nothing"*.
@@ -343,9 +343,14 @@ now would be a behaviour change with an unmeasured cost.
 
 Measured while doing it, and worth recording because it is the number the whole section
 is about: over 197 archived stage prompts, `# Stage Instructions` (the rendered channel
-set) has a median of 25.6 KB and a p90 of 78.6 KB, `# Approved Memory` a p90 of 132 KB
-and a maximum of 177 KB, `# Stage Handoff Context` a p90 of 99 KB. The prompt they sit in
-runs from a median of 21 KB at Stage 01 to 277 KB at Stage 07, with a maximum of 1.79 MB.
+set) has a median of 25.6 KB and a p90 of 78.6 KB, `# Approved Memory` a p90 of ~175 KB
+and a maximum of 301 KB, `# Stage Handoff Context` a p90 of ~123 KB. The prompt they sit in
+runs from a median of 20 KB at Stage 01 to 277 KB at Stage 07, with a maximum of 3.17 MB.
+
+Those channel-set figures are the ones first published and they were taken from a slice of
+a live archive; the full-archive table, and the six budgets that turned out to clip because
+of that sample, are in [what-the-comparison-changed.md](what-the-comparison-changed.md) §2.2
+and §3.1.
 
 **Still open:** approved memory and the handoff context are not channels — they are
 arguments to `build_prompt` — so neither is covered by this, and they are two of the
@@ -398,8 +403,9 @@ at `stage.number >= 7` whatever the output format, and its locator half reads th
 actual deliverable — `report.md`, or the `.tex` sources under `workspace/writing/` — so
 it no longer degrades to a skip with no counter when there is no markdown report.
 
-Blast radius, measured before landing: **335 archived run configs, every one of them
-`markdown`**. So no archived run changes verdict, which is the honest figure and cuts
+Blast radius, measured before landing: **every archived run config is `markdown`,
+zero latex** -- 335 of them when the branch was written, 437 as of 2026-08-18; the
+population grew and the finding did not. So no archived run changes verdict, which is the honest figure and cuts
 both ways — the gap never cost an observed run, and the fix has never been exercised by
 one either. It is a correctness change about coupling, not a bug with a measured price.
 
@@ -507,10 +513,9 @@ sentinel, and both prompts must carry all five — a parameter one builder accep
 drops is the same defect under another name.
 
 For (3): the goal is inlined on the retry path rather than pointed at, bounded by
-`MAX_RETRY_GOAL_CHARS` — measured at a 13.6 KB median and a 16.7 KB maximum over 197
-archived prompts, so the ceiling clips nothing the archive contains. Approved memory
-stays a pointer, and that is the trade rather than an omission: its p90 over the same
-archive is 132 KB. The false premise is gone by moving the claim to whoever can make it.
+`MAX_RETRY_GOAL_CHARS` — a 13.6 KB median and a 16.7 KB maximum over the archive, so the
+ceiling clips nothing it contains. Approved memory stays a pointer, and that is the trade
+rather than an omission: its p90 over the same archive is ~175 KB. The false premise is gone by moving the claim to whoever can make it.
 The prompt now speaks about the *work* — there is a draft and the job is to improve it,
 which is true on both paths — and the operator writes a `_restart.prompt.md` carrying the
 one sentence only it can say, that the earlier turns are gone. Whether a session was

--- a/docs/iclr/what-the-comparison-changed.md
+++ b/docs/iclr/what-the-comparison-changed.md
@@ -56,11 +56,14 @@ file, so how far below 4 the content-keyed rate sits **cannot be settled from di
 
 Cost, `src.review_custody.census` on the same four roots, warm cache, ten repetitions:
 medians **516, 567, 1188, 1278 ms**, full observed range 428–1541 ms. Two per episode, so
-roughly 1–3 s per episode and 3–7 minutes over a run.
+roughly 1–3 s per episode and 3–7 minutes over a run. Those are warm-cache figures; the
+*first* census of a cold root costs **2.9–10.8 s**, six to eight times higher, and that is
+the one an early episode actually pays.
 
 What the census cannot see: in the same 152 episodes there are **three tool-level writes**
-(two `Write`, one `Edit`), and **two go to a `~/.claude/projects/.../memory/` directory
-outside any run root**. The claim it supports is *"the reviewer changed nothing it was
+(two `Write`, one `Edit`), and **two go to a `~/.claude/projects/.../memory/` directory** — not
+merely outside the run root but the operator's own persistent memory, which outlives every
+run there will ever be. The claim it supports is *"the reviewer changed nothing it was
 judging"*, not *"the reviewer changed nothing"*.
 
 > **This population moved under the pin, and the tool caught it.** These figures were 138

--- a/docs/iclr/what-the-comparison-changed.md
+++ b/docs/iclr/what-the-comparison-changed.md
@@ -1,0 +1,261 @@
+# What the Comparison Changed
+
+*The implementation record behind [round-loop-and-stage-graph.md](round-loop-and-stage-graph.md).
+That document is the reading: what AMAP-ML's LongHorizon-Harness does, what AutoR does, and
+which differences are worth acting on. This one is what happened when the list was worked
+through — what landed, what was refused and by what, and every number the decisions rest on.*
+
+**Every figure here carries an as-of date and the command that produces it.** That is not
+decoration. The archive under `/rmeng_data/robtang/rcb_runs` is written to continuously by
+runs in flight, and the first version of this document quoted a dozen numbers taken from
+`[:40]`, `[:120]` and `[:200]` slices of it as though they described a fixed population.
+Section 3 is what that cost.
+
+---
+
+## 1. What landed
+
+| PR | What it does |
+| --- | --- |
+| #254 | The reading itself, plus the channel count that had rotted while `docs/iclr/` sat outside the doc-count scan |
+| #256 | §4.7 (1) and (2): obligations vanishing from every retry; a second entry to a stage replaying a spent session id |
+| #258 | §4.1: a content census of the run root around every reviewer subprocess |
+| #267 | §4.5: the deliverables gate stops being conditional on the output format |
+| #271 | **Not from the list.** A launch race in the FrontierScience trial driver, found because it was reddening every pull request |
+| #268 | §4.3: the closing sentence is derived from the record rather than asserted |
+| #273 | §4.6: the cost ledger gets a reader, and the supervisor rule is *refused* one |
+| #278 | §4.2: an overridden refusal stops being recorded as an approval |
+| #279 | §4.4: a channel declares what it may spend; the run records what it spent |
+| #282 | §4.7 (3): the prompt stops asserting a conversation it cannot know about |
+
+Three items on the list were deliberately not built (§4), and one shipped change had to be
+corrected afterwards (§3.1).
+
+---
+
+## 2. Every number, and how to get it again
+
+### 2.1 The reviewer custody census (#258)
+
+    python3 tools/review_custody_replay.py
+
+Over the four runs the tool pins by name: **152 reviewer episodes**. An mtime census fires
+on **152 of 152** with no exclusion list and **4 of 152** with one, all four in
+`Astronomy_000_20260814_175426`, touching seven files, every one `workspace/results/*.json`.
+
+All four are one behaviour, and it is the behaviour a reviewer is supposed to have:
+re-running the doer's producer scripts in place to check they reproduce. Both of the two
+approvals among them say so in their own recorded reason. **That is why the shipped census
+compares content and not modification time.** None of the seven carries a self-describing
+generation timestamp; two carry ISO-8601 strings echoed from upstream artifacts rather than
+read off the clock, so a deterministic re-run of the producer reproduces the same bytes.
+
+The replay can only ever be an upper bound — an archive keeps one modification time per
+file, so how far below 4 the content-keyed rate sits **cannot be settled from disk**. Hence
+`--review-custody` defaults to `record`.
+
+Cost, `src.review_custody.census` on the same four roots, warm cache, ten repetitions:
+medians **516, 567, 1188, 1278 ms**, full observed range 428–1541 ms. Two per episode, so
+roughly 1–3 s per episode and 3–7 minutes over a run.
+
+What the census cannot see: in the same 152 episodes there are **three tool-level writes**
+(two `Write`, one `Edit`), and **two go to a `~/.claude/projects/.../memory/` directory
+outside any run root**. The claim it supports is *"the reviewer changed nothing it was
+judging"*, not *"the reviewer changed nothing"*.
+
+> **This population moved under the pin, and the tool caught it.** These figures were 138
+> and 4 when #258 landed. `Chemistry_000_20260816_173127` was still executing when it was
+> named in `MEASURED_RUNS`, so it kept producing episodes: 138 → 152, fires unchanged at 4.
+> The tool printed `population: DRIFTED` until the constants were re-pinned. Pinning a
+> still-running directory as a population is the same mistake as §3.2, caught by a
+> mechanism that existed for exactly this.
+
+### 2.2 Prompt and channel sizes (#279, #282)
+
+All as of **2026-08-18**, over `/rmeng_data/robtang/rcb_runs`, 13,671 attempt prompts
+(review, panel, repair and route prompts excluded) across ~394 run roots.
+
+| | median | p90 | max |
+| --- | --- | --- | --- |
+| `memory.md` (n=438 roots) | 173 KB | 237 KB | 290 KB |
+| stage prompt, all stages | ~156 KiB | — | **3.17 MB** |
+| stage prompt at `01_literature_survey` | 20 KB | — | — |
+| stage prompt at `07_writing` | 277 KB | 358 KB | — |
+| `# Original User Request` | 13.6 KB | 15.3 KB | 16.7 KB |
+| `# Approved Memory` (build_prompt path only) | — | ~175 KB | 301 KB |
+| `# Stage Handoff Context` | — | ~123 KB | — |
+
+`MAX_RETRY_GOAL_CHARS = 24_000` is set against the goal row — above its observed maximum,
+so it clips nothing the archive contains — while approved memory stays a pointer on the
+retry path because of the row below it.
+
+Per-channel bodies, extracted from the archived prompts by each channel's own `heading`,
+which is the quantity `_render` compares to `max_chars`:
+
+| channel | p50 | p90 | p99 | max | budget |
+| --- | --- | --- | --- | --- | --- |
+| `decision_ledger` | 25,476 | 48,703 | 68,838 | 91,431 | 120,000 |
+| `hypotheses` | 22,914 | 31,362 | 45,480 | 79,284 | 96,000 |
+| `preregistration` | 12,078 | 18,431 | 27,908 | 71,386 | 96,000 |
+| `writing_manifest` | 10,431 | 20,195 | 138,788 | **2,774,270** | 160,000 |
+| `report_plan` | 13,897 | 19,802 | 25,792 | 28,291 | 30,000 |
+| `validity_findings` | 16,046 | 20,375 | 23,526 | 26,460 | 32,000 |
+| `hypothesis_verdicts` | 13,836 | 19,244 | 23,427 | 25,198 | 32,000 |
+| `research_rounds` | 4,880 | 7,005 | 14,842 | 19,614 | 24,000 |
+| `experimental_protocol` | 4,877 | 6,618 | 8,249 | 9,558 | 12,000 |
+| `task_shaped_skills` | 2,485 | 4,592 | 6,698 | 7,411 | 12,000 |
+| `artifact_index` | 1,820 | 2,281 | 2,718 | 4,552 | 6,000 |
+| `experiment_manifest` | 1,492 | 1,679 | 1,823 | 1,896 | 6,000 |
+| `intake_resources` | 1,430 | 1,517 | 1,620 | 1,620 | 4,000 |
+
+Every budget sits above its channel's observed maximum **except `writing_manifest`**, and
+that one is deliberate: a maximum two hundred times the p99 is an outlier, and a ceiling
+above it would be no ceiling. Four channels render nothing anywhere in this archive
+(`project_context`, `idea_pool`, `researcher_profile`, and the unbudgeted
+`settled_reasoning`), so their ceilings are stated guesses rather than measurements.
+
+### 2.3 The send-back override (#278)
+
+One pass, one instant, **as of 2026-08-18T21:23:09Z**, over 394 `logs.txt`, counting
+headings matching `=== <ts> | <slug> attempt <n> sendback_refused ===` with a Python scan:
+
+- **131 of 394 runs (33%)** contain at least one override
+- **2212 override events**, median **15** per affected run, maximum **52**
+- of **5534** recorded `choice: 5` lines, **2212 — 40% — are the harness overruling a
+  refusal** rather than a reviewer accepting the work
+
+Two things the number is not. The archive mixes builds: every run containing an override is
+from 2026-08-17 or later, so the archive-wide share **understates** the rate inside the arms
+that can produce one. And overrides are a *subset* of the `choice: 5` population rather than
+a comparison class — every overridden refusal is rewritten to `5` and then logged as one.
+
+**Do not count these with `grep -c`.** 44 of the 394 logs contain bytes GNU grep treats as
+binary; `grep -c` on those prints nothing at all and exits 1, which a shell reads as a zero.
+
+### 2.4 The launch race in the trial driver (#271)
+
+Not from the list. Found because `tests/test_fs_trial_driver.py` was failing about one
+module run in three under load — a different test each time, never in isolation.
+
+The defect is proven on a pure function. `next_actions` abandons a `launched` run whose
+`child_pid` is not in `autor_pids(...)`, and neither end of that test is observable when a
+run has just started: `tools/fs_trial.py` writes the state file *before* `Popen` with no pid
+at all, and `autor_pids` walks `/proc` — **31–37 ms on a quiet box, longer under load**,
+most of it the walk rather than the child. A healthy run could be pronounced dead
+microseconds after starting, its replacement given a fresh workspace, and both paid for.
+
+`FS_LAUNCH_GRACE_SECONDS = 60` closes it: three orders of magnitude above that latency and
+**forty-five times below `FS_STALL_SECONDS` (2700)**, the same module's existing statement
+about how long a run may be silent before anyone worries.
+
+**The attribution is not proven.** Eight loaded module runs with the fix and eight without
+both came back clean, so that comparison has no power. Since the fix landed the module has
+gone **8 consecutive clean runs** and CI has passed first time on six successive pull
+requests; against a 1-in-3 per-run failure rate eight clean runs has probability 0.039 —
+evidence, not proof, and a clean sample cannot distinguish "fixed" from "not triggered".
+
+### 2.5 The two smaller populations
+
+**Coverage (#267).** Every archived run config is `output_format: markdown`; zero latex.
+The count was **335 when the branch was written, 379 at merge, 437 as of 2026-08-18** — the
+population grew, the finding did not change. So moving `validate_deliverables_coverage` out
+of the markdown branch changes no archived run's verdict, which §3.3 returns to.
+
+**Supervisor (#273).** Replayed over `tools/supervisor_threshold_replay.py`'s
+`MEASURED_RUNS`, concatenating prior visits' failure digests into the repeat rule changes
+**0 of 22 visits**; only **2 of 20 stages** in that population were visited more than once,
+and neither repeated a digest. Both re-derived independently.
+
+---
+
+## 3. Where a measurement said the wrong thing
+
+Four times. This is the most transferable part of the record.
+
+### 3.1 A budget measured on a sample clipped the median render
+
+`Channel.max_chars` shipped in #279 with the claim that every ceiling sat above its
+channel's observed maximum. It was measured over a **40-run-root sample**. Over the full
+13,671 prompts, **six of sixteen budgets were below the real maximum and two were below the
+median**: `decision_ledger` clipped **53.6%** of renders and `writing_manifest` **72.0%**.
+
+A budget that bites the median render is not headroom — it is a silent edit to every prompt.
+The six were raised, and the full table now sits in `information_flow.py` beside the field.
+The sample was not merely small; it was unrepresentative in a knowable way, because a
+channel that appears late in a run is under-sampled by any slice of a directory that is
+still filling up.
+
+### 3.2 A ratio of two numbers taken ten hours apart
+
+The override rate was first published as **45%** — 1270 events over 2802 approvals. Those
+counts were taken about ten hours apart from a growing archive. At the moment 2802 held
+there were 512 events; at the moment 1270 held there were 4-and-a-bit thousand approvals.
+**The two were never simultaneously true, and no single-instant snapshot of the archive
+yields 45%.** §2.3 is one pass at one timestamp.
+
+### 3.3 A population with no instance of the case cannot price it
+
+The supervisor replay said the change was free — 0 of 22 visits. It was also wrong: feeding
+the closed rows into `unchanging_failure` ends a revisit at its first repeated attempt, and
+two tests already in the tree are this repository's decision the other way. The replay had
+no multi-visit repeat in it, so it could not see the case at all. **"The blast radius is
+zero" is not "the change is right."**
+
+The same shape twice more. The coverage measurement said 335 of 335 archived runs are
+markdown, so lifting the gate out of the markdown branch was free — and the *test suite*
+then found what the archive could not, because the fake operator carried the same coupling
+in a second place and no archived run exercised either. And the custody population moved
+under its own pin (§2.1) because a run named in it was still executing.
+
+### 3.4 A number read while it is being written is not a measurement
+
+Mid-work five benchmark scores were reported from `<workspace>/_score.json` and moved
+between two readings. They were the wrong artifact: the authoritative scores are written by
+`score_items.py` into `rcb_results/gpt51_*/` by the gpt-5.1 judge this repository's own rule
+names. The `_score.json` files were being rewritten by a scoring pass in flight.
+
+---
+
+## 4. What was refused, and by what
+
+| Proposal | What refused it |
+| --- | --- |
+| Feed closed visits' digests to the supervisor's repeat rule (§4.6) | Two existing tests. A revisit is entitled to its own attempts even when it meets the objection that ended the last one. `TheRepeatRuleDeliberatelyStopsAtTheVisitBoundaryTests` pins the refusal. |
+| A guard on the `finish` edge (§4.3) | Three measured decisions: the forward gate must still count a skipped stage's artifacts; `_route_to_deliverable` bypasses the writing guards on purpose; `default_move` excludes `finish` from its last-resort fallback. The fix went on the *label*. |
+| A fourth `run_status` value (§4.3) | Six places in `src/frontend/static/app.js` test `=== "completed"` for settledness, plus `humanStatus` and a CSS class — a wide change across a surface this suite does not cover, for a defect entirely in a sentence. |
+| A `promotion_basis` vocabulary (§4.2) | The skip paths already record authority through `skip_kind` and the nine-value outcome ledger, and an overridden refusal is a *third* state: the reviewer did read the draft and scored every mechanical criterion. |
+| A `prior_refusals` channel into the doer (§4.6) | Measured adversely already: `review_policy` excludes rules whose origin stage is this stage, because doing otherwise raised the bar one requirement per attempt and prevented convergence. |
+| Attempt-grained artifact attribution (§5) | Nothing consumes it, and the natural fix is the one `composable-stage-graphs.md` measured and reversed. |
+| A recovery rung for a spent session id (§4.7) | After the cause is fixed nothing can hand `--session-id` an id it has already spent. A rung with no caller is the mistake this repository names in its own design notes. |
+
+---
+
+## 5. Still open
+
+- **The three largest prompt blocks are still uncapped.** Approved memory and the handoff
+  context are arguments to `build_prompt` rather than channels, so `Channel.max_chars` does
+  not reach them — and at ~175 KB and ~123 KB at p90 they are larger than every channel put
+  together. The repair prompt still inlines whole stdout, stderr, original prompt, draft and
+  promoted file, while the same module caps stdout at 2000 characters for its *log* excerpt.
+- **The deliverables contract is still checked once, at the end.** #267 made it
+  format-independent; it did not give the coverage artifact an earlier writer or a reviewer
+  axis.
+- **`--review-custody` defaults to `record`.** Arming the demotion waits on a live arm's
+  ledger, for the reason in §2.1.
+- **Whether #271 removed the flake is unverified.** §2.4.
+- **Four channel budgets are untested**, because those channels render nothing in this
+  archive. §2.2.
+
+---
+
+## 6. What this cost, and what it did not buy
+
+Ten merged changes plus one correction. Four are behaviour changes; the rest change what the
+record says. Every one carries a test that goes red without it.
+
+None has been measured on a run. The benchmark arms in flight during this work were pinned
+to commits that predate all of it, deliberately — a measurement whose instrument changes
+underneath it is not a measurement. So the honest summary is the one this repository already
+applies to its own machinery: **a mechanism that improves the record and is never measured
+on a run has improved the record.** Whether any of it moves a score is unknown, and nothing
+here should be quoted as if it did.

--- a/src/information_flow.py
+++ b/src/information_flow.py
@@ -119,10 +119,45 @@ class Channel:
     #: every channel either declares a budget or is named in ``UNBOUNDED_BY_CONSTRUCTION``
     #: with the reason it cannot grow, so the exemption list cannot grow by assertion.
     #:
-    #: What the numbers are measured against: over 197 archived stage prompts the whole
-    #: rendered channel set -- everything under ``# Stage Instructions`` after the static
-    #: template -- has a median of 25.6 KB and a p90 of 78.6 KB, and the prompt it sits
-    #: in runs to a median of 277 KB by Stage 07 with a maximum of 1.79 MB.
+    #: What the numbers are measured against, and the mistake the first version made.
+    #:
+    #: These ceilings were first set from a 40-run-root sample of an archive that is still
+    #: being written to, and six of the sixteen came out **below** the channel's real
+    #: maximum -- two of them below its *median*, so `decision_ledger` was clipped on 53.6%
+    #: of renders and `writing_manifest` on 72.0%. A budget that bites the median render is
+    #: not headroom, it is a silent edit to every prompt. The table below is the full
+    #: archive: 13,671 attempt prompts (review, panel, repair and route excluded) under
+    #: ``/rmeng_data/robtang/rcb_runs`` as of 2026-08-18, with each channel's body extracted
+    #: by its own ``heading`` -- the same quantity ``_render`` compares.
+    #:
+    #: ====================  =======  =======  =======  =========  =======
+    #: channel                   p50      p90      p99        max   budget
+    #: ====================  =======  =======  =======  =========  =======
+    #: decision_ledger         25,476   48,703   68,838     91,431  120,000
+    #: hypotheses              22,914   31,362   45,480     79,284   96,000
+    #: preregistration         12,078   18,431   27,908     71,386   96,000
+    #: report_plan             13,897   19,802   25,792     28,291   30,000
+    #: validity_findings       16,046   20,375   23,526     26,460   32,000
+    #: hypothesis_verdicts     13,836   19,244   23,427     25,198   32,000
+    #: research_rounds          4,880    7,005   14,842     19,614   24,000
+    #: experimental_protocol    4,877    6,618    8,249      9,558   12,000
+    #: writing_manifest        10,431   20,195  138,788  2,774,270  160,000
+    #: artifact_index           1,820    2,281    2,718      4,552    6,000
+    #: experiment_manifest      1,492    1,679    1,823      1,896    6,000
+    #: intake_resources         1,430    1,517    1,620      1,620    4,000
+    #: task_shaped_skills       2,485    4,592    6,698      7,411   12,000
+    #: ====================  =======  =======  =======  =========  =======
+    #:
+    #: Every budget above sits over its channel's observed maximum **except**
+    #: ``writing_manifest``, and that one is deliberate: its maximum is 2.77 MB against a
+    #: p99 of 139 KB, so a single render is two hundred times the ninety-ninth percentile.
+    #: A ceiling above *that* would be no ceiling at all. 160,000 keeps 99% intact and
+    #: clips the outlier, which is the one case a budget is actually for.
+    #:
+    #: Four channels -- ``project_context``, ``idea_pool``, ``researcher_profile`` and the
+    #: unbudgeted ``settled_reasoning`` -- render nothing anywhere in this archive, so their
+    #: ceilings are stated guesses from the shape of what the builder emits and are
+    #: untested. Said here rather than left for a reader to assume all sixteen are measured.
     max_chars: int | None = None
 
     def serves(self, stage: StageSpec) -> bool:
@@ -591,7 +626,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="writing_manifest",
-        max_chars=8_000,
+        max_chars=160_000,
         heading="## Writing Manifest",
         produced_by=None,
         consumed_by=frozenset({"07_writing"}),
@@ -614,7 +649,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="decision_ledger",
-        max_chars=24_000,
+        max_chars=120_000,
         heading="# Decision Ledger (from prior stages)",
         produced_by="01_literature_survey",
         consumed_by=_from("02_hypothesis_generation"),
@@ -628,7 +663,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="hypotheses",
-        max_chars=40_000,
+        max_chars=96_000,
         heading="# Hypothesis Context (from Stage 02)",
         produced_by="02_hypothesis_generation",
         consumed_by=frozenset({"03_study_design", "04_implementation"}),
@@ -648,7 +683,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="preregistration",
-        max_chars=40_000,
+        max_chars=96_000,
         heading="# Preregistered Hypotheses (frozen — not editable)",
         produced_by="04_implementation",
         consumed_by=_from("05_experimentation"),
@@ -775,7 +810,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="validity_findings",
-        max_chars=24_000,
+        max_chars=32_000,
         heading="# Adversarial Validity Findings (each must be answered)",
         produced_by="05_experimentation",
         consumed_by=frozenset({"06_analysis", "07_writing"}),
@@ -784,7 +819,7 @@ CHANNELS: tuple[Channel, ...] = (
     ),
     Channel(
         key="hypothesis_verdicts",
-        max_chars=24_000,
+        max_chars=32_000,
         heading="# Hypothesis Verdicts",
         produced_by="06_analysis",
         consumed_by=frozenset({"07_writing", "08_dissemination"}),

--- a/src/review_custody.py
+++ b/src/review_custody.py
@@ -46,7 +46,10 @@ One census over the four archived run roots, re-measured with a warm page cache 
 repetitions: medians of 516 and 567 ms on the Astronomy roots (500-630 paths, 110-145 MB)
 and 1188 and 1278 ms on the Chemistry ones (1180-1260 paths, 1.8-4.7 GB), with a full
 observed range of 428-1541 ms. Two per episode, so roughly 1-3 s of the several minutes
-an episode takes, and 3-7 minutes over a whole run. The first figures recorded here --
+an episode takes, and 3-7 minutes over a whole run.
+
+Those are warm-cache numbers. The *first* census of a cold root costs 2.9-10.8 s here,
+six to eight times higher, which is the one an episode early in a run actually pays. The first figures recorded here --
 395-1190 ms -- were a single timing each and sat at the optimistic end of that range. Hashing dominates, which is why
 the cap in :func:`src.provenance.content_identity` is reused rather than re-picked: the
 4.7 GB root is mostly files above it, and those are stat-only.
@@ -56,7 +59,8 @@ What it cannot see
 The census is rooted at the run root because that is the reviewer's working directory. A
 reviewer that writes outside it is invisible here, and that is not hypothetical either:
 in the same 152 episodes there are three tool-level writes, and two of them go to a
-``~/.claude/projects/.../memory/`` directory far outside any run. What the census claims
+``~/.claude/projects/.../memory/`` directory -- not merely outside the run root but the
+operator's own persistent memory, which outlives every run there will ever be. What the census claims
 is narrower than "the reviewer changed nothing" -- it is "the reviewer changed nothing it
 was judging", which is the claim the verdict depends on.
 

--- a/src/review_custody.py
+++ b/src/review_custody.py
@@ -22,8 +22,8 @@ Content, not mtime, and the measurement that decided it
 -------------------------------------------------------
 The obvious census compares modification times, and it is the wrong one. Replayed over
 the four finished runs under ``tools/review_custody_replay.py``'s ``MEASURED_RUNS`` --
-138 reviewer episodes -- an mtime census fires on **138 of 138** with no exclusion list
-and on **4 of 138** with one. All four are the same behaviour, and it is the behaviour a
+152 reviewer episodes -- an mtime census fires on **152 of 152** with no exclusion list
+and on **4 of 152** with one. All four are the same behaviour, and it is the behaviour a
 reviewer is supposed to have: re-running the doer's producer scripts in place to check
 they reproduce. Both of the two approvals among those four say so in their own recorded
 reason (*"I re-ran all three producers from the workspace"*).
@@ -42,10 +42,12 @@ and it is why ``--review-custody`` defaults to ``record``.
 
 What it costs
 -------------
-One census over the four archived run roots: 395 ms and 472 ms on the Astronomy roots
-(500-630 paths, 110-145 MB) and 1026 ms and 1190 ms on the Chemistry ones (1180-1260
-paths, 1.8-4.7 GB). Two per episode, so 0.8-2.4 s of the several minutes an episode
-takes, and 2-5 minutes over a whole run's 138 episodes. Hashing dominates, which is why
+One census over the four archived run roots, re-measured with a warm page cache over ten
+repetitions: medians of 516 and 567 ms on the Astronomy roots (500-630 paths, 110-145 MB)
+and 1188 and 1278 ms on the Chemistry ones (1180-1260 paths, 1.8-4.7 GB), with a full
+observed range of 428-1541 ms. Two per episode, so roughly 1-3 s of the several minutes
+an episode takes, and 3-7 minutes over a whole run. The first figures recorded here --
+395-1190 ms -- were a single timing each and sat at the optimistic end of that range. Hashing dominates, which is why
 the cap in :func:`src.provenance.content_identity` is reused rather than re-picked: the
 4.7 GB root is mostly files above it, and those are stat-only.
 
@@ -53,7 +55,7 @@ What it cannot see
 ------------------
 The census is rooted at the run root because that is the reviewer's working directory. A
 reviewer that writes outside it is invisible here, and that is not hypothetical either:
-in the same 138 episodes there are three tool-level writes, and two of them go to a
+in the same 152 episodes there are three tool-level writes, and two of them go to a
 ``~/.claude/projects/.../memory/`` directory far outside any run. What the census claims
 is narrower than "the reviewer changed nothing" -- it is "the reviewer changed nothing it
 was judging", which is the claim the verdict depends on.

--- a/tools/review_custody_replay.py
+++ b/tools/review_custody_replay.py
@@ -19,10 +19,15 @@ RUN IT:
 
 WHAT IT PRINTED when the mechanism landed, over MEASURED_RUNS:
 
-    episodes                     138
-    fire without the exclusions  138  (100%) -- the list is load-bearing, not decorative
-    fire with them                 4  (2.9%), all in Astronomy_000_20260814_175426
-    of those, approvals             2  of 27 approvals across the four runs (7.4%)
+    episodes                     152
+    fire without the exclusions  152  (100%) -- the list is load-bearing, not decorative
+    fire with them                 4  (2.6%), all in Astronomy_000_20260814_175426
+
+**The population moved once, and the tool caught it.** These were 138 and 4 when the
+census landed. `Chemistry_000_20260816_173127` was still executing when it was pinned by
+name, so the run it names kept producing episodes: 138 -> 152, while the fires stayed at
+4. That is the drift line doing its job, and it is the reason a still-running directory
+must not be pinned as a population -- see the `population:` line this prints.
 
 All four are one behaviour: the reviewer re-running the doer's producer scripts in place
 to check they reproduce. Both demoted approvals say so in their own recorded reason. None
@@ -54,7 +59,7 @@ MEASURED_TRIAL_ROOT = Path("/rmeng_data/robtang/rcb-trial-graph/workspaces")
 
 #: What the replay printed when the mechanism landed. Printed beside the live figure so a
 #: population that has drifted says so instead of quietly reporting a different number.
-MEASURED_EPISODES = 138
+MEASURED_EPISODES = 152
 MEASURED_FIRES = 4
 
 #: `src/review_custody.churn_files` spelled for an archive, where there is no `RunPaths`


### PR DESCRIPTION
Writing the implementation record meant re-deriving every number in it. The re-derivation found a
**shipped regression** and two stale figures.

## The regression

[#279](https://github.com/tangxiangru/AutoR/pull/279)'s channel budgets were measured over a **40-run-root
sample** of an archive that is still being written to. Over the full **13,671 attempt prompts**, six of the
sixteen sit *below* their channel's observed maximum — and two sit below its **median**:

| channel | p50 | p99 | max | old budget | over budget | new |
| --- | --- | --- | --- | --- | --- | --- |
| `decision_ledger` | 25,476 | 68,838 | 91,431 | 24,000 | **53.6%** | 120,000 |
| `writing_manifest` | 10,431 | 138,788 | 2,774,270 | 8,000 | **72.0%** | 160,000 |
| `hypotheses` | 22,914 | 45,480 | 79,284 | 40,000 | 1.6% | 96,000 |
| `preregistration` | 12,078 | 27,908 | 71,386 | 40,000 | 0.3% | 96,000 |
| `validity_findings` | 16,046 | 23,526 | 26,460 | 24,000 | 0.8% | 32,000 |
| `hypothesis_verdicts` | 13,836 | 23,427 | 25,198 | 24,000 | 0.7% | 32,000 |

**A budget that bites the median render is not headroom — it is a silent edit to every prompt.** The full
p50/p90/p99/max table now sits in `information_flow.py` beside the field, including the one ceiling that
clips deliberately: `writing_manifest`, whose maximum is 2.77 MB against a p99 of 139 KB, where a ceiling
above the maximum would be no ceiling at all.

## Two stale figures

- **`MEASURED_EPISODES` 138 → 152.** `Chemistry_000_20260816_173127` was still executing when it was named
  in `MEASURED_RUNS`, so the pinned population kept growing; the fires stayed at 4. The tool printed
  `population: DRIFTED` the whole time — the drift line doing exactly what it was built for. Re-pinned,
  with the reason recorded next to it.
- **Census cost.** 395–1190 ms was one timing each. Ten warm repetitions per root give medians of
  516/567/1188/1278 ms, range 428–1541 ms. Same order, same ordering; the first numbers were the
  optimistic end.

## The record itself

`docs/iclr/what-the-comparison-changed.md`: what landed across the ten PRs, what was refused and by what,
every figure with an **as-of date and the command that reproduces it**, and the part worth keeping — the
four places a measurement said the wrong thing.

Those four are one failure mode with four faces:

1. A ratio published as **45%** was the quotient of two counts taken **ten hours apart**. No single-instant
   snapshot of the archive yields it. (§2.3 is one pass at one timestamp: 2212 of 5534 = 40%, as of
   2026-08-18T21:23Z.)
2. The supervisor replay said a change was free — 0 of 22 visits — and the change was wrong, because the
   population contained no instance of the case.
3. The coverage measurement said 335 of 335 archived runs were markdown, and the **test suite** then found
   the coupling the archive could not.
4. Five benchmark scores were read off `_score.json` while a scoring pass was rewriting it — the wrong
   artifact entirely; the authoritative ones are the gpt-5.1 judge's under `rcb_results/gpt51_*/`.

**A slice of a directory that is still filling up is not a population, and "the blast radius is zero" is
not "the change is right".**

Also documented: `grep -c` on 44 of the 394 archived logs prints nothing and exits 1, because they contain
bytes GNU grep treats as binary — a shell reads that as a zero.

Full suite: 4030 tests, OK (skipped=4). No behaviour change beyond the six raised ceilings, which restore
what #279 intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)