### PR TITLE
The narrowest task in the system was getting the biggest prompt

### DIFF
--- a/docs/iclr/what-the-comparison-changed.md
+++ b/docs/iclr/what-the-comparison-changed.md
@@ -235,11 +235,15 @@ names. The `_score.json` files were being rewritten by a scoring pass in flight.
 
 ## 5. Still open
 
-- **The three largest prompt blocks are still uncapped.** Approved memory and the handoff
-  context are arguments to `build_prompt` rather than channels, so `Channel.max_chars` does
-  not reach them — and at ~175 KB and ~123 KB at p90 they are larger than every channel put
-  together. The repair prompt still inlines whole stdout, stderr, original prompt, draft and
-  promoted file, while the same module caps stdout at 2000 characters for its *log* excerpt.
+- **Approved memory and the handoff context are still uncapped, and that is now a
+  decision.** They are arguments to `build_prompt` rather than channels, so
+  `Channel.max_chars` does not reach them, and at ~175 KB and ~123 KB at p90 they are
+  larger than every channel put together. But capping them would edit the *median* prompt
+  to solve something with no measured cost: over 13,980 attempts with both a prompt and an
+  outcome, failure rate by prompt size is 21.9% (0–100 KB), 16.3% (100–250 KB), 24.4%
+  (250–500 KB) — not monotone — and only **20 attempts in the whole archive (0.14%)** exceed
+  500 KB. Big is not, on this evidence, broken. Revisit if the telemetry from #279 shows a
+  channel or a block growing without bound on a live arm.
 - **The deliverables contract is still checked once, at the end.** #267 made it
   format-independent; it did not give the coverage artifact an earlier writer or a reviewer
   axis.
@@ -251,9 +255,44 @@ names. The `_score.json` files were being rewritten by a scoring pass in flight.
 
 ---
 
+### 5.1 The repair prompt, which was the one that *was* broken
+
+The same question asked of the recovery path gave the opposite answer, and it is in the
+record because the contrast is the point.
+
+Over 2,166 archived repair prompts: median **354 KB** against the attempt prompt's 156 KB
+— **1.84× its own attempt at the median, 6.55× at p90**, and **33.8% of repairs exceed
+500 KB where 0.14% of attempt prompts do**. The narrowest task in the system, *"overwrite
+this one markdown file, do not browse, do not continue the workflow"*, was being handed the
+largest prompt.
+
+Two blocks are all of it:
+
+| block | p50 | p90 | max |
+| --- | --- | --- | --- |
+| original prompt | 147,161 | 309,582 | 3,165,479 |
+| original stdout | 92,967 | 906,857 | 1,475,824 |
+| current draft | 16,584 | 36,461 | 95,942 |
+| current promoted file | 10 | 16,448 | 95,942 |
+| original stderr | 8 | 16 | 20,347 |
+
+And **nothing measurable is lost by clipping them**. Repair success over 2,157 recorded
+outcomes is flat across two orders of magnitude of prompt size — 98.1% below 150 KB, 100%
+at 150–300 KB, then 98.6%, 98.2%, 98.9% — so the 645 repairs that already got a small
+prompt are a control group that succeeds at the same rate as the ones given a megabyte.
+
+`REPAIR_PROMPT_EXCERPT_CHARS = 80_000` keeps the head, because `# Stage Instructions` is
+the first section and is what a rewrite needs; 80,000 is above that section's own p90.
+`REPAIR_STDOUT_EXCERPT_CHARS = 40_000` keeps the *tail*, because what matters is what the
+attempt ended up doing — the same reason `_write_attempt_state` records
+`stdout_text[-2000:]`. The draft, the promoted file and stderr stay whole; a ceiling on a
+median of 10 bytes is a mechanism with nothing to do.
+
+---
+
 ## 6. What this cost, and what it did not buy
 
-Ten merged changes plus one correction. Four are behaviour changes; the rest change what the
+Ten merged changes plus two corrections. Four are behaviour changes; the rest change what the
 record says. Every one carries a test that goes red without it.
 
 None has been measured on a run. The benchmark arms in flight during this work were pinned

