### PR TITLE
A benchmark run must not start from another run's notes

### DIFF
--- a/docs/frontierscience-results.md
+++ b/docs/frontierscience-results.md
@@ -238,6 +238,111 @@ reverting it fails three of its eight tests.
 
 ---
 
+## The capture defect, verified fixed
+
+Twelve `direct` runs on the repaired reader (`391cc0097251`), same model, same denied tools, same
+task instruction:
+
+| | defective reader | repaired |
+|:---|---:|---:|
+| answers opening with tool output | **6 / 28** | **0 / 12** |
+| refused by a content clause | 6 | **0** |
+
+Every first line is now the answer itself. The six that were thrown away were never bad answers —
+one ran to 62,491 characters and ended in a complete chemistry conclusion — they were good answers
+with a directory listing stapled to the front by the stream reader. See #297.
+
+The shape was also more varied than the first diagnosis said. Re-read across the eleven refusals in
+the trial's `direct` arm, only three open with the `ls` output originally described. Six open with
+`1\t---`, which is the `cat -n` rendering of a `Read` tool result, and two open with
+`{"type":"system","subtype":"init"` — the raw ndjson stream, 313,083 and 337,093 characters, which
+failed the length clause rather than the content clause. All the same defect from three directions.
+
+## A channel between runs, which the environment digest did not cover
+
+The `Read` results in those six answers are the more interesting finding, because of *what* was
+being read.
+
+Claude Code's auto-memory store is keyed on an **ancestor of the working directory**, not on the
+run. Probed against the real binary (2.1.229): a session whose cwd was
+`/rmeng_data/robtang/memprobe` and a benchmark stage whose cwd was
+`/rmeng_data/robtang/fs-trial-skills/workspaces/fs024_direct-opus_.../.autor/<ts>` both report the
+same `memory_paths.auto` — `~/.claude/projects/-rmeng-data-robtang/memory/`. Every run under one
+results directory shares one store, and its `MEMORY.md` index is loaded into each agent's context at
+session start. Nothing in the harness put it there: the word "memory" appears zero times in the
+prompt these runs were given.
+
+The store held 1,456 files, 294 of them written that day, and its two most-read entries were notes
+an **earlier run** had written about this harness's own exit clauses:
+
+```
+92 reads  fs-ideate-write-answer-md-yourself-to-preempt-synthesis.md
+56 reads  an-existing-answer-md-outranks-the-synthesizer.md
+11 reads  MEMORY.md
+ 4 reads  the-reviewer-sees-the-first-16000-characters.md
+```
+
+**Cause or consequence is separable, and the answer differs by subject.** The position of the read
+in the run's tool sequence says which. In the physics block it lands at call 68–151 of a 66–239 call
+run — an agent that worked the problem, got stuck, and went looking. In the chemistry block it is
+**tool call 1**, in *both* arms, before the agent has read the problem.
+
+It is also asymmetric, which is what makes it a problem for a paired design rather than a curiosity:
+**32 of 37 pipeline runs reached the store against 8 of 37 direct ones.** A channel that both arms
+used equally would cancel out of a paired difference. This one does not.
+
+**What did not happen: cross-task answer leakage.** Exactly one file in the 1,456 held solved content
+for a specific task — `fs:017`'s Schrödinger-Poisson constants, `eps = -0.692229`, `M_c r_c = 2.6794
+hbar^2/Gm^2` — and the only run that read or wrote it was `fs:017`'s own. A run taking notes on
+itself is not contamination. The channel was wide open and, on the answer content, it was not used.
+
+The store is closed for this benchmark from #298 onward, and `_meta.json` now records
+`auto_memory_isolated`. It is tri-state: `null` on every run above, because they ran with the store
+open and no field to say so, and defaulting that to `false` would assert a measurement nobody made.
+
+**None of this is repaired retroactively.** The trials on this page ran with the channel open, in a
+paired design that digested a comparability environment which did not include it. Their
+per-configuration accuracies stand as a record of what those configurations scored. The paired
+*difference* now carries a second arm-asymmetric confound alongside the duplication one, and the
+conclusion of the section above — that the difference is not quotable in either direction until the
+arms are re-run — is unchanged, with one more reason behind it.
+
+## What the `pipeline_completed` clause discards
+
+The five forced skills changed the *shape* of the pipeline arm's refusals rather than their count.
+In the trial before them, thirteen of fourteen refusals were `driver:fallback`: a 236-character
+placeholder, because the synthesizer would not write an answer from zero approved stages. With them,
+**every refusal is `answer_source: agent` with 35,097–78,794 characters of real answer** and exactly
+one clause failing — `pipeline_completed`, because Stage 02 never cleared its reviewer. Zero
+fallbacks. That is the first skill working: it says write the graded file first, and the file is
+there.
+
+The count is similar; what is being thrown away is not. Scored offline with the same judge, the same
+prompt and one draw — **outside the admitted set, and they stay outside it**, because an admission
+clause that decides after the score is known is not an admission clause:
+
+| task | chars | score |
+|:---|---:|---:|
+| fs:004 | 38,632 | 4.00 |
+| fs:012 | 60,720 | 3.50 |
+| fs:013 | 63,965 | 8.00 |
+| fs:014 | 56,996 | 8.00 |
+| fs:017 | 60,629 | 8.25 |
+| fs:019 | 78,794 | 5.30 |
+| **fs:022** | 35,097 | **10.00** |
+| fs:023 | 64,954 | 2.50 |
+| **mean** | | **6.194** (sd 2.719) |
+
+**Four of the eight clear the pass threshold, and one is a perfect score.** The admitted pipeline
+answers average about 5 points; the refused ones average 6.2. The clause is not filtering out weak
+work — it is discarding the arm's better answers on a procedural ground, and because it fires on one
+arm only, every one of these kills a *pair* and removes the task from the comparison entirely.
+
+This is a finding about the clause, not a correction to the numbers. It is not an argument for
+loosening the gate mid-trial, which is the thing this design specifically forbids; it is the
+measurement a future plan needs before it decides what `pipeline_completed` should mean for a run
+whose answer exists and whose process did not finish.
+
 ## Corrections to earlier claims on this branch
 
 **A three-task calibration is not a result, and this trial is the demonstration.** The calibration
@@ -277,6 +382,12 @@ Three things would move it and are worth separating:
    return the control's four refusals, and they are its longest and probably strongest answers. Any
    future comparison should do this first, or the control is being handicapped.
 
+Two of those three now have a measurement behind them rather than a guess. The refusals are worth
+**6.194 points each on average, four of eight above the pass threshold**, so recovering them is the
+largest single lever on this page — and the barrier is a procedural clause, not answer quality. And
+a re-run has to close the memory channel, which #298 does; a comparison against the baseline above
+that leaves it open is measuring two changes at once.
+
 ---
 
 ## Provenance
@@ -290,6 +401,9 @@ Three things would move it and are worth separating:
 | judge | `gpt-5.1`, high effort, 1 draw, serial, paper's Appendix B prompt verbatim |
 | API reference arm | `/home/robtang_google_com/fs-probe/opus_baseline/` |
 | figure | `/home/robtang_google_com/fs-runs/accuracy.html`, data derived by `chartdata.py` |
+| repaired-reader control | `/rmeng_data/robtang/fs-direct-clean/` — 12 `direct` runs on `391cc0097251`, 0 refusals, 0 leaks |
+| refused-answer scoring | `/rmeng_data/robtang/fs-refused-scored/` — `summary.json`, `raw/`; produced by `~/fs-runs/score_refused.py`, **outside the admitted set** |
+| memory-channel probe | `memory_paths` off the CLI's own `init` event; isolated run at `/rmeng_data/robtang/fs-memprobe-run/` reports `null` |
 
 Two notes for whoever runs the next one. The Claude CLI kills a stream after 300 s of silence and
 the variable that governs it is `CLAUDE_STREAM_IDLE_TIMEOUT_MS`, not the `BYTE_`-prefixed one that

--- a/docs/frontierscience-results.md
+++ b/docs/frontierscience-results.md
@@ -195,45 +195,66 @@ asked to write.
 
 ### What it did to the score
 
-Measured rather than argued: eleven doubled control answers, spread across the recorded score range,
-cut back to a single copy and re-judged with the same prompt and the same model.
+Measured rather than argued: twelve doubled control answers, spread across the recorded score range,
+cut back to a single copy and re-judged with the same prompt and the same model. The array is
+`~/fs-runs/dedup_recheck.json`, twelve records, each carrying `recorded_doubled`,
+`rejudged_single` and their difference.
 
 | | |
 |:---|---:|
-| mean change from de-duplicating | **−0.307 points** |
-| sd | 0.606 |
+| mean change from de-duplicating | **+0.033 points** |
+| sd | 0.633 |
 | median | 0.000 |
-| negative / zero / positive | 5 / 5 / 1 |
+| negative / zero / positive | 4 / 5 / 3 |
 
-**Duplication flattered the control by about three tenths of a point** on the tasks where it
-happened. Applied to the forty-two of forty-three paired tasks whose control answer carried a copy,
-the correction to the paired mean difference is **+0.300 in the pipeline's favour**, moving the
-published +0.085 to roughly **+0.384**.
+**Duplication did not move the control's score.** The mean is a thirtieth of a point in the
+*opposite* direction to the one a reader would guess, its standard error is 0.183, and seven of the
+twelve did not move at all. No re-judged answer crossed the pass threshold in either direction, so
+the control's accuracy is unchanged. Whatever the doubling did to the judge, it was not worth a
+measurable number of rubric points on this sample.
 
-At n = 11 the effect is not itself distinguishable from zero — standard error 0.183, and a sign test
-over the six non-zero deltas gives p ≈ 0.22. One of the eleven crossed the pass threshold: `fs:014`
-went 7.000 → 5.5, so the control's accuracy would fall slightly if every answer were de-duplicated.
+> **Correction, 2026-08-19.** An earlier revision of this section reported this table as
+> **−0.307 points** over **eleven** answers, sd 0.606, census 5/5/1, and concluded that duplication
+> had flattered the control by three tenths of a point and that the paired difference should move
+> from +0.085 to roughly +0.384. **Every one of those figures was wrong.** They are not in
+> `dedup_recheck.json`, they are not in `dedup_recheck.log` — which prints the same twelve deltas
+> and its own conclusion, "a mean delta near zero means the duplication did not move the control's
+> score" — and they are not recoverable from that array by dropping any record: reaching −0.307 over
+> eleven of these twelve would require deleting a value of +3.777, and the largest is +1.150. The
+> claim that "`fs:014` went 7.000 → 5.5" was a splice of two different records; `fs:014` is
+> `7.000 → 7.000, delta 0.000`, and 5.5 is `fs:034`'s re-judged value, down from 6.000 and nowhere
+> near the threshold. The prose was not a rounding of the array. It disagreed with it in n, in sign,
+> in sd and in census, and it reached this page, `src/operator.py` and a test docstring before
+> anyone compared the two. The structural finding underneath — 40 of 60 control answers carrying a
+> copy against 0 of 60 pipeline answers — is unaffected and was verified independently; what was
+> fabricated is the price.
 
 ### What that means for the numbers on this page
 
-The correction runs **in the pipeline's favour**, which is the opposite of the direction a reader
-would guess from a bug in the control arm's plumbing. It does not make the difference resolvable:
-+0.384 is still below the 0.654 this sample could detect at 80% power, and its standard error is
-0.233. But it is no longer near zero, and it is close to the 0.500 declared as the minimum effect of
-interest — so "the pipeline makes no difference" is not a conclusion this trial supports either.
+Less than the earlier revision of this section claimed, and in the opposite direction.
 
-It does change what may be said about the sign. **The confound and the effect are the same size.**
-A trial cannot report a difference of +0.085 while carrying an arm-asymmetric artifact worth 0.31,
-and no amount of caveat repairs that — the honest statement is that the paired difference is not
-quotable in either direction until the writer is fixed and the control arm re-run. The per-subject
-result is unaffected in shape, because the duplication is spread across subjects, but every
-per-subject difference inherits the same caveat.
+The duplication is still **arm-asymmetric and real**: 40 of the control's 60 answers repeat
+themselves and none of the pipeline's do, so on most paired tasks the judge was handed the control's
+answer twice and the pipeline's once. That is a difference between the arms that has nothing to do
+with the pipeline, and it should not exist.
+
+What the re-judging shows is that it **did not buy the control anything measurable**. +0.033 ± 0.183
+over twelve tasks does not move the published +0.085, and the honest reading is that the paired
+difference stands where it was: near zero, well below the 0.654 this sample could detect at 80%
+power, and not resolvable in either direction. The earlier revision used the fabricated 0.31 to
+argue that the confound and the effect were the same size; on the actual array they are not, because
+the confound's measured effect is indistinguishable from nothing.
+
+The reason to re-run the control arm is therefore not that the duplication is worth points. It is
+that an arm-asymmetric artifact should not be in a comparison at all, that the same arm turned out
+to carry two more (the capture defect, and the shared memory channel — both below), and that a
+measurement whose defects have to be priced after the fact is worth less than one that does not
+carry them.
 
 The accuracy tables stand as a record of what these two configurations scored. They are not a clean
 measurement of the pipeline's effect, and the reason is above rather than in a footnote.
 
-The writer is fixed on this branch, and the control arm has to be re-run before the paired
-difference means anything. `tests/test_the_reply_is_captured_once.py` holds the repair, and
+The writer is fixed on this branch. `tests/test_the_reply_is_captured_once.py` holds the repair, and
 reverting it fails three of its eight tests.
 
 ---

--- a/fs_agent.py
+++ b/fs_agent.py
@@ -452,6 +452,24 @@ def default_model_for(backend: str) -> str:
     return "default" if backend == "codex" else "sonnet"
 
 
+def auto_memory_isolation_for(operator: object, backend: str) -> bool | None:
+    """Whether this run was cut off from Claude Code's cross-session memory store.
+
+    Read off the operator that ran the stages rather than off the flags that built it, and
+    only when that operator is the one the field is about.
+
+    The second half is the trap. :class:`CodexOperator` subclasses :class:`ClaudeOperator`,
+    so it inherits ``isolate_auto_memory`` and a plain attribute read reports ``False`` for
+    a codex run -- "Claude Code's memory store was reachable", asserted of a run that never
+    started Claude Code. The store is not a fact about that run in either direction, and
+    ``None`` is the state that says so. It reads the same as a record written before the
+    field existed, which is the right reading: in both cases nobody measured this.
+    """
+    if backend != "claude":
+        return None
+    return bool(getattr(operator, "isolate_auto_memory", False))
+
+
 def create_operator(
     backend: str,
     *,
@@ -494,6 +512,12 @@ def create_operator(
         stage_timeout=stage_timeout,
         web_search_mcp=False,
         disallowed_tools=disallowed_tools,
+        # A benchmark run must not read the notes another run left behind. Not hypothetical
+        # here: measured on the sixty-task trial, the store this cuts off held two notes an
+        # earlier run had written about how to satisfy this harness's own exit clauses, and
+        # in the chemistry block reading them was the first thing runs in *both* arms did.
+        # See `ClaudeOperator.isolate_auto_memory` for the measurement.
+        isolate_auto_memory=True,
     )
 
 
@@ -892,6 +916,7 @@ def run(args: argparse.Namespace) -> FsRunResult:
         disallowed_tools_by_seat=seats,
         skill_forced=forced_skills,
         skill_withheld=withheld_skills,
+        auto_memory_isolated=auto_memory_isolation_for(operator, operator_backend),
         witness=read_transcript_witness(paths),
         dataset_path=dataset_path,
         dataset_sha256=dataset_sha256,

--- a/src/frontierscience.py
+++ b/src/frontierscience.py
@@ -1417,7 +1417,7 @@ class _OperatorCall:
             paths=paths,
             resume=False,
         )
-        exit_code, stdout, _stderr, _session, _meta = self.operator._run_streaming_command(  # noqa: SLF001
+        exit_code, stdout, _stderr, _session, meta = self.operator._run_streaming_command(  # noqa: SLF001
             command=command,
             cwd=cwd,
             stage=FS_ANSWER_STAGE,
@@ -1426,7 +1426,21 @@ class _OperatorCall:
             mode=label,
             stdin_text=stdin_text,
         )
-        return exit_code, stdout or ""
+        # The assistant's own words when the reader offers them, the whole stream otherwise.
+        #
+        # This class is the one seam in the tree that keeps a *reply* rather than parsing a
+        # section out of it, and the whole stream is not the reply: a `tool_result` block is
+        # text under `content`, so a directory listing the model ran for itself arrives in
+        # `stdout` ahead of the answer. Six of twenty-eight `direct` answers in the sixty-task
+        # trial began that way, the answer intact underneath, and a content-refusal clause
+        # reading the top of the file refused all six.
+        #
+        # Falling back rather than requiring the field keeps a backend that does not label
+        # its events working: `CodexOperator` goes through the same seam, and an operator
+        # that reports no assistant blocks should produce a whole-stream answer rather than
+        # an empty one.
+        assistant = str((meta or {}).get("assistant_text") or "").strip()
+        return exit_code, assistant or (stdout or "")
 
 
 class DirectAnswerWriter(_OperatorCall):

--- a/src/frontierscience.py
+++ b/src/frontierscience.py
@@ -1903,6 +1903,7 @@ def build_fs_meta(
     disallowed_tools_by_seat: Mapping[str, Sequence[str]] | None = None,
     skill_forced: Sequence[str] = (),
     skill_withheld: Sequence[str] = (),
+    auto_memory_isolated: bool | None = None,
     witness: Mapping[str, Any] | None = None,
     extra: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -1939,6 +1940,15 @@ def build_fs_meta(
     ``--no-forced-skills`` was denied the ones its sibling got. Only the second is a
     difference between two configurations of one producer, so it is the one the paired
     trial folds into its environment digest.
+
+    **``auto_memory_isolated`` is tri-state, and the third state is the point.** ``True``
+    means the run was cut off from Claude Code's cross-session memory store, ``False`` that
+    it was not, and ``None`` that this record predates the field -- which is the honest
+    answer for the sixty-task trials already on disk, where the store was open and nobody
+    had asked. Defaulting the missing case to ``True`` would let those runs claim an
+    isolation they did not have; defaulting it to ``False`` would assert a channel was used
+    by runs nobody measured. A reader comparing across trials has to be able to tell "not
+    isolated" from "not recorded", because only the first is a fact about the run.
     """
     payload: dict[str, Any] = {
         "schema": FS_META_SCHEMA,
@@ -1969,6 +1979,9 @@ def build_fs_meta(
         # order, and the trial hashes this list into a comparability digest -- two runs
         # that installed the same five skills must not be told they were measured in two
         # environments because a set iterated differently.
+        "auto_memory_isolated": (
+            None if auto_memory_isolated is None else bool(auto_memory_isolated)
+        ),
         "skill_forced": sorted(skill_forced),
         "skill_withheld": sorted(skill_withheld),
         "pipeline_completed": bool(pipeline_completed),

--- a/src/operator.py
+++ b/src/operator.py
@@ -806,9 +806,12 @@ Original stderr:
         nobody was watching -- measured on the sixty-task FrontierScience trial, **fifty-five
         of the control arm's sixty answers carried the answer twice** (forty of them an exact
         byte-for-byte halving) against none of the pipeline arm's, because only the control
-        arm keeps the reply. That asymmetry sat inside a paired comparison: re-judging eleven
-        of them once de-duplicated moved the score by -0.307 points on average, which is the
-        same size as the effect the trial was measuring.
+        arm keeps the reply. That asymmetry sat inside a paired comparison, which is reason
+        enough to repair it -- and note that it is the *asymmetry* that is the reason, not a
+        price: re-judging twelve of them once de-duplicated moved the score by +0.033 points
+        on average (sd 0.633, seven unchanged), so the doubling bought the arm that had it
+        nothing measurable. An earlier revision of this docstring said -0.307 over eleven,
+        which is not in the array it cited; see `docs/frontierscience-results.md`.
 
         So the result event is a fallback, not a contribution. It is the reply only when
         nothing else captured one -- a turn that emitted no assistant text at all, which is
@@ -1805,7 +1808,13 @@ Original stderr:
             # `--settings` adds to the settings already in force rather than replacing them,
             # so this turns off one feature and leaves the user's auth, model and env alone
             # -- checked against the real binary (2.1.229), where a run carrying this flag
-            # still reached its configured backend and reported `memory_paths: null`.
+            # still reached its configured backend.
+            #
+            # How to check a transcript for it, and the trap: the isolated run's `init` event
+            # **omits `memory_paths` entirely** rather than setting it to null. So
+            # `init["memory_paths"] is None` raises `KeyError` on precisely the run the check
+            # exists to recognise, and `init.get("memory_paths")` cannot tell an isolated run
+            # from a malformed event. Test `"memory_paths" not in init`.
             command.extend(["--settings", json.dumps({"autoMemoryEnabled": False})])
         if mcp_config is not None:
             # Not --strict-mcp-config: that would also drop whatever servers the user has

--- a/src/operator.py
+++ b/src/operator.py
@@ -82,6 +82,43 @@ REPAIR_PROMPT_EXCERPT_CHARS = 80_000
 REPAIR_STDOUT_EXCERPT_CHARS = 40_000
 
 
+def _assistant_text_blocks(payload: Any) -> list[str]:
+    """The text the assistant itself wrote in one stream event, and nothing else.
+
+    `extract_stream_text_fragments` harvests every string under `text`, `content`,
+    `message`, `delta`, `summary` or `result`, wherever it sits. That is the right rule for
+    a caller that parses a delimited section out of the whole text and the wrong one for a
+    caller that keeps the reply, because a `tool_result` block is text under `content` too:
+    the output of a shell command the model ran lands in the reply beside the reply.
+
+    Measured on the sixty-task FrontierScience trial, where the `direct` arm is the caller
+    that keeps the reply. Six of twenty-eight of its answers began with a directory listing
+    the model had run for itself, the whole answer still present underneath -- one of them
+    62,491 characters ending in a complete chemistry conclusion. The same shape appeared in
+    three of sixty answers on the previous trial and was scored normally, so the behaviour is
+    not new; what is new is that a content-refusal clause now reads the top of the file and
+    refuses the run. The answer was never the problem. The capture was.
+
+    So this reads only `assistant` events, and inside them only `text` blocks. Tool calls,
+    tool results, system events and the terminal result restatement are all somebody else's
+    text. It is additive: `stdout_text` is composed exactly as before, so stages and the
+    sibling benchmark's report path see no change at all.
+    """
+    if not isinstance(payload, dict) or payload.get("type") != "assistant":
+        return []
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return []
+    blocks: list[str] = []
+    for block in message.get("content") or []:
+        if not isinstance(block, dict) or block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and text.strip():
+            blocks.append(text.strip())
+    return blocks
+
+
 class ClaudeOperator:
     backend_name = "claude"
 
@@ -573,6 +610,11 @@ Original stderr:
         terminal_fragments: list[str] = []
         raw_lines: list[str] = []
         non_json_lines: list[str] = []
+        # The assistant's own words, kept apart from everything else in the stream. A caller
+        # that keeps a *reply* wants these; a caller that parses a delimited section out of
+        # the whole text does not care and still gets `stdout_text` unchanged. Collected here
+        # rather than reconstructed from `logs_raw.jsonl` afterwards, so the two cannot drift.
+        assistant_blocks: list[str] = []
         ended_with_newline = True
         observed_session_id: str | None = None
         tool_names: dict[str, str] = {}
@@ -638,6 +680,7 @@ Original stderr:
                     terminal_fragments.extend(extract_stream_text_fragments(payload))
                 else:
                     extracted_fragments.extend(extract_stream_text_fragments(payload))
+                assistant_blocks.extend(_assistant_text_blocks(payload))
                 self.ui.show_stream_event(payload, tool_names)
         except KeyboardInterrupt:
             elapsed = time.monotonic() - start_time
@@ -698,6 +741,7 @@ Original stderr:
                 "non_json_line_count": len(non_json_lines),
                 "malformed_json_count": malformed_json_count,
                 "observed_session_id": observed_session_id,
+                "assistant_text": "\n\n".join(assistant_blocks).strip(),
                 "timed_out": True,
                 RECORD_FIELD: spend.to_dict(),
             }
@@ -718,6 +762,7 @@ Original stderr:
             "non_json_line_count": len(non_json_lines),
             "malformed_json_count": malformed_json_count,
             "observed_session_id": observed_session_id,
+            "assistant_text": "\n\n".join(assistant_blocks).strip(),
             RECORD_FIELD: spend.to_dict(),
         }
 

--- a/src/operator.py
+++ b/src/operator.py
@@ -132,6 +132,7 @@ class ClaudeOperator:
         stage_timeout: int = 14400,
         web_search_mcp: bool = False,
         disallowed_tools: Sequence[str] | None = None,
+        isolate_auto_memory: bool = False,
     ) -> None:
         self.command = command
         self.model = model
@@ -150,6 +151,29 @@ class ClaudeOperator:
         # `disallowed_tools_for` is the only thing that fills it today, for a run whose
         # protocol says it must not browse.
         self.disallowed_tools = tuple(disallowed_tools or ())
+        # Whether to cut the agent off from Claude Code's cross-session memory store.
+        #
+        # The store is keyed on an ancestor of the run's working directory, not on the run:
+        # measured on this box, a probe in `/rmeng_data/robtang/memprobe` and a stage whose
+        # cwd was `/rmeng_data/robtang/fs-trial-skills/workspaces/fs024_.../.autor/<ts>`
+        # both reported the same `memory_paths.auto`. Every run under one benchmark's
+        # results directory therefore shares one store, and its `MEMORY.md` index is loaded
+        # into each agent's context at session start.
+        #
+        # That is a channel between runs of a benchmark, and it is used. On the sixty-task
+        # FrontierScience trial the two most-read files in a 1,456-file store were notes an
+        # earlier run had written about the harness's own scoring mechanics -- 92 and 56
+        # reads -- and in the chemistry block the read was the *first* tool call of the run,
+        # in both arms, before the agent looked at the problem. It is also asymmetric: 32 of
+        # 37 pipeline runs reached the store against 8 of 37 direct ones, so it does not
+        # cancel out of a paired comparison.
+        #
+        # Default off, and deliberately. AutoR's ordinary use is a researcher's own project
+        # where carrying notes between sessions is the feature working as intended; only a
+        # measurement wants each run to start from the same state as every other. Benchmark
+        # front ends opt in, and `build_operator_meta` records which way it was set so a run
+        # can say whether the channel was open rather than leaving a reader to assume.
+        self.isolate_auto_memory = isolate_auto_memory
 
     def run_stage(
         self,
@@ -1777,6 +1801,12 @@ Original stderr:
             "bypassPermissions",
             "--dangerously-skip-permissions",
         ]
+        if self.isolate_auto_memory:
+            # `--settings` adds to the settings already in force rather than replacing them,
+            # so this turns off one feature and leaves the user's auth, model and env alone
+            # -- checked against the real binary (2.1.229), where a run carrying this flag
+            # still reached its configured backend and reported `memory_paths: null`.
+            command.extend(["--settings", json.dumps({"autoMemoryEnabled": False})])
         if mcp_config is not None:
             # Not --strict-mcp-config: that would also drop whatever servers the user has
             # configured for their own environment, which is not AutoR's call to make.

--- a/tests/test_a_benchmark_run_starts_without_another_runs_notes.py
+++ b/tests/test_a_benchmark_run_starts_without_another_runs_notes.py
@@ -1,0 +1,219 @@
+"""Claude Code's memory store is keyed on an ancestor directory, so runs share it.
+
+The store is not per-run and not per-workspace. Probed against the real binary (2.1.229) on
+this box, a session whose cwd was `/rmeng_data/robtang/memprobe` and a benchmark stage whose
+cwd was `/rmeng_data/robtang/fs-trial-skills/workspaces/fs024_direct-opus_.../.autor/<ts>`
+both reported the same `memory_paths.auto`:
+
+    /home/robtang_google_com/.claude/projects/-rmeng-data-robtang/memory/
+
+Every run under one results directory therefore reads and writes one store, whose `MEMORY.md`
+index is loaded into each agent's context at session start. That is a channel between the
+runs of a benchmark, and on the sixty-task FrontierScience trial it carried traffic: the two
+most-read files in a 1,456-file store were notes an earlier run had written about this
+harness's own exit clauses -- `fs-ideate-write-answer-md-yourself-to-preempt-synthesis` at 92
+reads and `an-existing-answer-md-outranks-the-synthesizer` at 56 -- and in the chemistry block
+the read was the *first* tool call of the run, in both arms, before the agent had looked at
+the problem. It is asymmetric, too: 32 of 37 pipeline runs reached the store against 8 of 37
+direct ones, so it does not cancel out of a paired comparison.
+
+**The default stays off, and the control for that is a test here.** AutoR's ordinary use is a
+researcher's own project, where carrying notes between sessions is the feature working; only
+a measurement needs every run to start from the same state. So the isolation is opt-in, the
+FrontierScience front end opts in, and nothing else changes -- including the sibling
+benchmarks that were mid-flight when this landed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.frontierscience import FS_SOURCE_AGENT, FsAnswer, build_fs_meta  # noqa: E402
+from src.operator import ClaudeOperator  # noqa: E402
+
+SETTINGS_FLAG = "--settings"
+
+
+def command_for(**kwargs) -> list[str]:
+    operator = ClaudeOperator(model="opus", fake_mode=True, **kwargs)
+    return operator._build_cli_command(  # noqa: SLF001
+        Path("/tmp/p.md"), "sess-1", resume=False
+    )
+
+
+def settings_payloads(command: list[str]) -> list[dict]:
+    return [
+        json.loads(command[i + 1])
+        for i, arg in enumerate(command)
+        if arg == SETTINGS_FLAG and i + 1 < len(command)
+    ]
+
+
+class TheFlagTests(unittest.TestCase):
+    def test_an_isolated_operator_turns_the_memory_off(self) -> None:
+        self.assertEqual(
+            settings_payloads(command_for(isolate_auto_memory=True)),
+            [{"autoMemoryEnabled": False}],
+        )
+
+    def test_the_value_is_false_and_not_merely_present(self) -> None:
+        """A settings blob saying `true` would pass any check that only looks for the key.
+
+        Worth its own assertion because the flag's whole content is one boolean: a mutation
+        that writes the opposite one leaves the command line the right shape and the right
+        length, and turns the isolation into a no-op that still records itself as applied.
+        """
+        payload = settings_payloads(command_for(isolate_auto_memory=True))[0]
+        self.assertIn("autoMemoryEnabled", payload)
+        self.assertIs(payload["autoMemoryEnabled"], False)
+
+    def test_the_key_is_spelled_the_way_the_binary_spells_it(self) -> None:
+        """`autoMemoryEnabled`, exactly. An unknown key is accepted and does nothing.
+
+        This is the failure mode with no symptom: the CLI does not reject a settings blob it
+        does not recognise, so a misspelling produces a run that looks isolated in its own
+        metadata, reads the shared store anyway, and reports nothing unusual. The spelling
+        was taken off the binary's own symbol table and confirmed by probing
+        `memory_paths` -- `null` with the flag, the shared path without it.
+        """
+        self.assertEqual(
+            list(settings_payloads(command_for(isolate_auto_memory=True))[0]), ["autoMemoryEnabled"]
+        )
+
+    def test_an_ordinary_operator_is_left_alone(self) -> None:
+        self.assertEqual(settings_payloads(command_for(isolate_auto_memory=False)), [])
+        self.assertNotIn(SETTINGS_FLAG, command_for(isolate_auto_memory=False))
+
+    def test_the_default_is_not_isolated(self) -> None:
+        """The control on the blast radius: every other AutoR path keeps its memory.
+
+        Without this, flipping the default would be invisible -- every other test in the
+        repo passes either way, and the change would silently take the feature away from
+        the researcher-facing use it was built for.
+        """
+        self.assertIs(ClaudeOperator(model="opus", fake_mode=True).isolate_auto_memory, False)
+        self.assertNotIn(SETTINGS_FLAG, command_for())
+
+    def test_isolation_does_not_disturb_the_rest_of_the_command(self) -> None:
+        """`--settings` adds to the settings in force; it must not displace anything here.
+
+        The two commands are compared with the flag and its payload removed, so the test
+        fails if isolation reorders, drops or duplicates any other argument -- the model,
+        the permission mode, the session id.
+        """
+        isolated = command_for(isolate_auto_memory=True)
+        plain = command_for(isolate_auto_memory=False)
+        stripped = [
+            arg
+            for i, arg in enumerate(isolated)
+            if arg != SETTINGS_FLAG and (i == 0 or isolated[i - 1] != SETTINGS_FLAG)
+        ]
+        self.assertEqual(stripped, plain)
+
+    def test_it_survives_the_other_options(self) -> None:
+        operator = ClaudeOperator(
+            model="opus", fake_mode=True, isolate_auto_memory=True,
+            disallowed_tools=["WebSearch", "WebFetch"],
+        )
+        command = operator._build_cli_command(  # noqa: SLF001
+            Path("/tmp/p.md"), "sess-1", resume=True, tools="Bash,Read",
+            mcp_config=Path("/tmp/mcp.json"), disallowed_tools=["WebSearch"],
+        )
+        self.assertEqual(settings_payloads(command), [{"autoMemoryEnabled": False}])
+        self.assertIn("--resume", command)
+        self.assertIn("--mcp-config", command)
+
+
+class WhatTheFrontEndAsksForTests(unittest.TestCase):
+    def operator_for(self, backend: str):
+        from fs_agent import create_operator
+
+        return create_operator(
+            backend=backend, model="opus", fake_mode=True, ui=None, stage_timeout=60,
+            disallowed_tools=["WebSearch"], codex_sandbox="danger-full-access",
+            codex_command="codex",
+        )
+
+    def test_the_frontierscience_front_end_isolates(self) -> None:
+        self.assertIs(self.operator_for("claude").isolate_auto_memory, True)
+
+    def test_a_claude_seat_reports_what_it_did(self) -> None:
+        from fs_agent import auto_memory_isolation_for
+
+        operator = self.operator_for("claude")
+        self.assertIs(auto_memory_isolation_for(operator, "claude"), True)
+        operator.isolate_auto_memory = False
+        self.assertIs(auto_memory_isolation_for(operator, "claude"), False)
+
+    def test_a_codex_seat_claims_nothing(self) -> None:
+        """It never starts Claude Code, so the store is not a fact about it either way.
+
+        The trap this pins: `CodexOperator` subclasses `ClaudeOperator`, so it *inherits*
+        the attribute and a plain read returns `False` -- a codex run would record "the
+        memory store was reachable" about a binary it never ran. The assertion on the
+        inherited attribute is here so the test states why the branch exists rather than
+        looking like a redundant null check somebody could delete.
+        """
+        from fs_agent import auto_memory_isolation_for
+
+        operator = self.operator_for("codex")
+        self.assertIs(operator.isolate_auto_memory, False)
+        self.assertIsNone(auto_memory_isolation_for(operator, "codex"))
+
+    def test_an_operator_without_the_attribute_is_not_an_exception(self) -> None:
+        from fs_agent import auto_memory_isolation_for
+
+        self.assertIs(auto_memory_isolation_for(object(), "claude"), False)
+
+
+class WhatTheRecordSaysTests(unittest.TestCase):
+    """Tri-state, because "not isolated" and "not recorded" are different facts."""
+
+    def meta(self, **kwargs) -> dict:
+        return build_fs_meta(
+            workspace=Path("/tmp/ws"), task="fs:000", profile="direct",
+            answer_guidance="minimal", model="opus", review_model="opus",
+            operator="claude", pipeline_completed=True,
+            answer=FsAnswer(
+                path=Path("/tmp/ws/answer.md"), source=FS_SOURCE_AGENT,
+                chars=900, sha256="0" * 64, refusals=[],
+            ),
+            auto_skipped_stages=[], stages_approved=[], disallowed_tools=[],
+            dataset_path=None, dataset_sha256="d", run_id="r", duration_seconds=1,
+            **kwargs,
+        )
+
+    def test_true_is_recorded(self) -> None:
+        self.assertIs(self.meta(auto_memory_isolated=True)["auto_memory_isolated"], True)
+
+    def test_false_is_recorded(self) -> None:
+        self.assertIs(self.meta(auto_memory_isolated=False)["auto_memory_isolated"], False)
+
+    def test_a_record_that_was_never_asked_says_so(self) -> None:
+        """`None`, not `False`. The sixty-task trials on disk are exactly this case.
+
+        They ran with the store open and no field to say so. Defaulting the omission to
+        `False` would assert a measurement nobody made; defaulting it to `True` would let
+        them claim an isolation they did not have. The field is present either way, so a
+        reader gets `null` rather than a `KeyError` they might paper over.
+        """
+        payload = self.meta()
+        self.assertIn("auto_memory_isolated", payload)
+        self.assertIsNone(payload["auto_memory_isolated"])
+
+    def test_the_field_survives_a_round_trip(self) -> None:
+        self.assertIs(
+            json.loads(json.dumps(self.meta(auto_memory_isolated=True)))["auto_memory_isolated"],
+            True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a_benchmark_run_starts_without_another_runs_notes.py
+++ b/tests/test_a_benchmark_run_starts_without_another_runs_notes.py
@@ -80,8 +80,11 @@ class TheFlagTests(unittest.TestCase):
         This is the failure mode with no symptom: the CLI does not reject a settings blob it
         does not recognise, so a misspelling produces a run that looks isolated in its own
         metadata, reads the shared store anyway, and reports nothing unusual. The spelling
-        was taken off the binary's own symbol table and confirmed by probing
-        `memory_paths` -- `null` with the flag, the shared path without it.
+        was taken off the binary's own symbol table and confirmed by probing a real run's
+        `init` event: **no `memory_paths` key at all** with the flag, the shared path without
+        it. Note the shape -- the key is omitted, not nulled, so a reader that does
+        `init["memory_paths"] is None` raises `KeyError` on exactly the run it is checking
+        for, and `.get()` cannot distinguish isolation from a malformed event.
         """
         self.assertEqual(
             list(settings_payloads(command_for(isolate_auto_memory=True))[0]), ["autoMemoryEnabled"]

--- a/tests/test_a_tool_result_is_not_the_answer.py
+++ b/tests/test_a_tool_result_is_not_the_answer.py
@@ -1,0 +1,195 @@
+"""A directory listing the model ran for itself is not part of its answer.
+
+`extract_stream_text_fragments` harvests every string under `text`, `content`, `message`,
+`delta`, `summary` or `result`, wherever it sits in the event. That is the right rule for a
+caller that parses a delimited section out of the whole text -- every stage, and the sibling
+benchmark's report path -- and the wrong one for the one seam that keeps a *reply*, because a
+`tool_result` block is text under `content` too.
+
+Measured on the sixty-task FrontierScience trial. The `direct` arm is the caller that keeps
+the reply, and **six of its twenty-eight answers began with a directory listing**, the whole
+answer still sitting underneath: one of them ran to 62,491 characters and ended in a complete
+chemistry conclusion. Three of sixty answers on the previous trial had the same shape and were
+scored normally, so the behaviour is not new. What is new is that a content-refusal clause now
+reads the top of the file, so all six were refused -- and because only the arm that keeps a
+reply can produce that shape, the refusals fell entirely on one arm of a paired comparison.
+
+The answer was never the problem. The capture was.
+
+The fix is additive and the first test class is what makes that checkable: `stdout_text` is
+composed exactly as before, so nothing that reads it changes, and the assistant's own text
+rides out beside it for the one caller that wants it.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+from src.operator import ClaudeOperator, _assistant_text_blocks  # noqa: E402
+from src.utils import extract_stream_text_fragments  # noqa: E402
+
+ANSWER = "## Part 1\n\nThe rate-determining step is the second one, and here is why."
+LISTING = "total 0\ndrwx------  3 user user 0 Aug 19 05:11 .autor\n-rw-------  1 user user 0 logs.txt"
+
+ASSISTANT = {"type": "assistant", "message": {"content": [{"type": "text", "text": ANSWER}]}}
+TOOL_USE = {"type": "assistant", "message": {"content": [
+    {"type": "tool_use", "name": "Bash", "input": {"command": "ls -la"}}]}}
+TOOL_RESULT = {"type": "user", "message": {"content": [
+    {"type": "tool_result", "content": LISTING}]}}
+RESULT_EVENT = {"type": "result", "result": ANSWER, "subtype": "success"}
+
+# Two events that exist only to isolate the two checks from each other. Without them a
+# mutation loosening either one survives, because every other fixture here fails both: the
+# ordinary tool result is a `user` event carrying a `tool_result` block, so the event-type
+# check alone rejects it and the block-type check is never asked.
+# Carries a `text` key on purpose. A tool result normally puts its payload under `content`,
+# which the `text` lookup misses anyway, so a fixture in that shape cannot tell the block
+# filter from the lookup -- widening the filter to admit `tool_result` survives it. This is
+# the adversarial shape: block type and key both present, so only the filter can refuse it.
+TOOL_RESULT_INSIDE_AN_ASSISTANT_EVENT = {"type": "assistant", "message": {"content": [
+    {"type": "tool_result", "text": LISTING, "content": LISTING}]}}
+TEXT_INSIDE_A_NON_ASSISTANT_EVENT = {"type": "user", "message": {"content": [
+    {"type": "text", "text": LISTING}]}}
+
+
+class WhatTheAssistantSaidTests(unittest.TestCase):
+    def test_a_text_block_is_the_assistants_own_words(self) -> None:
+        self.assertEqual(_assistant_text_blocks(ASSISTANT), [ANSWER])
+
+    def test_a_tool_result_is_not(self) -> None:
+        """The defect, at its source. The listing is text under `content` and it is not a reply."""
+        self.assertEqual(_assistant_text_blocks(TOOL_RESULT), [])
+
+    def test_a_tool_call_is_not(self) -> None:
+        self.assertEqual(_assistant_text_blocks(TOOL_USE), [])
+
+    def test_the_block_type_is_checked_and_not_only_the_event_type(self) -> None:
+        """A `tool_result` block inside an assistant event. Isolates the inner check.
+
+        The ordinary tool result arrives as a `user` event, so the outer check rejects it and
+        the inner one is never exercised; a mutation widening the block filter to admit
+        `tool_result` survived every other test in this file.
+        """
+        self.assertEqual(_assistant_text_blocks(TOOL_RESULT_INSIDE_AN_ASSISTANT_EVENT), [])
+
+    def test_the_event_type_is_checked_and_not_only_the_block_type(self) -> None:
+        """A `text` block inside a non-assistant event. Isolates the outer check.
+
+        The mirror of the case above, and it failed nothing before this test existed:
+        dropping the event-type filter entirely left the file green.
+        """
+        self.assertEqual(_assistant_text_blocks(TEXT_INSIDE_A_NON_ASSISTANT_EVENT), [])
+
+    def test_the_terminal_restatement_is_not(self) -> None:
+        """It is the same words twice; the composer already treats it as a fallback."""
+        self.assertEqual(_assistant_text_blocks(RESULT_EVENT), [])
+
+    def test_several_blocks_in_one_message_keep_their_order(self) -> None:
+        payload = {"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "first"},
+            {"type": "tool_use", "name": "Bash", "input": {}},
+            {"type": "text", "text": "second"},
+        ]}}
+        self.assertEqual(_assistant_text_blocks(payload), ["first", "second"])
+
+    def test_a_malformed_event_is_not_an_exception(self) -> None:
+        for payload in (None, [], "assistant", {"type": "assistant"},
+                        {"type": "assistant", "message": None},
+                        {"type": "assistant", "message": {"content": None}},
+                        {"type": "assistant", "message": {"content": [None, 7, "x"]}}):
+            self.assertEqual(_assistant_text_blocks(payload), [], repr(payload))
+
+    def test_an_empty_text_block_contributes_nothing(self) -> None:
+        payload = {"type": "assistant", "message": {"content": [{"type": "text", "text": "   "}]}}
+        self.assertEqual(_assistant_text_blocks(payload), [])
+
+
+class TheWholeStreamIsUnchangedTests(unittest.TestCase):
+    """The control on the whole change: every other caller must see exactly what it saw.
+
+    Without this the fix could have been made by narrowing
+    `extract_stream_text_fragments`, which would have silently changed what every stage
+    reads. The test is here to make that difference a failure rather than a preference.
+    """
+
+    def test_the_shared_extractor_still_reads_a_tool_result(self) -> None:
+        self.assertIn(LISTING, extract_stream_text_fragments(TOOL_RESULT))
+
+    def test_the_shared_extractor_still_reads_a_result_payload(self) -> None:
+        self.assertIn(ANSWER, extract_stream_text_fragments(RESULT_EVENT))
+
+    def test_the_composer_still_puts_the_listing_in_the_whole_stream_text(self) -> None:
+        operator = ClaudeOperator(model="sonnet", fake_mode=True)
+        composed = operator._compose_stdout_text(  # noqa: SLF001
+            extracted_fragments=[LISTING, ANSWER], terminal_fragments=[ANSWER],
+            non_json_lines=[], raw_lines=[],
+        )
+        self.assertIn(LISTING, composed)
+        self.assertIn(ANSWER, composed)
+
+
+class TheReplyTheFrontEndKeepsTests(unittest.TestCase):
+    """`_OperatorCall.invoke` prefers the assistant's text and falls back to the stream.
+
+    The fallback is not politeness. `CodexOperator` reaches the same seam and does not label
+    its events, so a reader that required the field would hand that backend an empty answer
+    and score it as a refusal.
+    """
+
+    def setUp(self) -> None:
+        from src.frontierscience import _OperatorCall
+
+        self.calls: list[dict] = []
+        outer = self
+
+        class Recorder:
+            fake_mode = False
+
+            def _prepare_invocation(self, prompt_path, session, *, paths, resume):
+                return ["claude"], Path("/tmp"), None
+
+            def _run_streaming_command(self, **kwargs):
+                outer.calls.append(kwargs)
+                return 0, outer.stdout, "", None, outer.meta
+
+        class Call(_OperatorCall):
+            def invoke_here(self, paths):
+                return self.invoke(paths=paths, prompt="p", label="l", attempt=1)
+
+        self.Call = Call
+        self.operator = Recorder()
+
+    def _run(self, stdout: str, meta: dict) -> str:
+        import tempfile
+
+        from src.utils import build_run_paths
+
+        self.stdout, self.meta = stdout, meta
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = build_run_paths(Path(tmp))
+            paths.prompt_cache_dir.mkdir(parents=True, exist_ok=True)
+            return self.Call(self.operator).invoke_here(paths)[1]
+
+    def test_the_assistant_text_wins_over_the_whole_stream(self) -> None:
+        """The defect end to end: the listing is in the stream and not in the answer."""
+        reply = self._run(f"{LISTING}\n\n{ANSWER}", {"assistant_text": ANSWER})
+        self.assertEqual(reply, ANSWER)
+        self.assertNotIn("drwx", reply)
+
+    def test_a_reader_that_offers_nothing_falls_back_to_the_whole_stream(self) -> None:
+        self.assertEqual(self._run(ANSWER, {}), ANSWER)
+        self.assertEqual(self._run(ANSWER, {"assistant_text": ""}), ANSWER)
+        self.assertEqual(self._run(ANSWER, {"assistant_text": "   "}), ANSWER)
+
+    def test_a_missing_meta_is_not_an_exception(self) -> None:
+        self.assertEqual(self._run(ANSWER, None), ANSWER)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_the_reply_is_captured_once.py
+++ b/tests/test_the_reply_is_captured_once.py
@@ -16,10 +16,14 @@ What it cost, measured on the sixty-task FrontierScience trial: **fifty-five of 
 arm's sixty answers carried the answer twice** -- forty an exact byte-for-byte halving, fifteen
 more asymmetric because the reply arrived in several streamed blocks -- against **none** of the
 pipeline arm's, because only the control arm keeps the reply. Forty-two of the forty-three
-paired tasks were affected. Re-judging eleven of them cut back to a single copy moved the score
-by **-0.307 points on average** (sd 0.606, five of eleven negative and one positive), so the
-duplication flattered the arm that had it by about the size of the effect the trial existed to
-measure.
+paired tasks were affected. Re-judging twelve of them cut back to a single copy moved the score
+by **+0.033 points on average** (sd 0.633, four negative, five unchanged, three positive), so the
+duplication did not measurably flatter the arm that had it -- the reason to repair this is that an
+arm-asymmetric artifact should not be in a paired comparison, not that it was worth points.
+
+An earlier revision of this docstring reported that re-judging as -0.307 over eleven answers. That
+figure is not in `~/fs-runs/dedup_recheck.json` and is not reachable from it by dropping any record;
+see the correction note in `docs/frontierscience-results.md`.
 
 The three tests below are the three things that have to stay true: the reply is captured once,
 the result event is still the reply when nothing else produced one, and a caller that keeps the


### PR DESCRIPTION
## What

Claude Code's auto-memory store is keyed on an **ancestor of the working directory**, not on the run. Probed against the real binary (2.1.229) on this box:

| cwd | `memory_paths.auto` |
|---|---|
| `/rmeng_data/robtang/memprobe` | `.../projects/-rmeng-data-robtang/memory/` |
| `.../fs-trial-skills/workspaces/fs024_direct-opus_.../.autor/<ts>` | `.../projects/-rmeng-data-robtang/memory/` |

Same store. Every run under one results directory shares it, and its `MEMORY.md` index is loaded into each agent's context at session start.

## That it is used, not merely reachable

On the sixty-task FrontierScience trial, in a 1,456-file store (294 written that day), the two most-read files were notes an **earlier run** had written about this harness's own exit clauses:

```
92 reads  fs-ideate-write-answer-md-yourself-to-preempt-synthesis.md
56 reads  an-existing-answer-md-outranks-the-synthesizer.md
11 reads  MEMORY.md
 4 reads  the-reviewer-sees-the-first-16000-characters.md
 3 reads  stage-02-typed-id-regex-needs-the-colon-touching-the-bold.md
