### PR TITLE
Close the memory channel on ResearchClawBench too, where it runs between the arms

### DIFF
--- a/docs/researchclawbench-arms.md
+++ b/docs/researchclawbench-arms.md
@@ -77,6 +77,51 @@ keyhole.** Arms remain comparable to each other; none is comparable to an upstre
 
 ---
 
+## The second measurement fault: the arms shared a memory store
+
+Every arm above ran with Claude Code's auto-memory store open. The store is keyed on an
+**ancestor of the working directory**, not on the run root, so every run under
+`/rmeng_data/robtang` read and wrote one `MEMORY.md`, loaded into each agent's context at
+session start. Probed from that directory against the real binary (2.1.229) on 2026-08-19:
+
+```
+no flag:  memory_paths.auto = ~/.claude/projects/-rmeng-data-robtang/memory/
+--settings '{"autoMemoryEnabled": false}':  no memory_paths key at all
+```
+
+**What hides it is that the transcripts *are* isolated.** Each run gets its own project
+directory — `-rmeng-data-robtang-rcb-runs-topo-adaptive-Math-000-...` — and those
+directories hold `.jsonl` files and no `memory/`. Per-run isolation looks done from a
+directory listing. The memory store resolves separately, and upward.
+
+For the single-arm rows above this is a channel from one run into the next. **For the
+paired topology ablation it is a channel between the two things being compared**, because
+both arms run the same forty tasks: whichever arm reaches a task first writes notes filed
+under that task's name and the other reads them before it starts. Measured while the first
+attempt was in flight, the store held 1,531 files / 9.1 MB, took 378 writes on 2026-08-19
+alone, and 29 of that day's files are named after a specific task in `tasks40.txt` —
+`math-000-score-mixture-disables-track-initialisation.md`,
+`energy-001-ships-a-20-bus-two-region-ladder-not-29-nodes.md`, and so on.
+
+The direction matters more than the size. A channel that makes each arm partly a copy of
+the other **shrinks the difference the ablation exists to measure**: a real topology effect
+would present as absent, and the run would read as a clean null result rather than as a
+broken one. That is why the first attempt was cancelled at roughly two hours rather than
+footnoted at forty.
+
+Closed for the RCB front end by this change, which passes
+`--settings '{"autoMemoryEnabled": false}'` — the mechanism #298 verified for
+FrontierScience and did not wire here. Confirmed live rather than by inspection: on a
+sampled compute node all three `claude` processes carry the flag and none is without it,
+and the shared store took **zero** writes in the period after the relaunch while 27 runs
+were active, against 27 in the twelve minutes before it.
+
+The first attempt's 58 workspaces are kept at
+`rcb_runs/topo_{adaptive,linear}_v1_shared_memory`. They are evidence, not an arm; nothing
+in them should be scored as the ablation.
+
+---
+
 ## The arms
 
 Paired against the control. `diff` is AutoR − control in benchmark points; the interval is

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -425,6 +425,13 @@ def create_operator(
         stage_timeout=stage_timeout,
         web_search_mcp=web_search_mcp,
         disallowed_tools=disallowed_tools,
+        # A benchmark run must not start from another run's notes. #298 closed this for
+        # FrontierScience and left ResearchClawBench open; the store is keyed on an
+        # ancestor of the working directory, so every RCB run under one results directory
+        # shared one `MEMORY.md`. That is worse for a paired ablation than for a single
+        # arm: both arms run the same forty tasks, so whichever arm reaches a task first
+        # writes notes about that exact task and the other reads them at session start.
+        isolate_auto_memory=True,
     )
 
 

--- a/tests/test_a_benchmark_run_starts_without_another_runs_notes.py
+++ b/tests/test_a_benchmark_run_starts_without_another_runs_notes.py
@@ -81,7 +81,11 @@ class TheFlagTests(unittest.TestCase):
         does not recognise, so a misspelling produces a run that looks isolated in its own
         metadata, reads the shared store anyway, and reports nothing unusual. The spelling
         was taken off the binary's own symbol table and confirmed by probing
