### PR TITLE
`None` does not mean no field skills; it means no field filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ naming them.
 | Required stage-summary headings | `REQUIRED_STAGE_HEADINGS` | 7 |
 | Rubric criteria (weighted, backend-free) | `CRITERIA`, [src/rubric.py](src/rubric.py) | 10 |
 | Flags on `main.py` / `rcb_agent.py` | `parse_args` | 61 / 37 |
-| Python modules / lines / tests | the tree | 254 / 137 k / 4048 |
+| Python modules / lines / tests | the tree | 254 / 137 k / 4053 |
 
-`python -m unittest discover -s tests -p "test_*.py"` runs **4048 tests in ~440 s across 143 test
+`python -m unittest discover -s tests -p "test_*.py"` runs **4053 tests in ~440 s across 143 test
 modules**, with no third-party dependency.
 
 ## Quick start

--- a/airs_agent.py
+++ b/airs_agent.py
@@ -399,11 +399,22 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
                                    stage_timeout=args.stage_timeout, unattended=True)
         )
 
-    # No field-specific skills. AutoR's eleven skill disciplines are ResearchClawBench's
-    # fields -- astronomy, chemistry, materials, and so on -- and none of them is what an
-    # AIRS-Bench task is about. Mapping "Text Extraction and Matching" onto one of them
-    # would be a guess dressed as routing, and the general pack is offered either way.
-    manager.skill_discipline = None
+    # The task's own declared category, normalised -- *not* `None`.
+    #
+    # AutoR's eleven skill disciplines are ResearchClawBench's fields, and none of them is
+    # what an AIRS-Bench task is about, so the first version of this line set `None` to mean
+    # "no field skills". It means the opposite: `select_run_skills` reads a falsy discipline
+    # as "do not apply the field filter", so an AIRS run was offered **124** skills where a
+    # ResearchClawBench run is offered 16. Measured on a pre-flight before the arm that would
+    # have used it. That is not a cosmetic difference -- the pack's own measured failure is
+    # that a run opens about 1.75 of the descriptions it is shown, so seven skills written for
+    # this benchmark were being buried under eighty-nine written for other fields.
+    #
+    # A category like "Text Extraction and Matching" is truthy and matches none of the eleven
+    # prefixes, which filters every field skill out and keeps the general pack -- the
+    # behaviour the first version intended. It is also the honest value: it is the field the
+    # benchmark itself assigns, rather than a sentinel chosen to make a filter behave.
+    manager.skill_discipline = (task.category or task.research_problem or task.name).casefold().replace(" ", "-")
     # The pin seam stays wired even though no AIRS task is pinned today, so a pin derived
     # from a scored AIRS arm lands the same way an RCB one does, and announces itself in
     # the run config the same way.

--- a/tests/test_airsbench.py
+++ b/tests/test_airsbench.py
@@ -1251,5 +1251,90 @@ class ReportFormattingTest(unittest.TestCase):
         self.assertEqual(values, {"x": 0.5, "y": None})
 
 
