### PR TITLE
A measure with a gloss is still that measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Eighteen `validate_*` functions are reachable from it in all:
 | 05+ | `validate_experimental_protocol` | No primary metric, `planned_seeds < 1`, or a baseline missing `why_competent` / `tuning_budget` |
 | 05+ | `validate_experiment_manifest` | The manifest does not parse into the declared shape |
 | 06+ | `validate_hypothesis_outcomes` | A frozen hypothesis has no verdict, a verdict adjudicates something unpreregistered, or a `supported`/`refuted` verdict cites an evidence path that does not exist |
-| 06+ | `validate_outcome_statistics` | A verdict has no `n_seeds`, an unrecognised `dispersion_type`, a single seed with no justification, or `dispersion_type: none` with two or more seeds |
+| 06+ | `validate_outcome_statistics` | A verdict has no `n_seeds`, a `dispersion_type` naming no known measure, a single seed with no justification, or `dispersion_type: none` with two or more seeds |
 | 06+ | `validate_report_plan_sources` | A planned figure or headline number's `source_artifact` is missing or empty |
 | 06, 07 | `validate_validity_response` | The stage did not answer every adversarial finding from the one before it, with a status, a ≥40-character explanation, and evidence when it claims `addressed` — or the workspace copy of that review disagrees with AutoR's stamped copy |
 | 06 | `validate_round_decision` | A round closes as `converged` with no supported hypothesis and no `negative_result: true` |

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -491,7 +491,7 @@ The chain that runs unconditionally at every rigor level, `fast` included:
 | Every attempt from 05 | A frozen file that disagrees with the stamp, or is missing, is written back from AutoR's copy rather than re-derived | `freeze_preregistration` |
 | Stage 05+ | A protocol declares a primary metric, planned seeds, and per-baseline `why_competent` + `tuning_budget` | `validate_experimental_protocol` |
 | Stage 06+ | Exactly one verdict per frozen hypothesis, nothing unpreregistered adjudicated, every `supported`/`refuted` verdict citing an evidence file that exists | `validate_hypothesis_outcomes` |
-| Stage 06+ | A verdict carries `n_seeds`, a `dispersion_type` from a fixed vocabulary, and a written justification if a single seed settled it | `validate_outcome_statistics` |
+| Stage 06+ | A verdict carries `n_seeds`, a `dispersion_type` that starts with a known measure and may then gloss it, and a written justification if a single seed settled it | `validate_outcome_statistics` |
 | Stage 06 close | `converged` is refused when nothing came out supported, unless the round declares `negative_result: true` | `validate_round_decision` |
 | Stage 06→07 edge | The move into Writing is taken off the agent's menu until every empirical id has a verdict and a figure exists — a routing preference, not the gate; see below | `_guard_validity_chain` |
 | Stage 07+ | Every manuscript claim is `confirmatory` on a `supported` hypothesis, or labelled `exploratory` — and cites a file that exists | `validate_claim_provenance` |

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -1376,9 +1376,12 @@ Stage 06's verdict on every preregistered hypothesis.
   `exploratory_findings`, never in `outcomes`.
 
 - A `supported` or `refuted` verdict needs a `statistics` block naming how many
-  runs it rests on and how the spread was measured. `dispersion_type` is one of
-  `std`, `stderr`, `ci95`, `iqr`, `range`, `none` — an interval whose meaning is
-  unstated cannot be read. A verdict from a single run is refused unless
+  runs it rests on and how the spread was measured. `dispersion_type` *starts* with
+  one of `std`, `stderr`, `ci95`, `iqr`, `range`, `var`, `mad`, `none` — an interval
+  whose meaning is unstated cannot be read — and may then say what the spread is of,
+  as in `range of the skillful lead time across the three cascades`. A common
+  spelling of a measure is read as that measure, so `standard deviation`, `variance`
+  and `median absolute deviation` are all accepted. A verdict from a single run is refused unless
   `single_run_justification` says why one run settles it.
 - `inconclusive` and `not_tested` are exempt: they are the honest verdicts when
   the evidence is thin, and requiring statistics for them would push a run