--- a/src/operator.py
+++ b/src/operator.py
@@ -30,6 +30,58 @@ from .utils import (
 )
 
 
+def _head(text: str, max_chars: int) -> str:
+    """The opening of *text*, saying how much it dropped. ``(empty)`` for nothing."""
+
+    body = (text or "").strip()
+    if not body:
+        return "(empty)"
+    if len(body) <= max_chars:
+        return body
+    return body[:max_chars].rstrip() + f"\n\n[... {len(body) - max_chars} character(s) dropped from the end]"
+
+
+def _tail(text: str, max_chars: int) -> str:
+    """The end of *text*, saying how much it dropped. ``(empty)`` for nothing."""
+
+    body = (text or "").strip()
+    if not body:
+        return "(empty)"
+    if len(body) <= max_chars:
+        return body
+    return f"[... {len(body) - max_chars} character(s) dropped from the start ...]\n\n" + body[-max_chars:].lstrip()
+
+
+#: What a repair may be told about the attempt it is repairing.
+#:
+#: The repair prompt is the narrowest task in the system -- "overwrite this one markdown
+#: file, do not browse, do not continue the workflow" -- and it was handed the largest
+#: prompt. Measured over 2,166 archived repair prompts, it runs to a median of 354 KB
+#: against the attempt prompt's 156 KB: **1.84x its own attempt at the median, 6.55x at
+#: p90**, and a third of all repairs exceed 500 KB where 0.14% of attempt prompts do.
+#:
+#: Two blocks are all of it. The whole original prompt (median 147 KB, max 3.17 MB) and
+#: the whole original stdout (median 93 KB, p90 907 KB). The objects the task actually
+#: rewrites are small -- the draft is 17 KB at the median and the promoted file 10 bytes
+#: -- and stderr is 8 bytes, so those three stay whole and a ceiling on them would be a
+#: mechanism with nothing to do.
+#:
+#: **Nothing measurable is lost.** Repair success over 2,157 recorded outcomes is flat
+#: across two orders of magnitude of prompt size: 98.1% below 150 KB, 100% at 150-300 KB,
+#: 98.6%, 98.2%, 98.9% above. The 645 repairs that already got a small prompt are the
+#: control group, and they succeed at the same rate as the ones given a megabyte.
+#:
+#: The directions differ because the blocks differ. The prompt is kept from the head:
+#: `# Stage Instructions` is its first section and is what a rewrite needs, while the
+#: accumulated channels and memory at the end are what it does not. 80,000 is above that
+#: section's own p90 of 78.6 KB, so a typical repair still sees the whole instruction set.
+#: The stdout is kept from the *tail*: what matters is what the attempt ended up doing,
+#: which is also why `_write_attempt_state` records `stdout_text[-2000:]` rather than the
+#: first 2,000 characters. 40,000 is twenty times that excerpt.
+REPAIR_PROMPT_EXCERPT_CHARS = 80_000
+REPAIR_STDOUT_EXCERPT_CHARS = 40_000
+
+
 class ClaudeOperator:
     backend_name = "claude"
 
@@ -319,10 +371,10 @@ Current promoted stage file contents:
 {current_final_text}
 
 Original prompt:
-{original_prompt}
+{_head(original_prompt, REPAIR_PROMPT_EXCERPT_CHARS)}
 
 Original stdout:
-{original_result.stdout or "(empty)"}
+{_tail(original_result.stdout, REPAIR_STDOUT_EXCERPT_CHARS)}
 
 Original stderr:
 {original_result.stderr or "(empty)"}

--- a/tests/test_bounded_recovery.py
+++ b/tests/test_bounded_recovery.py
@@ -381,3 +381,96 @@ class TheGoalSurvivesARetryTest(unittest.TestCase):
             block = prompt.split("# Continuation Discipline", 1)[1].split("\n# ", 1)[0]
             numbers = [int(m.group(1)) for m in re.finditer(r"^(\d+)\. ", block, re.M)]
             self.assertEqual(numbers, list(range(1, len(numbers) + 1)))
