### PR TITLE
Keep the task ids as provenance, drop the rubric maps

### DIFF
--- a/src/skills/answer-in-the-symbols-the-problem-printed/SKILL.md
+++ b/src/skills/answer-in-the-symbols-the-problem-printed/SKILL.md
@@ -85,41 +85,44 @@ So:
 Measured on the sixty-task FrontierScience-Research trial, one draw per task,
 judged by gpt-5.1 at high effort. Two physics tasks carry **4.575 of the 5.100**
 points the pipeline arm lost across eleven complete physics pairs; the other
-nine average −0.058.
+nine average −0.058. Bracketed material inside a quoted judgement is a redaction
+and not the grader's words.
 
-**fs:006, −1.575, confirmed.** The sheet's Hamiltonian is printed with two
-symbols. The pipeline's Stage 02 stage document uses a substitute symbol 30
-times and the sheet's two symbols **0 times each**; its answer inherits the
-substitution 72 times against a single use of the printed symbol, while the
-control uses the printed symbol 25 times and the substitute 0. The renaming
-touches six separate criteria. On item 3 the grader wrote of the control `the
-specific form ... is not written. Score: 0/0.5`; on item 6 the control's summary
-table gave the printed form with its rate variable intact and was marked `This
-matches exactly` for the full 0.5, while the pipeline substituted the rate away
-and produced an algebraically equivalent pair that does not contain it. On
-item 13 the pipeline solved a different differential equation, because it took
-its limiting case in the substituted variable rather than in the printed one —
-so the structure the criterion asks for could not appear at all, and one
-function in the printed set appears **0 times** in the answer.
+**fs:006, physics, −1.575 against the pipeline arm, confirmed.** The sheet
+prints its own symbols for the quantities it asks about. The pipeline's Stage 02
+stage document uses a substitute symbol 30 times and the printed notation **not
+at all**; its answer inherits the substitution 72 times against a single use of
+a printed symbol, while the control uses the printed symbol 25 times and the
+substitute 0. The renaming reaches criteria spread across the whole sheet rather
+than one corner of it. The grader's judgements on the affected items run in both
+directions: on one, `the specific form ... is not written. Score: 0/0.5` against
+the control; on another, `This matches exactly` for full credit where the
+control had kept the printed form intact and the pipeline had substituted it
+away for an algebraically equivalent expression. On a third the pipeline
+answered a different question from the one asked, having carried its own
+variable into a step the criterion was checked against in the printed one; the
+structure the criterion asks for could not appear at all, and one of the printed
+quantities appears **0 times** in the answer.
 
-Record the counter-evidence: fs:006 is not monotone. On item 8, worth 1.0, the
-control was marked `The specific [equations that item names] are not written
-anywhere in the answer. Score: 0/1.0` while the pipeline wrote part of that set.
-This skill is about which symbols, not about how much.
+Record the counter-evidence: fs:006 is not monotone. On one item worth 1.0 the
+control was marked `The specific [expressions that item names] are not written
+anywhere in the answer. Score: 0/1.0` while the pipeline wrote part of what was
+asked for. This skill is about which symbols, not about how much.
 