--- a/docs/stage-contract.md
+++ b/docs/stage-contract.md
@@ -265,7 +265,7 @@ listed separately, but they fail a stage exactly the same way.
 | **05+** | A frozen preregistration exists, holds at least one empirical hypothesis, every one carries a `decision_rule`, and the manifest has not silently changed under it. | `validate_preregistration` |
 | **05+** | An experimental protocol declares a primary metric, planned seeds, and per-baseline `why_competent` and `tuning_budget`. | `validate_experimental_protocol` |
 | **06+** | Exactly one verdict per frozen hypothesis, nothing unpreregistered adjudicated, and every `supported`/`refuted` verdict citing an evidence file that exists. | `validate_hypothesis_outcomes` |
-| **06+** | Each `supported` or `refuted` verdict carries `statistics.n_seeds`, a `dispersion_type` from a fixed vocabulary, and a written justification when a single run settled it (`MIN_SEEDS_FOR_A_VERDICT` is 2). `inconclusive` and `not_tested` are exempt on purpose. | `validate_outcome_statistics` |
+| **06+** | Each `supported` or `refuted` verdict carries `statistics.n_seeds`, a `dispersion_type` that starts with a known measure and may then gloss it, and a written justification when a single run settled it (`MIN_SEEDS_FOR_A_VERDICT` is 2). `inconclusive` and `not_tested` are exempt on purpose. | `validate_outcome_statistics` |
 
 The argument for the chain, and where each link is frozen, is in
 [The AutoR Framework](framework.md#33-the-validity-chain).

--- a/src/experimental_protocol.py
+++ b/src/experimental_protocol.py
@@ -30,7 +30,51 @@ from .utils import RunPaths
 
 #: How a spread was computed. Reporting `0.74 ± 0.03` without saying which of
 #: these it is makes the interval unreadable, and every venue asks.
-DISPERSION_TYPES = ("std", "stderr", "ci95", "iqr", "range", "none")
+DISPERSION_TYPES = ("std", "stderr", "ci95", "iqr", "range", "var", "mad", "none")
+
+#: Spellings of a dispersion measure that name it unambiguously and are not the
+#: canonical token. Longest first, so "median absolute" is tried before "median".
+_MEASURE_ALIASES: tuple[tuple[str, str], ...] = (
+    ("median absolute", "mad"),
+    ("interquartile", "iqr"),
+    ("standard error", "stderr"),
+    ("standard deviation", "std"),
+    ("variance", "var"),
+    ("95% ci", "ci95"),
+    ("95%ci", "ci95"),
+)
+
+
+def canonical_dispersion(text: str) -> str:
+    """The measure `text` names, or "" if it names none.
+
+    The field is an enum and the agent keeps writing prose into it, because there is
+    nowhere else to say what the spread is a spread *of*: "range of the Z500 skillful
+    lead time across the complete cascades", "ci95 half-width on sigma*, bootstrap over
+    per-level repeats", "std of the relative error over independent Voronoi fields".
+    Each of those names its measure correctly in the first word and was refused for the
+    rest of the sentence. Two more, "median absolute relative deviation over 24
+    tabulated solids" and "variance", name a real measure the enum simply lacked.
+
+    Of seven distinct refusals collected across the run archive, four were a correct
+    measure plus a gloss and three were a measure with no canonical spelling. On the
+    `full40_pins` arm this cost Earth_003 four attempts at Stage 07 while a finished
+    45 KB report and eleven figures sat on disk. The gate's message is "an interval
+    whose meaning is unstated cannot be read" -- and the meaning was stated, at greater
+    length than the enum allowed.
+
+    So: read the measure out of the sentence and keep the sentence. Nothing downstream
+    computes with this field -- it is validated and displayed -- so accepting more of
+    what an author might write cannot move a number.
+    """
+    lowered = " ".join(str(text or "").casefold().split())
+    if not lowered:
+        return ""
+    for spelling, canon in _MEASURE_ALIASES:
+        if lowered.startswith(spelling):
+            return canon
+    head = lowered.split(" ", 1)[0].strip(":,;.")
+    return head if head in DISPERSION_TYPES else ""
 
 #: Below this, an effect and its noise are not separable by inspection. Not a
 #: statistical threshold — a floor under "we ran it more than once".
@@ -198,13 +242,16 @@ def validate_outcome_statistics(paths: RunPaths) -> list[str]:
             )
 
         dispersion_type = str(statistics.get("dispersion_type") or "").strip()
