### PR TITLE
The control arm the framework owes could not be passed on the path it runs

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1099,7 +1099,12 @@ nobody chose.
 
 **The experiment this document owes.** Same model, same judge, same 40 tasks, `--stage-graph
 adaptive` against `--stage-graph linear`, paired, with enough seeds to say something. The control arm
-is one flag and has still never been passed. The ordering was repair, re-measure, then ablate; the
+is one flag and has still never been passed — and until now it *could not* be, on the path the
+benchmark runs. `main.py` has offered `--stage-graph` since the topology existed; `rcb_agent.py` never
+did, and built its `ResearchManager` without the argument, so every benchmark run took the default.
+All 398 archived benchmark run configs read `adaptive`, and not one of them chose it. The flag is on
+`rcb_agent.py` now, which makes the sentence above a statement about an experiment nobody has run
+rather than one nobody could. The ordering was repair, re-measure, then ablate; the
 first two are done (§6.8) and the third is not. Until that ablation lands, the correct summary of
 this document is:
 

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -63,7 +63,10 @@ from src.deliberation import DEFAULT_MAX_DELIBERATIONS  # noqa: E402
 from src.rigor import DEFAULT_LEVEL, LEVELS, feature_flags  # noqa: E402
 from src.rigor import help_text as rigor_help_text  # noqa: E402
 from src.rigor import resolve as resolve_rigor  # noqa: E402
+from src.stage_graph import StageGraph  # noqa: E402
 from src.utils import (  # noqa: E402
+    DEFAULT_STAGE_GRAPH,
+    STAGE_GRAPH_CHOICES,
     BENCHMARK_MIN_REPORT_FIGURES,
     DEFAULT_OUTPUT_FORMAT,
     MAX_STAGE_ATTEMPTS,
@@ -129,6 +132,20 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         choices=["claude", "codex"],
         default="claude",
         help="Execution backend for the research stages. Defaults to claude.",
+    )
+    parser.add_argument(
+        "--stage-graph",
+        choices=list(STAGE_GRAPH_CHOICES),
+        default=DEFAULT_STAGE_GRAPH,
+        help=(
+            "How the run moves between stages, the same choice `main.py` offers. "
+            f"Defaults to '{DEFAULT_STAGE_GRAPH}'. 'linear' restores the strict 01-through-08 "
+            "sequence and is the control arm for the topology this system's stated "
+            "contribution is: `docs/framework.md` §6.7 says the ablation is 'one flag and has "
+            "still never been passed', and it could not be passed here, because this entry "
+            "point did not have it. Every one of the 398 archived benchmark run configs reads "
+            "`adaptive`, and none of them chose it."
+        ),
     )
     parser.add_argument("--model", help="Model for the execution backend. Defaults to the backend default.")
     parser.add_argument(
@@ -621,6 +638,11 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         # gate while forfeiting criteria it never addressed.
         min_report_figures=BENCHMARK_MIN_REPORT_FIGURES,
         cross_reviewer=resolve_cross_reviewer(args.cross_review, args.cross_review_model),
+        # `StageGraph.named` rather than `main.py`'s `resolve_graph`, which additionally
+        # lets the cross-run archive pick a topology. A benchmark arm must be the
+        # configuration it says it is: an archive that steered one run's topology and not
+        # another's would put a variable in the comparison that no flag records.
+        stage_graph=StageGraph.named(args.stage_graph),
     )
 
     if args.ideation_panel:

--- a/tests/test_rcb_adapter.py
+++ b/tests/test_rcb_adapter.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 
 import rcb_agent
