### PR TITLE
"The pins are worth negative three points" was two experiments read as one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,17 +1011,34 @@ comparable to these** and the reason is
 agent it wraps, by between 5 and 9 points depending on the arm, on the same judge and the same
 forty tasks. That claim is retired.
 
-**But the arm in front is the one with the skills deleted.** `abl40` is `main40` with 40
-task-scoped skill directories removed and their pins struck; it is otherwise the same commit and
-the same flags. Paired over the 33 tasks both finished:
+**But the arm in front is the one with a set of skills deleted.** `abl40` is `main40` with 41
+task-scoped `SKILL.md` files removed; it is otherwise the same commit and the same flags. Paired
+over the 35 tasks both finished:
 
-> `main40` − `abl40` = **−3.16 ± 1.48**, 95% CI −6.06 … −0.25, winning 10 and losing 23.
+> `main40` − `abl40` = **−2.75 ± 1.08**, 95% CI −4.88 … −0.63, winning 10 and losing 25.
 
-So the pins are worth **negative** three points, and the interval excludes zero. The manipulation
-is not uniform — the struck pins fall on a minority of the forty tasks and the rest lose nothing,
-so the per-affected-task effect is larger than −3.16, not smaller. Both arms are still ahead of the
-control; what the ablation says is that they are ahead *despite* the pinned skills rather than
-because of them.
+Those 41 skills are worth **negative** two-and-three-quarter points and the interval excludes
+zero. Both arms are still well ahead of the control (+7.01 and +8.81), so they are ahead *despite*
+that skill set rather than because of it. The manipulation is not uniform — the deletions bear on
+a minority of the forty tasks and the rest lose nothing — so the per-affected-task effect is
+larger than −2.75, not smaller.
+
+**This is not a verdict on pinning, and an earlier version of this paragraph said it was.** It
+read "the pins are worth negative three points", which conflated two different experiments.
+`abl40` deletes skill *files* and leaves 240 pins across 25 tasks in place: pinning is still on in
+both of its arms. The ablation that actually isolates pinning is a different pair, `pins_on`
+against `pins_off` — same commit, all 168 skill directories present on both sides, 420 pins
+against **zero** — and it points the other way:
+
+| ablation | what differs | n | difference | 95% CI |
+|:---|:---|---:|---:|:---|
+| `main40` − `abl40` | 41 skill files deleted; pinning on in both | 35 | **−2.75 ± 1.08** | −4.88 … −0.63 |
+| `pins_on` − `pins_off` | pinning on vs off; every skill present in both | 21 | **+1.82 ± 1.63** | −1.36 … +5.01 |
+
+Read together: **a particular set of skills hurts, and the mechanism that routes skills to tasks
+does not** — it is mildly positive and nowhere near significant at n=21. Those are complementary
+answers, not contradictory ones, and telling them apart required reading the two worktrees rather
+than the two names.
 
 **`a9c2b48` is the row that answers the caveat the other three carry.** Every other arm above is
 35–39 of 40, so each is a subset selected on its own completions — and that selection is not

--- a/docs/researchclawbench-arms.md
+++ b/docs/researchclawbench-arms.md
@@ -462,39 +462,53 @@ scaffold — does not survive them and should be retired rather than hedged.
 
 ### The pin ablation, which is the one that stings
 
-`full40_abl40` is `full40_main40` with 40 task-scoped skill directories deleted and their
-pins struck. Same commit, same flags, same forty tasks; the skills are the only difference.
-Paired over the 33 tasks both arms finished:
+`full40_abl40` is `full40_main40` with 41 task-scoped `SKILL.md` files deleted. Same commit,
+same flags, same forty tasks. Paired over the 35 tasks both arms finished, beside the
+ablation that isolates pinning instead:
 
-| | mean on the 33 shared | paired difference | 95% CI | W–L |
+| ablation | mean on the shared set | paired difference | 95% CI | W–L |
 |:---|---:|---:|:---|---:|
-| `main40` − `abl40` | 37.38 vs 40.53 | **−3.16 ± 1.48** | **−6.06 … −0.25** | 10–23 |
+| `main40` − `abl40` (n=35) | 37.98 vs 40.73 | **−2.75 ± 1.08** | **−4.88 … −0.63** | 10–25 |
+| `pins_on` − `pins_off` (n=21) | 41.78 vs 39.95 | +1.82 ± 1.63 | −1.36 … +5.01 | 13–8 |
 
-**The pinned skills are worth negative three points, and the interval excludes zero.** The
-arm in front of every other arm in this file is the one with them removed.
+**That set of 41 skills is worth negative two-and-three-quarter points, and the interval
+excludes zero.** The arm in front of every other arm in this file is the one with them
+removed.
 
-Three things that make the effect *larger* than −3.16 rather than smaller, all of which
-argue against reading this as noise:
+**It is not a verdict on pinning, and this section said it was.** It read "the pinned
+skills are worth negative three points" over the first row alone, which is two experiments
+run together. Read the worktrees rather than the names:
 