-**fs:009, −3.000, inferred, and the inference is flagged.** The pipeline arm's
-per-item reasoning was overwritten on disk and cannot be quoted; what follows
-is a comparison of the two answers against the criteria. Item 3 carries 3.0 of
-the task's 10 and the control was scored `This is the complete solution for [the
-dynamics item 3 names] ... Score: 3.0/3.0`. The structurally identical solution
-is present in the pipeline answer at 26% of the document — and 400 characters
-later it is replaced by a boxed limiting form, under a principal section
-heading naming the approximation, with the exact solution carried through only
-under a route labelled a cross-check at 69% of the document. The
-approximation's name appears 9 times against the control's 2. The pipeline
-scored 1.0 of 10. The
-placement is measured; the causal link to item 3 is not, because the reasoning
-file is gone.
+**fs:009, physics, −3.000 against the pipeline arm, inferred, and the inference
+is flagged.** The pipeline arm's per-item reasoning was overwritten on disk and
+cannot be quoted; what follows is a comparison of the two answers against the
+criteria. The heaviest single item on the sheet went to the control at full
+marks, on a judgement of the shape `This is the complete solution ... full
+marks` — one of several shapes seen in the trial wherever an exact result was
+written out on the main line. The structurally identical solution is present in
+the pipeline answer at 26% of the document — and 400 characters later it is
+replaced by a boxed limiting form, under a principal section heading naming the
+approximation, with the exact solution carried through only under a route
+labelled a cross-check at 69% of the document. The approximation's name appears
+9 times against the control's 2. The pipeline took a tenth of the available
+points. The placement is measured; the causal link to that item is not, because
+the reasoning file is gone.
 
 Two candidate explanations are excluded quantitatively and must not be designed
 against: the pipeline's physics answers are **not shorter** (unique-content ratio
@@ -134,6 +137,7 @@ sheet's criteria ask for intermediate quantities in the units the sheet itself
 works in, an answer that silently carries them in another unit system loses
 those items; the trial has one task where that happened to **both** arms at
 once, so it is an observation about the failure mode and not a gain either arm
-made, and no advice here is designed against it. On fs:036 the control merged
-two opposing contributions into one row and scored 0.0/1.0; nothing here
-licenses that merge. The rule against renaming is the same rule chemistry needs.
+made, and no advice here is designed against it. On fs:036 the control collapsed
+content the criteria credited separately into a single row and scored 0.0/1.0
+for it; nothing here licenses that collapse. The rule against renaming is the
+same rule chemistry needs.

--- a/src/skills/bind-every-deliverable-to-the-file-that-is-graded/SKILL.md
+++ b/src/skills/bind-every-deliverable-to-the-file-that-is-graded/SKILL.md
@@ -89,21 +89,25 @@ were provider-side refusals of the stage prompt itself and are outside what any
 craft advice can reach. **Nine were review send-backs and summary-shape
 failures**, which is what this is for.
 
-Both send-backs on fs:007 and fs:017 are bookkeeping, verbatim. fs:007, second
-review: `Fix the paths. "Derivations: notes/typed_claims_T_and_C.json" and
-"code/pilot_fisher.py, code/pilot_bias_operator.py" do not resolve from the run
-root; there is no code/ or notes/ there. ... either populate
-derived_from/depends_on in the manifest or stop advertising "prior expectation,
-what-would-surprise-me, dependencies" for a file whose schema has no such
-fields.` fs:017, second review, carry-forward: `answer.md is the graded
-deliverable and deliverables_coverage.json binds its seven where locators to
+Both send-backs on fs:007 and fs:017 are bookkeeping. The two quotations are
+verbatim except in brackets, where three file names coined from the tasks' own
+subject matter and one count have been redacted. fs:007, second review: `Fix
+the paths. "Derivations: [a redacted notes/ path]" and "[redacted code/ paths]"
+do not resolve from the run root; there is no code/ or notes/ there. ... either
+populate derived_from/depends_on in the manifest or stop advertising "prior
+expectation, what-would-surprise-me, dependencies" for a file whose schema has
+no such fields.` fs:017, second review, carry-forward: `answer.md is the graded
+deliverable and deliverables_coverage.json binds its [n] where locators to
 report.md only. Bind them to answer.md as well.` Neither objection is about
-science. Both runs spent `sendback_count = 2` and forfeited the question.
+science, and neither would have read any differently against a different
+question — that is why they generalise. Both runs spent `sendback_count = 2`
+and forfeited the question.
 
