### PR TITLE
A scheduler kill must leave a verdict, not silence

### DIFF
--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -22,12 +22,14 @@ Nothing here ever reads stdin. Any prompt that would block raises
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import signal
 import sys
 import time
 import traceback
 from pathlib import Path
-from typing import Sequence
+from typing import Iterator, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parent
 if str(REPO_ROOT) not in sys.path:
@@ -720,21 +722,22 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
 
     pipeline_completed = False
     aborted_with = ""
-    try:
-        pipeline_completed = manager.run(
-            goal,
-            venue=resolve_venue_key(args.venue),
-            skip_intake=not args.intake,
-            output_format=output_format,
-            resources=collect_reference_resources(workspace) or None,
-            final_stage=resolve_stage(args.final_stage),
-        )
-    except Exception as exc:  # noqa: BLE001 - a crashed pipeline must still export what it produced
-        # Exporting the salvage is right. Reporting the salvage as a finished run is not,
-        # and that is what happened until this line existed: the exception was recorded in
-        # `_agent_output.jsonl` and nowhere a downstream reader looks.
-        aborted_with = f"{type(exc).__name__}: {exc}"[:500]
-        emit_event({"type": "error", "where": "pipeline", "traceback": traceback.format_exc()})
+    with _sigterm_as_exception():
+        try:
+            pipeline_completed = manager.run(
+                goal,
+                venue=resolve_venue_key(args.venue),
+                skip_intake=not args.intake,
+                output_format=output_format,
+                resources=collect_reference_resources(workspace) or None,
+                final_stage=resolve_stage(args.final_stage),
+            )
+        except Exception as exc:  # noqa: BLE001 - a crashed pipeline must still export what it produced
+            # Exporting the salvage is right. Reporting the salvage as a finished run is
+            # not, and that is what happened until this line existed: the exception was
+            # recorded in `_agent_output.jsonl` and nowhere a downstream reader looks.
+            aborted_with = f"{type(exc).__name__}: {exc}"[:500]
+            emit_event({"type": "error", "where": "pipeline", "traceback": traceback.format_exc()})
 
     paths = build_run_paths_for_workspace(workspace)
     if paths is None:
@@ -784,6 +787,53 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         },
     )
     return result
+
+
+class Terminated(Exception):
+    """The scheduler asked this run to stop.
+
+    Raised out of a ``SIGTERM`` handler so a kill takes the same path a crash already
+    takes: export whatever the run produced, record ``aborted``, write ``_meta.json``.
+    An ordinary :class:`Exception`, deliberately -- the point is to be caught by the
+    handler that already exists around :meth:`Manager.run`.
+    """
+
+
+@contextlib.contextmanager
+def _sigterm_as_exception() -> Iterator[None]:
+    """Make a scheduler kill produce a verdict instead of silence.
+
+    A run that is killed never writes a terminal status, so ``_meta.json`` keeps the
+    ``running`` the harness wrote at launch -- forever, since nothing revisits it. Both
+    readers gate on that field: ``run_arm.py`` will not resume the task and the scoring
+    driver will not score it. The workspace is then indistinguishable from one still in
+    flight, and the arm silently loses a task rather than reporting a failed one.
+
+    It cost a real measurement. On the `full40_pins` arm, Earth_003 hit its 40 h wall
+    during Stage 07 holding a finished 45 KB report and eleven figures. The scoring pass
+    logged ``scoreable workspaces: 39`` and named nothing it had dropped; the arm was
+    written up at n=39 for two days with the fortieth deliverable complete on disk.
+
+    Slurm sends ``SIGTERM`` and waits ``KillWait`` (30 s by default) before ``SIGKILL``,
+    which is enough to export a report that has already been written. If it is not, the
+    export is partial and the status still says what happened -- both better than a
+    workspace that claims to be running.
+
+    Restores the previous handler on the way out, and does nothing at all off the main
+    thread, where :func:`signal.signal` is not available.
+    """
+    def _raise(signum: int, _frame: object) -> None:
+        raise Terminated(f"signal {signum} (SIGTERM); the scheduler ended this run")
+
+    try:
+        previous = signal.signal(signal.SIGTERM, _raise)
+    except ValueError:  # not the main thread; nothing to install
+        yield
+        return
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, previous)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_rcb.py
+++ b/tests/test_rcb.py
@@ -9,10 +9,15 @@ consults.
 
 from __future__ import annotations
 
+import os
+import signal
 import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 
+from rcb_agent import Terminated, _sigterm_as_exception
 from src.rcb import MIN_REPORT_CHARS, BenchmarkResult, ExportResult
 
 
@@ -81,3 +86,102 @@ class AnAbortedRunIsNotACompletedOneTest(unittest.TestCase):
         """Which one it is matters: `failed` means it tried and produced nothing."""
         r = self._result("", aborted="MemoryError: ")
         self.assertEqual(r.status, "aborted")