-- **The manipulation is not uniform.** The struck pins fall on a minority of the forty
-  tasks and the rest lose nothing, so a 40-task mean dilutes whatever happened on the
-  tasks that actually changed. −3.16 is the diluted number.
-- **Both arms are ahead of the control.** +6.00 and +9.23. This is not a scaffold-versus-
-  nothing result, it is a within-scaffold result, and the two arms share every other
-  source of variance the pairing does not already cancel.
-- **The loss count carries it, not one collapse.** 23 of 33 tasks, not a handful of
-  outliers dragging a mean.
+| worktree | commit | `SKILL.md` files | pins | tasks pinned |
+|:---|:---|---:|---:|---:|
+| `autor-main40` | 48501e7 | 161 | 280 | 27 |
+| `autor-abl40` | 48501e7 | **120** | 240 | 25 |
+| `autor-pinson` | f0f469c | 168 | 420 | 47 |
+| `autor-pinsoff` | f0f469c | 168 | **0** | **0** |
 
-What it does not license:
+`abl40` deletes 41 skill files and leaves 240 pins in place — **pinning is on in both of
+its arms**, so it cannot say anything about pinning. `pins_off` deletes no skill at all and
+sets every pin to zero, so it is the one that can. They answer different questions and give
+different answers: a particular skill set hurts; the routing mechanism does not.
 
-- **It is 33 pairs.** That resolves about 3 points at 80% power and the effect is about
-  that size, so the sign is better supported than the magnitude.
-- **Each arm is 35 of 40**, so each is selected on its own completions, and the two arms
-  are missing *different* tasks — `main40` lacks `Information_003` and `Physics_000`,
-  `abl40` lacks `Astronomy_001` and `Energy_000`. The 33-task intersection is what the
-  pairing is over; neither arm's own 35-task mean is comparable to the other's.
-- **It does not say which skills.** Forty directories were struck together. Attributing
-  the −3.16 to any one of them needs an arm that strikes one of them.
+Three things that make the −2.75 *larger* rather than smaller:
+
+- **The manipulation is not uniform.** The deletions bear on a minority of the forty tasks
+  and the rest lose nothing, so a 40-task mean dilutes whatever happened on the tasks that
+  actually changed. −2.75 is the diluted number.
+- **Both arms are ahead of the control.** +7.01 and +8.81. This is a within-scaffold
+  result, and the pairing already cancels every source of variance the two arms share.
+- **The loss count carries it.** 25 of 35 tasks, not a handful of outliers dragging a mean.
+
+What neither row licenses:
+
+- **`pins_on` − `pins_off` is 21 pairs at t=1.12.** It is not evidence that pinning helps;
+  it is the absence of evidence that it hurts, and it will move.
+- **The arms are missing different tasks.** `main40` and `abl40` are 39 and 36 of 40, and
+  the 35-task intersection is what the pairing is over — neither arm's own mean is
+  comparable to the other's.
+- **Neither says which skill.** Forty-one files were struck together. Attributing the
+  −2.75 to any one of them needs an arm that strikes one of them.
 
 ## Reproducing the table
 


### PR DESCRIPTION
[#315](https://github.com/tangxiangru/AutoR/pull/315) landed `main40 − abl40` and called the
result a verdict on pinning: *"the pins are worth negative three points."* It is not. A second
ablation has since produced scores and points the **other way** — and reading the two worktrees
rather than the two names says why they do not conflict.

| worktree | commit | `SKILL.md` files | pins | tasks pinned |
|:---|:---|---:|---:|---:|
| `autor-main40` | 48501e7 | 161 | 280 | 27 |
| `autor-abl40` | 48501e7 | **120** | 240 | 25 |
| `autor-pinson` | f0f469c | 168 | 420 | 47 |
| `autor-pinsoff` | f0f469c | 168 | **0** | **0** |

`abl40` deletes 41 skill **files** and leaves 240 pins across 25 tasks in place — pinning is on
in *both* of its arms, so it cannot say anything about pinning. `pins_off` deletes no skill at
all and zeroes every pin, so it is the pair that can.

## The two results

| ablation | what differs | n | difference | 95% CI | W–L |
|:---|:---|---:|---:|:---|---:|
| `main40` − `abl40` | 41 skill files deleted; pinning on in both | 35 | **−2.75 ± 1.08** | −4.88 … −0.63 | 10–25 |
| `pins_on` − `pins_off` | pinning on vs off; every skill present in both | 21 | +1.82 ± 1.63 | −1.36 … +5.01 | 13–8 |

**A particular set of 41 skills hurts, and the mechanism that routes skills to tasks does not.**
Complementary answers, not contradictory ones.

The first row also firmed up as tasks landed — it was −3.16 ± 1.48 over 33 pairs in #315 and is
−2.75 ± 1.08 over 35: same sign, tighter interval, loss count 23 of 33 → 25 of 35. Both arms
remain well ahead of the control (+7.01 and +8.81), so they are ahead *despite* that skill set.

## What neither row licenses

- `pins_on` − `pins_off` is 21 pairs at t=1.12. It is **not** evidence that pinning helps; it is
  the absence of evidence that it hurts, and it will move.
- The arms are missing different tasks, so only the intersection is paired — neither arm's own
  mean is comparable to the other's.
- Neither says **which** skill. Forty-one files were struck together.

## On keeping the mistake

The conflating sentence is quoted where it stood rather than deleted, in both files, because the
reusable part is the error itself: two ablations with adjacent names were not the same
manipulation, and nothing but the worktrees said so.

## Test

Anchors verified to resolve across `README.md`, the notebook and `framework.md`. `py_compile` on
CI's exact argument list passes; `test_doc_counts` + `test_path_reference_heuristic` pass (35
tests); full suite run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