-The control arm passed four of the forfeited tasks outright — fs:007 at 7.0,
-fs:017 at 7.6, fs:049 at 9.25, fs:057 at 8.94 against a 7.0 threshold. fs:057
-never reached review at all: two attempts, 2,827 s and 212,219 output tokens,
-and the log ends `Repair output for Stage 02 ... is still incomplete.
+The control arm passed four of the forfeited tasks outright — fs:007, fs:017,
+fs:049 and fs:057 — scoring between 7.0 and 9.25 against a 7.0 threshold, one
+of them clearing by nothing at all. One of those four never reached review in
+the pipeline arm at all: two attempts, 2,827 s and 212,219 output tokens, and
+the log ends `Repair output for Stage 02 ... is still incomplete.
 Normalizing locally... / Local normalization ... is still incomplete. Re-running
 the stage... / Stage 02 ... was stopped by the run supervisor: the auto-skip
 budget (0) is spent.`

--- a/src/skills/every-printed-part-gets-its-own-answered-section/SKILL.md
+++ b/src/skills/every-printed-part-gets-its-own-answered-section/SKILL.md
@@ -83,42 +83,47 @@ comparison arm ends up appearing zero times in the document.
 ## Why this is here
 
 Measured on the sixty-task FrontierScience-Research trial, one draw per task,
-judged by gpt-5.1 at high effort. Task totals below are the recorded ones. On
-fs:053 and fs:042 the run's own per-item reasoning for the pipeline arm was
-overwritten on disk, so the per-item numbers for that arm come from re-judging
-its answer under the same prompt template; those re-judgements return 8.0
-against a recorded 7.8 and 7.7 against a recorded 8.0, which is the size of
-disagreement to read the item splits against.
+judged by gpt-5.1 at high effort. Task totals below are the recorded ones. The
+three tasks below are all biology, and in each of them it is the pipeline arm
+that lost. On fs:053 and fs:042 the run's own per-item reasoning for that arm
+was overwritten on disk, so the per-item numbers for that arm come from
+re-judging its answer under the same prompt template; those re-judgements return
+8.0 against a recorded 7.8 and 7.7 against a recorded 8.0, which is the size of
+disagreement to read the item splits against. Bracketed material inside a quoted
+judgement is a redaction and not the grader's words.
 
-**fs:044, 10.000 to 6.000.** The sheet prints nine sub-parts and the criteria
-list ten items. The ideation pool's ten candidate titles covered items 1A, 1C,
-1D and 1G and 2A; the number of candidates touching 1B, 1E, 2B or 2C was
-**zero**. The pipeline arm scored exactly 1A, 1C, 1D-family, 1D-member, 1E and
-1G, and lost 1B, 2A, 2B and 2C — the loss set and the uncovered set are the same
-set, four points on one task.
+**fs:044, 10.000 to 6.000.** Four items of one point each, and the ideation
+pool's ten candidate titles touched none of the four: the number of candidates
+pointing at any of them was **zero**. The pipeline arm scored where its pool had
+looked and lost where it had not — four points on one task. The criteria and the
+printed parts are not quite in one-to-one correspondence, and the loss set and
+the uncovered set coincide to within one item either way, so read the identity
+as close rather than exact. Three of these four points are claimed again under a
+different mechanism by `grant-the-expected-reading-before-you-depart-from-it`;
+the two accounts are of the same items at two points in the pipeline, and the
+figures must not be added.
 
 **fs:053, task −1.700 (9.500 to 7.800), of which 1.750 sits on the three items
 below.** The item sum is larger than the task delta because other items moved
 the other way; every other per-task figure in this pack is a task total, and
-this one and the next are item sums stated as such. Item 3, one point: the
-control committed to a default
-ordering in one clause and the grader wrote `... is defined as "[the ordering it
-committed to]," which is precisely ... Score: 1.0/1.0`. The pipeline arm was
-marked `treats order as an experimental variable (2x2 over the ordering, §3.4)
-but never commits to or justifies a specific default order (+0.0)`. Item 6,
-−0.25: `It does not provide a concrete narrative example`. Item 2, −0.5: the
-named instance the criterion asks for appears **0 times** in the pipeline answer
-and twice in the control.
+this one and the next are item sums stated as such. Three items moved: one
+point, half a point and a quarter of a point, and all three are one failure at
+three prices. In each the criterion names something the writer is to produce by
+hand and commit to, and on one of the three that thing appears **0 times** in
+the pipeline answer where it appears twice in the control. The judgements on
+either side read `... is defined as "[the thing it committed to]," which is
+precisely ... Score: 1.0/1.0` for the control and, for the pipeline arm, that it
+treated the same thing as an experimental variable `but never commits to or
+justifies a specific default (+0.0)`.
 
 **fs:042, task −1.000 (9.000 to 8.000), 1.150 of it on the two items below.**
