### PR TITLE
The pin count adds 4046 characters of prose to 280 pins

### DIFF
--- a/rcb_tools/run_arm.py
+++ b/rcb_tools/run_arm.py
@@ -42,11 +42,22 @@ AUTOR_PIN_A9C = Path("/home/robtang_google_com/autor-pin-a9c2b48")
 #: because that one is under a live array and a benchmark run measures the clone it was
 #: launched from.
 AUTOR_SKILLS161 = Path("/home/robtang_google_com/autor-skills161")
-#: main at 48501e7, all 161 skills and all 4326 pins. The pair below is the one-variable
+#: main at 48501e7, all 161 skills and all 280 pins. The pair below is the one-variable
 #: control the `autor_skills161` arm could not be: the two trees differ in `src/skills` and
 #: `configs/task_skill_pins.json` and in nothing else (`diff -rq` clears everything but
 #: .git and __pycache__). `autor-abl40` has the 41 skill directories added by #270 deleted
-#: and their 40 pins struck, leaving 120 skills and 4286 pins.
+#: and their 40 pins struck, leaving 120 skills and 240 pins.
+#:
+#: 280 and 240, not the 4326 and 4286 this comment carried until now and the launchers
+#: printed into every run record. `sum(len(v) for v in table.values())` counts the six
+#: underscore-prefixed metadata keys too, and five of those are prose, so it was adding
+#: 4046 *characters* of `_provenance` and `_maximum` to the pin count. `slurm_pins.sbatch`
+#: has said "27 of the forty tasks carry 280 entries between them" the whole time; the two
+#: numbers were in the same repository disagreeing by a factor of fifteen.
+#:
+#: It is not a cosmetic error. Struck against 4326 the ablation reads as 0.9% of the pin
+#: table and beneath notice; struck against 280 it is 14%, one entry in seven, which is the
+#: size the -2.16 +/- 1.06 arm gap has to be explained against.
 #:
 #: Forty tasks rather than the twelve #270 was written from, for two reasons. Current main
 #: has no 40-task score at all -- the twelve in flight are the tasks that were losing, so

--- a/rcb_tools/slurm_ablation40.sbatch
+++ b/rcb_tools/slurm_ablation40.sbatch
@@ -56,7 +56,7 @@ echo "task      : $TASK  (index $SLURM_ARRAY_TASK_ID)"
 # A benchmark run measures the clone it was launched from, so the SHA goes in the log at
 # launch rather than being read off the tree afterwards.
 echo "checkout  : $TREE @ $(git -C "$TREE" rev-parse --short HEAD 2>/dev/null)"
-echo "skills    : $(ls "$TREE/src/skills" | wc -l)   pins: $(python3 -c "import json;print(sum(len(v) for v in json.load(open('$TREE/configs/task_skill_pins.json')).values()))")"
+echo "skills    : $(ls "$TREE/src/skills" | wc -l)   pins: $(python3 -c "import json;d=json.load(open('$TREE/configs/task_skill_pins.json'));print(sum(len(v) for k,v in d.items() if not k.startswith('_')))")"
 echo
 
 ( while sleep 600; do

--- a/rcb_tools/slurm_ablation40_a3.sbatch
+++ b/rcb_tools/slurm_ablation40_a3.sbatch
@@ -53,7 +53,7 @@ echo "arm       : $ARM"
 # A benchmark run measures the clone it was launched from, so the SHA is printed at launch
 # rather than read off the tree afterwards.
 echo "checkout  : $TREE @ $(git -C "$TREE" rev-parse --short HEAD 2>/dev/null)"
-echo "skills    : $(ls "$TREE/src/skills" | wc -l)   pins: $(python3 -c "import json;print(sum(len(v) for v in json.load(open('$TREE/configs/task_skill_pins.json')).values()))")"
+echo "skills    : $(ls "$TREE/src/skills" | wc -l)   pins: $(python3 -c "import json;d=json.load(open('$TREE/configs/task_skill_pins.json'));print(sum(len(v) for k,v in d.items() if not k.startswith('_')))")"
 echo "tasks     : $(echo $TASKS | wc -w)   concurrency: $RCB_MAX_CONCURRENT"
 echo
 


### PR DESCRIPTION
## The bug

`sum(len(v) for v in json.load(...).values())` over `configs/task_skill_pins.json` walks every key. Six are underscore-prefixed metadata and five of those are **strings**, so `len` returns a character count:

| key | type | `len` |
|:---|:---|---:|
| `_provenance` | str | 1624 |
| `_maximum` | str | 1295 |
| `_columns` | str | 586 |
| `_declares_itself` | str | 289 |
| `_what` | str | 226 |
| `_rationale` | dict | 26 |

4046 characters, added to 280 pins, printed as **4326**.

## Measured on the two live trees

```
autor-main40   expression 4326   real pins 280
autor-abl40    expression 4286   real pins 240
```

## Where it leaked

- `rcb_tools/slurm_ablation40.sbatch:59` and `slurm_ablation40_a3.sbatch:56` print it at launch, so **4326 / 4286 are in the log of every main40 and abl40 run**
- `rcb_tools/run_arm.py:45,49` repeats them in the header comment

Both fixed by skipping keys that start with `_`.

## The repository already knew

`rcb_tools/slurm_pins.sbatch:17` has said *"27 of the forty tasks carry 280 entries between them"* since it was written. Two numbers fifteen times apart, in the same directory, neither citing the other.

## Why it is not cosmetic

The ablation strikes 40 pins.

- against **4326** → 0.9% of the table, beneath notice
- against **280** → **14%, one entry in seven**

The arm gap those 40 pins have to account for is `−2.16 ± 1.06`, 95% CI `[−4.24, −0.09]`. Which framing a reader carries decides whether that reads as a large effect from a trivial change or a modest effect from a substantial one.

## Deliberately not touched

- **`autor-abl40`'s copy of the table** stores those six metadata keys as *lists* — `_what` is a 226-element list of single characters — where main40 stores strings. That is why an `isinstance(v, list)` filter reads 280 on one tree and 4286 on the other. The file is under a live 40-task arm; rewriting it mid-flight would change the tree the runs are measuring. It wants its own change once the arm lands.
- **Numbers already in `docs/` and in run records.** Those are what the launchers printed at the time; correcting them in place would rewrite the record instead of the code that produced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)