### PR TITLE
The first complete AutoR arm separates from the control: +7.33 over all forty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,7 @@ comparable to these** and the reason is
 | arm | n | mean | paired vs bare Claude Code | 95% CI | won |
 |:---|---:|---:|---:|:---|---:|
 | `full40_abl40` — pins struck | 35 | **40.17** | **+9.23 ± 1.59** | +6.13 … +12.34 | 27 of 35 |
+| `full40_a9c2b48` — **all forty** | **40** | 38.80 | **+7.33 ± 1.53** | +4.33 … +10.33 | 30 of 40 |
 | `full40_skills161` | 35 | 38.71 | **+7.82 ± 1.43** | +5.02 … +10.63 | 29 of 35 |
 | `full40_main40` — full pin set | 35 | 37.23 | **+6.00 ± 2.22** | +1.65 … +10.35 | 27 of 35 |
 | `full40_skills` | 39 | 36.89 | **+5.29 ± 1.62** | +2.12 … +8.46 | 30 of 39 |
@@ -1066,9 +1067,18 @@ so the per-affected-task effect is larger than −3.16, not smaller. Both arms a
 control; what the ablation says is that they are ahead *despite* the pinned skills rather than
 because of them.
 
-Two caveats that travel with the four rows. Each arm is 35–39 of 40, so each is still a subset
-selected on its own completions; and `abl40`'s lead over `main40` rests on 33 pairs, which resolves
-about 3 points and is measuring an effect of about that size.
+**`a9c2b48` is the row that answers the caveat the other three carry.** Every other arm above is
+35–39 of 40, so each is a subset selected on its own completions — and that selection is not
+neutral: when this arm stood at 33 of 40 the seven it had not finished were ones the control scored
+*well* on, 33.90 against 27.11 on the tasks that had paired, which is the flattering direction.
+Assuming the worst for those seven would have collapsed it from +8.29 to +0.72. It was held back
+from this table for that reason. All forty have now landed and the estimate moved the other way,
+to **+7.33 over 40 pairs with nothing dropped**. That is the first complete AutoR arm to separate
+from the control, and it is what makes the four incomplete rows readable as low rather than
+inflated.
+
+One caveat still travels with the rest: `abl40`'s lead over `main40` rests on 33 pairs, which
+resolves about 3 points and is measuring an effect of about that size.
 
 [The framework document's §6](docs/framework.md#6-the-system-measured-against-itself) is the full
 account, including the part that is worse than the mean: the two highest scores came from runs that

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -1121,9 +1121,20 @@ this document is:
 > in mid-August and the reasoning that was correct for the arms then on disk; read it as
 > history, and read
 > [the lab notebook](researchclawbench-arms.md#four-arms-nobody-was-scoring) for where it
-> landed. One sting survives the reversal: the arm in front is `full40_abl40`, which is
+> landed.
+>
+> **A fifth arm closes the hole in those four.** Each of them is 35–39 of 40 and therefore a
+> subset selected on its own completions, which is the objection this reversal was most
+> vulnerable to. `full40_a9c2b48` has finished all forty: **38.80, paired +7.33 ± 1.53 over
+> 40 tasks with nothing dropped, winning 30**. The selection worry was not idle — at 33 of 40
+> that arm's unfinished seven were ones the control did *well* on (33.90 against 27.11), and
+> assuming the worst for them would have read +0.72. Completing them moved it to +7.33.
+>
+> One sting survives the reversal: the arm in front is `full40_abl40`, which is
 > `full40_main40` with its forty pinned task-scoped skills **deleted**, and the pins are
-> worth −3.16 ± 1.48 paired over 33 tasks.
+> worth −3.16 ± 1.48 paired over 33 tasks. Four ablations launched on 2026-08-20 —
+> `xrev`, `pins`, `opcalls`, and the topology pair — are the follow-up, and none of them
+> reports yet.
 
 The repairs of §6.5 worked, in the sense that they were aimed at: the floor came up from 14.16 to
 **23.57**, and six of the seven zeros went away — every one of the forty runs now ships a report


### PR DESCRIPTION
`full40_a9c2b48` has finished every task. On the three-draw reference instrument -- the same
one the rest of the table uses -- it reads **38.80, paired +7.33 +/- 1.53 over 40 tasks with
nothing dropped, winning 30 of 40**.

It matters more than another row. Every other arm in that table is 35-39 of 40, so each is a
subset selected on its own completions, which is the objection the whole reversal of §6.8 was
most exposed to. This one has no dropped tasks.

The objection was not idle. When this arm stood at 33 of 40 it read +8.29, and the seven it
had not finished were ones the control scored *well* on -- 33.90 against 27.11 on the tasks
that had paired. Assuming the worst for those seven collapsed it to +0.72. It was deliberately
kept out of the README on 2026-08-19 for exactly that reason. All forty have now landed and
the estimate moved the other way, to +7.33, so the four incomplete rows read low rather than
inflated.

Also recorded in §6.8: the four ablations launched 2026-08-20 -- the cross-model veto, the pin
layer, the operator-call ceiling, and the topology pair -- none of which reports yet.

Instrument note, because this is the second time it has mattered: every number here is
`tools/score_rcb_run.py --judge reference --draws 3`, and it reproduces the existing table row
for row (control 31.48, pins 34.47/+2.99, main40 37.23/+6.00, abl40 40.17/+9.23,
skills161 38.71/+7.82). The single-draw `score_arm.py` files that also exist on disk put the
control at 28.33 and are not comparable -- `docs/researchclawbench-arms.md` says so at length,
and the draw count is visible only inside the file, as a `draws` key.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