+
+
+class ASchedulerKillMustLeaveAVerdictTest(unittest.TestCase):
+    """A run that is killed has to say so, or the arm loses a task instead of failing one.
+
+    The class above is about a walk that raised. This is the same defect one level out:
+    a walk that never gets to raise. `_meta.json` is written once, after the result
+    exists, so a process ended by a signal leaves the `running` the harness wrote at
+    launch -- and nothing ever revisits it. Both readers gate on that field: `run_arm.py`
+    will not resume the task and the scoring driver will not score it. The workspace
+    reads as still in flight, permanently.
+
+    Measured. On the `full40_pins` arm, Earth_003 reached its 40 h wall during Stage 07
+    holding a finished 45,132-byte report and eleven figures. The scoring pass logged
+    `scoreable workspaces: 39`, named nothing it had dropped, and the arm was written up
+    at n=39 for two days with the fortieth deliverable complete on disk. A silent drop,
+    not a failure: nothing anywhere said a task was missing.
+
+    The fix routes SIGTERM into the handler that already exists, so a kill produces the
+    same salvage-and-record path a crash does.
+    """
+
+    def test_sigterm_inside_the_block_raises_rather_than_killing(self) -> None:
+        caught = ""
+        with _sigterm_as_exception():
+            try:
+                os.kill(os.getpid(), signal.SIGTERM)
+                time.sleep(2)  # the handler fires long before this returns
+            except Terminated as exc:
+                caught = str(exc)
+        self.assertIn("SIGTERM", caught)
+        self.assertIn("scheduler", caught)
+
+    def test_it_is_an_ordinary_exception_so_the_existing_handler_catches_it(self) -> None:
+        """The whole design is to reuse `except Exception` around `manager.run`.
+
+        A `BaseException` subclass would sail past it, skip the export, and leave exactly
+        the silence this removes.
+        """
+        self.assertTrue(issubclass(Terminated, Exception))
+
+    def test_the_previous_handler_is_restored_on_the_way_out(self) -> None:
+        """Leaving the handler installed would swallow the kill that follows the export."""
+        before = signal.getsignal(signal.SIGTERM)
+        with _sigterm_as_exception():
+            self.assertIsNot(signal.getsignal(signal.SIGTERM), before)
+        self.assertIs(signal.getsignal(signal.SIGTERM), before)
+
+    def test_it_is_restored_even_when_the_body_raises(self) -> None:
+        before = signal.getsignal(signal.SIGTERM)
+        with self.assertRaises(ZeroDivisionError):
+            with _sigterm_as_exception():
+                _ = 1 / 0
+        self.assertIs(signal.getsignal(signal.SIGTERM), before)
+
+    def test_off_the_main_thread_it_is_a_no_op_rather_than_a_crash(self) -> None:
+        """`signal.signal` raises off the main thread; a run there must still proceed.
+
+        Nothing in the adapter calls `run` from a worker today. The guard is here so that
+        the day something does, the failure is a run without kill-handling rather than a
+        run that will not start.
+        """
+        outcome: list[str] = []
+
+        def body() -> None:
+            try:
+                with _sigterm_as_exception():
+                    outcome.append("ran")
+            except Exception as exc:  # noqa: BLE001 - the point of the test
+                outcome.append(f"raised {type(exc).__name__}")
+
+        thread = threading.Thread(target=body)
+        thread.start()
+        thread.join(timeout=10)
+        self.assertEqual(outcome, ["ran"])
+
+    def test_a_killed_run_holding_a_real_report_is_aborted_not_completed(self) -> None:
+        """The record the salvage path then writes, end to end on the result object.
+
+        Earth_003's report was substantive, so every `report exists` test passes on it.
+        `status` is the field that has to disagree.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            report = root / "report.md"
+            report.write_text("x" * (MIN_REPORT_CHARS + 10), encoding="utf-8")
+            result = BenchmarkResult(
+                workspace=root,
+                run_root=root / ".autor" / "r",
+                pipeline_completed=False,
+                export=ExportResult(
+                    report_path=report, report_source="stage_07", figures=[], code_files=0,
+                    output_files=0,
+                ),
+                aborted_with="Terminated: signal 15 (SIGTERM); the scheduler ended this run",
+            )
+            self.assertEqual(result.status, "aborted")
+            self.assertEqual(result.exit_code, 1)
+            self.assertTrue(result.aborted)


### PR DESCRIPTION
## What was wrong

`_meta.json` is written **once, after the result exists**. A run ended by a signal never gets there, so the file keeps the `running` the harness wrote at launch — and nothing revisits it.

Both readers gate on that field: `run_arm.py` will not resume the task, and the scoring driver will not score it. The workspace reads as still in flight, permanently.

That is a **silent drop, not a failure**. Nothing anywhere says a task is missing.

## What it cost

On the `full40_pins` arm, **Earth_003** reached its 40 h wall during Stage 07 holding a finished **45,132-byte report and eleven figures**. The scoring pass logged `scoreable workspaces: 39`, named nothing it had dropped, and the arm was **written up at n=39 for two days** with the fortieth deliverable complete on disk.

Scored by hand afterwards it is **27.27** — a perfectly ordinary number. The point is that nobody knew it was missing.

## The change

`_sigterm_as_exception()` installs a SIGTERM handler that raises `Terminated`, an ordinary `Exception`, around `manager.run`. A kill then takes the salvage path a crash already takes: export what the run produced, record `aborted_with`, write `_meta.json` with `status: aborted`.

Slurm waits `KillWait` (30 s by default) before SIGKILL — enough to export a report already on disk. If it is not, the export is partial and the status still says what happened. Both beat a workspace that claims to be running.

**`aborted`, not `completed`, deliberately.** The salvage-is-not-a-result argument from `AnAbortedRunIsNotACompletedOneTest` is unchanged. The gain is that the run *declares itself*, so a reader sees one killed task instead of a silently shorter arm.

Handler restored on the way out, including when the body raises. Off the main thread, where `signal.signal` raises, the context manager degrades to a no-op rather than a crash.

## Verification

- 6 new tests; full suite **3662 passed, 4 skipped**.
- **Four mutants killed**: `Terminated` as a `BaseException` (sails past the handler that makes this work); handler left installed; handler never installed — *this one kills the test runner*, the loudest detection available; re-raising instead of degrading off the main thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)