-Two criteria require a mechanistic comparison against a comparator the sheet
-names. The control was scored `... implying [the named comparator]'s [pathway]
--> ~0.2/0.2 pts (conceptually correct, albeit using a neighbouring pair)` for
-0.7 of 1.0 on item 6 and 0.95 of 1.0 on item 1. In the
-pipeline answer the named comparator's terms appear **0 times each**, and the
-grader wrote `it does not explicitly compare ... Score: 0.0 + 0.0 + 0.0 =
-0.0/1.0`. The budget went into a self-chosen quantitative model, which took full
-marks on its own item.
+Both items turn on something the sheet itself names and the answer is expected
+to take up. The control took it up only loosely — `-> ~0.2/0.2 pts
+(conceptually correct)` — and still scored 0.7 of 1.0 on one of the two and 0.95
+of 1.0 on the other. In the pipeline answer the thing the sheet names appears
+**0 times**, and the grader wrote `it does not explicitly [take it up] ...
+Score: 0.0/1.0`. The budget had gone into a self-chosen quantitative model
+instead, and that model scored well on its own terms.
 
 Length is not the cause and must not be treated as one: after removing the
 control arm's duplicated text, the pipeline's biology answers total 887k
@@ -127,11 +132,11 @@ characters against 803k. The pipeline writes **more** and covers **less**.
 **Checked against what chemistry pays for.** The main effect is additive: it
 increases the number of separately headed, separately answered units, which is
 exactly the granularity chemistry criteria reward — on fs:022 the control scored
-0 of 3.5 points across four parts for never stating the per-part combination as
-its own line. It merges no rows and removes no working. It does contain two
-sentences that shorten — discharge an obvious part in two lines, give the reason
-in one sentence — and chemistry criteria do pay separately for the verdict and
-for the explanation behind it, so those two are a ceiling on the *cheap* part of
-a sheet and never a licence to compress a part that asks why. The other risk is
-budget dilution across many small sections; that is why
-it says to discharge an obvious part in two lines rather than to expand it.
+0 of 3.5 points on items of that granularity. It merges no rows and removes no
+working. It does contain two sentences that shorten — discharge an obvious part
+in two lines, give the reason in one sentence — and chemistry criteria do pay
+separately for the verdict and for the explanation behind it, so those two are a
+ceiling on the *cheap* part of a sheet and never a licence to compress a part
+that asks why. The other risk is budget dilution across many small sections;
+that is why it says to discharge an obvious part in two lines rather than to
+expand it.

--- a/src/skills/grant-the-expected-reading-before-you-depart-from-it/SKILL.md
+++ b/src/skills/grant-the-expected-reading-before-you-depart-from-it/SKILL.md
@@ -94,74 +94,82 @@ standing behind it word for word.
 
 ## Why this is here
 