-        `memory_paths` -- `null` with the flag, the shared path without it.
+        `memory_paths`: the shared path without the flag, and with it **no `memory_paths`
+        key at all** rather than a `null` one. Re-probed from `/rmeng_data/robtang` on
+        2026-08-19 against 2.1.229, because the difference matters to whoever reads an
+        init event next -- a check written as `init["memory_paths"] is None` raises
+        `KeyError` on exactly the run it exists to recognise.
         """
         self.assertEqual(
             list(settings_payloads(command_for(isolate_auto_memory=True))[0]), ["autoMemoryEnabled"]
@@ -171,6 +175,49 @@ class WhatTheFrontEndAsksForTests(unittest.TestCase):
         from fs_agent import auto_memory_isolation_for
 
         self.assertIs(auto_memory_isolation_for(object(), "claude"), False)
+
+
+class WhatTheResearchClawBenchFrontEndAsksForTests(unittest.TestCase):
+    """The sibling benchmark, whose paired ablation is the worst case for the channel.
+
+    FrontierScience runs one arm per task. ResearchClawBench's topology ablation runs
+    *two* arms over the same forty tasks under one results directory, so the store is not
+    a channel from last week's run into this one -- it is a channel between the two things
+    being compared, carrying notes filed under the name of the task both arms are working
+    on right now. Measured on 2026-08-19 while the first attempt was in flight: 378 writes
+    to `-rmeng-data-robtang/memory/` that day, 29 of them named after a specific task in
+    `tasks40.txt`.
+
+    The direction is the damaging one. A channel that makes each arm partly a copy of the
+    other shrinks the difference the ablation exists to measure, so a real topology effect
+    would present as absent, and the run would look like a clean null result.
+    """
+
+    def operator_for(self, backend: str):
+        from rcb_agent import create_operator
+
+        return create_operator(
+            backend=backend, model="opus", fake_mode=True, ui=None, stage_timeout=60,
+            disallowed_tools=["WebSearch"], codex_sandbox="danger-full-access",
+            codex_command="codex",
+        )
+
+    def test_the_researchclawbench_front_end_isolates(self) -> None:
+        self.assertIs(self.operator_for("claude").isolate_auto_memory, True)
+
+    def test_the_command_it_builds_carries_the_flag(self) -> None:
+        """Not just the attribute: the argument that reaches the binary.
+
+        The attribute assertion above passes on a front end that sets the field on an
+        operator whose command builder never reads it. This one fails there.
+        """
+        command = self.operator_for("claude")._build_cli_command(  # noqa: SLF001
+            Path("/tmp/p.md"), "sess-1", resume=False
+        )
+        self.assertEqual(settings_payloads(command), [{"autoMemoryEnabled": False}])
+
+    def test_a_codex_seat_is_untouched_here_too(self) -> None:
+        self.assertIs(self.operator_for("codex").isolate_auto_memory, False)
 
 
 class WhatTheRecordSaysTests(unittest.TestCase):


### PR DESCRIPTION
Stacked on #298. That PR closes Claude Code's cross-session memory store for
FrontierScience; this one closes it for ResearchClawBench, which builds its operator on
the same code path and did not opt in.

## Why it is worse here

RCB's topology ablation runs `--stage-graph adaptive` against `--stage-graph linear` over
**the same forty tasks under one results directory**. The store is keyed on an ancestor of
the working directory, so it is not a channel from last week's run into this one — it is a
channel **between the two things being compared**, carrying notes filed under the name of
the task both arms are working on right now.

Measured 2026-08-19 while the first attempt was in flight:

| | |
|:---|---:|
| files in `-rmeng-data-robtang/memory/` | 1,531 (9.1 MB) |
| writes on 2026-08-19 alone | 378 |
| of those, named after a task in `tasks40.txt` | 29 |

Examples: `math-000-score-mixture-disables-track-initialisation.md`,
`energy-001-ships-a-20-bus-two-region-ladder-not-29-nodes.md`.

**The direction is the damaging one.** A channel that makes each arm partly a copy of the
other shrinks the difference the ablation exists to measure, so a real topology effect
would present as absent and the run would read as a clean null result rather than a broken
one. The first attempt was cancelled at two hours rather than footnoted at forty; its 58
workspaces are kept at `rcb_runs/topo_{adaptive,linear}_v1_shared_memory` as evidence and
must not be scored as the arm.

## What hides it

The transcripts *are* isolated. Each run gets its own project directory —
`-rmeng-data-robtang-rcb-runs-topo-adaptive-Math-000-…` — and those hold `.jsonl` files
and **no `memory/`**. Per-run isolation looks done from a directory listing; the memory
store resolves separately, and upward.

## One correction to #298

Re-probed from `/rmeng_data/robtang` against 2.1.229 on 2026-08-19:

```
no flag:  memory_paths.auto = ~/.claude/projects/-rmeng-data-robtang/memory/
--settings '{"autoMemoryEnabled": false}':  no memory_paths key at all
```

#298's test docstring says the flagged run reports `null`. It reports **no key**. A reader
who writes `init["memory_paths"] is None` gets a `KeyError` on exactly the run the check
exists to recognise; the docstring is corrected here.

## Verification

- **Mutation-checked.** Flipping `isolate_auto_memory=True` → `False` in `rcb_agent.py`
  turns both new tests red and leaves the other 16 green.
- The attribute assertion alone would pass on a front end whose command builder never
  reads the field, so the second test asserts the argument that **reaches the binary**.
- **Confirmed live, not by inspection.** On a sampled compute node all three `claude`
  processes of a running arm carry the flag and none is without it.
- Full suite green: 4171 passed, 4 skipped, 3418 subtests, 366s.

Default is unchanged: `isolate_auto_memory` stays `False`, only the two benchmark front
ends opt in, and the built command is byte-identical without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)