+
+
+class TheNarrowestTaskGetsTheBiggestPromptTest(unittest.TestCase):
+    """The repair prompt inlined the whole attempt it was repairing.
+
+    Measured over 2,166 archived repair prompts: median 354 KB against the attempt
+    prompt's 156 KB -- 1.84x its own attempt at the median, 6.55x at p90, and a third of
+    all repairs over 500 KB where 0.14% of attempt prompts are. Two blocks are all of it,
+    the whole original prompt and the whole stdout; the objects the task actually rewrites
+    are 17 KB and 10 bytes at the median.
+
+    And nothing measurable is lost by clipping them. Repair success over 2,157 recorded
+    outcomes is flat across two orders of magnitude of prompt size -- 98.1% below 150 KB,
+    100% at 150-300 KB, 98.6/98.2/98.9% above -- so the 645 repairs that already got a
+    small prompt are the control group.
+    """
+
+    def _repair_prompt(self, *, prompt: str, stdout: str, stderr: str = "boom") -> str:
+        import io
+        from unittest.mock import patch
+
+        from src.operator import ClaudeOperator
+        from src.utils import (
+            STAGES, OperatorResult, build_run_paths, ensure_run_layout, write_text,
+        )
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        paths = build_run_paths(Path(tmp.name) / "run")
+        ensure_run_layout(paths)
+        write_text(paths.user_input, "goal")
+        stage = STAGES[0]
+        write_text(paths.stage_tmp_file(stage), "# draft\n")
+        operator = ClaudeOperator(fake_mode=False, output_stream=io.StringIO())
+        seen = {}
+
+        def fake_stream(*args, **kwargs):
+            command = kwargs["command"]
+            seen["text"] = Path(command[command.index("-p") + 1].lstrip("@")).read_text()
+            return (0, "ok", "", None,
+                    {"raw_line_count": 1, "non_json_line_count": 0, "malformed_json_count": 0})
+
+        result = OperatorResult(
+            success=False, exit_code=1, stdout=stdout, stderr=stderr,
+            stage_file_path=paths.stage_tmp_file(stage), session_id="s",
+        )
+        with patch("src.operator.shutil.which", return_value="/usr/bin/claude"), patch.object(
+            operator, "_run_streaming_command", side_effect=fake_stream
+        ):
+            operator.repair_stage_summary(stage, prompt, result, paths, attempt_no=1)
+        return seen["text"]
+
+    def test_a_huge_original_prompt_is_clipped_from_the_end(self) -> None:
+        """The head is what a rewrite needs: `# Stage Instructions` is the first section."""
+        from src.operator import REPAIR_PROMPT_EXCERPT_CHARS
+
+        text = self._repair_prompt(
+            prompt="# Stage Instructions\nHEAD" + ("p" * REPAIR_PROMPT_EXCERPT_CHARS) + "TAILMARKER",
+            stdout="short",
+        )
+        self.assertIn("# Stage Instructions", text)
+        self.assertNotIn("TAILMARKER", text)
+        self.assertIn("dropped from the end", text)
+
+    def test_a_huge_stdout_is_clipped_from_the_start(self) -> None:
+        """What matters is what the attempt ended up doing -- the same reason
+        `_write_attempt_state` records `stdout_text[-2000:]`."""
+        from src.operator import REPAIR_STDOUT_EXCERPT_CHARS
+
+        text = self._repair_prompt(
+            prompt="p",
+            stdout="STARTMARKER" + ("s" * REPAIR_STDOUT_EXCERPT_CHARS) + "ENDMARKER",
+        )
+        self.assertIn("ENDMARKER", text)
+        self.assertNotIn("STARTMARKER", text)
+        self.assertIn("dropped from the start", text)
+
+    def test_what_the_task_rewrites_is_not_clipped(self) -> None:
+        """The control on the trade. The draft is the object of the task and it is small:
+        17 KB at the median, 65 KB at p99."""
+        text = self._repair_prompt(prompt="p", stdout="s")
+        self.assertIn("# draft", text)
+
+    def test_a_small_attempt_is_passed_through_whole(self) -> None:
+        """The second control: the clip only moves what would have been enormous."""
+        text = self._repair_prompt(prompt="tiny prompt", stdout="tiny stdout")
+        self.assertIn("tiny prompt", text)
+        self.assertIn("tiny stdout", text)
+        self.assertNotIn("dropped", text)
+
+    def test_an_empty_stream_says_so_rather_than_going_blank(self) -> None:
+        text = self._repair_prompt(prompt="p", stdout="", stderr="")
+        self.assertIn("(empty)", text)