-Measured on the sixty-task FrontierScience-Research trial, judged by gpt-5.1 at
-high effort. The pipeline arm's per-item reasoning was re-obtained by re-judging
-under the same prompt template; four of eight biology re-judgements reproduced
-the recorded totals digit for digit, and the rest were within 1.0 with a mean
-absolute difference of 0.29. **On its four biology tasks this is the only
-mechanism in the trial with quoted per-item reasoning on both arms.** Its two
-chemistry tasks are not in that position — only the control arm's judgement
-survives on disk for either — and the chemistry section below says where that
-makes the attribution an inference.
+Measured on the sixty-task FrontierScience-Research trial, one draw per task,
+judged by gpt-5.1 at high effort. The pipeline arm's per-item reasoning was
+re-obtained by re-judging under the same prompt template; four of eight biology
+re-judgements reproduced the recorded totals digit for digit, and the rest were
+within 1.0 with a mean absolute difference of 0.29. **On its four biology tasks
+this is the only mechanism in the trial with quoted per-item reasoning on both
+arms.** Its two chemistry tasks are not in that position — only the control
+arm's judgement survives on disk for either — and the chemistry section below
+says where that makes the attribution an inference.
 
 Four biology tasks, **7.0 points**, all the same shape:
 
-- **fs:044**, items 1B, 2A and 2C, one point each. Control: `Part 2B heading ...
-  explicitly stated. Points: 1.0`. Pipeline: `Identifies Protein 1 as [a
-  different node] ... Points: 0.0`, and the criterion for the motif scan was
-  marked `the motif scan is generic and tied to the student's proposed target
-  ... Points: 0.0`. The commitment is traceable: a contrarian lens statement
-  ends with a clause that explicitly rules one reading out, it was scored
-  relevance 6 into the stage, and the reviewer endorsed it.
-- **fs:054**, items 3 and 9, −2.0. The two criteria pin one technique to one
-  scenario. Control: `Scenario 2 is explicitly assigned to ... Score: 1.0`.
-  Pipeline: `Scenario 2 ... is answered with [another technique] ... Score: 0.0`
-  — moved on the strength of the run's own rule, quoted in its answer as `the
-  combined score is 0.833 against 0.750`. No-reuse across scenarios turned one
-  swap into two lost points.
-- **fs:058**, −1.0. Control hedged and scored: `"If [the stated condition]
-  holds, the intended answer is ..." Score: 1`. The pipeline wrote instead that
-  the reading was eliminated by another part's own design, and was scored
-  `explicitly eliminating ... Score: 0.0`.
-- **fs:056**, −1.0. Pipeline: `The explanation directly rejects [the rationale
-  the criterion asks for] ... 0.0/1.0` — **and it was scientifically right**.
-  Correcting the expected rationale cost exactly one point.
+- **fs:044**, −3.0, three items of one point each. The control was paid for
+  saying the conventional thing outright — `... explicitly stated. Points: 1.0`
+  — and the pipeline was marked zero for having committed elsewhere. It was
+  marked zero a second time on the item scoring the analysis behind that
+  commitment, judged generic because the analysis followed the answer's own
+  choice rather than the conventional one. The commitment is traceable: a
+  contrarian lens statement ends with a clause that explicitly rules one reading
+  out, it was scored relevance 6 into the stage, and the reviewer endorsed it.
+- **fs:054**, −2.0, two items. The pipeline departed from the conventional
+  answer on the strength of a rule it had invented itself, whose two candidates
+  it separated by less than a tenth; the control's conventional answer was paid
+  and the pipeline's was not. A self-generated margin that small is not evidence
+  enough to displace the conventional reading.
+- **fs:058**, −1.0. The control kept the conventional reading as a conditional
+  and was paid for it — `"... the intended answer is ..." Score: 1`. The
+  pipeline ruled the same reading out instead, and was scored `explicitly
+  eliminating ... Score: 0.0`.
+- **fs:056**, −1.0, one item, and the clearest case of the shape: a refinement
+  that was defensible on the science displaced the statement the criterion was
+  keyed to, and the item went to zero. Being right about the science is not what
+  the item scored.
+
+The assignment section above is priced inside that 7.0 and not separately; it
+has no independent evidence of its own.
 
 The mirror confirms the mechanism rather than the arm: on fs:047 it was the