+from src.utils import DEFAULT_STAGE_GRAPH
 from src.rcb import (
     MIN_REPORT_CHARS,
     infer_task_id,
@@ -655,6 +656,59 @@ class ManagerArtifactDirWiringTest(unittest.TestCase):
         self.assertEqual(manager.artifact_dirs["figures"], [ws / "report" / "images"])
         # The read-only benchmark input must never appear.
         self.assertNotIn(ws / "data", manager.artifact_dirs["data"])
+
+
+class TheControlArmHasAFlagNowTest(unittest.TestCase):
+    """`docs/framework.md` §6.7 owes an ablation and calls it "one flag".
+
+    The flag existed on `main.py` and not here, so the benchmark entry point could only
+    ever run the default. All 398 archived benchmark run configs read `adaptive`, and none
+    of them chose it -- which is why "the control arm has still never been passed" was true
+    and could not have been otherwise.
+    """
+
+    def test_the_default_is_still_adaptive(self) -> None:
+        """The control on the change: adding the flag must not move the default arm."""
+        self.assertEqual(rcb_agent.parse_args([]).stage_graph, DEFAULT_STAGE_GRAPH)
+        self.assertEqual(DEFAULT_STAGE_GRAPH, "adaptive")
+
+    def test_linear_is_selectable(self) -> None:
+        self.assertEqual(
+            rcb_agent.parse_args(["--stage-graph", "linear"]).stage_graph, "linear"
+        )
+
+    def test_an_unknown_topology_is_refused_rather_than_defaulted(self) -> None:
+        with self.assertRaises(SystemExit):
+            rcb_agent.parse_args(["--stage-graph", "spiral"])
+
+    def test_the_manager_is_given_the_topology_the_flag_names(self) -> None:
+        """Through the manager, because a flag argparse accepts and nothing reads is the
+        shape `tests/test_cli_flags_are_read.py` exists for."""
+        from src.manager import ResearchManager
+        from src.stage_graph import StageGraph
+
+        for name in ("linear", "adaptive"):
+            with self.subTest(name):
+                manager = ResearchManager(
+                    project_root=Path(__file__).resolve().parent.parent,
+                    runs_dir=Path("/tmp/runs"),
+                    operator=type("Op", (), {"model": "m", "backend_name": "claude"})(),
+                    stage_graph=StageGraph.named(name),
+                )
+                self.assertEqual(manager.stage_graph.name, name)
+
+    def test_the_two_topologies_are_not_the_same_object(self) -> None:
+        """The control on the control: if `named` returned one graph the arm would be a
+        label on an identical run, which is the confound this experiment exists to avoid."""
+        from src.stage_graph import StageGraph
+
+        linear = StageGraph.named("linear")
+        adaptive = StageGraph.named("adaptive")
+        self.assertNotEqual(len(linear.edges), len(adaptive.edges))
+        self.assertEqual(
+            [edge for edge in linear.edges if edge.kind == "revisit"], [],
+            "a linear topology with a backward edge is not a linear topology",
+        )
 
 
 class ExportOnlyMetadataTest(unittest.TestCase):


### PR DESCRIPTION
`docs/framework.md` §6.7 says the ablation this system's stated contribution depends on —
`--stage-graph adaptive` against `--stage-graph linear`, paired, same model and judge and tasks — is
**"one flag and has still never been passed"**.

The flag does not exist where the benchmark runs.

- `main.py` has offered `--stage-graph` since the topology did.
- `rcb_agent.py` never has, and builds its `ResearchManager` **with no `stage_graph` argument at all**,
  so every benchmark run takes `DEFAULT_STAGE_GRAPH`.

All **398 archived benchmark run configs read `adaptive`, and not one of them chose it.** The unanimity
was the entry point, not a preference — which makes §6.7's sentence true for a reason it does not give.

## The change

`rcb_agent.py --stage-graph {linear,adaptive}`, reaching the manager.

`StageGraph.named` rather than `main.py`'s `resolve_graph`, deliberately: the latter additionally lets
the cross-run archive pick a topology, and an arm whose topology an archive steered is not the
configuration its flag says it is.

## Tests

Five, two of them controls:

- the default is still `adaptive` — adding the flag must not move the existing arm
- the two topologies are genuinely different objects (`linear` has no `revisit` edge), because a `named`
  that returned one graph would make the arm a label on an identical run — the exact confound this
  experiment exists to avoid
- the flag reaches `manager.stage_graph` rather than merely being accepted by argparse, which is the
  shape `tests/test_cli_flags_are_read.py` exists for
- an unknown topology is refused rather than silently defaulted

No behaviour change for any existing arm: the default is unmoved and every archived run already took it.

Full suite: 4063 tests, OK (skipped=4).

Next: the arms themselves. One pinned tree, two arms differing by this one argument, run concurrently so
the comparison is not confounded by model drift or box load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)