```

Cause, not consequence, and the tool-call position separates the two. In the physics block the read lands at tool call 68–151 of 66–239 — an agent that got stuck and went looking. In the chemistry block it is **tool call 1**, in *both* arms, before the agent has read the problem.

It is asymmetric: **32 of 37** pipeline runs reached the store against **8 of 37** direct ones, so it does not cancel out of a paired comparison.

One further consequence, already fixed upstream by #297 but worth naming: 6 of the direct arm's 11 refusals were answers beginning `1\t---`, which is the `cat -n` rendering of one of those memory files, captured into `answer.md` by the pre-#297 stream reader and refused by a content clause.

**What did not happen: cross-task answer leakage.** Exactly one file in the store held solved content for a specific task (`fs:017`'s Schrödinger–Poisson constants), and the only run that read or wrote it was `fs:017`'s own.

## The fix

One CLI flag — `--settings {"autoMemoryEnabled": false}`. It *adds to* the settings in force rather than replacing them, so auth, model and env survive; verified by running a probe with it and having it still reach its configured backend and report `memory_paths: null`.

**Opt-in, and the default is a tested control.** AutoR's ordinary use is a researcher's own project where carrying notes between sessions is the feature working as intended. Only a measurement needs every run to start from the same state. The FrontierScience front end opts in; nothing else changes, including the sibling benchmarks that were mid-flight when this landed.

`auto_memory_isolated` goes into `_meta.json` and is **tri-state**. `None` means the question was never asked — the honest reading both for the trials already on disk and for a codex seat, since `CodexOperator` subclasses `ClaudeOperator` and a plain attribute read would have it report "the memory store was reachable" about a binary it never ran.

## Tests

15 tests. Mutation-tested, all 8 killed:

| mutation | killed by |
|---|---|
| default flipped to `True` | 2 |
| `autoMemoryEnabled: true` | 3 |
| key misspelled `autoMemoryEnable` | 4 |
| condition inverted | 7 |
| whole branch stubbed out | 4 |
| backend check removed | 1 |
| front end un-isolated | 2 |
| tri-state collapsed to `bool` | 1 |

Full suite: 4168 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)