-**control** that wrote a "better described as ... than as ..." refinement and
-scored 0.0 where the pipeline's plain statement took 1.0, and on fs:052 the
-control's explicit rejection of a stated alternative scored 0/1.25 against the
-pipeline's 1.25/1.25. Across the twenty biology answers, explicit-elimination
+**control** that refined the conventional statement into something better
+described another way, and scored 0.0 on the item where the pipeline's plain
+statement took 1.0, and on fs:052, −1.25, an explicit rejection of a
+conventional alternative cost the control where the pipeline's plain statement
+was paid in full. Across the twenty biology answers, explicit-elimination
 phrasing runs at 0.28 per ten thousand characters in the pipeline arm against
 0.10 in the control — 2.8 times.
 
 **Checked against what chemistry pays for — and this is the one skill of the
 five with a known risk surface in chemistry.** Take the benefit first. The two
 chemistry losses in the trial are the same shape as the four biology ones.
-fs:024, −1.000, item 4: the control was given `Partial credit: 0.5/1.0` for
-keeping the conventional reading alongside its own variants; the pipeline
-replaced it with a single committed value, and the conventional reading appears
-**0 times** in its answer against 1 in the control. fs:033, −1.170 as a task
-total (8.17 to 7.00): here the attribution to items 4 and 5 is **inferred, and
-the inference is flagged** — the pipeline arm's per-item reasoning for this task
-was overwritten on disk and both arms' score records now point at the surviving
-judgement of the other arm, so what is checkable is the two totals and the fact
-that the pipeline's own answer names the mechanism the criteria ask for and then
-demotes it in the following sentence. No grader sentence about that demotion
-exists to quote. Granting the reading first would have kept both statements
-without changing either commitment.
+fs:024, −1.000: the control kept the conventional reading alongside its own and
+was given partial credit for doing so; the pipeline replaced it outright, and
+the conventional reading appears **0 times** in the pipeline's answer against 1
+in the control. fs:033, −1.170 as a task total: here the attribution to two of
+its items is **inferred, and the inference is flagged** — the pipeline arm's
+per-item reasoning for this task was overwritten on disk and both arms' score
+records now point at the surviving judgement of the other arm, so what is
+checkable is the two totals and the fact that the pipeline's own answer states
+the conventional reading the items turn on and then demotes it in the following
+sentence. No grader sentence about that demotion exists to quote. Granting the
+reading first would have kept both statements without changing either
+commitment.
 
 Now the risk. Three chemistry criteria across two tasks, one rubric point each,
 pay for an exclusion: they ask the answer to say why a competing pathway is not
 the operative one, and the sentence that does that is exactly the sentence the
-closing checklist tells a writer to hunt for. One of those two tasks is fs:033
-itself, which passed at exactly 7.0 against a 7.0 threshold, inside the ±0.33
-single-draw noise band; the other is fs:036, a +1.500 chemistry win for the
-pipeline. Applied mechanically — delete
-every sentence whose job is to remove a named mechanism — this skill would take
-points off both. That is why the checklist carries the carve-out above and why
-the three rewrites are stated as *add in front of*, never *replace*. This is the
-skill to withdraw first if the next trial's chemistry number moves down.
+closing checklist tells a writer to hunt for. One of those two tasks is also one
+of the two chemistry losses above, so there the skill's benefit and its risk
+land on the same answer and the net is not established; that task passed at
+exactly 7.0 against a 7.0 threshold, inside the ±0.33 single-draw noise band. On
+the other there is no benefit to set against the risk at all — nothing in that
+answer was lost to a departure from the conventional reading — so the exposure
+stands on its own. Applied mechanically — delete every sentence whose job is to
+remove a named mechanism — this skill would take points off both. That is why
+the checklist carries the carve-out above and why the three rewrites are stated
+as *add in front of*, never *replace*. This is the skill to withdraw first if
+the next trial's chemistry number moves down.
 
 Beyond that surface, nothing here compresses a ledger, merges an opposing pair,
 or moves a verdict sentence later; it adds one paragraph per elimination.

