### PR TITLE
Three knobs an arm needs and did not have: the pack, the withheld set, and the figure floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ options, concrete file paths under `Files Produced`, and no `[In progress]`, `[P
 | Stage 03+ | Machine-readable data under `workspace/data/`, plus a `report_plan.json` committing to the figures and headline numbers the report will carry |
 | Stage 05+ | Machine-readable results under `workspace/results/`, plus a valid `experiment_manifest.json` |
 | Stage 06+ | Real figure files under `workspace/figures/`, and every planned figure's `source_artifact` resolving to a non-empty file |
-| Stage 07+ (markdown) | `report/report.md` with resolving figure references, between `min_report_figures` and 5 figures under `report/images/`, `deliverables_coverage.json`, `citation_verification.json`, `self_review.json`, `report_review.json` |
+| Stage 07+ (markdown) | `report/report.md` with resolving figure references, between `min_report_figures` and `MAX_REPORT_FIGURES` figures under `report/images/`, `deliverables_coverage.json`, `citation_verification.json`, `self_review.json`, `report_review.json` |
 | Stage 07+ (latex) | `main.tex` matching the venue, `sections/*.tex`, a bibliography, a compiled PDF, `build_log.txt`, `citation_verification.json`, `self_review.json`, `layout_review.json` |
 | Stage 08+ | Review and readiness assets under `workspace/reviews/` |
 
@@ -541,7 +541,7 @@ Requirements are cumulative, and the stage that *produces* a class of artifact m
 cutoff is `stage_execution_started_at` feeding `recent_in`, and the rubric enforces the same rule
 independently in `_fresh_artifact_kinds`, so a Stage 07 draft cannot score on Stage 06's figures.
 
-`min_report_figures` is a `run_config.json` field with no CLI flag, clamped to `[1, 5]`. It is 1 for
+`min_report_figures` is a `run_config.json` field, set by `rcb_agent.py --min-report-figures`, clamped to `[1, MAX_REPORT_FIGURES]` (15). It is 1 for
 an ordinary run and **3** for a ResearchClawBench run (`BENCHMARK_MIN_REPORT_FIGURES`).
 
 **Validity gates.** The same function — `validate_stage_artifacts` ([src/utils.py](src/utils.py)) —

--- a/docs/run-artifacts.md
+++ b/docs/run-artifacts.md
@@ -158,7 +158,7 @@ The settings the run was started with, so a resume reproduces them.
 | `evolve_rounds` | Improvement rounds per stage; `2` by default, `0` measures without polishing. |
 | `archive_steer` | Whether the cross-run archive may choose this run's topology, as opposed to only recording what it did. `false` by default. |
 | `web_search` | `auto`, `gemini`, `native`, or `off`. The mode, not the resolved backend. Absent in runs created before it existed, and read as `auto`. |
-| `min_report_figures` | Distinct rendered figures `workspace/report/images/` must hold before Stage 07 can be approved in `markdown` mode. `MIN_REPORT_FIGURES` = 1 for an ordinary run; `rcb_agent.py` sets `BENCHMARK_MIN_REPORT_FIGURES` = 3. `resolve_min_report_figures` clamps whatever it reads into `[1, MAX_REPORT_FIGURES]`, so a value of `0`, `99` or `"three"` becomes 1, 5 and 1 respectively rather than failing the run. Read as a hard gate by `validate_markdown_report`. |
+| `min_report_figures` | Distinct rendered figures `workspace/report/images/` must hold before Stage 07 can be approved in `markdown` mode. `MIN_REPORT_FIGURES` = 1 for an ordinary run; `rcb_agent.py` defaults it to `BENCHMARK_MIN_REPORT_FIGURES` = 3 and `--min-report-figures` overrides that. `resolve_min_report_figures` clamps whatever it reads into `[1, MAX_REPORT_FIGURES]`, so a value of `0`, `99` or `"three"` becomes 1, 15 and 1 respectively rather than failing the run. Read as a hard gate by `validate_markdown_report`. |
 | `created_at` | ISO-8601 to the second. Preserved across rewrites. |
 
 A missing or corrupt file falls back to defaults rather than failing the run.

--- a/rcb_agent.py
+++ b/rcb_agent.py
@@ -382,6 +382,31 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Use the fake operator instead of a real backend. For smoke-testing the adapter.",
     )
     parser.add_argument(
+        "--min-report-figures",
+        type=int,
+        default=None,
+        help=f"Distinct figures report/images/ must hold before Stage 07 can be approved. "
+             f"Defaults to {BENCHMARK_MIN_REPORT_FIGURES}. Clamped to [1, MAX_REPORT_FIGURES]. "
+             "The judge is shown a fixed set of the first MAX_REPORT_FIGURES images, and most "
+             "runs stop well under it, so this is the knob for an arm that tests whether "
+             "filling the window is worth anything.",
+    )
+    parser.add_argument(
+        "--skills-dir",
+        default=None,
+        help="Directory to load the agent skill pack from, instead of <repo>/src/skills. "
+             "For arms that measure a different pack: the pack becomes an argument the "
+             "artifact records rather than an edit to a worktree nobody can pin.",
+    )
+    parser.add_argument(
+        "--withhold-skills",
+        default=None,
+        help="Skills this run is denied whatever the field filter, the predicates or the pin "
+             "table say. A comma-separated list of names, or @PATH to read one name per line "
+             "(blank lines and # comments ignored). This is the control arm of any experiment "
+             "about skills.",
+    )
+    parser.add_argument(
         "--export-only",
         action="store_true",
         help="Skip the pipeline and only re-export the most recent run in the workspace into "
@@ -638,7 +663,14 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
         # and validation/comparison plots" -- three distinct questions -- and 27 of its 40
         # tasks carry two or more image criteria. A one-figure report clears AutoR's ordinary
         # gate while forfeiting criteria it never addressed.
-        min_report_figures=BENCHMARK_MIN_REPORT_FIGURES,
+        # Measured over 541 scored runs, with task and arm fixed effects, a published figure
+        # is worth about +0.79 benchmark points -- and 423 of those runs published fewer than
+        # the MAX_REPORT_FIGURES the judge is handed, median twelve. The slope is partly a
+        # proxy for run quality (the image-criterion slope is +0.72 against +0.41 on text),
+        # so it is an upper bound and not a promise. It is still the largest effect anyone
+        # has measured here, which is why the floor is now an argument: an arm can raise it
+        # and find out, and `run_config.json` records which arm did.
+        min_report_figures=benchmark_figure_floor(args.min_report_figures),
         cross_reviewer=resolve_cross_reviewer(args.cross_review, args.cross_review_model),
         # `StageGraph.named` rather than `main.py`'s `resolve_graph`, which additionally
         # lets the cross-run archive pick a topology. A benchmark arm must be the
@@ -719,6 +751,15 @@ def run(args: argparse.Namespace) -> BenchmarkResult:
     # derived from the task statement; a pin is derived from a previous run's score, so
     # it needs the name of the task that produced it. `configs/task_skill_pins.json`.
     manager.skill_task_id = _task_id or None
+    # The pack itself, as an argument. Until this existed the only way to measure a
+    # different pack was to delete files in a worktree, which is how the best-scoring arm
+    # on the board came to exist as a dirty checkout with no SHA that nobody can re-run.
+    if args.skills_dir:
+        skills_dir = Path(args.skills_dir).expanduser()
+        if not skills_dir.is_dir():
+            raise SystemExit(f"--skills-dir: not a directory: {skills_dir}")
+        manager.skills_dir = skills_dir
+    manager.skill_withhold = read_withheld_skills(args.withhold_skills)
 
     pipeline_completed = False
     aborted_with = ""
@@ -834,6 +875,50 @@ def _sigterm_as_exception() -> Iterator[None]:
         yield
     finally:
         signal.signal(signal.SIGTERM, previous)
+
+
+
+
+def benchmark_figure_floor(requested: int | None) -> int:
+    """The figure floor a benchmark run gets, given what the caller asked for.
+
+    Unasked, a benchmark run keeps :data:`BENCHMARK_MIN_REPORT_FIGURES` rather than AutoR's
+    ordinary floor of one: the benchmark's own instructions ask every agent for "data
+    overview, main results, and validation/comparison plots", and 27 of its 40 tasks carry
+    two or more image criteria, so a one-figure report clears the ordinary gate while
+    forfeiting criteria it never addressed.
+
+    A caller may raise it. `resolve_min_report_figures` clamps the result into
+    ``[1, MAX_REPORT_FIGURES]`` downstream, so a value past the window the judge sees cannot
+    turn the gate into busywork.
+    """
+    return BENCHMARK_MIN_REPORT_FIGURES if requested is None else requested
+
+
+def read_withheld_skills(spec: str | None) -> frozenset[str]:
+    """The skills this run is denied, from a comma list or ``@file``.
+
+    A file, because the useful ablation names forty-odd skills and a command line that long
+    stops being readable in `_meta.json` -- which is where anyone later reconstructs what an
+    arm actually ran. Blank lines and `#` comments are allowed so the file can say why.
+
+    Unknown names are not an error here. `install_run_skills` applies the set by exclusion,
+    so a name matching nothing withholds nothing, and the run config records the set that
+    was asked for beside the pack digest that resulted -- which is the pair a reader needs
+    to tell "withheld nothing" from "asked for nothing".
+    """
+    if not spec:
+        return frozenset()
+    text = spec.strip()
+    if text.startswith("@"):
+        try:
+            raw = Path(text[1:]).expanduser().read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            raise SystemExit(f"--withhold-skills: cannot read {text[1:]}: {exc}") from exc
+        names = [line.split("#", 1)[0].strip() for line in raw.splitlines()]
+    else:
+        names = [part.strip() for part in text.split(",")]
+    return frozenset(n for n in names if n)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/manager.py
+++ b/src/manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import datetime
+import hashlib
 import shutil
 import sys
 from pathlib import Path
@@ -5271,6 +5272,27 @@ class ResearchManager:
                 f"Could not install the agent skill pack from {self.skills_dir}: {exc}",
             )
             return []
+        # What pack this run actually had. `skills_dir` and `skill_withhold` are arguments
+        # now, so an arm that measures a different pack is a configuration rather than an
+        # edit to somebody's worktree -- but only if the run says which pack it got. The
+        # best-scoring arm on the board at the time of writing exists solely as a dirty
+        # checkout with 41 deleted files and no SHA, and cannot be re-run by anyone.
+        #
+        # The digest is over the installed names, so two runs are comparable without
+        # reconstructing anyone's flags: same digest, same pack.
+        try:
+            config = load_run_config(paths)
+            config["skill_pack"] = {
+                "source": str(self.skills_dir),
+                "installed": len(installed),
+                "withheld_requested": sorted(self.skill_withhold),
+                "digest": hashlib.sha256(
+                    "\n".join(sorted(installed)).encode("utf-8", "replace")
+                ).hexdigest()[:16],
+            }
+            save_run_config(paths, config)
+        except (OSError, TypeError, ValueError):
+            pass
         if installed:
             append_log_entry(
                 paths.logs,

--- a/tests/test_rcb_adapter.py
+++ b/tests/test_rcb_adapter.py
@@ -815,3 +815,74 @@ class RecoveredDurationTest(unittest.TestCase):
         self._age_run_tree(4000)
         rcb_agent.main(["--workspace", str(self.workspace), "--export-only", "--no-synthesis"])
         self.assertNotEqual(self._meta()["duration_seconds"], 0)
+
+
+class ThePackAnArmRanMustBeNameableTest(unittest.TestCase):
+    """The skill pack was the one part of a run that could not be stated as an argument.
+
+    `Manager.skills_dir` was `project_root / "src" / "skills"` with no flag, no config key
+    and no environment override, so the only way to measure a different pack was to delete
+    files in a worktree. That is how `full40_abl40` -- the highest-scoring arm on the board
+    -- came to exist as a dirty checkout with 41 deleted files and no SHA, reproducible by
+    nobody, with a JSON-corrupted pin table beside it.
+
+    Two flags fix it. `--skills-dir` names a pack; `--withhold-skills` denies named skills
+    from the pack that is there, which is the cheaper form for an ablation because it does
+    not require building and pinning a second tree.
+    """
+
+    def test_a_comma_list_is_read(self) -> None:
+        self.assertEqual(rcb_agent.read_withheld_skills("a,b , c"), frozenset({"a", "b", "c"}))
+
+    def test_nothing_asked_for_is_nothing_withheld(self) -> None:
+        """The default may not deny anything, or every existing arm changes meaning."""
+        for spec in (None, "", "   ", ",", " , , "):
+            with self.subTest(spec=spec):
+                self.assertEqual(rcb_agent.read_withheld_skills(spec), frozenset())
+
+    def test_a_file_is_read_one_name_per_line(self) -> None:
+        """The useful ablation names forty-odd skills.
+
+        A command line that long stops being legible in `_meta.json`, which is where anyone
+        later reconstructs what an arm ran -- so the list has to be able to live in a file.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp, "withhold.txt")
+            path.write_text(
+                "# the 3 lowest-read skills, see docs/what-actually-moves-the-score.md\n"
+                "alpha\n"
+                "\n"
+                "beta  # never opened in 1016 runs\n"
+                "   gamma   \n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                rcb_agent.read_withheld_skills(f"@{path}"),
+                frozenset({"alpha", "beta", "gamma"}),
+            )
+
+    def test_a_comment_only_file_withholds_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp, "w.txt")
+            path.write_text("# nothing yet\n\n   \n", encoding="utf-8")
+            self.assertEqual(rcb_agent.read_withheld_skills(f"@{path}"), frozenset())
+
+    def test_an_unreadable_file_stops_the_run_rather_than_withholding_nothing(self) -> None:
+        """The failure that matters. A typo'd path that silently withheld nothing would
+        produce an arm labelled as the ablation and identical to the control, and the
+        score file would not say so."""
+        with self.assertRaises(SystemExit):
+            rcb_agent.read_withheld_skills("@/nonexistent/withhold/list.txt")
+
+    def test_both_flags_are_on_the_parser_and_default_to_today_s_behaviour(self) -> None:
+        args = rcb_agent.parse_args(["--workspace", "/tmp/x", "--prompt", "/tmp/p"])
+        self.assertIsNone(args.skills_dir)
+        self.assertIsNone(args.withhold_skills)
+
+    def test_the_flags_parse(self) -> None:
+        args = rcb_agent.parse_args(
+            ["--workspace", "/tmp/x", "--prompt", "/tmp/p",
+             "--skills-dir", "/tmp/pack", "--withhold-skills", "a,b"]
+        )
+        self.assertEqual(args.skills_dir, "/tmp/pack")
+        self.assertEqual(args.withhold_skills, "a,b")

--- a/tests/test_report_figure_floor.py
+++ b/tests/test_report_figure_floor.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import rcb_agent
 from src.utils import (
     BENCHMARK_MIN_REPORT_FIGURES,
     MAX_REPORT_FIGURES,
@@ -148,10 +149,69 @@ class ConfigPersistenceTest(unittest.TestCase):
 
 
 class BenchmarkAdapterTest(unittest.TestCase):
-    def test_the_adapter_raises_the_floor(self) -> None:
-        source = (Path(__file__).resolve().parent.parent / "rcb_agent.py").read_text(encoding="utf-8")
-        self.assertIn("min_report_figures=BENCHMARK_MIN_REPORT_FIGURES", source)
+    """The adapter raises the floor above AutoR's ordinary one, and still can.
+
+    This asserted the literal source text `min_report_figures=BENCHMARK_MIN_REPORT_FIGURES`
+    until the floor became an argument. The invariant it was protecting is behavioural --
+    *a benchmark run that was not told otherwise gets the benchmark floor, not the ordinary
+    one* -- so it is now tested as behaviour, which also lets the argument exist.
+    """
+
+    def test_a_run_that_asks_for_nothing_gets_the_benchmark_floor(self) -> None:
+        self.assertEqual(rcb_agent.benchmark_figure_floor(None), BENCHMARK_MIN_REPORT_FIGURES)
+        self.assertGreater(BENCHMARK_MIN_REPORT_FIGURES, MIN_REPORT_FIGURES)
+
+    def test_a_caller_can_raise_it(self) -> None:
+        self.assertEqual(rcb_agent.benchmark_figure_floor(15), 15)
+
+    def test_a_caller_can_lower_it_and_the_clamp_still_holds(self) -> None:
+        """Lowering is allowed here and clamped downstream; the gate must not vanish."""
+        self.assertEqual(resolve_min_report_figures(rcb_agent.benchmark_figure_floor(0)), 1)
 
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheFigureFloorMustBeSettableTest(unittest.TestCase):
+    """The floor existed, was read as a hard gate, and could not be moved.
+
+    `min_report_figures` is written into `run_config.json`, clamped by
+    `resolve_min_report_figures`, and read back by `validate_markdown_report` as a hard
+    gate on the count of distinct figures in `report/images/`. `rcb_agent.py` pinned it at
+    `BENCHMARK_MIN_REPORT_FIGURES` = 3 with no way to say otherwise, and the README said so
+    outright: *"a `run_config.json` field with no CLI flag"*.
+
+    Three is far below where runs actually land. Measured over 541 scored runs with task and
+    arm fixed effects, a published figure is worth about +0.79 benchmark points, and 423 of
+    those runs published fewer than the `MAX_REPORT_FIGURES` the judge is handed — median
+    twelve. The gate at 3 has never fired against a real run. Making it an argument is what
+    turns that observation into an experiment somebody can run.
+    """
+
+    def test_the_flag_exists_and_defaults_to_the_benchmark_floor(self) -> None:
+        args = rcb_agent.parse_args(["--workspace", "/tmp/x", "--prompt", "/tmp/p"])
+        self.assertIsNone(args.min_report_figures)
+
+    def test_the_flag_parses_an_integer(self) -> None:
+        args = rcb_agent.parse_args(
+            ["--workspace", "/tmp/x", "--prompt", "/tmp/p", "--min-report-figures", "15"]
+        )
+        self.assertEqual(args.min_report_figures, 15)
+
+    def test_the_clamp_admits_the_whole_window_the_judge_sees(self) -> None:
+        """A floor of 15 has to survive the clamp, or the arm cannot be run at all.
+
+        `resolve_min_report_figures` clamps to `[1, MAX_REPORT_FIGURES]`. The README and
+        `docs/run-artifacts.md` both described that ceiling as 5, which was true when
+        `MAX_REPORT_FIGURES` was 5 and has been wrong since it became 15 — a stale bound is
+        how an arm gets configured to something it cannot reach.
+        """
+        self.assertEqual(MAX_REPORT_FIGURES, 15)
+        self.assertEqual(resolve_min_report_figures(MAX_REPORT_FIGURES), MAX_REPORT_FIGURES)
+        self.assertEqual(resolve_min_report_figures(MAX_REPORT_FIGURES + 1), MAX_REPORT_FIGURES)
+
+    def test_a_floor_of_zero_or_nonsense_still_falls_back_rather_than_failing(self) -> None:
+        for value in (0, -3, "", "three", None):
+            with self.subTest(value=value):
+                self.assertGreaterEqual(resolve_min_report_figures(value), 1)


### PR DESCRIPTION
None of these is a new mechanism. **All three already existed and none could be set** — which is why the two experiments the measurements point at could not be run, and why the best-scoring arm on the board cannot be reproduced by anyone.

## `--skills-dir`

`Manager.skills_dir` was `project_root / "src" / "skills"` with no flag, config key or env override. The only way to measure a different pack was to delete files in a worktree — which is how `full40_abl40` (the top arm) came to exist as a **dirty checkout with 41 deleted files, no SHA, and a JSON-corrupted pin table** beside it.

## `--withhold-skills`

`Manager.skill_withhold` was already wired end to end — `install_run_skills` applies it last, over pins and forces, and removes a withheld skill an earlier install of the same run wrote. It had no CLI surface.

Takes a comma list or `@file`, because the ablation the read census points at names **45 skills** and a command line that long stops being legible in `_meta.json` — which is where anyone later reconstructs what an arm ran. A file may carry `#` comments so it can say why.

**An unreadable `@file` raises rather than withholding nothing.** A typo would otherwise produce an arm labelled as the ablation, identical to the control, with nothing in the record saying so.

## `--min-report-figures`

The floor already existed, was clamped to `[1, MAX_REPORT_FIGURES]`, was read as a **hard gate** by `validate_markdown_report`, and was pinned at `BENCHMARK_MIN_REPORT_FIGURES` = 3. The README said so outright: *"a `run_config.json` field with no CLI flag"*.

Three never fires. Over 541 scored runs with task and arm fixed effects:

```
score ~ images_available    beta = +0.786 ± 0.161   t = +4.87
```

and **423 of 541 runs published fewer than the 15 the judge is handed**, median 12. The slope is partly a proxy for run quality (image slope +0.72 vs +0.41 on text), so it is an **upper bound, not a promise** — which is exactly why it should be an arm rather than a default. **Default behaviour is unchanged.**

## The run now declares its pack

`_install_skills` writes `skill_pack` into `run_config.json`: source directory, installed count, the withheld set as requested, and a sha256 over the installed names. Two runs are comparable without reconstructing anyone's flags — same digest, same pack.

## One test changed from textual to behavioural

`test_the_adapter_raises_the_floor` asserted the literal source string `min_report_figures=BENCHMARK_MIN_REPORT_FIGURES`. The invariant under it is behavioural — *a benchmark run not told otherwise gets the benchmark floor, not AutoR's ordinary one* — so it is now `benchmark_figure_floor()` and tested as behaviour, which is what lets the argument exist at all.

## Two stale bounds fixed on the way

README and `docs/run-artifacts.md` both described the clamp as `[1, 5]` — true when `MAX_REPORT_FIGURES` was 5, wrong since it became 15. A stale bound is how an arm gets configured to a value it cannot reach.

## Verification

Full suite **3694 passed, 4 skipped**. **Seven mutants killed**: default dropped to the ordinary floor · caller's floor ignored · missing `@file` withholding nothing · blank names kept · comments not stripped · `@file` read as a literal name · non-empty default withhold set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)