### PR DESCRIPTION
Three blocks were listed as still uncapped in the record. Asking the same question of each gave **two
different answers**, and both are in the doc.

## Approved memory and the handoff context stay uncapped — now a decision, not an omission

They are the largest blocks in a stage prompt: ~175 KB and ~123 KB at p90, larger than every channel put
together. But capping them edits the **median** prompt, and there is no measured cost to pay for that.

Over **13,980 attempts** with both a prompt and a recorded outcome:

| prompt size | n | failure rate |
| --- | --- | --- |
| 0–100 KB | 4,379 | 21.9% |
| 100–250 KB | 7,484 | 16.3% |
| 250–500 KB | 2,097 | 24.4% |
| 500 KB–1 MB | 15 | 46.7% |
| > 1 MB | 5 | 20.0% |

Not monotone — the *smallest* bucket is worse than the middle — and only **20 attempts in the whole
archive (0.14%)** exceed 500 KB. On this evidence, big is not broken.

## The repair prompt is the one that was

| | n | p50 | p90 | > 500 KB |
| --- | --- | --- | --- | --- |
| attempt prompt | 13,983 | 156 KB | 273 KB | 20 (**0.14%**) |
| repair prompt | 2,165 | **354 KB** | **1.15 MB** | 731 (**33.8%**) |

**1.84× its own attempt at the median, 6.55× at p90, 23.8× at worst.** The narrowest task in the system —
*"overwrite this one markdown file, do not browse, do not continue the workflow"* — was handed the largest
document the run produces.

Two blocks are all of it:

| block | p50 | p90 | max |
| --- | --- | --- | --- |
| original prompt | 147,161 | 309,582 | 3,165,479 |
| original stdout | 92,967 | 906,857 | 1,475,824 |
| current draft | 16,584 | 36,461 | 95,942 |
| current promoted file | 10 | 16,448 | 95,942 |
| original stderr | 8 | 16 | 20,347 |

What the task actually rewrites is small, so the draft, the promoted file and stderr stay whole — a
ceiling on a median of 10 bytes is a mechanism with nothing to do.

## Nothing measurable is lost

Repair success over **2,157 recorded outcomes**, flat across two orders of magnitude:

| repair prompt size | n | success |
| --- | --- | --- |
| 0–150 KB | 645 | **98.1%** |
| 150–300 KB | 283 | 100.0% |
| 300–600 KB | 590 | 98.6% |
| 600 KB–1.2 MB | 455 | 98.2% |
| > 1.2 MB | 184 | 98.9% |

The 645 repairs that already got a small prompt **are the control group**, and they succeed at the same
rate as the ones handed a megabyte.

## The two directions, and why they differ

- `REPAIR_PROMPT_EXCERPT_CHARS = 80_000` keeps the **head**: `# Stage Instructions` is the first section
  and is what a rewrite needs; the accumulated channels and memory at the end are what it does not.
  80,000 is above that section's own p90 of 78.6 KB, so a typical repair still sees the whole instruction
  set.
- `REPAIR_STDOUT_EXCERPT_CHARS = 40_000` keeps the **tail**: what matters is what the attempt ended up
  doing — the same reason `_write_attempt_state` records `stdout_text[-2000:]`. This is twenty times that
  excerpt.

Both clips say how much they dropped, for the reason `_render` does.

## Tests

Five, two of them controls: a small attempt passes through untouched, and the draft the task rewrites is
never clipped. Removing either clip turns one red.

Full suite: 4058 tests, OK (skipped=4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)