--- a/src/skills/one-visible-line-per-quantity-the-answer-owes/SKILL.md
+++ b/src/skills/one-visible-line-per-quantity-the-answer-owes/SKILL.md
@@ -85,36 +85,43 @@ does separate them and is not the thing being claimed here. **The separation
 this section claims is the constraint**, and
 in sixty tasks it was recorded exactly once — as a typed claim from one ideation
 lens on one task, which then survived into the writing stage. This skill exists
-to stop that from being luck.
+to stop that from being luck. The three tasks below are all chemistry, and in
+each of them it is the pipeline arm that moved.
 
-**fs:022, +3.500.** Five criteria are per-part counts. On four of them the
-control was scored, verbatim: `the answer provides [the totals] and a detailed
-pathway, but does not anywhere state the specific combination ... Award 0 pts` —
-0 of 3.5. Its one expanded part took the credit. The pipeline scored 10.0/10
-with a separate row-per-contributor table under each part, each with a bolded
-total row, and its own text states the rule it was following: the contributing
-counts are displayed on separate lines throughout rather than folded into a
-total. The rule is traceable from a lens output through the stage's locked
-decisions into the synthesis prompt, where the phrase appears twice.
+**fs:022, +3.500.** The control produced the totals, and the working that led to
+them, but nowhere put the individual contributions where a reader could take one
+off the page; four items of the same shape were scored against it, three and a
+half points between them. A judgement of that shape, generalised off the task,
+runs: the answer provides the totals and a detailed derivation, but does not
+anywhere state the individual quantities — award 0 pts. The one part it did
+expand took the credit. The pipeline took all four with the per-part ledger this
+skill describes, and its own text states the rule it was following: the
+contributing counts are displayed on separate lines throughout rather than
+folded into a total. The rule is traceable from a lens output through the
+stage's locked decisions into the synthesis prompt, where the phrase appears
+twice.
 
 **fs:036, +1.500, two items attributed, and the attribution is one-sided.** Only
 the control arm's per-item judgement survives on disk here; the pipeline's was
-overwritten, so what is quoted below is the control's and what is said about the
-pipeline is its recorded total against a reading of its answer. The control's own
-step table merged two opposing requirements into one row and lost the item,
-`0.0 / 1.0`. The pipeline split the same physics into two rows with separate
-signed magnitudes — while its net conclusion was no closer to the expected one
-than the control's, so if it took that item it was paid for by the display and
-not by the physics. Granularity, not correctness. The second item is the cycle
-named as its own step sequence, where the control was scored `Score: 0.5 / 1.0`
-for using a different one in its main line.
+overwritten, so what is described below is the control's and what is said about
+the pipeline is its recorded total against a reading of its answer. The control
+lost one item, one point, to exactly the merged row this skill's second section
+forbids. The pipeline split the same reasoning into two rows with separate
+signed magnitudes — while its substantive conclusion was no better than the
+control's, so if it took that item it was paid for by the display and not by the
+content. Granularity, not correctness. The second of the two items is a
+different shape altogether, nothing this skill teaches, and it sits inside the
+same delta: read the +1.500 as an upper bound on what splitting the row bought,
+not as its price.
 
