### PR TITLE
A shared channel must leave a receipt: fingerprint the learned-notes pool, and let an arm isolate it

### DIFF
--- a/src/manager.py
+++ b/src/manager.py
@@ -119,7 +119,7 @@ from .run_skills import (
     read_skill_pack,
     validate_task_pins,
 )
-from .skill_evolution import install_learned_skill
+from .skill_evolution import install_learned_skill, pool_fingerprint
 from .manifest import (
     ensure_run_manifest,
     format_manifest_status,
@@ -5251,6 +5251,19 @@ class ResearchManager:
                     learned = ""
                 if learned:
                     installed.append(learned)
+                    # The pool lives outside every worktree, so two arms of an ablation
+                    # pinned to different commits still read this same file -- and it is
+                    # rewritten, twelve notes per field with the oldest evicted, while they
+                    # run. Nothing recorded which twelve a given run saw, so a paired
+                    # comparison could only assume the channel was constant. Record the
+                    # digest and it can be checked, and the pairs where it was not can be
+                    # dropped instead of quietly averaged in.
+                    try:
+                        config = load_run_config(paths)
+                        config["learned_pool"] = pool_fingerprint(self.skill_discipline)
+                        save_run_config(paths, config)
+                    except (OSError, TypeError, ValueError):
+                        pass
         except OSError as exc:
             append_log_entry(
                 paths.logs,

--- a/src/skill_evolution.py
+++ b/src/skill_evolution.py
@@ -32,6 +32,8 @@ method: what to check, what to run, what to look at. `looks_like_a_result` refus
 from __future__ import annotations
 
 import json
+import hashlib
+import os
 import re
 from dataclasses import dataclass
 from datetime import datetime
@@ -41,8 +43,21 @@ from .utils import RunPaths, read_text, write_text
 
 
 #: Where learned notes accumulate across runs. Outside any run directory, because the point
-#: is to outlive the run that wrote it.
+#: is to outlive the run that wrote it -- and therefore **outside any worktree**, which makes
+#: it the one input two arms of an ablation share no matter how carefully their trees are
+#: pinned. ``AUTOR_LEARNED_POOL`` moves it, so a paired arm can be given a frozen or private
+#: pool; unset, behaviour is exactly what it was.
 DEFAULT_POOL = Path.home() / ".autor" / "learned_skills"
+
+#: Environment variable that relocates the pool. Read at call time rather than import time
+#: so a test, or a launcher that sets it after import, gets the pool it asked for.
+POOL_ENV_VAR = "AUTOR_LEARNED_POOL"
+
+
+def default_pool() -> Path:
+    """The pool this run should read, honouring :data:`POOL_ENV_VAR`."""
+    override = os.environ.get(POOL_ENV_VAR, "").strip()
+    return Path(override).expanduser() if override else DEFAULT_POOL
 
 #: Notes kept per field. Past this the oldest go; see the module docstring on why a cap.
 MAX_NOTES_PER_DISCIPLINE = 12
@@ -122,8 +137,8 @@ def _pool_file(pool: Path, discipline: str) -> Path:
     return pool / safe / POOL_FILENAME
 
 
-def load_notes(discipline: str, *, pool: Path = DEFAULT_POOL) -> list[LearnedNote]:
-    path = _pool_file(pool, discipline)
+def load_notes(discipline: str, *, pool: Path | None = None) -> list[LearnedNote]:
+    path = _pool_file(pool if pool is not None else default_pool(), discipline)
     if not path.is_file():
         return []
     try:
@@ -144,9 +159,15 @@ def load_notes(discipline: str, *, pool: Path = DEFAULT_POOL) -> list[LearnedNot
 
 def record_note(
     discipline: str, title: str, body: str, learned_in: str,
-    *, pool: Path = DEFAULT_POOL, now: str | None = None,
+    *, pool: Path | None = None, now: str | None = None,
 ) -> tuple[LearnedNote | None, list[str]]:
-    """File a note, or refuse it and say why. Never raises on a bad note."""
+    """File a note, or refuse it and say why. Never raises on a bad note.
+
+    Reads and writes the same pool. A default that read the override and wrote the shared
+    location would give an "isolated" arm a private view and a shared side effect, which
+    is worse than no isolation because it looks like isolation.
+    """
+    pool = pool if pool is not None else default_pool()
     problems = validate_note(discipline, title, body)
     if problems:
         return None, problems
@@ -167,14 +188,47 @@ def record_note(
     return note, []
 
 
-def install_learned_skill(paths: RunPaths, discipline: str, *, pool: Path = DEFAULT_POOL) -> str:
+def pool_fingerprint(discipline: str, *, pool: Path | None = None) -> dict[str, object]:
+    """What this run read out of the shared pool, in a form a later reader can compare.
+
+    The pool lives outside every worktree and every run directory, so two arms of an
+    ablation pinned to different commits still read the same file, and it is rewritten
+    while they run -- twelve notes per field, oldest evicted. Nothing recorded that.
+
+    On the `pins_on`/`pins_off` ablation this turned out to be harmless, and only because
+    the twins launch in the same second: the installed skill was byte-identical in all
+    forty pairs, so the channel was held constant within each pair and cancelled in the
+    paired difference. That is luck about scheduling, not a property of the design. A task
+    relaunched out of step with its twin reads a different pool and nothing says so.
+
+    So record it: the field, how many notes were read, and a digest of exactly what they
+    were. A paired analysis can then *verify* the channel was constant instead of assuming
+    it, and drop the pairs where it was not.
+    """
+    resolved = pool if pool is not None else default_pool()
+    notes = load_notes(discipline, pool=resolved)
+    digest = hashlib.sha256()
+    for note in notes:
+        digest.update(note.title.encode("utf-8", "replace"))
+        digest.update(b"\x00")
+        digest.update(note.body.encode("utf-8", "replace"))
+        digest.update(b"\x00")
+    return {
+        "pool": str(resolved),
+        "discipline": discipline,
+        "notes": len(notes),
+        "digest": digest.hexdigest()[:16] if notes else "",
+    }
+
+
+def install_learned_skill(paths: RunPaths, discipline: str, *, pool: Path | None = None) -> str:
     """Write the field's learned notes into the run as one skill. Returns its name, or "".
 
     One skill rather than one per note: they are short, they are all about the same field,
     and a pool that installs twelve descriptions crowds out the twenty-nine the pack already
     has. The model reads the file when the field comes up and finds every note in it.
     """
-    notes = load_notes(discipline, pool=pool)
+    notes = load_notes(discipline, pool=pool if pool is not None else default_pool())
     if not notes:
         return ""
     name = "learned-from-earlier-runs"

--- a/tests/test_skill_evolution.py
+++ b/tests/test_skill_evolution.py
@@ -13,16 +13,21 @@ instead of measuring one. Most of these tests are about refusing that.
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
 
 from src.skill_evolution import (
+    DEFAULT_POOL,
     MAX_NOTES_PER_DISCIPLINE,
     MIN_NOTE_CHARS,
+    POOL_ENV_VAR,
+    default_pool,
     install_learned_skill,
     load_notes,
     looks_like_a_result,
+    pool_fingerprint,
     record_note,
     validate_note,
 )
@@ -146,3 +151,164 @@ class InstallTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ASharedChannelMustLeaveAReceiptTest(unittest.TestCase):
+    """The pool is the one input two arms of an ablation cannot pin.
+
+    Everything else a run reads is inside its worktree, so an ablation pins two commits
+    and the difference between them is the treatment. This is not: `DEFAULT_POOL` is
+    `~/.autor/learned_skills`, outside every worktree and every run directory, and it is
+    rewritten while arms run -- twelve notes per field, oldest evicted.
+
+    Measured on the `pins_on`/`pins_off` ablation: the installed skill was byte-identical
+    in all forty pairs, so the channel cancelled in the paired difference. But that is a
+    fact about scheduling -- the twins launch in the same second and read the same
+    snapshot -- not about the design. A task relaunched out of step with its twin reads a
+    different pool, and nothing anywhere said which one it read.
+
+    Two things follow: a run records what it read, and a paired arm can be given a pool
+    of its own.
+    """
+
+    def setUp(self) -> None:
+        self._saved = os.environ.pop(POOL_ENV_VAR, None)
+
+    def tearDown(self) -> None:
+        os.environ.pop(POOL_ENV_VAR, None)
+        if self._saved is not None:
+            os.environ[POOL_ENV_VAR] = self._saved
+
+    def test_unset_the_pool_is_exactly_where_it_was(self) -> None:
+        """The override may not move the default for anyone who has not asked."""
+        self.assertEqual(default_pool(), DEFAULT_POOL)
+
+    def test_the_environment_moves_the_pool(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ[POOL_ENV_VAR] = tmp
+            self.assertEqual(default_pool(), Path(tmp))
+
+    def test_it_is_read_at_call_time_not_import_time(self) -> None:
+        """A launcher that sets it after import must still get the pool it asked for."""
+        with tempfile.TemporaryDirectory() as tmp:
+            before = default_pool()
+            os.environ[POOL_ENV_VAR] = tmp
+            self.assertNotEqual(default_pool(), before)
+
+    def test_reads_and_writes_go_to_the_same_pool(self) -> None:
+        """A private read with a shared write is worse than no isolation: it looks isolated.
+
+        `record_note` defaulted to `DEFAULT_POOL` while `load_notes` honoured the override,
+        which would have given an isolated arm a private view and a shared side effect.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ[POOL_ENV_VAR] = tmp
+            note, problems = record_note("physics", "A title that is long enough", GOOD, "run-1")
+            self.assertEqual(problems, [])
+            self.assertIsNotNone(note)
+            self.assertTrue((Path(tmp) / "physics" / "learned_notes.json").is_file())
+            self.assertEqual(len(load_notes("physics")), 1)
+
+    def test_the_fingerprint_names_what_was_read(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ[POOL_ENV_VAR] = tmp
+            record_note("physics", "A title that is long enough", GOOD, "run-1")
+            fp = pool_fingerprint("physics")
+            self.assertEqual(fp["pool"], tmp)
+            self.assertEqual(fp["discipline"], "physics")
+            self.assertEqual(fp["notes"], 1)
+            self.assertTrue(fp["digest"])
+
+    def test_an_empty_pool_fingerprints_as_empty_rather_than_as_a_hash(self) -> None:
+        """A digest over nothing is a constant, and a constant reads as agreement."""
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ[POOL_ENV_VAR] = tmp
+            fp = pool_fingerprint("physics")
+            self.assertEqual(fp["notes"], 0)
+            self.assertEqual(fp["digest"], "")
+
+    def test_the_digest_changes_when_the_notes_change(self) -> None:
+        """The whole point: two runs that read different pools must not agree."""
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ[POOL_ENV_VAR] = tmp
+            record_note("physics", "A title that is long enough", GOOD, "run-1")
+            first = pool_fingerprint("physics")["digest"]
+            record_note("physics", "A second title, also long enough", GOOD.replace("latitude", "longitude"), "run-2")
+            second = pool_fingerprint("physics")["digest"]
+            self.assertNotEqual(first, second)
+
+    def test_two_runs_reading_the_same_pool_agree(self) -> None:
+        """And the converse, or the receipt would flag every pair as contaminated."""
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ[POOL_ENV_VAR] = tmp
+            record_note("physics", "A title that is long enough", GOOD, "run-1")
+            self.assertEqual(
+                pool_fingerprint("physics")["digest"], pool_fingerprint("physics")["digest"]
+            )
+
+    def test_different_fields_do_not_collide(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ[POOL_ENV_VAR] = tmp
+            record_note("physics", "A title that is long enough", GOOD, "run-1")
+            self.assertEqual(pool_fingerprint("chemistry")["notes"], 0)
+            self.assertNotEqual(
+                pool_fingerprint("physics")["digest"], pool_fingerprint("chemistry")["digest"]
+            )
+
+    def test_the_digest_covers_the_body_and_not_just_the_title(self) -> None:
+        """A note's content is its body; two pools can agree on titles and differ entirely.
+
+        `record_note` replaces a note with the same title, so this rewrites one note's body
+        and nothing else. A digest over titles alone passes every other test in this class
+        and would report a contaminated pair as clean.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ[POOL_ENV_VAR] = tmp
+            title = "A title that is long enough"
+            record_note("physics", title, GOOD, "run-1")
+            first = pool_fingerprint("physics")["digest"]
+            record_note("physics", title, GOOD.replace("latitude", "longitude"), "run-2")
+            after = pool_fingerprint("physics")
+            self.assertEqual(after["notes"], 1, "the title should have deduplicated")
+            self.assertNotEqual(first, after["digest"])
+
+    def test_the_digest_covers_the_title_too(self) -> None:
+        """Titles are rendered as headings in the installed skill, so they are content.
+
+        Two pools, one note each, same body and different titles: a digest over bodies
+        alone calls them identical.
+        """
+        with tempfile.TemporaryDirectory() as a, tempfile.TemporaryDirectory() as b:
+            os.environ[POOL_ENV_VAR] = a
+            record_note("physics", "The first title, long enough", GOOD, "run-1")
+            first = pool_fingerprint("physics")["digest"]
+            os.environ[POOL_ENV_VAR] = b
+            record_note("physics", "A different title, also long", GOOD, "run-1")
+            second = pool_fingerprint("physics")["digest"]
+            self.assertNotEqual(first, second)
+
+    def test_the_field_separators_are_load_bearing(self) -> None:
+        """Without them the digest hashes a concatenation, and boundaries stop mattering.
+
+        `("ab", "c")` and `("a", "bc")` are different pools that a separator-free digest
+        calls identical. Contrived, and pinned anyway: a separator is invisible, cheap, and
+        the sort of thing a later edit removes as noise. Written straight into the pool
+        file because `record_note` would reject titles and bodies this short, and the
+        digest reads whatever is on disk.
+        """
+        def write(pool: str, title: str, body: str) -> None:
+            path = Path(pool) / "physics" / "learned_notes.json"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps([{"discipline": "physics", "title": title, "body": body,
+                             "learned_in": "run-1", "recorded_at": "2026-01-01"}]),
+                encoding="utf-8",
+            )
+
+        with tempfile.TemporaryDirectory() as a, tempfile.TemporaryDirectory() as b:
+            write(a, "ab", "c")
+            write(b, "a", "bc")
+            os.environ[POOL_ENV_VAR] = a
+            first = pool_fingerprint("physics")["digest"]
+            os.environ[POOL_ENV_VAR] = b
+            self.assertNotEqual(first, pool_fingerprint("physics")["digest"])


### PR DESCRIPTION
## The channel

`DEFAULT_POOL` is `~/.autor/learned_skills` — **outside every worktree and every run directory**. That is deliberate: a note is meant to outlive the run that wrote it.

It also makes the pool **the one input two arms of an ablation cannot pin**. Everything else a run reads lives in its tree, so pinning two commits fixes the treatment. This does not. `install_learned_skill` installs it into *every* run, from a twelve-note-per-field buffer with the oldest evicted, that every concurrent arm on the machine writes to.

## Why it isn't currently doing damage — and why that's luck

Found while auditing the in-flight `pins_on`/`pins_off` ablation, where it looked fatal. It is not: the installed skill is **byte-identical in all forty pairs**, because the twins launch in the same second and read the same snapshot. The channel is held constant within each pair and cancels in the paired difference.

That is a fact about *scheduling*, not about the design. A task relaunched out of step with its twin reads a different pool — and nothing recorded which one either of them read, so the check could not be performed at all, only assumed.

## Two changes, both inert unless asked for

**A receipt.** `pool_fingerprint(discipline)` returns the pool path, field, note count, and a sha256 over every note's title and body. `Manager._install_skills` writes it into `run_config.json` as `learned_pool`, beside the pins declaration it already writes. A paired analysis can now *verify* the channel was constant and drop the pairs where it wasn't.

**An override.** `AUTOR_LEARNED_POOL` relocates the pool, read at call time so a launcher that sets it after import still gets what it asked for. Unset, `default_pool()` is `DEFAULT_POOL` and nothing changes.

**A bug found on the way:** `record_note` defaulted to `DEFAULT_POOL` while `load_notes` would have honoured the override — a private read with a shared write, which is *worse* than no isolation because it looks like isolation. Both now resolve the same way.

## Verification

Full suite **3681 passed, 4 skipped**. Eight mutants; **two survived the first pass and both were real gaps in the digest**, now closed:

- digest over titles alone — two pools agreeing on titles and differing entirely in content read as identical
- digest with no field separators — `("ab","c")` and `("a","bc")` collide

The separator test writes the pool file directly, because `record_note` rejects strings that short and the digest reads what is on disk.

Six died first time: override ignored · override read at import time · shared write · empty pool hashing to a constant · fields colliding · bodies excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)