### PR TITLE
A directory listing the model ran for itself is not part of its answer

### DIFF
--- a/src/frontierscience.py
+++ b/src/frontierscience.py
@@ -1417,7 +1417,7 @@ class _OperatorCall:
             paths=paths,
             resume=False,
         )
-        exit_code, stdout, _stderr, _session, _meta = self.operator._run_streaming_command(  # noqa: SLF001
+        exit_code, stdout, _stderr, _session, meta = self.operator._run_streaming_command(  # noqa: SLF001
             command=command,
             cwd=cwd,
             stage=FS_ANSWER_STAGE,
@@ -1426,7 +1426,21 @@ class _OperatorCall:
             mode=label,
             stdin_text=stdin_text,
         )
-        return exit_code, stdout or ""
+        # The assistant's own words when the reader offers them, the whole stream otherwise.
+        #
+        # This class is the one seam in the tree that keeps a *reply* rather than parsing a
+        # section out of it, and the whole stream is not the reply: a `tool_result` block is
+        # text under `content`, so a directory listing the model ran for itself arrives in
+        # `stdout` ahead of the answer. Six of twenty-eight `direct` answers in the sixty-task
+        # trial began that way, the answer intact underneath, and a content-refusal clause
+        # reading the top of the file refused all six.
+        #
+        # Falling back rather than requiring the field keeps a backend that does not label
+        # its events working: `CodexOperator` goes through the same seam, and an operator
+        # that reports no assistant blocks should produce a whole-stream answer rather than
+        # an empty one.
+        assistant = str((meta or {}).get("assistant_text") or "").strip()
+        return exit_code, assistant or (stdout or "")
 
 
 class DirectAnswerWriter(_OperatorCall):

--- a/src/operator.py
+++ b/src/operator.py
@@ -82,6 +82,43 @@ REPAIR_PROMPT_EXCERPT_CHARS = 80_000
 REPAIR_STDOUT_EXCERPT_CHARS = 40_000
 
 
+def _assistant_text_blocks(payload: Any) -> list[str]:
+    """The text the assistant itself wrote in one stream event, and nothing else.
+
+    `extract_stream_text_fragments` harvests every string under `text`, `content`,
+    `message`, `delta`, `summary` or `result`, wherever it sits. That is the right rule for
+    a caller that parses a delimited section out of the whole text and the wrong one for a
+    caller that keeps the reply, because a `tool_result` block is text under `content` too:
+    the output of a shell command the model ran lands in the reply beside the reply.
+
+    Measured on the sixty-task FrontierScience trial, where the `direct` arm is the caller
+    that keeps the reply. Six of twenty-eight of its answers began with a directory listing
+    the model had run for itself, the whole answer still present underneath -- one of them
+    62,491 characters ending in a complete chemistry conclusion. The same shape appeared in
+    three of sixty answers on the previous trial and was scored normally, so the behaviour is
+    not new; what is new is that a content-refusal clause now reads the top of the file and
+    refuses the run. The answer was never the problem. The capture was.
+
+    So this reads only `assistant` events, and inside them only `text` blocks. Tool calls,
+    tool results, system events and the terminal result restatement are all somebody else's
+    text. It is additive: `stdout_text` is composed exactly as before, so stages and the
+    sibling benchmark's report path see no change at all.
+    """
+    if not isinstance(payload, dict) or payload.get("type") != "assistant":
+        return []
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return []
+    blocks: list[str] = []
+    for block in message.get("content") or []:
+        if not isinstance(block, dict) or block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and text.strip():
+            blocks.append(text.strip())
+    return blocks
+
+
 class ClaudeOperator:
     backend_name = "claude"
 
@@ -573,6 +610,11 @@ Original stderr:
         terminal_fragments: list[str] = []
         raw_lines: list[str] = []
         non_json_lines: list[str] = []
+        # The assistant's own words, kept apart from everything else in the stream. A caller
+        # that keeps a *reply* wants these; a caller that parses a delimited section out of
+        # the whole text does not care and still gets `stdout_text` unchanged. Collected here
+        # rather than reconstructed from `logs_raw.jsonl` afterwards, so the two cannot drift.
+        assistant_blocks: list[str] = []
         ended_with_newline = True
         observed_session_id: str | None = None
         tool_names: dict[str, str] = {}
@@ -638,6 +680,7 @@ Original stderr:
                     terminal_fragments.extend(extract_stream_text_fragments(payload))
                 else:
                     extracted_fragments.extend(extract_stream_text_fragments(payload))
+                assistant_blocks.extend(_assistant_text_blocks(payload))
                 self.ui.show_stream_event(payload, tool_names)
         except KeyboardInterrupt:
             elapsed = time.monotonic() - start_time
@@ -698,6 +741,7 @@ Original stderr:
                 "non_json_line_count": len(non_json_lines),
                 "malformed_json_count": malformed_json_count,
                 "observed_session_id": observed_session_id,
+                "assistant_text": "\n\n".join(assistant_blocks).strip(),
                 "timed_out": True,
                 RECORD_FIELD: spend.to_dict(),
             }