-**fs:034, +2.500.** Item 3 asks for a plain verdict. The control stated the
-verdict the part asks for and then spent a long section on the ways it can
-fail; the judgement quotes that section's closing sentence as the position it
-took, and scored the item `0.0`. The pipeline put a bolded unhedged verdict at
-the top of a dedicated Answer subsection for each of the five parts and
-qualified afterwards.
+**fs:034, +2.500.** The control stated the verdict a part asked for and then
+qualified backwards at length; the judgement quoted the section's closing
+sentence back as the position the answer took, and scored the item `0.0`. The
+verdict was there, and it was read off the end of the section instead of the
+top. That is one item, and the +2.500 is again a bound on what the change
+bought rather than its price. The pipeline put a bolded unhedged verdict at
+the top of a dedicated Answer subsection under every part and qualified
+afterwards.
 
 **This is the guardrail on the other four skills.** Three chemistry passes sit
 at exactly 7.0 against a 7.0 threshold, and the recorded single-draw judge noise


### PR DESCRIPTION
## Why

The five FrontierScience skills are installed on **one arm** of a paired trial, and they named **19 of the benchmark's 60 graded tasks**. Naming a task is wanted — it is what makes a lesson evidence rather than opinion, and it prices it. What was in there and was not wanted is a **map of what those tasks' rubrics pay for**, handed to one side only, on a benchmark scored item by item against a rubric.

The intent behind the pack is *abstractable capability*: a general ability that transfers to any sheet of that shape. So the ids stay and the maps go.

**The line, applied to every sentence:** an agent handed task `fs:0NN`, having read this skill, must not know anything about `fs:0NN`'s problem or rubric that an agent who understood the general lesson would not.

## What went

| before | after |
|:---|:---|
| `fs:044, items 1B, 2A and 2C, one point each` | `fs:044, −3.0, three items of one point each` |
| `fs:022. Five criteria are per-part counts` | `fs:022, +3.500. … four items of the same shape` |
| `Identifies Protein 1 as [a different node]` | `the pipeline was marked zero for having committed elsewhere` |
| `The two criteria pin one technique to one scenario` · `Scenario 2 is explicitly assigned to …` | `two items … departed from the conventional answer on the strength of a rule it had invented itself` |
| `The sheet's Hamiltonian is printed with two symbols` | *(gone; the general lesson already says "when a sheet prints a Hamiltonian, a coordinate pair, a coupling constant…")* |
| `One of those two tasks is fs:033 itself … the other is fs:036` | `one of those two tasks is also one of the two chemistry losses above … that task passed at exactly 7.0 against a 7.0 threshold` |

## What stayed, in force

Every point delta, every subject, which arm moved, and **every** risk disclosure, carve-out, `this attribution is inferred` flag and `only one arm's judgement survives on disk` caveat. The chemistry risk section still makes its whole argument — benefit and risk land on the same answer, the net is not established, that task sits at exactly 7.0 inside the ±0.33 noise band, this is the skill to withdraw first — without the identification.

Arm-level aggregates stay too (`explicit-elimination phrasing runs at 0.28 per ten thousand characters against 0.10`); those describe a population, not a task.

## Three markers added rather than lost

- `fs:044`'s loss set and uncovered set "coincide to within one item either way, so read the identity as close rather than exact" — the original overstated it as exact.
- Three of those four points are claimed again by a second skill under a different mechanism, and **"the figures must not be added"**.
- The assignment section is "priced inside that 7.0 and not separately; it has no independent evidence of its own."

## One residual, stated rather than hidden

The chemistry risk paragraph says the risky task is also one of the two chemistry losses named above, which narrows it from sixty to two. Closing that would mean deleting the disclosure, which is the more useful half.

## Constraints held

- **19 tasks still named** — unchanged by design.
- Frontmatter and the lesson half of all five files are **byte-identical to HEAD** (verified per file by hashing everything above `## Why this is here`).
- `git diff --name-only` is exactly the five `SKILL.md` files.
- **4168 passed, 4 skipped.**

## What this does not fix

The trial currently finishing measured the **un-weakened** skills, and its last eight `ideate` runs — the biology block, where 10 of the 19 named tasks live — ran with them. That arm's biology number is the least trustworthy part of it. A clean measurement of what these skills are worth needs a re-run on this branch, after #298 closes the shared-memory channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)