### PR TITLE
Grade at the concurrency the plan declares

### DIFF
--- a/tests/test_grading_runs_at_the_declared_concurrency.py
+++ b/tests/test_grading_runs_at_the_declared_concurrency.py
@@ -1,0 +1,202 @@
+"""`judge_concurrency` was a plan field that reached nothing, and the pass it should have
+governed was serial for a reason that inverts on inspection.
+
+The old docstring said one continuous serial pass is the only arrangement under which the
+first task's total and the last task's were produced by the same instrument. A pass that takes
+ten hours straddles *more* of whatever drift a hosted judge has than one that takes forty
+minutes, so serialising widens the window it was meant to close. Measured on the trial of
+2026-08-19: ninety-five answers at one draw each, one at a time, was still running six hours
+after the last agent finished. At three draws it would have been the larger half of the trial.
+
+Meanwhile `judge_concurrency` was in the plan, in the freeze, in the printed summary and in
+the fake scorer's metadata -- and the real path never read it. That is a field recorded and
+never used, which is the exact shape this module's own arm validation refuses a plan for.
+
+The tests below hold the three things the change must not cost:
+
+1. the default is still 1, so an existing plan replays what it measured, one call at a time;
+2. every draw is still attempted, retried and reported, so a pool cannot silently drop one;
+3. a lost draw is still named in `final_pass.json`, because a draw that failed quietly is an
+   arm published as replicated when it was not.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+REPO = Path(__file__).resolve().parents[1]
+for path in (str(REPO), str(REPO / "tools")):
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+from src.fs_trial import FsArmSpec, FsTrialPlan  # noqa: E402
+from tools import fs_trial  # noqa: E402
+
+DIRECT = FsArmSpec(label="direct-opus", kind="direct", model="opus", answer_guidance="minimal")
+PIPELINE = FsArmSpec(
+    label="abc1234-autor-ideate", kind="autor", model="opus", answer_guidance="minimal",
+    worktree="/tmp/wt", sha="abc1234", review_model="opus", profile="ideate",
+)
+
+
+class FinalPassTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.state_dir = Path(self.tmp.name)
+        (self.state_dir / "scores").mkdir()
+        self.addCleanup(self.tmp.cleanup)
+
+    def a_plan(self, **overrides) -> FsTrialPlan:
+        kwargs = dict(
+            capability="cap", dataset="/tmp/d.jsonl", dataset_sha256="0" * 64,
+            tasks=tuple(f"fs:{i:03d}" for i in range(6)),
+            control=DIRECT, treatment=PIPELINE, cost_note="UNMEASURED",
+            state_dir=str(self.state_dir),
+        )
+        kwargs.update(overrides)
+        return FsTrialPlan(**kwargs)
+
+    def states(self, n: int) -> list[dict]:
+        return [
+            {"task_key": f"fs:{i:03d}", "arm": "direct-opus", "attempt": 1,
+             "phase": "finished", "classification": "ok", "workspace": f"/tmp/ws{i}"}
+            for i in range(n)
+        ]
+
+    def run_pass(self, plan: FsTrialPlan, states: list[dict], scorer) -> None:
+        with mock.patch.object(fs_trial, "all_states", return_value=states), \
+             mock.patch.object(fs_trial, "score_once", side_effect=scorer), \
+             mock.patch.object(fs_trial, "read_json", return_value={"total_score": 7.0}):
+            fs_trial.final_pass(plan)
+
+    def final_pass_json(self) -> dict:
+        return json.loads((self.state_dir / "final_pass.json").read_text())
+
+    # -- what the pool must still do -------------------------------------------------
+
+    def test_every_state_and_draw_is_attempted_exactly_once(self) -> None:
+        seen: list[str] = []
+        lock = threading.Lock()
+
+        def scorer(plan, state, out):
+            with lock:
+                seen.append(out.name)
+            out.write_text("{}")
+            return True
+
+        self.run_pass(self.a_plan(judge_replicates=3, judge_concurrency=4), self.states(6), scorer)
+        self.assertEqual(len(seen), 18)
+        self.assertEqual(len(set(seen)), 18)
+        self.assertEqual(sorted(set(name.split(".")[-1] for name in seen)),
+                         ["json"])
+        self.assertEqual(sorted({name.split(".")[-2] for name in seen}), ["r0", "r1", "r2"])
+
+    def test_a_draw_already_on_disk_is_not_rejudged(self) -> None:
+        """Resume has to stay free. Re-judging a scored draw spends money and changes it."""
+        existing = fs_trial.score_path(
+            self.a_plan(), "fs:000", "direct-opus", 1, 0
+        )
+        existing.write_text("{}")
+        calls: list[str] = []
+
+        def scorer(plan, state, out):
+            calls.append(out.name)
+            out.write_text("{}")
+            return True
+
+        self.run_pass(self.a_plan(judge_replicates=1, judge_concurrency=4), self.states(3), scorer)
+        self.assertEqual(len(calls), 2)
+        self.assertNotIn(existing.name, calls)
+
+    def test_a_lost_draw_is_named_rather_than_dropped(self) -> None:
+        def scorer(plan, state, out):
+            return "fs:002" not in str(state["task_key"])
+
+        self.run_pass(self.a_plan(judge_replicates=2, judge_concurrency=4), self.states(4), scorer)
+        lost = self.final_pass_json()["unscored_draws"]
+        self.assertEqual(len(lost), 2)
+        self.assertTrue(all("fs002" in name for name in lost), lost)
+        self.assertEqual(lost, sorted(lost))
+
+    def test_a_lost_draw_is_retried_before_it_is_lost(self) -> None:
+        attempts: list[str] = []
+        lock = threading.Lock()
+
+        def scorer(plan, state, out):
+            with lock:
+                attempts.append(out.name)
+            return False
+
+        self.run_pass(self.a_plan(judge_replicates=1, judge_concurrency=2), self.states(1), scorer)
+        self.assertEqual(len(attempts), fs_trial.JUDGE_TRIES)
+
+    def test_the_done_marker_is_written(self) -> None:
+        self.run_pass(
+            self.a_plan(judge_replicates=1, judge_concurrency=3), self.states(2),
+            lambda plan, state, out: (out.write_text("{}"), True)[1],
+        )
+        self.assertIs(self.final_pass_json()["done"], True)
+
+    # -- that the concurrency is the declared one ------------------------------------
+
+    def test_the_pass_actually_overlaps_at_the_declared_width(self) -> None:
+        """The load-bearing one. Without it the pool could be a one-worker pool.
+
+        Counts how many scorers are inside the call at once. Asserting `> 1` rather than
+        `== 4` because a thread pool is not obliged to have all its workers resident, but
+        one is a serial pass wearing a pool.
+        """
+        live = 0
+        peak = 0
+        lock = threading.Lock()
+
+        def scorer(plan, state, out):
+            nonlocal live, peak
+            with lock:
+                live += 1
+                peak = max(peak, live)
+            time.sleep(0.05)
+            with lock:
+                live -= 1
+            out.write_text("{}")
+            return True
+
+        self.run_pass(self.a_plan(judge_replicates=2, judge_concurrency=4), self.states(6), scorer)
+        self.assertGreater(peak, 1, "the pass ran one call at a time")
+        self.assertLessEqual(peak, 4, "the pass exceeded the concurrency the plan declared")
+
+    def test_the_default_plan_is_still_one_at_a_time(self) -> None:
+        """Replay fidelity, and the control on the change.
+
+        Every plan already on disk omits this field. If the default moved, those plans
+        would be re-scored under an arrangement they did not declare.
+        """
+        self.assertEqual(self.a_plan().judge_concurrency, 1)
+        live = 0
+        peak = 0
+        lock = threading.Lock()
+
+        def scorer(plan, state, out):
+            nonlocal live, peak
+            with lock:
+                live += 1
+                peak = max(peak, live)
+            time.sleep(0.02)
+            with lock:
+                live -= 1
+            out.write_text("{}")
+            return True
+
+        self.run_pass(self.a_plan(judge_replicates=2), self.states(5), scorer)
+        self.assertEqual(peak, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fs_trial.py
+++ b/tools/fs_trial.py
@@ -54,6 +54,7 @@ import json
 import os
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -600,36 +601,66 @@ def fake_score(plan: FsTrialPlan, state: Mapping[str, Any], out: Path) -> bool:
     return True
 
 
-def final_pass(plan: FsTrialPlan) -> None:
-    """Grade every finished, unrefused workspace, back to back, at the end.
+def _grade_one_draw(plan: FsTrialPlan, state: Mapping[str, Any], draw: int) -> tuple[str, str]:
+    """One draw, retried, returning ``(status_line, lost_name)`` with an empty name on success.
 
-    One continuous pass with one judge, serially, because that is the only arrangement
-    under which the published totals of the first task and the last were produced by the
-    same instrument. Progress is printed per file: the judge is the one part of this
-    trial nothing can warn about early, so an operator watching a wrong endpoint refuse
-    every call should see it on the second line rather than in the report.
+    Split out of :func:`final_pass` so the pass can run several at once. It returns its line
+    rather than printing it, because interleaved prints from a pool are how a progress log
+    stops being readable in the order things happened.
     """