@@ -718,6 +762,7 @@ Original stderr:
             "non_json_line_count": len(non_json_lines),
             "malformed_json_count": malformed_json_count,
             "observed_session_id": observed_session_id,
+            "assistant_text": "\n\n".join(assistant_blocks).strip(),
             RECORD_FIELD: spend.to_dict(),
         }
 

--- a/tests/test_a_tool_result_is_not_the_answer.py
+++ b/tests/test_a_tool_result_is_not_the_answer.py
@@ -1,0 +1,195 @@
+"""A directory listing the model ran for itself is not part of its answer.
+
+`extract_stream_text_fragments` harvests every string under `text`, `content`, `message`,
+`delta`, `summary` or `result`, wherever it sits in the event. That is the right rule for a
+caller that parses a delimited section out of the whole text -- every stage, and the sibling
+benchmark's report path -- and the wrong one for the one seam that keeps a *reply*, because a
+`tool_result` block is text under `content` too.
+
+Measured on the sixty-task FrontierScience trial. The `direct` arm is the caller that keeps
+the reply, and **six of its twenty-eight answers began with a directory listing**, the whole
+answer still sitting underneath: one of them ran to 62,491 characters and ended in a complete
+chemistry conclusion. Three of sixty answers on the previous trial had the same shape and were
+scored normally, so the behaviour is not new. What is new is that a content-refusal clause now
+reads the top of the file, so all six were refused -- and because only the arm that keeps a
+reply can produce that shape, the refusals fell entirely on one arm of a paired comparison.
+
+The answer was never the problem. The capture was.
+
+The fix is additive and the first test class is what makes that checkable: `stdout_text` is
+composed exactly as before, so nothing that reads it changes, and the assistant's own text
+rides out beside it for the one caller that wants it.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.operator import ClaudeOperator, _assistant_text_blocks  # noqa: E402
+from src.utils import extract_stream_text_fragments  # noqa: E402
+
+ANSWER = "## Part 1\n\nThe rate-determining step is the second one, and here is why."
+LISTING = "total 0\ndrwx------  3 user user 0 Aug 19 05:11 .autor\n-rw-------  1 user user 0 logs.txt"
+
+ASSISTANT = {"type": "assistant", "message": {"content": [{"type": "text", "text": ANSWER}]}}
+TOOL_USE = {"type": "assistant", "message": {"content": [
+    {"type": "tool_use", "name": "Bash", "input": {"command": "ls -la"}}]}}
+TOOL_RESULT = {"type": "user", "message": {"content": [
+    {"type": "tool_result", "content": LISTING}]}}
+RESULT_EVENT = {"type": "result", "result": ANSWER, "subtype": "success"}
+
+# Two events that exist only to isolate the two checks from each other. Without them a
+# mutation loosening either one survives, because every other fixture here fails both: the
+# ordinary tool result is a `user` event carrying a `tool_result` block, so the event-type
+# check alone rejects it and the block-type check is never asked.
+# Carries a `text` key on purpose. A tool result normally puts its payload under `content`,
+# which the `text` lookup misses anyway, so a fixture in that shape cannot tell the block
+# filter from the lookup -- widening the filter to admit `tool_result` survives it. This is
+# the adversarial shape: block type and key both present, so only the filter can refuse it.
+TOOL_RESULT_INSIDE_AN_ASSISTANT_EVENT = {"type": "assistant", "message": {"content": [
+    {"type": "tool_result", "text": LISTING, "content": LISTING}]}}
+TEXT_INSIDE_A_NON_ASSISTANT_EVENT = {"type": "user", "message": {"content": [
+    {"type": "text", "text": LISTING}]}}
+
+
+class WhatTheAssistantSaidTests(unittest.TestCase):
+    def test_a_text_block_is_the_assistants_own_words(self) -> None:
+        self.assertEqual(_assistant_text_blocks(ASSISTANT), [ANSWER])
+
+    def test_a_tool_result_is_not(self) -> None:
+        """The defect, at its source. The listing is text under `content` and it is not a reply."""
+        self.assertEqual(_assistant_text_blocks(TOOL_RESULT), [])
+
+    def test_a_tool_call_is_not(self) -> None:
+        self.assertEqual(_assistant_text_blocks(TOOL_USE), [])
+
+    def test_the_block_type_is_checked_and_not_only_the_event_type(self) -> None:
+        """A `tool_result` block inside an assistant event. Isolates the inner check.
+
+        The ordinary tool result arrives as a `user` event, so the outer check rejects it and
+        the inner one is never exercised; a mutation widening the block filter to admit
+        `tool_result` survived every other test in this file.
+        """
+        self.assertEqual(_assistant_text_blocks(TOOL_RESULT_INSIDE_AN_ASSISTANT_EVENT), [])
+
+    def test_the_event_type_is_checked_and_not_only_the_block_type(self) -> None:
+        """A `text` block inside a non-assistant event. Isolates the outer check.
+
+        The mirror of the case above, and it failed nothing before this test existed:
+        dropping the event-type filter entirely left the file green.
+        """
+        self.assertEqual(_assistant_text_blocks(TEXT_INSIDE_A_NON_ASSISTANT_EVENT), [])
+
+    def test_the_terminal_restatement_is_not(self) -> None:
+        """It is the same words twice; the composer already treats it as a fallback."""
+        self.assertEqual(_assistant_text_blocks(RESULT_EVENT), [])
+
+    def test_several_blocks_in_one_message_keep_their_order(self) -> None:
+        payload = {"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "first"},
+            {"type": "tool_use", "name": "Bash", "input": {}},
+            {"type": "text", "text": "second"},
+        ]}}
+        self.assertEqual(_assistant_text_blocks(payload), ["first", "second"])
+
+    def test_a_malformed_event_is_not_an_exception(self) -> None:
+        for payload in (None, [], "assistant", {"type": "assistant"},
+                        {"type": "assistant", "message": None},
+                        {"type": "assistant", "message": {"content": None}},
+                        {"type": "assistant", "message": {"content": [None, 7, "x"]}}):
+            self.assertEqual(_assistant_text_blocks(payload), [], repr(payload))
+
+    def test_an_empty_text_block_contributes_nothing(self) -> None:
+        payload = {"type": "assistant", "message": {"content": [{"type": "text", "text": "   "}]}}
+        self.assertEqual(_assistant_text_blocks(payload), [])
+
+
+class TheWholeStreamIsUnchangedTests(unittest.TestCase):
+    """The control on the whole change: every other caller must see exactly what it saw.
+
+    Without this the fix could have been made by narrowing
+    `extract_stream_text_fragments`, which would have silently changed what every stage
+    reads. The test is here to make that difference a failure rather than a preference.
+    """
+
+    def test_the_shared_extractor_still_reads_a_tool_result(self) -> None:
+        self.assertIn(LISTING, extract_stream_text_fragments(TOOL_RESULT))
+
+    def test_the_shared_extractor_still_reads_a_result_payload(self) -> None:
+        self.assertIn(ANSWER, extract_stream_text_fragments(RESULT_EVENT))
+
+    def test_the_composer_still_puts_the_listing_in_the_whole_stream_text(self) -> None:
+        operator = ClaudeOperator(model="sonnet", fake_mode=True)
+        composed = operator._compose_stdout_text(  # noqa: SLF001
+            extracted_fragments=[LISTING, ANSWER], terminal_fragments=[ANSWER],
+            non_json_lines=[], raw_lines=[],
+        )
+        self.assertIn(LISTING, composed)
+        self.assertIn(ANSWER, composed)
+
+
+class TheReplyTheFrontEndKeepsTests(unittest.TestCase):
+    """`_OperatorCall.invoke` prefers the assistant's text and falls back to the stream.
+
+    The fallback is not politeness. `CodexOperator` reaches the same seam and does not label
+    its events, so a reader that required the field would hand that backend an empty answer
+    and score it as a refusal.
+    """
+
+    def setUp(self) -> None:
+        from src.frontierscience import _OperatorCall
+
+        self.calls: list[dict] = []
+        outer = self
+
+        class Recorder:
+            fake_mode = False
+
+            def _prepare_invocation(self, prompt_path, session, *, paths, resume):
+                return ["claude"], Path("/tmp"), None
+
+            def _run_streaming_command(self, **kwargs):
+                outer.calls.append(kwargs)
+                return 0, outer.stdout, "", None, outer.meta
+
+        class Call(_OperatorCall):
+            def invoke_here(self, paths):
+                return self.invoke(paths=paths, prompt="p", label="l", attempt=1)
+
+        self.Call = Call
+        self.operator = Recorder()
+
+    def _run(self, stdout: str, meta: dict) -> str:
+        import tempfile
+
+        from src.utils import build_run_paths
+
+        self.stdout, self.meta = stdout, meta
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = build_run_paths(Path(tmp))
+            paths.prompt_cache_dir.mkdir(parents=True, exist_ok=True)
+            return self.Call(self.operator).invoke_here(paths)[1]
+
+    def test_the_assistant_text_wins_over_the_whole_stream(self) -> None:
+        """The defect end to end: the listing is in the stream and not in the answer."""
+        reply = self._run(f"{LISTING}\n\n{ANSWER}", {"assistant_text": ANSWER})
+        self.assertEqual(reply, ANSWER)
+        self.assertNotIn("drwx", reply)
+
+    def test_a_reader_that_offers_nothing_falls_back_to_the_whole_stream(self) -> None:
+        self.assertEqual(self._run(ANSWER, {}), ANSWER)
+        self.assertEqual(self._run(ANSWER, {"assistant_text": ""}), ANSWER)
+        self.assertEqual(self._run(ANSWER, {"assistant_text": "   "}), ANSWER)
+
+    def test_a_missing_meta_is_not_an_exception(self) -> None:
+        self.assertEqual(self._run(ANSWER, None), ANSWER)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`extract_stream_text_fragments` harvests every string under `text`, `content`, `message`,
`delta`, `summary` or `result`, wherever it sits in the event. That is the right rule for a caller
that parses a delimited section out of the whole text — every stage, and ResearchClawBench's report
path — and the wrong one for the one seam that keeps a **reply**, because a `tool_result` block is
text under `content` too.

## What it did, measured

The `direct` arm of the FrontierScience trial is the caller that keeps the reply. **Six of its
twenty-eight answers began with a directory listing the model had run for itself**, with the whole
answer still sitting underneath — one of them 62,491 characters ending in a complete chemistry
conclusion.

Three of sixty answers on the previous trial had the same shape and were **scored normally**, so the
behaviour is not new. What is new is a content-refusal clause that reads the top of the file, so all
six were refused. And because only an arm that keeps a reply can produce that shape, those refusals
landed entirely on one arm of a paired comparison: the control's refusal rate went 6.7% → 26%, and
the runs it removed are ones that would have scored.

**The answer was never the problem. The capture was.**

## The fix, and why it is shaped this way

`_assistant_text_blocks` reads only `assistant` events and, inside them, only `text` blocks. The
streaming reader collects them alongside everything else and returns them in the meta dict it
already returns. **`stdout_text` is composed exactly as before**, so nothing that reads it changes.

Narrowing the shared extractor instead would have been the smaller diff and would have silently
changed what every stage reads — `TheWholeStreamIsUnchangedTests` exists to make that difference a
failure rather than a preference.

The front end prefers the assistant's text and falls back to the whole stream. The fallback is not
politeness: `CodexOperator` reaches the same seam and does not label its events, so a reader that
required the field would hand that backend an empty answer and score it as a refusal.

## Two mutations survived the first draft, and they were the same mistake

Every fixture in the file failed *both* the event-type check and the block-type check, so neither
was ever asked on its own — an ordinary tool result is a `user` event carrying a `tool_result`
block, rejected by the outer check before the inner one runs. Widening either filter left the file
green.

It now carries two fixtures that exist only to isolate them: a `text` block inside a non-assistant
event, and a `tool_result` block **bearing a `text` key**, which is the only shape that can tell the
block filter from the key lookup — a real tool result puts its payload under `content`, which the
lookup misses anyway. All three mutations now fail.

Scoped deliberately: this repairs the capture, and nothing else. Two neighbouring questions the same
investigation raised — that the model sometimes reads the grading harness at all (3/60 then 6/28),
and that the admission clause set changed between two trials so their numbers are not comparable —
are left alone here.

Suite `Ran 4157 tests`, `OK (skipped=4)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)