-        if dispersion_type not in DISPERSION_TYPES:
+        measure = canonical_dispersion(dispersion_type)
+        if not measure:
             problems.append(
                 f"hypothesis_outcomes.json outcome {identifier} has dispersion_type "
-                f"{dispersion_type!r}; expected one of {', '.join(DISPERSION_TYPES)}. "
+                f"{dispersion_type!r}, which names no measure; expected one of "
+                f"{', '.join(DISPERSION_TYPES)}, optionally followed by what the spread is "
+                "of. "
                 "An interval whose meaning is unstated cannot be read."
             )
-        elif dispersion_type == "none" and (seeds or 0) >= MIN_SEEDS_FOR_A_VERDICT:
+        elif measure == "none" and (seeds or 0) >= MIN_SEEDS_FOR_A_VERDICT:
             problems.append(
                 f"hypothesis_outcomes.json outcome {identifier} reports {seeds} runs but no "
                 "dispersion. If it was run more than once, say how much it varied."

--- a/src/prompts/06_analysis.md
+++ b/src/prompts/06_analysis.md
@@ -58,7 +58,7 @@ Write `{{WORKSPACE_RESULTS_DIR}}/hypothesis_outcomes.json`:
       "statistics": {
         "n_seeds": 5,
         "dispersion": 0.012,
-        "dispersion_type": "std | stderr | ci95 | iqr | range | none",
+        "dispersion_type": "std | stderr | ci95 | iqr | range | var | mad | none, optionally followed by what the spread is of",
         "single_run_justification": "only when n_seeds is 1"
       }
     }
@@ -84,7 +84,9 @@ Rules:
   the mean looks.
 - `supported` and `refuted` require at least one `evidence` path that exists in the run.
 - `supported` and `refuted` also require a `statistics` block: how many runs the verdict
-  rests on, and how the spread was measured. `dispersion_type` must name the measure —
+  rests on, and how the spread was measured. `dispersion_type` must *start* with the
+  measure and may then say what the spread is of — `range of the skillful lead time
+  across the three cascades` is better than a bare `range`, and both are accepted —
   an interval whose meaning is unstated cannot be read, and every venue asks.
 - A verdict from a single run is refused unless `single_run_justification` says why one
   run settles it. A deterministic procedure is a legitimate reason; it is a claim worth