+class SkillDisciplineTest(unittest.TestCase):
+    """`None` does not mean "no field skills". It means "do not filter by field".
+
+    An AIRS-Bench task is in none of AutoR's eleven skill disciplines, and the first version
+    of the adapter expressed that by setting `skill_discipline = None`. `select_run_skills`
+    reads a falsy discipline as "skip the field filter", so the run was offered **124**
+    skills where a ResearchClawBench run is offered 16 -- every field skill in the pack,
+    burying the ones written for this benchmark under eighty-nine written for other fields.
+    Caught by a pre-flight run, not by a test, which is why there is now a test.
+    """
+
+    def setUp(self) -> None:
+        from src.run_skills import DISCIPLINE_PREFIXES, discipline_of, select_run_skills
+
+        self.prefixes = DISCIPLINE_PREFIXES
+        self.discipline_of = discipline_of
+        self.select = select_run_skills
+        from src.run_skills import read_skill_pack
+
+        self.pack = read_skill_pack(REPO_ROOT / "src" / "skills")
+
+    def _airs_discipline(self, category: str) -> str:
+        """What `airs_agent.run` computes. Mirrored rather than imported: importing the
+        agent pulls in the whole manager, and the value is one expression."""
+        return category.casefold().replace(" ", "-")
+
+    def test_a_real_airs_category_is_truthy_and_matches_no_discipline(self) -> None:
+        for category in ("Text Extraction and Matching", "Time Series", "Code"):
+            with self.subTest(category=category):
+                value = self._airs_discipline(category)
+                self.assertTrue(value, "a falsy discipline disables the field filter")
+                self.assertNotIn(value, self.prefixes)
+
+    def test_that_discipline_excludes_every_field_skill(self) -> None:
+        offered = self.select(
+            self.pack,
+            discipline=self._airs_discipline("Text Extraction and Matching"),
+            brief="Your predictions will be scored against the label column of the test set.",
+        )
+        leaked = sorted(e.name for e in offered if self.discipline_of(e.name))
+        self.assertEqual(leaked, [], f"field skills reached an AIRS run: {leaked}")
+
+    def test_none_would_not_have(self) -> None:
+        """The bug, pinned. Without this the fix reads as a stylistic preference."""
+        offered = self.select(
+            self.pack,
+            discipline=None,
+            brief="Your predictions will be scored against the label column of the test set.",
+        )
+        self.assertTrue(
+            [e.name for e in offered if self.discipline_of(e.name)],
+            "if this is empty the field filter no longer needs a truthy discipline and "
+            "the comment in airs_agent.py should be retired",
+        )
+
+    def test_the_seven_airs_skills_survive_that_filter(self) -> None:
+        offered = {
+            e.name for e in self.select(
+                self.pack,
+                discipline=self._airs_discipline("Text Extraction and Matching"),
+                brief="Your predictions will be scored against the label column of the test set.",
+            )
+        }
+        for name in (
+            "a-scoreable-file-in-the-first-hour",
+            "the-row-count-comes-from-the-split-not-the-brief",
+            "assume-this-stage-is-the-last-one-you-get",
+            "the-submission-is-the-only-artifact-that-scores",
+            "your-survey-already-named-the-method-that-hits-the-number",
+            "a-model-you-can-audit-is-not-a-model-that-scores",
+            "the-audit-trail-is-not-the-deliverable-here",
+        ):
+            with self.subTest(skill=name):
+                self.assertIn(name, offered)
+
+    def test_a_brief_from_another_benchmark_gets_none_of_them(self) -> None:
+        offered = {
+            e.name for e in self.select(
+                self.pack, discipline="astronomy",
+                brief="Reproduce the exclusion curve for axion-photon coupling from the survey data.",
+            )
+        }
+        self.assertNotIn("the-submission-is-the-only-artifact-that-scores", offered)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`airs_agent.py` set `manager.skill_discipline = None`, with a comment explaining that an AIRS-Bench task is in none of AutoR's eleven skill disciplines and should therefore get no field skills.

`select_run_skills` reads a falsy discipline as **skip the field filter**:

```python
if discipline:            # None -> the whole block is skipped
    entries = [e for e in entries if ... discipline_of(e.name) == wanted]
```

So the run got every field skill: **124 installed for an AIRS run, against the 16 a ResearchClawBench run is offered.**

## Why it matters

The pack's own measured failure is that a run opens about 1.75 of the descriptions it is shown. The seven skills written for this benchmark in #288 were being buried under eighty-nine written for astronomy, chemistry, materials and the rest — which is the exact problem the field filter exists to prevent, reintroduced by the line intended to express that no field applies.

## The fix

`skill_discipline` is now the task's own declared category, normalised (`"Text Extraction and Matching"` → `text-extraction-and-matching`). Truthy, so the filter runs; matching none of the eleven prefixes, so every field skill is excluded and the general pack survives. It is also the honest value rather than a sentinel chosen to make a filter behave — it is the field the benchmark itself assigns.

Measured on the same pre-flight that found it:

| | before | after |
|:---|---:|---:|
| skills installed | 124 | **69** |
| field skills present | 89 | **0** |
| the seven AIRS skills | 7 | 7 |
| pins firing | yes | yes |

(Three `price-*` skills survive the filter and should: `price` is a verb there, not a discipline.)

## How it was found

By running the adapter once with `--fake-operator` before committing a four-hour arm to it — not by a test. Four tests now pin the behaviour, including `test_none_would_not_have`, which asserts that `None` *would* leak field skills. Without that one the fix reads as a stylistic preference and the next person to simplify the line reintroduces the bug.

Full suite green: 4053 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)