-    lost: list[str] = []
-    for state in all_states(plan):
-        if state.get("phase") != "finished" or state.get("classification") != "ok":
-            continue
-        task, arm = str(state["task_key"]), str(state["arm"])
-        for draw in range(plan.judge_replicates):
-            out = score_path(plan, task, arm, int(state.get("attempt") or 1), draw)
-            if out.exists():
-                continue
-            for _try in range(JUDGE_TRIES):
-                if score_once(plan, state, out):
-                    break
-            else:
-                # Giving up quietly is how an arm scored once is published as an arm
-                # scored three times. The count reaches the report through
-                # `FsRunEnvironment.judge_replicates`; this is the operator's copy.
-                lost.append(out.name)
-                print(f"  LOST DRAW: {out.name} could not be scored in {JUDGE_TRIES} tries")
-                continue
+    task, arm = str(state["task_key"]), str(state["arm"])
+    out = score_path(plan, task, arm, int(state.get("attempt") or 1), draw)
+    if out.exists():
+        return "", ""
+    for _try in range(JUDGE_TRIES):
+        if score_once(plan, state, out):
             payload = read_json(out)
-            print(f"  scored {task}/{arm} draw {draw}: {payload.get('total_score')}")
+            return f"  scored {task}/{arm} draw {draw}: {payload.get('total_score')}", ""
+    # Giving up quietly is how an arm scored once is published as an arm scored three
+    # times. The count reaches the report through `FsRunEnvironment.judge_replicates`;
+    # this is the operator's copy.
+    return f"  LOST DRAW: {out.name} could not be scored in {JUDGE_TRIES} tries", out.name
+
+
+def final_pass(plan: FsTrialPlan) -> None:
+    """Grade every finished, unrefused workspace at the end, ``judge_concurrency`` at a time.
+
+    **This pass used to be serial, and the reason given for it was backwards.** The argument
+    was that one continuous serial pass is the only arrangement under which the first task's
+    total and the last task's were produced by the same instrument. But a pass that takes ten
+    hours straddles *more* of whatever drift a hosted judge deployment has than one that takes
+    forty minutes; serialising widens the window it was meant to close. Measured on the trial
+    of 2026-08-19: ninety-five answers at one draw each, one at a time, was still running six
+    hours after the last run finished.
+
+    ``judge_concurrency`` existed as a plan field the whole time and reached nothing but a
+    metadata line in the fake scorer -- a field recorded and never used, which is the same
+    defect this module's own arm validation refuses a plan for. It is now what it says.
+
+    Default 1, so an existing plan replays exactly what it measured, one call at a time.
+
+    Two properties the pool must not cost, both of which are what the serial version was
+    actually buying. Progress is still printed one line per draw as each finishes, because
+    the judge is the one part of this trial nothing can warn about early and an operator
+    watching a wrong endpoint refuse every call should see it on the second line rather than
+    in the report. And a lost draw is still named in ``final_pass.json`` rather than dropped,
+    because a draw that failed silently is an arm published as replicated when it was not.
+    """
+    work = [
+        (state, draw)
+        for state in all_states(plan)
+        if state.get("phase") == "finished" and state.get("classification") == "ok"
+        for draw in range(plan.judge_replicates)
+    ]
+    lost: list[str] = []
+    with ThreadPoolExecutor(max_workers=max(1, plan.judge_concurrency)) as pool:
+        futures = [pool.submit(_grade_one_draw, plan, state, draw) for state, draw in work]
+        for future in as_completed(futures):
+            line, lost_name = future.result()
+            if line:
+                print(line, flush=True)
+            if lost_name:
+                lost.append(lost_name)
     write_json(
         Path(plan.state_dir) / "final_pass.json",
         {"done": True, "at": time.time(), "unscored_draws": sorted(lost)},


### PR DESCRIPTION
## Two defects, one line apart

**`judge_concurrency` reached nothing.** It is a plan field, it is in the freeze, it is in the printed summary and it is written into the fake scorer's metadata — and the real grading path never read it. A field recorded and never used, which is the same shape this module's own arm validation refuses a plan for:

> a field that is recorded and never used is a description of a producer that does not exist

**The pass it should have governed was serial, for a reason that inverts.** The old docstring:

> One continuous pass with one judge, serially, because that is the only arrangement under which the published totals of the first task and the last were produced by the same instrument.

A pass that takes ten hours straddles **more** of whatever drift a hosted judge deployment has than one that takes forty minutes. Serialising widens the window it was meant to close.

Measured on the trial that finished today: **95 answers at one draw each, one at a time, was still running six hours after the last agent finished.** At the three draws a new plan wants, grading would have been the larger half of the trial.

## The change

`final_pass` builds its work list and runs it through a `ThreadPoolExecutor` bounded by `plan.judge_concurrency`. `score_once` already shells out to a subprocess writing its own output file, so the pool costs no shared state.

**Default stays 1**, so every plan on disk replays exactly what it measured, one call at a time.

## What the serial version was actually buying, kept

- **Progress is still one printed line per draw**, as each finishes. The judge is the one part of a trial nothing warns about early; an operator watching a wrong endpoint refuse every call should see it on the second line, not in the report.
- **A lost draw is still named** in `final_pass.json`. A draw that failed quietly is an arm published as replicated when it was not.

## Tests

7 tests. Mutation-tested, all 7 killed:

| mutation | killed by |
|---|---|
| default raised to 8 | 1 |
| `max_workers=1` hardcoded | 1 |
| `max_workers=64`, ignoring the plan | 2 |
| lost draws not recorded | 1 |
| an already-scored draw re-judged | 1 |
| retry loop cut to one try | 1 |
| replicate loop cut to one draw | 2 |

The overlap test asserts `1 < peak <= judge_concurrency` rather than an exact count — a pool is not obliged to keep every worker resident, but a peak of one is a serial pass wearing a pool.

`4183 passed, 4 skipped.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)