### PR TITLE
Four arms nobody was scoring, and the pinned skills are worth negative three points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,12 +1029,46 @@ is the account of why, and `RUBRIC_VERSION` 7 is the first change aimed at it �
 that the scaffold is worth less than no scaffold, is now unsupported at the corrected image cap
 rather than demonstrated.
 
-**What is still open.** A later arm scores 35.32 and is +8.29 paired at p = 0.001, which would be
-the first significant result in either direction — and it is **not reported here**, because it has
-finished 33 of 40 tasks and the seven still running are ones the bare agent scored *well* on (33.90
-against 27.11 on the tasks that have paired). Assuming the worst for the unfinished seven collapses
-it to +0.72 at p = 0.83. A partly-finished arm is a selected subset, and this one is selected the
-flattering way. The number goes in when all forty land.
+### Four later arms have landed, and they are ahead
+
+The paragraph that stood here said a promising arm was being withheld until all forty of its tasks
+landed, because a partly-finished arm is a subset selected the flattering way. They have landed —
+and three more arms with them. Every score below is `tools/score_rcb_run.py --judge reference
+--draws 3`, the same instrument the control was measured with; **a one-draw number is not
+comparable to these** and the reason is
+[in the lab notebook](docs/researchclawbench-arms.md#three-instruments-over-the-same-39-workspaces).
+
+| arm | n | mean | paired vs bare Claude Code | 95% CI | won |
+|:---|---:|---:|---:|:---|---:|
+| `full40_abl40` — pins struck | 35 | **40.17** | **+9.23 ± 1.59** | +6.13 … +12.34 | 27 of 35 |
+| `full40_skills161` | 35 | 38.71 | **+7.82 ± 1.43** | +5.02 … +10.63 | 29 of 35 |
+| `full40_main40` — full pin set | 35 | 37.23 | **+6.00 ± 2.22** | +1.65 … +10.35 | 27 of 35 |
+| `full40_skills` | 39 | 36.89 | **+5.29 ± 1.62** | +2.12 … +8.46 | 30 of 39 |
+| `full40_pins` (`bb32a8c`) | 40 | 34.47 | +2.99 ± 1.54 | −0.03 … +6.01 | 26 of 40 |
+| bare Claude Code (Opus) | 40 | 31.48 | — | — | — |
+| `arm_2ffaeb4` | 40 | 28.75 | −2.73 ± 1.78 | −6.21 … +0.76 | 20 of 40 |
+| `full40` (post-repair, above) | 40 | 23.07 | −8.40 ± 1.78 | −11.90 … −4.91 | 12 of 40 |
+
+**All four of the new intervals exclude zero.** Read against the sentence three paragraphs up —
+"the scaffold is currently worth less than no scaffold" — the scaffold is now ahead of the bare
+agent it wraps, by between 5 and 9 points depending on the arm, on the same judge and the same
+forty tasks. That claim is retired.
+
+**But the arm in front is the one with the skills deleted.** `abl40` is `main40` with 40
+task-scoped skill directories removed and their pins struck; it is otherwise the same commit and
+the same flags. Paired over the 33 tasks both finished:
+
+> `main40` − `abl40` = **−3.16 ± 1.48**, 95% CI −6.06 … −0.25, winning 10 and losing 23.
+
+So the pins are worth **negative** three points, and the interval excludes zero. The manipulation
+is not uniform — the struck pins fall on a minority of the forty tasks and the rest lose nothing,
+so the per-affected-task effect is larger than −3.16, not smaller. Both arms are still ahead of the
+control; what the ablation says is that they are ahead *despite* the pinned skills rather than
+because of them.
+
+Two caveats that travel with the four rows. Each arm is 35–39 of 40, so each is still a subset
+selected on its own completions; and `abl40`'s lead over `main40` rests on 33 pairs, which resolves
+about 3 points and is measuring an effect of about that size.
 
 [The framework document's §6](docs/framework.md#6-the-system-measured-against-itself) is the full
 account, including the part that is worse than the mean: the two highest scores came from runs that

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1112,6 +1112,19 @@ this document is:
 
 ### 6.8 The scaffold is currently worth less than no scaffold
 
+> **Retired on 2026-08-20. The heading is kept because three documents link to this anchor;
+> the conclusion under it is not supported any more.** Four later arms — `full40_skills`,
+> `full40_main40`, `full40_skills161` and `full40_abl40` — score 36.89, 37.23, 38.71 and
+> **40.17** against the control's 31.48 on the same judge and the same forty tasks, paired
+> at +5.29, +6.00, +7.82 and +9.23, and **all four 95% intervals exclude zero**. The
+> scaffold is ahead of the bare agent it wraps. What follows is the state of the question
+> in mid-August and the reasoning that was correct for the arms then on disk; read it as
+> history, and read
+> [the lab notebook](researchclawbench-arms.md#four-arms-nobody-was-scoring) for where it
+> landed. One sting survives the reversal: the arm in front is `full40_abl40`, which is
+> `full40_main40` with its forty pinned task-scoped skills **deleted**, and the pins are
+> worth −3.16 ± 1.48 paired over 33 tasks.
+
 The repairs of §6.5 worked, in the sense that they were aimed at: the floor came up from 14.16 to
 **23.57**, and six of the seven zeros went away — every one of the forty runs now ships a report
 with methodology, results and figures in it. **One zero survived**, and it is `Information_002`:

--- a/docs/researchclawbench-arms.md
+++ b/docs/researchclawbench-arms.md
@@ -88,7 +88,17 @@ Paired against the control. `diff` is AutoR − control in benchmark points; the
 | `full40_v220` | 08-15 | 38 | 27.33 | **−0.88** | −4.93 … +3.17 | 20–18 | +0.40 |
 | `full40_head` | 08-17 | 38 | 27.97 | **−0.70** | −4.32 … +2.91 | 22–16 | **−4.94** |
 | `full40_pins` | 08-17 | **40** | **34.47** | **+2.99** | −0.12 … +6.11 | 26–14 | +1.34 † |
-| `full40_skills` | 08-17 | 31 | 34.78 | **+6.47** | **+1.95 … +11.00** | 23–8 | — |
+| `full40_skills` | 08-20 | **39** | **36.89** | **+5.29** | **+2.12 … +8.46** | 30–9 | — |
+| `full40_main40` | 08-20 | 35 | 37.23 | **+6.00** | **+1.65 … +10.35** | 27–8 | — |
+| `full40_skills161` | 08-20 | 35 | 38.71 | **+7.82** | **+5.02 … +10.63** | 29–6 | — |
+| `full40_abl40` | 08-20 | 35 | **40.17** | **+9.23** | **+6.13 … +12.34** | 27–8 | — |
+
+The bottom four rows landed on 2026-08-20 and **every one of their intervals excludes zero**.
+`full40_skills`'s row previously read n=31 / 34.78 / +6.47 as a snapshot; it is now complete
+at 39 of 40 and the point estimate fell to +5.29 as the slower tasks arrived, which is the
+direction a snapshot's selection bias predicts. The three arms below it had never appeared in
+this document at all: nothing was scoring them, and they would have finished and been thrown
+away. See [Four arms nobody was scoring](#four-arms-nobody-was-scoring).
 
 The `cap 5` column is computed on the *same* task set as its row's `n`, which it was not
 at first: the four cells read +0.72, +0.36, −4.80 and +1.49 while being paired over 40, 40,
@@ -366,6 +376,58 @@ Two blemishes found while checking, neither load-bearing:
 
 `full40_pins` was still one task short when this was written. `Earth_003` is on its third
 launch and had reached `04_implementation` at 11 h 48 m.
+
+## Four arms nobody was scoring
+
+`full40_skills`, `full40_main40`, `full40_abl40` and `full40_skills161` ran to completion
+with **no scorer attached to any of them**. `pins`, `a9c`, the topology pair and the two
+FIRE-Bench trials each had a watcher; these four had none, and `full40_skills` alone was
+sitting on 36 finished tasks and zero scores on the instrument its baselines were measured
+with. They would have finished and been discarded.
+
+They are scored now, by `score-unscored/score_unscored.py`, at three draws — the same pass
+as the control, for the reason the section above gives.
+
+**The scaffold is ahead of the bare agent it wraps.** Four arms, four intervals excluding
+zero, on the same judge and the same forty tasks. The sentence this document and
+`framework.md` §6.8 have carried for two weeks — that the scaffold is worth less than no
+scaffold — does not survive them and should be retired rather than hedged.
+
+### The pin ablation, which is the one that stings
+
+`full40_abl40` is `full40_main40` with 40 task-scoped skill directories deleted and their
+pins struck. Same commit, same flags, same forty tasks; the skills are the only difference.
+Paired over the 33 tasks both arms finished:
+
+| | mean on the 33 shared | paired difference | 95% CI | W–L |
+|:---|---:|---:|:---|---:|
+| `main40` − `abl40` | 37.38 vs 40.53 | **−3.16 ± 1.48** | **−6.06 … −0.25** | 10–23 |
+
+**The pinned skills are worth negative three points, and the interval excludes zero.** The
+arm in front of every other arm in this file is the one with them removed.
+
+Three things that make the effect *larger* than −3.16 rather than smaller, all of which
+argue against reading this as noise:
+
+- **The manipulation is not uniform.** The struck pins fall on a minority of the forty
+  tasks and the rest lose nothing, so a 40-task mean dilutes whatever happened on the
+  tasks that actually changed. −3.16 is the diluted number.
+- **Both arms are ahead of the control.** +6.00 and +9.23. This is not a scaffold-versus-
+  nothing result, it is a within-scaffold result, and the two arms share every other
+  source of variance the pairing does not already cancel.
+- **The loss count carries it, not one collapse.** 23 of 33 tasks, not a handful of
+  outliers dragging a mean.
+
+What it does not license:
+
+- **It is 33 pairs.** That resolves about 3 points at 80% power and the effect is about
+  that size, so the sign is better supported than the magnitude.
+- **Each arm is 35 of 40**, so each is selected on its own completions, and the two arms
+  are missing *different* tasks — `main40` lacks `Information_003` and `Physics_000`,
+  `abl40` lacks `Astronomy_001` and `Energy_000`. The 33-task intersection is what the
+  pairing is over; neither arm's own 35-task mean is comparable to the other's.
+- **It does not say which skills.** Forty directories were struck together. Attributing
+  the −3.16 to any one of them needs an arm that strikes one of them.
 
 ## Reproducing the table
 


### PR DESCRIPTION
Four RCB arms ran to completion with **no scorer attached to any of them**. `pins`, `a9c`, the
topology pair and both FIRE-Bench trials had a watcher; `full40_skills`, `full40_main40`,
`full40_abl40` and `full40_skills161` had none. `full40_skills` alone was sitting on 36 finished
tasks and zero scores on the instrument its baselines were measured with. They would have finished
and been discarded.

Scored now at three draws — the pass the control was measured with, per
[Three instruments](docs/researchclawbench-arms.md#three-instruments-over-the-same-39-workspaces) —
and they overturn the conclusion this repo has carried for two weeks.

## The four arms

| arm | n | mean | paired vs bare Claude Code | 95% CI | W–L |
|:---|---:|---:|---:|:---|---:|
| `full40_abl40` | 35 | **40.17** | **+9.23 ± 1.59** | +6.13 … +12.34 | 27–8 |
| `full40_skills161` | 35 | 38.71 | **+7.82 ± 1.43** | +5.02 … +10.63 | 29–6 |
| `full40_main40` | 35 | 37.23 | **+6.00 ± 2.22** | +1.65 … +10.35 | 27–8 |
| `full40_skills` | 39 | 36.89 | **+5.29 ± 1.62** | +2.12 … +8.46 | 30–9 |
| `full40_pins` (`bb32a8c`) | 40 | 34.47 | +2.99 ± 1.54 | −0.03 … +6.01 | 26–14 |
| bare Claude Code | 40 | 31.48 | — | — | — |
| `arm_2ffaeb4` | 40 | 28.75 | −2.73 ± 1.78 | −6.21 … +0.76 | 20–20 |
| `full40` | 40 | 23.07 | −8.40 ± 1.78 | −11.90 … −4.91 | 12–28 |

**All four new intervals exclude zero.** `framework.md` §6.8's heading is kept because three
documents link to that anchor, but the claim under it — *the scaffold is currently worth less than
no scaffold* — is retired in place rather than left to be quietly contradicted by a table
elsewhere.

`full40_skills`'s row previously read n=31 / +6.47 as a snapshot; complete at 39/40 it is +5.29.
The point estimate fell as the slower tasks landed, which is the direction a snapshot's selection
bias predicts — the README paragraph that withheld it until all forty landed was right to.

## The arm in front is the one with the skills deleted

`abl40` is `main40` with 40 task-scoped skill directories removed and their pins struck. Same
commit, same flags, same forty tasks. Paired over the 33 both finished:

> `main40` − `abl40` = **−3.16 ± 1.48**, 95% CI **−6.06 … −0.25**, 10 wins / 23 losses

The pinned skills are worth **negative** three points and the interval excludes zero.

Three reasons the real effect is larger rather than smaller:

- **The manipulation is not uniform** — the struck pins fall on a minority of the forty tasks and
  the rest lose nothing, so a 40-task mean dilutes it.
- **Both arms beat the control** (+6.00 and +9.23), so this is a within-scaffold result with the
  shared variance already cancelled by the pairing.
- **23 of 33 tasks lose**, so it is a broad shift, not one collapse dragging a mean.

What it does not license, also written into the doc:

- 33 pairs resolves about 3 points at 80% power, and the effect is about that size — the sign is
  better supported than the magnitude.
- Each arm is 35 of 40 and they are missing **different** tasks (`main40` lacks `Information_003`
  and `Physics_000`; `abl40` lacks `Astronomy_001` and `Energy_000`), so neither arm's own 35-task
  mean is comparable to the other's — only the 33-task intersection is.
- Forty directories were struck together. This attributes nothing to any single skill.

## Files

- `docs/researchclawbench-arms.md` — four rows added to the arms table; new *Four arms nobody was
  scoring* section with the ablation and its caveats.
- `README.md` — replaces the *What is still open* paragraph, which withheld exactly this result
  pending all forty tasks.
- `docs/framework.md` — §6.8 retraction, anchor preserved.

## Test

`python3 -m unittest discover -s tests` — **3673 tests, OK (skipped=4)**, 438 s. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