--- a/tests/test_experimental_protocol.py
+++ b/tests/test_experimental_protocol.py
@@ -14,7 +14,9 @@ import unittest
 from pathlib import Path
 
 from src.experimental_protocol import (
+    DISPERSION_TYPES,
     MIN_SEEDS_FOR_A_VERDICT,
+    canonical_dispersion,
     format_protocol_for_prompt,
     load_experimental_protocol,
     validate_experimental_protocol,
@@ -229,3 +231,78 @@ class StageGateWiringTest(ProtocolTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ADispersionMeasureMayCarryAGlossTest(ProtocolTestCase):
+    """The field is an enum and authors write sentences into it, correctly.
+
+    `dispersion_type` had to equal one of six tokens exactly. Across the run archive
+    seven distinct values were refused, and only three of them named a measure the
+    enum lacked; the other four named the right measure and were refused for saying
+    what the spread was taken over — "range of the Z500 skillful lead time across the
+    complete cascades", "ci95 half-width on sigma*, bootstrap over per-level repeats",
+    "std of the relative error over independent Voronoi fields".
+
+    On the `full40_pins` arm that cost Earth_003 four attempts at Stage 07 while a
+    finished 45 KB report and eleven figures sat on disk. The gate's own message is
+    "an interval whose meaning is unstated cannot be read", and in every one of those
+    four cases the meaning was stated at greater length than the enum allowed.
+    """
+
+    def test_the_measure_is_read_out_of_the_sentence(self) -> None:
+        for text, want in (
+            ("range of the Z500 skillful lead time across the complete cascades", "range"),
+            ("ci95 half-width on sigma*, bootstrap over per-level repeats", "ci95"),
+            ("std of the relative error over independent Voronoi fields", "std"),
+            ("none: the verdict is identical at every case", "none"),
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(canonical_dispersion(text), want)
+
+    def test_measures_the_enum_had_no_spelling_for(self) -> None:
+        for text, want in (
+            ("median absolute relative deviation over 24 tabulated solids", "mad"),
+            ("median absolute difference in K over the 8,424 per-vitrimer means", "mad"),
+            ("variance", "var"),
+            ("Standard Deviation across seeds", "std"),
+            ("interquartile range", "iqr"),
+            ("standard error of the mean", "stderr"),
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(canonical_dispersion(text), want)
+
+    def test_a_bare_token_still_works(self) -> None:
+        for token in DISPERSION_TYPES:
+            with self.subTest(token=token):
+                self.assertEqual(canonical_dispersion(token), token)
+
+    def test_prose_that_names_no_measure_is_still_refused(self) -> None:
+        """The widening may not become an acceptance of anything at all."""
+        for text in ("", "   ", "we ran it a few times", "see the appendix", "ranger", "n/a"):
+            with self.subTest(text=text):
+                self.assertEqual(canonical_dispersion(text), "")
+
+    def test_the_validator_accepts_a_glossed_measure(self) -> None:
+        self.write_outcome({
+            "n_seeds": 3, "dispersion": 0.4,
+            "dispersion_type": "range of the skillful lead time across the cascades",
+        })
+        self.assertEqual(validate_outcome_statistics(self.paths), [])
+
+    def test_the_validator_still_refuses_a_measureless_one(self) -> None:
+        self.write_outcome({"n_seeds": 3, "dispersion": 0.4, "dispersion_type": "quite tight"})
+        problems = validate_outcome_statistics(self.paths)
+        self.assertTrue(any("names no measure" in p for p in problems), problems)
+
+    def test_none_with_a_gloss_is_still_held_to_the_seed_rule(self) -> None:
+        """Reading the measure out of prose must not smuggle past the second check.
+
+        `none: the verdict is identical at every case` normalises to `none`, and a run
+        that says it had three seeds and no spread is still owed the spread.
+        """
+        self.write_outcome({
+            "n_seeds": 3, "dispersion": 0.0,
+            "dispersion_type": "none: the verdict is identical at every case",
+        })
+        problems = validate_outcome_statistics(self.paths)
+        self.assertTrue(any("no dispersion" in p for p in problems), problems)


### PR DESCRIPTION
## What was wrong

`dispersion_type` was an enum of six tokens compared with `==`. The agent kept writing sentences into it, because there is nowhere else to say what the spread is a spread *of*.

Across the run archive, **seven distinct values were refused. Four named the right measure** and were rejected only for the rest of the sentence:

```
range of the Z500 skillful lead time across the complete cascades
ci95 half-width on sigma*, bootstrap over per-level repeats
std of the relative error over independent Voronoi fields
none: the verdict is identical at every case
```

The other three named a measure the enum simply lacked — `variance`, and twice a median absolute deviation.

The gate's own message is *"an interval whose meaning is unstated cannot be read."* In four of seven cases the meaning **was** stated, at greater length than the enum allowed.

## What it cost

On the `full40_pins` arm, **Earth_003 spent four attempts at Stage 07** failing this check on H2, H5 and H7 — while a finished 45 KB report and eleven figures sat on disk — and reached its 40 h wall still trying.

## The change

`canonical_dispersion(text)` reads the measure out of the sentence and keeps the sentence: the leading token, or a common spelling (`standard deviation`, `interquartile`, `median absolute`, `variance`), normalised to a canonical member. `var` and `mad` join the vocabulary.

Still refused, unchanged: `quite tight`, `we ran it a few times`, `ranger`, empty. `none` **with** a gloss is still held to the seed rule — reading the measure out of prose must not smuggle a verdict past the second check, and there is a test for exactly that.

## Why this is safe

Nothing computes with this field — it is validated and displayed. Widening what an author may write cannot move a number.

## Verification

- 7 new tests; full suite **3663 passed, 4 skipped**.
- **Five mutants killed**: accept-anything; drop the alias table; exact-match only (the old behaviour); read the raw field in the seed rule; mis-order aliases so `median` shadows `median absolute`.
- Prompt (`06_analysis.md`), `README`, `framework`, `stage-contract` and `run-artifacts` all updated to say the gloss is allowed — the prompt is where the agent learns the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)