### PR TITLE
The image-cap bullet asserts a constant it disclaims in its own next clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,9 +965,12 @@ post-repair re-run at **23.57** against a 29.24 control, and the re-score that c
 both. Each was wrong in a way worth knowing about rather than wrong by accident, and the
 notebook keeps each one next to the correction that retired it:
 
-- **The judge was shown a third of the figures it should have been.** Upstream sends the
-  grader `generated_images[:15]`; the local scorer was capped at 5, and arms differ in how
-  many figures they ship, so the cap was not a constant offset.
+- **The judge was shown between 29% and 80% of the figures, depending on the arm.**
+  `gpt51_judge.py` held `MAX_IMAGES = 5` for four days after upstream raised its own cap
+  from five to fifteen (`bfffc48`, 2026-08-14) — a lag behind upstream, not a local
+  deviation from it — and `image_paths[0]` is the target figure, so four workspace slots
+  were left. Arms differ in how many figures they ship, so the clip was not a constant
+  offset: four slots showed the control 67% of its figures and the skills arm 29%.
 - **The arms were not given the same budget.** The AutoR side ran `--stage-timeout 1800`
   and 28 of its 40 runs logged `Stage timed out`; the bare arm had no per-stage cap.
 - **The draw count decides the verdict.** One judge draw against three moves an arm's


### PR DESCRIPTION
## Two errors in one sentence, both checkable

> **The judge was shown a third of the figures it should have been.** Upstream sends the grader `generated_images[:15]`; the local scorer was capped at 5, and arms differ in how many figures they ship, so the cap was not a constant offset.

### 1. "a third" is the ratio of the *caps*, not of the figures shown

`docs/researchclawbench-arms.md` already has the measured per-arm number, and it spans nearly three to one:

| arm | median figures | shown at cap 5 |
|:---|---:|---:|
| control | 6 | **67%** |
| `full40` | 5 | **80%** |
| `full40_v220`, `full40_head` | 10 | 40% |
| `arm_2ffaeb4` | 11 | 36% |
| `full40_pins` | 13.5 | 30% |
| `full40_skills` | 14 | **29%** |

Only the last two are near a third. Asserting a single ratio is the same mistake the sentence's own closing clause warns about — *"the cap was not a constant offset"* — so it argued against itself two lines later.

### 2. "Upstream sends `[:15]`; the local scorer was capped at 5" reads as a deviation. It was a lag.

| when | upstream `evaluation/score.py:163` | local `gpt51_judge.py` |
|:---|:---|:---|
| file created (`595f318`) → 2026-08-14 06:36 UTC | `generated_images[:5]` | `MAX_IMAGES = 5` |
| `bfffc48` 2026-08-14 06:36 UTC | → `generated_images[:15]` | still 5 |
| 2026-08-18 | `[:15]` | → 15 |

`[:5]` was upstream's own value for most of that history, and the RCB checkout here is unmodified against its pin (`git status` clean). The fault was four days of staleness, so the lesson is **fetch before scoring**, not *don't patch the scorer*. The notebook states the ordering correctly; the README dropped it.

### Also restored

`image_paths[0]` is the paper's target figure, so a cap of five left **four** workspace slots. That is what makes the notebook's column arithmetic (it is 4/median, and it says so, having read 5/median for two days).

No number in this PR is new — it only stops the README from disagreeing with the notebook it points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)